### PR TITLE
Simple and small refactoring - Remove redundant else block in the XPBD simulator

### DIFF
--- a/warp/sim/integrator_xpbd.py
+++ b/warp/sim/integrator_xpbd.py
@@ -2808,12 +2808,8 @@ class XPBDIntegrator(Integrator):
 
         with wp.ScopedTimer("simulate", False):
             if model.particle_count:
-                if requires_grad:
-                    particle_q = state_out.particle_q
-                    particle_qd = state_out.particle_qd
-                else:
-                    particle_q = state_out.particle_q
-                    particle_qd = state_out.particle_qd
+                particle_q = state_out.particle_q
+                particle_qd = state_out.particle_qd
 
                 self.particle_q_init = wp.clone(state_in.particle_q)
                 if self.enable_restitution:


### PR DESCRIPTION
## Category

- [ ] New feature
- [ ] Bugfix
- [ ] Breaking change
- [X] Refactoring
- [ ] Documentation
- [ ] Other (please explain)

## Description

A very simple pull request, removing the redundant else block, i.e., if and else blocks are identical.

## Changelog

- warp/sim/integrator_xpbd.py -> L2811-2816 (remove the latter three lines). 

## Before your PR is "Ready for review"

- [X] Do you agree to the terms under which contributions are accepted as described in Section 9 the Warp [License](https://github.com/NVIDIA/warp/blob/main/LICENSE.md)?
- [X] Have you read the [Contributor Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md)?
- [ ] Have you written any new necessary tests?
- [ ] Have you added or updated any necessary documentation?
- [ ] Have you added any files modified by compiling Warp and building the documentation to this PR (.e.g. `stubs.py`, `functions.rst`)?
- [X] Does your code pass `ruff check` and `ruff format --check`?