### PR TITLE
Warp-JAX multi-GPU interoperability and added custom launch dimension

### DIFF
--- a/warp/jax_experimental.py
+++ b/warp/jax_experimental.py
@@ -21,17 +21,21 @@ _registered_kernels = [None]
 _registered_kernel_to_id = {}
 
 
-def jax_kernel(wp_kernel):
+def jax_kernel(wp_kernel, launch_dims=None):
     """Create a Jax primitive from a Warp kernel.
 
     NOTE: This is an experimental feature under development.
 
+    Args:
+        wp_kernel: The Warp kernel to be wrapped.
+        launch_dims: Optional. Specify the kernel launch dimensions. If None,
+                     dimensions are inferred from the shape of the first argument.
+
     Current limitations:
     - All kernel arguments must be arrays.
-    - Kernel launch dimensions are inferred from the shape of the first argument.
+    - If launch_dims is not provided, kernel launch dimensions are inferred from the shape of the first argument.
     - Input arguments are followed by output arguments in the Warp kernel definition.
     - There must be at least one input argument and at least one output argument.
-    - Output shapes must match the launch dimensions (i.e., output shapes must match the shape of the first argument).
     - All arrays must be contiguous.
     - Only the CUDA backend is supported.
     """
@@ -47,7 +51,7 @@ def jax_kernel(wp_kernel):
         id = _registered_kernel_to_id[wp_kernel]
 
     def bind(*args):
-        return _jax_warp_p.bind(*args, kernel=id)
+        return _jax_warp_p.bind(*args, kernel=id, launch_dims=launch_dims)
 
     return bind
 
@@ -106,7 +110,7 @@ def _get_jax_device():
     device = jax.config.jax_default_device
     # if default device is not set, use first device
     if device is None:
-        device = jax.devices()[0]
+        device = jax.local_devices()[0]
     return device
 
 
@@ -223,12 +227,17 @@ def _create_jax_warp_primitive():
             raise TypeError(f"Invalid or unsupported data type: {jax_ir_type}")
 
     # Abstract evaluation.
-    def jax_warp_abstract(*args, kernel=None):
+    def jax_warp_abstract(*args, kernel=None, launch_dims=None):
         wp_kernel = _registered_kernels[kernel]
         # All the extra arguments to the warp kernel are outputs.
         warp_outputs = [o.type for o in wp_kernel.adj.args[len(args) :]]
-        # TODO. Let's just use the first input dimension to infer the output's dimensions.
-        dims = strip_vecmat_dimensions(wp_kernel.adj.args[0], list(args[0].shape))
+
+        if launch_dims is None:
+            # Use the first input dimension to infer the output's dimensions if launch_dims is not provided
+            dims = strip_vecmat_dimensions(wp_kernel.adj.args[0], list(args[0].shape))
+        else:
+            dims = launch_dims
+
         jax_outputs = []
         for o in warp_outputs:
             shape = list(dims) + list(get_vecmat_shape(o))
@@ -260,7 +269,7 @@ def _create_jax_warp_primitive():
     def default_layout(shape):
         return range(len(shape) - 1, -1, -1)
 
-    def warp_call_lowering(ctx, *args, kernel=None):
+    def warp_call_lowering(ctx, *args, kernel=None, launch_dims=None):
         if not kernel:
             raise Exception("Unknown kernel id " + str(kernel))
         wp_kernel = _registered_kernels[kernel]
@@ -272,12 +281,15 @@ def _create_jax_warp_primitive():
         if not module.load(device):
             raise Exception("Could not load kernel on device")
 
-        # Infer dimensions from the first input.
-        warp_arg0 = wp_kernel.adj.args[0]
-        actual_shape0 = ir.RankedTensorType(args[0].type).shape
-        dims = strip_vecmat_dimensions(warp_arg0, actual_shape0)
-        warp_dims = collapse_into_leading_dimension(warp_arg0, dims)
-
+        if launch_dims is None:
+            # Infer dimensions from the first input.
+            warp_arg0 = wp_kernel.adj.args[0]
+            actual_shape0 = ir.RankedTensorType(args[0].type).shape
+            dims = strip_vecmat_dimensions(warp_arg0, actual_shape0)
+            warp_dims = collapse_into_leading_dimension(warp_arg0, dims)
+        else:
+            dims = launch_dims
+            warp_dims = launch_dims
         # Figure out the types and shapes of the input arrays.
         arg_strings = []
         operand_layouts = []


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
-->

## Category
<!--
Please check all applicable options from the list below (use [x] in Markdown)
-->

- [x] New feature
- [x] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please explain)

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

1. In `warp/jax_experimental.py`:
- Modified the jax_kernel function to accept an optional launch_dims parameter.
- Updated the abstract evaluation and lowering functions to use the provided launch_dims when available.
- Changed jax.devices() to jax.local_devices() in the _get_jax_device function (this was a bug, as in multi-GPU settings Warp may select non-addressable devices).
2. In `warp/tests/test_jax.py`:
Added a new test case test_jax_kernel_launch_dims to verify the functionality of custom launch dimensions for both 1D and 2D kernels.
3. In `docs/modules/interoperability.rst`:
- Removed the limitation that output shapes must match launch dimensions given the new feature.
- Added a new section on using shardmap for distributed multi-GPU computation with Warp and JAX.
- Added a section on specifying launch dimensions for multi-GPU matrix operations.

## Changelog
<!--The list in this section will be used creating the changelog for the next release. -->

- `jax_kernel` now accepts an optional `launch_dims` parameter. The launch dim is no longer limited the the shape of the first input.
- Changed device selection from `jax.devices()` to `jax.local_devices()` to address multi-GPU launch issues.
- Added tutorials on using JAX's `shardmap` for multi-GPU computations and specifying custom launch dimensions.

## Before your PR is "Ready for review"

- [x] Do you agree to the terms under which contributions are accepted as described in Section 9 the Warp [License](https://github.com/NVIDIA/warp/blob/main/LICENSE.md)?
- [x] Have you read the [Contributor Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md)?
- [x] Have you written any new necessary tests?
- [x] Have you added or updated any necessary documentation?
- [ ] Have you added any files modified by compiling Warp and building the documentation to this PR (.e.g. `stubs.py`, `functions.rst`)?
- [x] Does your code pass `ruff check` and `ruff format --check`?
