### PR TITLE
Update annotation checks to make it work with 'self' keyword

### DIFF
--- a/warp/codegen.py
+++ b/warp/codegen.py
@@ -312,7 +312,11 @@ class Adjoint:
         if overload_annotations is None:
             # use source-level argument annotations
             if len(argspec.annotations) < len(argspec.args):
-                raise RuntimeError(f"Incomplete argument annotations on function {adj.fun_name}")
+                if not (
+                    len(argspec.annotations) == len(argspec.args) - 1
+                    and argspec.args[0] == "self"
+                ):
+                    raise RuntimeError(f"Incomplete argument annotations on function {adj.fun_name}")
             adj.arg_types = argspec.annotations
         else:
             # use overload argument annotations


### PR DESCRIPTION
## Description
With 0.8, it seems that it is not possible to define kernel functions that are members of a class because of the annotation checks to make sure that the number of arguments matches the number of annotations.
I propose this change to be able to use the `self` keyword for kernel functions except if this is not the expected behaviour.

## Changes
- `codegen.py` &rarr; do not raise the error if the number of annotations is equal to the number of arguments - 1 and the first argument is `self`