### PR TITLE
Fixes a bug when assigning a function to an intermediate variable

### DIFF
--- a/warp/codegen.py
+++ b/warp/codegen.py
@@ -1659,6 +1659,9 @@ class Adjoint:
         # lookup symbol, if it has already been assigned to a variable then return the existing mapping
         if node.id in adj.symbols:
             return adj.symbols[node.id]
+        # Check if the node has a warp_func attribute
+        if hasattr(node, 'warp_func'):
+            return node.warp_func
 
         obj = adj.resolve_external_reference(node.id)
 
@@ -2323,6 +2326,18 @@ class Adjoint:
                 raise WarpCodegenError(
                     "Tuple constructs are not supported in kernels. Use vectors like `wp.vec3()` for small collections instead."
                 )
+            elif isinstance(lhs, ast.Name):
+                # symbol name
+                name = lhs.id
+
+                # evaluate rhs
+                rhs = adj.eval(node.value)
+
+                # Check if rhs is a function object
+                if isinstance(rhs, warp.context.Function):
+                    # Assign the function directly to the symbol table
+                    adj.symbols[name] = rhs
+                    return
 
         # handle the case where we are assigning multiple output variables
         if isinstance(lhs, ast.Tuple):

--- a/warp/codegen.py
+++ b/warp/codegen.py
@@ -1660,7 +1660,7 @@ class Adjoint:
         if node.id in adj.symbols:
             return adj.symbols[node.id]
         # Check if the node has a warp_func attribute
-        if hasattr(node, 'warp_func'):
+        if hasattr(node, "warp_func"):
             return node.warp_func
 
         obj = adj.resolve_external_reference(node.id)

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -576,8 +576,8 @@ def test_while_condition_eval():
     while it.valid:
         it.valid = False
 
-def test_function_assignment(test, device):
 
+def test_function_assignment(test, device):
     @wp.func
     def multiply_by_two(a: float):
         return a * 2.0
@@ -590,9 +590,12 @@ def test_function_assignment(test, device):
 
     input_data = wp.array([1.0, 2.0, 3.0], dtype=wp.float32, device=device)
     output_data = wp.empty_like(input_data)
-    wp.launch(kernel_function_assignment, dim=input_data.size, inputs=[input_data], outputs=[output_data], device=device)
+    wp.launch(
+        kernel_function_assignment, dim=input_data.size, inputs=[input_data], outputs=[output_data], device=device
+    )
     expected_output = np.array([2.0, 4.0, 6.0], dtype=np.float32)
     assert_np_equal(output_data.numpy(), expected_output)
+
 
 class TestCodeGen(unittest.TestCase):
     pass
@@ -736,13 +739,7 @@ add_function_test(
     name="test_error_mutating_constant_in_dynamic_loop",
     devices=devices,
 )
-add_function_test(
-    TestCodeGen,
-    func=test_function_assignment,
-    name="test_function_assignment",
-    devices=devices
-)
-
+add_function_test(TestCodeGen, func=test_function_assignment, name="test_function_assignment", devices=devices)
 add_kernel_test(TestCodeGen, name="test_call_syntax", kernel=test_call_syntax, dim=1, devices=devices)
 add_kernel_test(TestCodeGen, name="test_shadow_builtin", kernel=test_shadow_builtin, dim=1, devices=devices)
 add_kernel_test(TestCodeGen, name="test_while_condition_eval", kernel=test_while_condition_eval, dim=1, devices=devices)


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
-->

## Category
<!--
Please check all applicable options from the list below (use [x] in Markdown)
-->

- [ ] New feature
- [x] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please explain)

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Fixes a bug when assigning a function to an intermediate variable. Warp's code generator currently doesn't handle this pattern correctly. When a function is returned, the code generator replaces the expression with a special AST node (`ast.Name`) with an identifier `__warp_func__` and attaches the actual function object to it using an attribute `warp_func`.

In the example repro below from the doc, when the code generator later encounters the name `func` in `output[tid] = func(a, b)`, it tries to resolve `func` but fails because it doesn't find `__warp_func__` in its symbol table, leading to the error.

**NOTE: All tests pass, including the newly added test. However, please review carefully. Fingers crossed my tweaks don't unleash chaos.**

```python
import warp as wp

@wp.func
def do_add(a: float, b: float):
    return a + b

@wp.func
def do_sub(a: float, b: float):
    return a - b

@wp.func
def do_mul(a: float, b: float):
    return a * b

op_handlers = {
    "add": do_add,
    "sub": do_sub,
    "mul": do_mul,
}

inputs = wp.array([[1, 2], [3, 0]], dtype=wp.float32)
outputs = wp.empty(2, dtype=wp.float32)

for op in op_handlers.keys():

    @wp.kernel
    def operate(input: wp.array(dtype=inputs.dtype, ndim=2), output: wp.array(dtype=wp.float32)):
        tid = wp.tid()
        a, b = input[tid, 0], input[tid, 1]
        # retrieve the right function to use for the captured dtype variable
        output[tid] = wp.static(op_handlers[op])(a, b) # this works (as per the docs)
        # ERROR: But below does not work unexpectedly (even though it should be equivalent)
        # func = wp.static(op_handlers[op])
        # output[tid] = func(a, b) # this does not work

    wp.launch(operate, dim=2, inputs=[inputs], outputs=[outputs])

print(outputs.numpy())
```

## Changelog
<!--The list in this section will be used creating the changelog for the next release. -->

- Allow functions to be correctly assigned to variables in Warp kernels.

## Before your PR is "Ready for review"

- [x] Do you agree to the terms under which contributions are accepted as described in Section 9 the Warp [License](https://github.com/NVIDIA/warp/blob/main/LICENSE.md)?
- [x] Have you read the [Contributor Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md)?
- [x] Have you written any new necessary tests?
- [ ] Have you added or updated any necessary documentation?
- [x] Have you added any files modified by compiling Warp and building the documentation to this PR (.e.g. `stubs.py`, `functions.rst`)?
- [x] Does your code pass `ruff check` and `ruff format --check`?