### PR TITLE
Replace more generic ValueError with specific FileNotFoundError for warp.sim.load_mesh

### DIFF
--- a/warp/sim/utils.py
+++ b/warp/sim/utils.py
@@ -311,7 +311,7 @@ def load_mesh(filename: str, method: str = None):
     import os
 
     if not os.path.exists(filename):
-        raise ValueError(f"File not found: {filename}")
+        raise FileNotFoundError(f"File not found: {filename}")
 
     def load_mesh_with_method(method):
         if method == "meshio":


### PR DESCRIPTION


## Category


- [ ] New feature
- [ ] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [X] Other 


## Description
Changing the error type of the warp.sim.load_mesh function for files which don't exist makes it easier to differentiate between wrong paths and invalid meshes programmatically.

Example: Iterating over multiple directories to find a mesh with a given name.
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Changelog
<!--The list in this section will be used creating the changelog for the next release. -->
Changes
`raise ValueError(f"File not found: {filename}")`
to
`raise FileNotFoundError(f"File not found: {filename}")`


## Before your PR is "Ready for review"

- [X] Do you agree to the terms under which contributions are accepted as described in Section 9 the Warp [License](https://github.com/NVIDIA/warp/blob/main/LICENSE.md)?
- [X] Have you read the [Contributor Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md)?
- [ ] Have you written any new necessary tests?
- [ ] Have you added or updated any necessary documentation?
- [ ] Have you added any files modified by compiling Warp and building the documentation to this PR (.e.g. `stubs.py`, `functions.rst`)?
- [X] Does your code pass `ruff check` and `ruff format --check`?
