### PR TITLE
3D Volume initialization from numpy

### DIFF
--- a/warp/tests/test_volume.py
+++ b/warp/tests/test_volume.py
@@ -63,11 +63,7 @@ def test_volume_sample_linear_f(volume: wp.uint64, points: wp.array(dtype=wp.vec
         return  # not testing against background values
 
     expect_near(wp.volume_sample_f(volume, p, wp.Volume.LINEAR), expected, 2.0e-4)
-    expect_near(
-        wp.volume_sample(volume, p, wp.Volume.LINEAR, dtype=wp.float32),
-        expected,
-        2.0e-4,
-    )
+    expect_near(wp.volume_sample(volume, p, wp.Volume.LINEAR, dtype=wp.float32), expected, 2.0e-4)
 
 
 @wp.kernel
@@ -102,9 +98,7 @@ def test_volume_sample_grad_linear_f(volume: wp.uint64, points: wp.array(dtype=w
 
 @wp.kernel
 def test_volume_sample_local_f_linear_values(
-    volume: wp.uint64,
-    points: wp.array(dtype=wp.vec3),
-    values: wp.array(dtype=wp.float32),
+    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)
 ):
     tid = wp.tid()
     p = points[tid]
@@ -113,10 +107,7 @@ def test_volume_sample_local_f_linear_values(
 
 @wp.kernel
 def test_volume_sample_grad_local_f_linear_values(
-    volume: wp.uint64,
-    points: wp.array(dtype=wp.vec3),
-    values: wp.array(dtype=wp.float32),
-    case_num: int,
+    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32), case_num: int
 ):
     tid = wp.tid()
     p = points[tid]
@@ -135,9 +126,7 @@ def test_volume_sample_grad_local_f_linear_values(
 
 @wp.kernel
 def test_volume_sample_world_f_linear_values(
-    volume: wp.uint64,
-    points: wp.array(dtype=wp.vec3),
-    values: wp.array(dtype=wp.float32),
+    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)
 ):
     tid = wp.tid()
     q = points[tid]
@@ -147,10 +136,7 @@ def test_volume_sample_world_f_linear_values(
 
 @wp.kernel
 def test_volume_sample_grad_world_f_linear_values(
-    volume: wp.uint64,
-    points: wp.array(dtype=wp.vec3),
-    values: wp.array(dtype=wp.float32),
-    case_num: int,
+    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32), case_num: int
 ):
     tid = wp.tid()
     q = points[tid]
@@ -175,9 +161,7 @@ def test_volume_lookup_v(volume: wp.uint64, points: wp.array(dtype=wp.vec3)):
 
     p = points[tid]
     expected = wp.vec3(
-        p[0] + 2.0 * p[1] + 3.0 * p[2],
-        4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2],
-        7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2],
+        p[0] + 2.0 * p[1] + 3.0 * p[2], 4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2], 7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2]
     )
     if abs(p[0]) > 10.0 or abs(p[1]) > 10.0 or abs(p[2]) > 10.0:
         expected = wp.vec3(10.8, -4.13, 10.26)
@@ -217,9 +201,7 @@ def test_volume_sample_linear_v(volume: wp.uint64, points: wp.array(dtype=wp.vec
     p = points[tid]
 
     expected = wp.vec3(
-        p[0] + 2.0 * p[1] + 3.0 * p[2],
-        4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2],
-        7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2],
+        p[0] + 2.0 * p[1] + 3.0 * p[2], 4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2], 7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2]
     )
     if abs(p[0]) > 10.0 or abs(p[1]) > 10.0 or abs(p[2]) > 10.0:
         return  # not testing against background values
@@ -238,9 +220,7 @@ def test_volume_sample_grad_linear_v(volume: wp.uint64, points: wp.array(dtype=w
         return  # not testing against background values
 
     expected_val = wp.vec3(
-        p[0] + 2.0 * p[1] + 3.0 * p[2],
-        4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2],
-        7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2],
+        p[0] + 2.0 * p[1] + 3.0 * p[2], 4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2], 7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2]
     )
     expected_grad = wp.mat33(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)
 
@@ -255,9 +235,7 @@ def test_volume_sample_grad_linear_v(volume: wp.uint64, points: wp.array(dtype=w
 
 @wp.kernel
 def test_volume_sample_local_v_linear_values(
-    volume: wp.uint64,
-    points: wp.array(dtype=wp.vec3),
-    values: wp.array(dtype=wp.float32),
+    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)
 ):
     tid = wp.tid()
     p = points[tid]
@@ -267,9 +245,7 @@ def test_volume_sample_local_v_linear_values(
 
 @wp.kernel
 def test_volume_sample_world_v_linear_values(
-    volume: wp.uint64,
-    points: wp.array(dtype=wp.vec3),
-    values: wp.array(dtype=wp.float32),
+    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)
 ):
     tid = wp.tid()
     q = points[tid]
@@ -346,11 +322,7 @@ def test_volume_world_to_index(
 
 # Volume write tests
 @wp.kernel
-def test_volume_store_f(
-    volume: wp.uint64,
-    points: wp.array(dtype=wp.vec3),
-    values: wp.array(dtype=wp.float32),
-):
+def test_volume_store_f(volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)):
     tid = wp.tid()
 
     p = points[tid]
@@ -420,11 +392,7 @@ volume_paths = {
 }
 
 test_volume_tiles = (
-    np.array(
-        [[i, j, k] for i in range(-2, 2) for j in range(-2, 2) for k in range(-2, 2)],
-        dtype=np.int32,
-    )
-    * 8
+    np.array([[i, j, k] for i in range(-2, 2) for j in range(-2, 2) for k in range(-2, 2)], dtype=np.int32) * 8
 )
 
 volumes = {}
@@ -620,21 +588,10 @@ def test_volume_allocation_f(test, device):
     points_np = np.append(point_grid, [[8096, 8096, 8096]], axis=0)
     values_ref = np.append(np.array([x + 100 * y + 10000 * z for x, y, z in point_grid]), bg_value)
 
-    volume = wp.Volume.allocate(
-        min=[-11, -11, -11],
-        max=[11, 11, 11],
-        voxel_size=0.1,
-        bg_value=bg_value,
-        device=device,
-    )
+    volume = wp.Volume.allocate(min=[-11, -11, -11], max=[11, 11, 11], voxel_size=0.1, bg_value=bg_value, device=device)
     points = wp.array(points_np, dtype=wp.vec3, device=device)
     values = wp.empty(len(points_np), dtype=wp.float32, device=device)
-    wp.launch(
-        test_volume_store_f,
-        dim=len(points_np),
-        inputs=[volume.id, points, values],
-        device=device,
-    )
+    wp.launch(test_volume_store_f, dim=len(points_np), inputs=[volume.id, points, values], device=device)
 
     values_res = values.numpy()
     np.testing.assert_equal(values_res, values_ref)
@@ -645,21 +602,10 @@ def test_volume_allocation_v(test, device):
     points_np = np.append(point_grid, [[8096, 8096, 8096]], axis=0)
     values_ref = np.append(point_grid, [bg_value], axis=0)
 
-    volume = wp.Volume.allocate(
-        min=[-11, -11, -11],
-        max=[11, 11, 11],
-        voxel_size=0.1,
-        bg_value=bg_value,
-        device=device,
-    )
+    volume = wp.Volume.allocate(min=[-11, -11, -11], max=[11, 11, 11], voxel_size=0.1, bg_value=bg_value, device=device)
     points = wp.array(points_np, dtype=wp.vec3, device=device)
     values = wp.empty(len(points_np), dtype=wp.vec3, device=device)
-    wp.launch(
-        test_volume_store_v,
-        dim=len(points_np),
-        inputs=[volume.id, points, values],
-        device=device,
-    )
+    wp.launch(test_volume_store_v, dim=len(points_np), inputs=[volume.id, points, values], device=device)
 
     values_res = values.numpy()
     np.testing.assert_equal(values_res, values_ref)
@@ -668,26 +614,12 @@ def test_volume_allocation_v(test, device):
 def test_volume_allocation_i(test, device):
     bg_value = -123
     points_np = np.append(point_grid, [[8096, 8096, 8096]], axis=0)
-    values_ref = np.append(
-        np.array([x + 100 * y + 10000 * z for x, y, z in point_grid], dtype=np.int32),
-        bg_value,
-    )
+    values_ref = np.append(np.array([x + 100 * y + 10000 * z for x, y, z in point_grid], dtype=np.int32), bg_value)
 
-    volume = wp.Volume.allocate(
-        min=[-11, -11, -11],
-        max=[11, 11, 11],
-        voxel_size=0.1,
-        bg_value=bg_value,
-        device=device,
-    )
+    volume = wp.Volume.allocate(min=[-11, -11, -11], max=[11, 11, 11], voxel_size=0.1, bg_value=bg_value, device=device)
     points = wp.array(points_np, dtype=wp.vec3, device=device)
     values = wp.empty(len(points_np), dtype=wp.int32, device=device)
-    wp.launch(
-        test_volume_store_i,
-        dim=len(points_np),
-        inputs=[volume.id, points, values],
-        device=device,
-    )
+    wp.launch(test_volume_store_i, dim=len(points_np), inputs=[volume.id, points, values], device=device)
 
     values_res = values.numpy()
     np.testing.assert_equal(values_res, values_ref)
@@ -824,33 +756,13 @@ def test_volume_sample_index(test, device):
 
             ijk = volume.get_voxels()
 
-            values = wp.empty(
-                shape=volume.get_voxel_count(),
-                dtype=volume.dtype,
-                device=device,
-                requires_grad=True,
-            )
+            values = wp.empty(shape=volume.get_voxel_count(), dtype=volume.dtype, device=device, requires_grad=True)
 
             vid = wp.uint64(volume.id)
-            wp.launch(
-                fill_leaf_values_kernel,
-                dim=values.shape,
-                inputs=[vid, ijk, values],
-                device=device,
-            )
+            wp.launch(fill_leaf_values_kernel, dim=values.shape, inputs=[vid, ijk, values], device=device)
 
-            sampled_values = wp.empty(
-                shape=points.shape[0],
-                dtype=volume.dtype,
-                device=device,
-                requires_grad=True,
-            )
-            background = wp.array(
-                [bg_values[volume_names]],
-                dtype=volume.dtype,
-                device=device,
-                requires_grad=True,
-            )
+            sampled_values = wp.empty(shape=points.shape[0], dtype=volume.dtype, device=device, requires_grad=True)
+            background = wp.array([bg_values[volume_names]], dtype=volume.dtype, device=device, requires_grad=True)
 
             tape = wp.Tape()
             with tape:
@@ -875,24 +787,14 @@ def test_volume_sample_index(test, device):
             tape.reset()
 
             sampled_grads = wp.empty(
-                shape=points.shape[0],
-                dtype=grad_types[volume_names],
-                device=device,
-                requires_grad=True,
+                shape=points.shape[0], dtype=grad_types[volume_names], device=device, requires_grad=True
             )
 
             with tape:
                 wp.launch(
                     test_volume_sample_grad_index_kernel,
                     dim=points.shape[0],
-                    inputs=[
-                        vid,
-                        uvws,
-                        values,
-                        background,
-                        sampled_values,
-                        sampled_grads,
-                    ],
+                    inputs=[vid, uvws, values, background, sampled_values, sampled_grads],
                     device=device,
                 )
 
@@ -996,73 +898,36 @@ class TestVolume(unittest.TestCase):
 
 
 add_function_test(
-    TestVolume,
-    "test_volume_sample_linear_f_gradient",
-    test_volume_sample_linear_f_gradient,
-    devices=devices,
+    TestVolume, "test_volume_sample_linear_f_gradient", test_volume_sample_linear_f_gradient, devices=devices
 )
 add_function_test(
-    TestVolume,
-    "test_volume_sample_grad_linear_f_gradient",
-    test_volume_sample_grad_linear_f_gradient,
-    devices=devices,
+    TestVolume, "test_volume_sample_grad_linear_f_gradient", test_volume_sample_grad_linear_f_gradient, devices=devices
 )
 add_function_test(
-    TestVolume,
-    "test_volume_sample_linear_v_gradient",
-    test_volume_sample_linear_v_gradient,
-    devices=devices,
+    TestVolume, "test_volume_sample_linear_v_gradient", test_volume_sample_linear_v_gradient, devices=devices
 )
-add_function_test(
-    TestVolume,
-    "test_volume_transform_gradient",
-    test_volume_transform_gradient,
-    devices=devices,
-)
+add_function_test(TestVolume, "test_volume_transform_gradient", test_volume_transform_gradient, devices=devices)
 add_function_test(TestVolume, "test_volume_store", test_volume_store, devices=devices)
 add_function_test(
-    TestVolume,
-    "test_volume_allocation_f",
-    test_volume_allocation_f,
-    devices=get_selected_cuda_test_devices(),
+    TestVolume, "test_volume_allocation_f", test_volume_allocation_f, devices=get_selected_cuda_test_devices()
 )
 add_function_test(
-    TestVolume,
-    "test_volume_allocation_v",
-    test_volume_allocation_v,
-    devices=get_selected_cuda_test_devices(),
+    TestVolume, "test_volume_allocation_v", test_volume_allocation_v, devices=get_selected_cuda_test_devices()
 )
 add_function_test(
-    TestVolume,
-    "test_volume_allocation_i",
-    test_volume_allocation_i,
-    devices=get_selected_cuda_test_devices(),
+    TestVolume, "test_volume_allocation_i", test_volume_allocation_i, devices=get_selected_cuda_test_devices()
 )
 add_function_test(TestVolume, "test_volume_introspection", test_volume_introspection, devices=devices)
 add_function_test(
-    TestVolume,
-    "test_volume_from_numpy",
-    test_volume_from_numpy,
-    devices=get_selected_cuda_test_devices(),
+    TestVolume, "test_volume_from_numpy", test_volume_from_numpy, devices=get_selected_cuda_test_devices()
 )
 add_function_test(
-    TestVolume,
-    "test_volume_from_numpy_3d",
-    test_volume_from_numpy_3d,
-    devices=get_selected_cuda_test_devices(),
+    TestVolume, "test_volume_from_numpy_3d", test_volume_from_numpy_3d, devices=get_selected_cuda_test_devices()
 )
 add_function_test(
-    TestVolume,
-    "test_volume_aniso_transform",
-    test_volume_aniso_transform,
-    devices=get_selected_cuda_test_devices(),
+    TestVolume, "test_volume_aniso_transform", test_volume_aniso_transform, devices=get_selected_cuda_test_devices()
 )
-add_function_test(
-    TestVolume,
-    "test_volume_multiple_grids",
-    test_volume_multiple_grids,
-    devices=devices,
-)
+add_function_test(TestVolume, "test_volume_multiple_grids", test_volume_multiple_grids, devices=devices)
 add_function_test(TestVolume, "test_volume_feature_array", test_volume_feature_array, devices=devices)
 add_function_test(TestVolume, "test_volume_sample_index", test_volume_sample_index, devices=devices)
 

--- a/warp/tests/test_volume.py
+++ b/warp/tests/test_volume.py
@@ -63,7 +63,11 @@ def test_volume_sample_linear_f(volume: wp.uint64, points: wp.array(dtype=wp.vec
         return  # not testing against background values
 
     expect_near(wp.volume_sample_f(volume, p, wp.Volume.LINEAR), expected, 2.0e-4)
-    expect_near(wp.volume_sample(volume, p, wp.Volume.LINEAR, dtype=wp.float32), expected, 2.0e-4)
+    expect_near(
+        wp.volume_sample(volume, p, wp.Volume.LINEAR, dtype=wp.float32),
+        expected,
+        2.0e-4,
+    )
 
 
 @wp.kernel
@@ -98,7 +102,9 @@ def test_volume_sample_grad_linear_f(volume: wp.uint64, points: wp.array(dtype=w
 
 @wp.kernel
 def test_volume_sample_local_f_linear_values(
-    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)
+    volume: wp.uint64,
+    points: wp.array(dtype=wp.vec3),
+    values: wp.array(dtype=wp.float32),
 ):
     tid = wp.tid()
     p = points[tid]
@@ -107,7 +113,10 @@ def test_volume_sample_local_f_linear_values(
 
 @wp.kernel
 def test_volume_sample_grad_local_f_linear_values(
-    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32), case_num: int
+    volume: wp.uint64,
+    points: wp.array(dtype=wp.vec3),
+    values: wp.array(dtype=wp.float32),
+    case_num: int,
 ):
     tid = wp.tid()
     p = points[tid]
@@ -126,7 +135,9 @@ def test_volume_sample_grad_local_f_linear_values(
 
 @wp.kernel
 def test_volume_sample_world_f_linear_values(
-    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)
+    volume: wp.uint64,
+    points: wp.array(dtype=wp.vec3),
+    values: wp.array(dtype=wp.float32),
 ):
     tid = wp.tid()
     q = points[tid]
@@ -136,7 +147,10 @@ def test_volume_sample_world_f_linear_values(
 
 @wp.kernel
 def test_volume_sample_grad_world_f_linear_values(
-    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32), case_num: int
+    volume: wp.uint64,
+    points: wp.array(dtype=wp.vec3),
+    values: wp.array(dtype=wp.float32),
+    case_num: int,
 ):
     tid = wp.tid()
     q = points[tid]
@@ -161,7 +175,9 @@ def test_volume_lookup_v(volume: wp.uint64, points: wp.array(dtype=wp.vec3)):
 
     p = points[tid]
     expected = wp.vec3(
-        p[0] + 2.0 * p[1] + 3.0 * p[2], 4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2], 7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2]
+        p[0] + 2.0 * p[1] + 3.0 * p[2],
+        4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2],
+        7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2],
     )
     if abs(p[0]) > 10.0 or abs(p[1]) > 10.0 or abs(p[2]) > 10.0:
         expected = wp.vec3(10.8, -4.13, 10.26)
@@ -201,7 +217,9 @@ def test_volume_sample_linear_v(volume: wp.uint64, points: wp.array(dtype=wp.vec
     p = points[tid]
 
     expected = wp.vec3(
-        p[0] + 2.0 * p[1] + 3.0 * p[2], 4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2], 7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2]
+        p[0] + 2.0 * p[1] + 3.0 * p[2],
+        4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2],
+        7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2],
     )
     if abs(p[0]) > 10.0 or abs(p[1]) > 10.0 or abs(p[2]) > 10.0:
         return  # not testing against background values
@@ -220,7 +238,9 @@ def test_volume_sample_grad_linear_v(volume: wp.uint64, points: wp.array(dtype=w
         return  # not testing against background values
 
     expected_val = wp.vec3(
-        p[0] + 2.0 * p[1] + 3.0 * p[2], 4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2], 7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2]
+        p[0] + 2.0 * p[1] + 3.0 * p[2],
+        4.0 * p[0] + 5.0 * p[1] + 6.0 * p[2],
+        7.0 * p[0] + 8.0 * p[1] + 9.0 * p[2],
     )
     expected_grad = wp.mat33(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0)
 
@@ -235,7 +255,9 @@ def test_volume_sample_grad_linear_v(volume: wp.uint64, points: wp.array(dtype=w
 
 @wp.kernel
 def test_volume_sample_local_v_linear_values(
-    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)
+    volume: wp.uint64,
+    points: wp.array(dtype=wp.vec3),
+    values: wp.array(dtype=wp.float32),
 ):
     tid = wp.tid()
     p = points[tid]
@@ -245,7 +267,9 @@ def test_volume_sample_local_v_linear_values(
 
 @wp.kernel
 def test_volume_sample_world_v_linear_values(
-    volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)
+    volume: wp.uint64,
+    points: wp.array(dtype=wp.vec3),
+    values: wp.array(dtype=wp.float32),
 ):
     tid = wp.tid()
     q = points[tid]
@@ -322,7 +346,11 @@ def test_volume_world_to_index(
 
 # Volume write tests
 @wp.kernel
-def test_volume_store_f(volume: wp.uint64, points: wp.array(dtype=wp.vec3), values: wp.array(dtype=wp.float32)):
+def test_volume_store_f(
+    volume: wp.uint64,
+    points: wp.array(dtype=wp.vec3),
+    values: wp.array(dtype=wp.float32),
+):
     tid = wp.tid()
 
     p = points[tid]
@@ -392,7 +420,11 @@ volume_paths = {
 }
 
 test_volume_tiles = (
-    np.array([[i, j, k] for i in range(-2, 2) for j in range(-2, 2) for k in range(-2, 2)], dtype=np.int32) * 8
+    np.array(
+        [[i, j, k] for i in range(-2, 2) for j in range(-2, 2) for k in range(-2, 2)],
+        dtype=np.int32,
+    )
+    * 8
 )
 
 volumes = {}
@@ -588,10 +620,21 @@ def test_volume_allocation_f(test, device):
     points_np = np.append(point_grid, [[8096, 8096, 8096]], axis=0)
     values_ref = np.append(np.array([x + 100 * y + 10000 * z for x, y, z in point_grid]), bg_value)
 
-    volume = wp.Volume.allocate(min=[-11, -11, -11], max=[11, 11, 11], voxel_size=0.1, bg_value=bg_value, device=device)
+    volume = wp.Volume.allocate(
+        min=[-11, -11, -11],
+        max=[11, 11, 11],
+        voxel_size=0.1,
+        bg_value=bg_value,
+        device=device,
+    )
     points = wp.array(points_np, dtype=wp.vec3, device=device)
     values = wp.empty(len(points_np), dtype=wp.float32, device=device)
-    wp.launch(test_volume_store_f, dim=len(points_np), inputs=[volume.id, points, values], device=device)
+    wp.launch(
+        test_volume_store_f,
+        dim=len(points_np),
+        inputs=[volume.id, points, values],
+        device=device,
+    )
 
     values_res = values.numpy()
     np.testing.assert_equal(values_res, values_ref)
@@ -602,10 +645,21 @@ def test_volume_allocation_v(test, device):
     points_np = np.append(point_grid, [[8096, 8096, 8096]], axis=0)
     values_ref = np.append(point_grid, [bg_value], axis=0)
 
-    volume = wp.Volume.allocate(min=[-11, -11, -11], max=[11, 11, 11], voxel_size=0.1, bg_value=bg_value, device=device)
+    volume = wp.Volume.allocate(
+        min=[-11, -11, -11],
+        max=[11, 11, 11],
+        voxel_size=0.1,
+        bg_value=bg_value,
+        device=device,
+    )
     points = wp.array(points_np, dtype=wp.vec3, device=device)
     values = wp.empty(len(points_np), dtype=wp.vec3, device=device)
-    wp.launch(test_volume_store_v, dim=len(points_np), inputs=[volume.id, points, values], device=device)
+    wp.launch(
+        test_volume_store_v,
+        dim=len(points_np),
+        inputs=[volume.id, points, values],
+        device=device,
+    )
 
     values_res = values.numpy()
     np.testing.assert_equal(values_res, values_ref)
@@ -614,12 +668,26 @@ def test_volume_allocation_v(test, device):
 def test_volume_allocation_i(test, device):
     bg_value = -123
     points_np = np.append(point_grid, [[8096, 8096, 8096]], axis=0)
-    values_ref = np.append(np.array([x + 100 * y + 10000 * z for x, y, z in point_grid], dtype=np.int32), bg_value)
+    values_ref = np.append(
+        np.array([x + 100 * y + 10000 * z for x, y, z in point_grid], dtype=np.int32),
+        bg_value,
+    )
 
-    volume = wp.Volume.allocate(min=[-11, -11, -11], max=[11, 11, 11], voxel_size=0.1, bg_value=bg_value, device=device)
+    volume = wp.Volume.allocate(
+        min=[-11, -11, -11],
+        max=[11, 11, 11],
+        voxel_size=0.1,
+        bg_value=bg_value,
+        device=device,
+    )
     points = wp.array(points_np, dtype=wp.vec3, device=device)
     values = wp.empty(len(points_np), dtype=wp.int32, device=device)
-    wp.launch(test_volume_store_i, dim=len(points_np), inputs=[volume.id, points, values], device=device)
+    wp.launch(
+        test_volume_store_i,
+        dim=len(points_np),
+        inputs=[volume.id, points, values],
+        device=device,
+    )
 
     values_res = values.numpy()
     np.testing.assert_equal(values_res, values_ref)
@@ -756,13 +824,33 @@ def test_volume_sample_index(test, device):
 
             ijk = volume.get_voxels()
 
-            values = wp.empty(shape=volume.get_voxel_count(), dtype=volume.dtype, device=device, requires_grad=True)
+            values = wp.empty(
+                shape=volume.get_voxel_count(),
+                dtype=volume.dtype,
+                device=device,
+                requires_grad=True,
+            )
 
             vid = wp.uint64(volume.id)
-            wp.launch(fill_leaf_values_kernel, dim=values.shape, inputs=[vid, ijk, values], device=device)
+            wp.launch(
+                fill_leaf_values_kernel,
+                dim=values.shape,
+                inputs=[vid, ijk, values],
+                device=device,
+            )
 
-            sampled_values = wp.empty(shape=points.shape[0], dtype=volume.dtype, device=device, requires_grad=True)
-            background = wp.array([bg_values[volume_names]], dtype=volume.dtype, device=device, requires_grad=True)
+            sampled_values = wp.empty(
+                shape=points.shape[0],
+                dtype=volume.dtype,
+                device=device,
+                requires_grad=True,
+            )
+            background = wp.array(
+                [bg_values[volume_names]],
+                dtype=volume.dtype,
+                device=device,
+                requires_grad=True,
+            )
 
             tape = wp.Tape()
             with tape:
@@ -787,14 +875,24 @@ def test_volume_sample_index(test, device):
             tape.reset()
 
             sampled_grads = wp.empty(
-                shape=points.shape[0], dtype=grad_types[volume_names], device=device, requires_grad=True
+                shape=points.shape[0],
+                dtype=grad_types[volume_names],
+                device=device,
+                requires_grad=True,
             )
 
             with tape:
                 wp.launch(
                     test_volume_sample_grad_index_kernel,
                     dim=points.shape[0],
-                    inputs=[vid, uvws, values, background, sampled_values, sampled_grads],
+                    inputs=[
+                        vid,
+                        uvws,
+                        values,
+                        background,
+                        sampled_values,
+                        sampled_grads,
+                    ],
                     device=device,
                 )
 
@@ -843,6 +941,33 @@ def test_volume_from_numpy(test, device):
     test.assertIsNone(sphere_vdb_array.deleter)
 
 
+def test_volume_from_numpy_3d(test, device):
+    # Volume.allocate_from_tiles() is only available with CUDA
+    mins = np.array([-3.0, -3.0, -3.0])
+    voxel_size = 0.2
+    maxs = np.array([3.0, 3.0, 3.0])
+    nums = np.ceil((maxs - mins) / (voxel_size)).astype(dtype=int)
+    centers = np.array([[-1.0, -1.0, -1.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+    rad = 2.5
+    sphere_sdf_np = np.zeros(tuple(nums) + (3,))
+    for x in range(nums[0]):
+        for y in range(nums[1]):
+            for z in range(nums[2]):
+                for k in range(3):
+                    pos = mins + voxel_size * np.array([x, y, z])
+                    dis = np.linalg.norm(pos - centers[k])
+                    sphere_sdf_np[x, y, z, k] = dis - rad
+    sphere_vdb = wp.Volume.load_from_numpy(
+        sphere_sdf_np, mins, voxel_size, (rad + 3.0 * voxel_size,) * 3, device=device
+    )
+
+    test.assertNotEqual(sphere_vdb.id, 0)
+
+    sphere_vdb_array = sphere_vdb.array()
+    test.assertEqual(sphere_vdb_array.dtype, wp.uint8)
+    test.assertIsNone(sphere_vdb_array.deleter)
+
+
 def test_volume_aniso_transform(test, device):
     # XY-rotation + z scale
     transform = [
@@ -871,33 +996,73 @@ class TestVolume(unittest.TestCase):
 
 
 add_function_test(
-    TestVolume, "test_volume_sample_linear_f_gradient", test_volume_sample_linear_f_gradient, devices=devices
+    TestVolume,
+    "test_volume_sample_linear_f_gradient",
+    test_volume_sample_linear_f_gradient,
+    devices=devices,
 )
 add_function_test(
-    TestVolume, "test_volume_sample_grad_linear_f_gradient", test_volume_sample_grad_linear_f_gradient, devices=devices
+    TestVolume,
+    "test_volume_sample_grad_linear_f_gradient",
+    test_volume_sample_grad_linear_f_gradient,
+    devices=devices,
 )
 add_function_test(
-    TestVolume, "test_volume_sample_linear_v_gradient", test_volume_sample_linear_v_gradient, devices=devices
+    TestVolume,
+    "test_volume_sample_linear_v_gradient",
+    test_volume_sample_linear_v_gradient,
+    devices=devices,
 )
-add_function_test(TestVolume, "test_volume_transform_gradient", test_volume_transform_gradient, devices=devices)
+add_function_test(
+    TestVolume,
+    "test_volume_transform_gradient",
+    test_volume_transform_gradient,
+    devices=devices,
+)
 add_function_test(TestVolume, "test_volume_store", test_volume_store, devices=devices)
 add_function_test(
-    TestVolume, "test_volume_allocation_f", test_volume_allocation_f, devices=get_selected_cuda_test_devices()
+    TestVolume,
+    "test_volume_allocation_f",
+    test_volume_allocation_f,
+    devices=get_selected_cuda_test_devices(),
 )
 add_function_test(
-    TestVolume, "test_volume_allocation_v", test_volume_allocation_v, devices=get_selected_cuda_test_devices()
+    TestVolume,
+    "test_volume_allocation_v",
+    test_volume_allocation_v,
+    devices=get_selected_cuda_test_devices(),
 )
 add_function_test(
-    TestVolume, "test_volume_allocation_i", test_volume_allocation_i, devices=get_selected_cuda_test_devices()
+    TestVolume,
+    "test_volume_allocation_i",
+    test_volume_allocation_i,
+    devices=get_selected_cuda_test_devices(),
 )
 add_function_test(TestVolume, "test_volume_introspection", test_volume_introspection, devices=devices)
 add_function_test(
-    TestVolume, "test_volume_from_numpy", test_volume_from_numpy, devices=get_selected_cuda_test_devices()
+    TestVolume,
+    "test_volume_from_numpy",
+    test_volume_from_numpy,
+    devices=get_selected_cuda_test_devices(),
 )
 add_function_test(
-    TestVolume, "test_volume_aniso_transform", test_volume_aniso_transform, devices=get_selected_cuda_test_devices()
+    TestVolume,
+    "test_volume_from_numpy_3d",
+    test_volume_from_numpy_3d,
+    devices=get_selected_cuda_test_devices(),
 )
-add_function_test(TestVolume, "test_volume_multiple_grids", test_volume_multiple_grids, devices=devices)
+add_function_test(
+    TestVolume,
+    "test_volume_aniso_transform",
+    test_volume_aniso_transform,
+    devices=get_selected_cuda_test_devices(),
+)
+add_function_test(
+    TestVolume,
+    "test_volume_multiple_grids",
+    test_volume_multiple_grids,
+    devices=devices,
+)
 add_function_test(TestVolume, "test_volume_feature_array", test_volume_feature_array, devices=devices)
 add_function_test(TestVolume, "test_volume_sample_index", test_volume_sample_index, devices=devices)
 

--- a/warp/types.py
+++ b/warp/types.py
@@ -3614,8 +3614,11 @@ class Volume:
         )
         if hasattr(bg_value, "__len__"):
             # vec3, assuming the numpy array is 4D
-            padded_array = np.zeros((target_shape[0], target_shape[1], target_shape[2], 3), dtype=np.single)
-            padded_array[:, :, :, :] = np.array(bg_value)
+            padded_array = np.full(
+                shape=(target_shape[0], target_shape[1], target_shape[2], 3),
+                fill_value=bg_value,
+                dtype=np.single,
+            )
             padded_array[0 : ndarray.shape[0], 0 : ndarray.shape[1], 0 : ndarray.shape[2], :] = ndarray
         else:
             padded_amount = (

--- a/warp/types.py
+++ b/warp/types.py
@@ -12,7 +12,18 @@ import ctypes
 import inspect
 import struct
 import zlib
-from typing import Any, Callable, Generic, List, NamedTuple, Optional, Sequence, Tuple, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
 
@@ -1110,7 +1121,11 @@ ARRAY_TYPE_FABRIC_INDEXED = 3
 
 # represents bounds for kernel launch (number of threads across multiple dimensions)
 class launch_bounds_t(ctypes.Structure):
-    _fields_ = [("shape", ctypes.c_int32 * LAUNCH_MAX_DIMS), ("ndim", ctypes.c_int32), ("size", ctypes.c_size_t)]
+    _fields_ = [
+        ("shape", ctypes.c_int32 * LAUNCH_MAX_DIMS),
+        ("ndim", ctypes.c_int32),
+        ("size", ctypes.c_size_t),
+    ]
 
     def __init__(self, shape):
         if isinstance(shape, int):
@@ -1766,7 +1781,11 @@ class array(Array):
                 if arr.shape[-1] == dtype._length_:
                     target_npshape = (*arr.shape[:-1], *dtype_shape)
                 elif arr.shape[-1] % dtype._length_ == 0:
-                    target_npshape = (*arr.shape[:-1], arr.shape[-1] // dtype._length_, *dtype_shape)
+                    target_npshape = (
+                        *arr.shape[:-1],
+                        arr.shape[-1] // dtype._length_,
+                        *dtype_shape,
+                    )
                 else:
                     if dtype_ndim == 1:
                         raise RuntimeError(
@@ -2033,7 +2052,9 @@ class array(Array):
             # Performance note: avoid wrapping the external stream in a temporary Stream object
             if external_stream != array_stream.cuda_stream:
                 warp.context.runtime.core.cuda_stream_wait_stream(
-                    external_stream, array_stream.cuda_stream, array_stream.cached_event.cuda_event
+                    external_stream,
+                    array_stream.cuda_stream,
+                    array_stream.cached_event.cuda_event,
                 )
 
         return warp.dlpack.to_dlpack(self)
@@ -2181,7 +2202,13 @@ class array(Array):
         if self.ctype is None:
             data = 0 if self.ptr is None else ctypes.c_uint64(self.ptr)
             grad = 0 if self.grad is None or self.grad.ptr is None else ctypes.c_uint64(self.grad.ptr)
-            self.ctype = array_t(data=data, grad=grad, ndim=self.ndim, shape=self.shape, strides=self.strides)
+            self.ctype = array_t(
+                data=data,
+                grad=grad,
+                ndim=self.ndim,
+                shape=self.shape,
+                strides=self.strides,
+            )
 
         return self.ctype
 
@@ -2248,7 +2275,11 @@ class array(Array):
 
     def _alloc_grad(self):
         self._grad = warp.zeros(
-            dtype=self.dtype, shape=self.shape, strides=self.strides, device=self.device, pinned=self.pinned
+            dtype=self.dtype,
+            shape=self.shape,
+            strides=self.strides,
+            device=self.device,
+            pinned=self.pinned,
         )
 
         # trigger re-creation of C-representation
@@ -2366,7 +2397,11 @@ class array(Array):
 
             if self.device.is_cuda:
                 warp.context.runtime.core.array_fill_device(
-                    self.device.context, carr_ptr, ARRAY_TYPE_REGULAR, cvalue_ptr, cvalue_size
+                    self.device.context,
+                    carr_ptr,
+                    ARRAY_TYPE_REGULAR,
+                    cvalue_ptr,
+                    cvalue_size,
                 )
             else:
                 warp.context.runtime.core.array_fill_host(carr_ptr, ARRAY_TYPE_REGULAR, cvalue_ptr, cvalue_size)
@@ -2666,7 +2701,7 @@ def from_ptr(ptr, length, dtype=None, shape=None, device=None):
         dtype=dtype,
         length=length,
         capacity=length * type_size_in_bytes(dtype),
-        ptr=0 if ptr == 0 else ctypes.cast(ptr, ctypes.POINTER(ctypes.c_size_t)).contents.value,
+        ptr=(0 if ptr == 0 else ctypes.cast(ptr, ctypes.POINTER(ctypes.c_size_t)).contents.value),
         shape=shape,
         device=device,
         requires_grad=False,
@@ -2777,7 +2812,13 @@ class indexedarray(noncontiguous_array_base[T]):
     # (initialized when needed)
     _vars = None
 
-    def __init__(self, data: array = None, indices: Union[array, List[array]] = None, dtype=None, ndim=None):
+    def __init__(
+        self,
+        data: array = None,
+        indices: Union[array, List[array]] = None,
+        dtype=None,
+        ndim=None,
+    ):
         super().__init__(ARRAY_TYPE_INDEXED)
 
         # canonicalize types
@@ -2956,7 +2997,10 @@ class Bvh:
             self.id = self.runtime.core.bvh_create_host(get_data(lowers), get_data(uppers), int(len(lowers)))
         else:
             self.id = self.runtime.core.bvh_create_device(
-                self.device.context, get_data(lowers), get_data(uppers), int(len(lowers))
+                self.device.context,
+                get_data(lowers),
+                get_data(uppers),
+                int(len(lowers)),
             )
 
     def __del__(self):
@@ -3104,7 +3148,11 @@ class Volume:
             )
         else:
             self.id = self.runtime.core.volume_create_device(
-                self.device.context, ctypes.cast(data.ptr, ctypes.c_void_p), data.size, copy, owner
+                self.device.context,
+                ctypes.cast(data.ptr, ctypes.c_void_p),
+                data.size,
+                copy,
+                owner,
             )
 
         if self.id == 0:
@@ -3126,7 +3174,13 @@ class Volume:
         buf = ctypes.c_void_p(0)
         size = ctypes.c_uint64(0)
         self.runtime.core.volume_get_buffer_info(self.id, ctypes.byref(buf), ctypes.byref(size))
-        return array(ptr=buf.value, dtype=uint8, shape=size.value, device=self.device, owner=False)
+        return array(
+            ptr=buf.value,
+            dtype=uint8,
+            shape=size.value,
+            device=self.device,
+            owner=False,
+        )
 
     def get_tile_count(self) -> int:
         """Returns the number of tiles (NanoVDB leaf nodes) of the volume"""
@@ -3386,7 +3440,13 @@ class Volume:
         if type_size_in_bytes(dtype) != value_size:
             raise RuntimeError(f"Cannot cast feature data of size {value_size} to array dtype {type_repr(dtype)}")
 
-        return array(ptr=info.ptr, dtype=dtype, shape=value_count, device=self.device, owner=False)
+        return array(
+            ptr=info.ptr,
+            dtype=dtype,
+            shape=value_count,
+            device=self.device,
+            owner=False,
+        )
 
     @classmethod
     def load_from_nvdb(cls, file_or_buffer, device=None) -> Volume:
@@ -3402,7 +3462,10 @@ class Volume:
             data = file_or_buffer
 
         magic, version, grid_count, codec = struct.unpack("<QIHH", data[0:16])
-        if magic not in (0x304244566F6E614E, 0x324244566F6E614E):  # NanoVDB0 or NanoVDB2 in hex, little-endian
+        if magic not in (
+            0x304244566F6E614E,
+            0x324244566F6E614E,
+        ):  # NanoVDB0 or NanoVDB2 in hex, little-endian
             raise RuntimeError("NanoVDB signature not found")
         if version >> 21 != 32:  # checking major version
             raise RuntimeError("Unsupported NanoVDB version")
@@ -3445,7 +3508,10 @@ class Volume:
             raise RuntimeError(f"Unsupported codec code: {codec}")
 
         magic = struct.unpack("<Q", grid_data[0:8])[0]
-        if magic not in (0x304244566F6E614E, 0x314244566F6E614E):  # NanoVDB0 or NanoVDB1 in hex, little-endian
+        if magic not in (
+            0x304244566F6E614E,
+            0x314244566F6E614E,
+        ):  # NanoVDB0 or NanoVDB1 in hex, little-endian
             raise RuntimeError("NanoVDB signature not found on grid!")
 
         data_array = array(np.frombuffer(grid_data, dtype=np.byte), device=device)
@@ -3506,7 +3572,9 @@ class Volume:
             return None
 
         next_volume = Volume.load_from_address(
-            array.ptr + grid.size_in_bytes, buffer_size=array.capacity - grid.size_in_bytes, device=self.device
+            array.ptr + grid.size_in_bytes,
+            buffer_size=array.capacity - grid.size_in_bytes,
+            device=self.device,
         )
         # makes the new Volume keep a reference to the current grid, as we're aliasing its buffer
         next_volume._previous_grid = self
@@ -3515,7 +3583,12 @@ class Volume:
 
     @classmethod
     def load_from_numpy(
-        cls, ndarray: np.array, min_world=(0.0, 0.0, 0.0), voxel_size=1.0, bg_value=0.0, device=None
+        cls,
+        ndarray: np.array,
+        min_world=(0.0, 0.0, 0.0),
+        voxel_size=1.0,
+        bg_value=0.0,
+        device=None,
     ) -> Volume:
         """Creates a Volume object from a dense 3D NumPy array.
 
@@ -3541,7 +3614,7 @@ class Volume:
         )
         if hasattr(bg_value, "__len__"):
             # vec3, assuming the numpy array is 4D
-            padded_array = np.array((target_shape[0], target_shape[1], target_shape[2], 3), dtype=np.single)
+            padded_array = np.zeros((target_shape[0], target_shape[1], target_shape[2], 3), dtype=np.single)
             padded_array[:, :, :, :] = np.array(bg_value)
             padded_array[0 : ndarray.shape[0], 0 : ndarray.shape[1], 0 : ndarray.shape[2], :] = ndarray
         else:
@@ -3577,21 +3650,30 @@ class Volume:
             warp.launch(
                 warp.utils.copy_dense_volume_to_nano_vdb_v,
                 dim=(shape[0], shape[1], shape[2]),
-                inputs=[volume.id, warp.array(padded_array, dtype=warp.vec3, device=device)],
+                inputs=[
+                    volume.id,
+                    warp.array(padded_array, dtype=warp.vec3, device=device),
+                ],
                 device=device,
             )
         elif isinstance(bg_value, int):
             warp.launch(
                 warp.utils.copy_dense_volume_to_nano_vdb_i,
                 dim=shape,
-                inputs=[volume.id, warp.array(padded_array, dtype=warp.int32, device=device)],
+                inputs=[
+                    volume.id,
+                    warp.array(padded_array, dtype=warp.int32, device=device),
+                ],
                 device=device,
             )
         else:
             warp.launch(
                 warp.utils.copy_dense_volume_to_nano_vdb_f,
                 dim=shape,
-                inputs=[volume.id, warp.array(padded_array, dtype=warp.float32, device=device)],
+                inputs=[
+                    volume.id,
+                    warp.array(padded_array, dtype=warp.float32, device=device),
+                ],
                 device=device,
             )
 
@@ -3659,7 +3741,17 @@ class Volume:
 
             if isinstance(voxel_size, float):
                 voxel_size = (voxel_size, voxel_size, voxel_size)
-            transform = mat33f(voxel_size[0], 0.0, 0.0, 0.0, voxel_size[1], 0.0, 0.0, 0.0, voxel_size[2])
+            transform = mat33f(
+                voxel_size[0],
+                0.0,
+                0.0,
+                0.0,
+                voxel_size[1],
+                0.0,
+                0.0,
+                0.0,
+                voxel_size[2],
+            )
         else:
             if voxel_size is not None:
                 raise ValueError("Only one of 'voxel_size' or 'transform' must be provided")
@@ -4080,7 +4172,13 @@ def adj_matmul(
     ):
         raise RuntimeError(
             "Invalid shapes for matrices: A = {} B = {} C = {} adj_D = {} adj_A = {} adj_B = {} adj_C = {}".format(
-                a.shape, b.shape, c.shape, adj_d.shape, adj_a.shape, adj_b.shape, adj_c.shape
+                a.shape,
+                b.shape,
+                c.shape,
+                adj_d.shape,
+                adj_a.shape,
+                adj_b.shape,
+                adj_c.shape,
             )
         )
 
@@ -4385,7 +4483,13 @@ def adj_batched_matmul(
     ):
         raise RuntimeError(
             "Invalid shapes for matrices: A = {} B = {} C = {} adj_D = {} adj_A = {} adj_B = {} adj_C = {}".format(
-                a.shape, b.shape, c.shape, adj_d.shape, adj_a.shape, adj_b.shape, adj_c.shape
+                a.shape,
+                b.shape,
+                c.shape,
+                adj_d.shape,
+                adj_a.shape,
+                adj_b.shape,
+                adj_c.shape,
             )
         )
 


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
-->

## Category
<!--
Please check all applicable options from the list below (use [x] in Markdown)
-->

- [ ] New feature
- [X] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please explain)

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->
The current Volume.load_from_numpy method mistakenly initializes a 1D numpy array with values `(target_shape[0], target_shape[1], target_shape[2], 3)` instead of that shape.

## Changelog
<!--The list in this section will be used creating the changelog for the next release. -->

- In case bg_value is multidimensional, correctly initialize an array filled by the bg_value
- Adding a test which is not passed by the original version
- Running ruff format 

## Before your PR is "Ready for review"

- [X] Do you agree to the terms under which contributions are accepted as described in Section 9 the Warp [License](https://github.com/NVIDIA/warp/blob/main/LICENSE.md)?
- [X] Have you read the [Contributor Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md)?
- [X] Have you written any new necessary tests?
- [ ] Have you added or updated any necessary documentation?
- [ ] Have you added any files modified by compiling Warp and building the documentation to this PR (.e.g. `stubs.py`, `functions.rst`)?
- [X] Does your code pass `ruff check` and `ruff format --check`?
