### PR TITLE
Fix model defaults

### DIFF
--- a/warp/sim/model.py
+++ b/warp/sim/model.py
@@ -1749,8 +1749,8 @@ class ModelBuilder:
         mode: int = JOINT_MODE_FORCE,
         limit_lower: float = -2 * math.pi,
         limit_upper: float = 2 * math.pi,
-        limit_ke: float = default_joint_limit_ke,
-        limit_kd: float = default_joint_limit_kd,
+        limit_ke: float = None,
+        limit_kd: float = None,
         linear_compliance: float = 0.0,
         angular_compliance: float = 0.0,
         armature: float = 1e-2,
@@ -1771,8 +1771,8 @@ class ModelBuilder:
             target_kd: The damping of the joint target
             limit_lower: The lower limit of the joint
             limit_upper: The upper limit of the joint
-            limit_ke: The stiffness of the joint limit
-            limit_kd: The damping of the joint limit
+            limit_ke: The stiffness of the joint limit (None to use the default value :attr:`default_joint_limit_ke`)
+            limit_kd: The damping of the joint limit (None to use the default value :attr:`default_joint_limit_kd`)
             linear_compliance: The linear compliance of the joint
             angular_compliance: The angular compliance of the joint
             armature: Artificial inertia added around the joint axis
@@ -1789,6 +1789,9 @@ class ModelBuilder:
 
         if child_xform is None:
             child_xform = wp.transform()
+
+        limit_ke = limit_ke if limit_ke is not None else self.default_joint_limit_ke
+        limit_kd = limit_kd if limit_kd is not None else self.default_joint_limit_kd
 
         action = 0.0
         if target is None and mode == JOINT_MODE_TARGET_POSITION:
@@ -1836,8 +1839,8 @@ class ModelBuilder:
         mode: int = JOINT_MODE_FORCE,
         limit_lower: float = -1e4,
         limit_upper: float = 1e4,
-        limit_ke: float = default_joint_limit_ke,
-        limit_kd: float = default_joint_limit_kd,
+        limit_ke: float = None,
+        limit_kd: float = None,
         linear_compliance: float = 0.0,
         angular_compliance: float = 0.0,
         armature: float = 1e-2,
@@ -1858,8 +1861,8 @@ class ModelBuilder:
             target_kd: The damping of the joint target
             limit_lower: The lower limit of the joint
             limit_upper: The upper limit of the joint
-            limit_ke: The stiffness of the joint limit
-            limit_kd: The damping of the joint limit
+            limit_ke: The stiffness of the joint limit (None to use the default value :attr:`default_joint_limit_ke`)
+            limit_kd: The damping of the joint limit (None to use the default value :attr:`default_joint_limit_ke`)
             linear_compliance: The linear compliance of the joint
             angular_compliance: The angular compliance of the joint
             armature: Artificial inertia added around the joint axis
@@ -1876,6 +1879,9 @@ class ModelBuilder:
 
         if child_xform is None:
             child_xform = wp.transform()
+
+        limit_ke = limit_ke if limit_ke is not None else self.default_joint_limit_ke
+        limit_kd = limit_kd if limit_kd is not None else self.default_joint_limit_kd
 
         action = 0.0
         if target is None and mode == JOINT_MODE_TARGET_POSITION:
@@ -3503,11 +3509,11 @@ class ModelBuilder:
         i: int,
         j: int,
         k: int,
-        tri_ke: float = default_tri_ke,
-        tri_ka: float = default_tri_ka,
-        tri_kd: float = default_tri_kd,
-        tri_drag: float = default_tri_drag,
-        tri_lift: float = default_tri_lift,
+        tri_ke: float = None,
+        tri_ka: float = None,
+        tri_kd: float = None,
+        tri_drag: float = None,
+        tri_lift: float = None,
     ) -> float:
         """Adds a triangular FEM element between three particles in the system.
 
@@ -3527,6 +3533,11 @@ class ModelBuilder:
             between the particles in their initial configuration.
         """
         # TODO: Expose elastic parameters on a per-element basis
+        tri_ke = tri_ke if tri_ke is not None else self.default_tri_ke
+        tri_ka = tri_ka if tri_ka is not None else self.default_tri_ka
+        tri_kd = tri_kd if tri_kd is not None else self.default_tri_kd
+        tri_drag = tri_drag if tri_drag is not None else self.default_tri_drag
+        tri_lift = tri_lift if tri_lift is not None else self.default_tri_lift
 
         # compute basis for 2D rest pose
         p = self.particle_q[i]
@@ -3707,8 +3718,8 @@ class ModelBuilder:
         k: int,
         l: int,
         rest: float = None,
-        edge_ke: float = default_edge_ke,
-        edge_kd: float = default_edge_kd,
+        edge_ke: float = None,
+        edge_kd: float = None,
     ):
         """Adds a bending edge element between four particles in the system.
 
@@ -3729,6 +3740,9 @@ class ModelBuilder:
             winding: (i, k, l), (j, l, k).
 
         """
+        edge_ke = edge_ke if edge_ke is not None else self.default_edge_ke
+        edge_kd = edge_kd if edge_kd is not None else self.default_edge_kd
+
         # compute rest angle
         if rest is None:
             x1 = self.particle_q[i]
@@ -3836,17 +3850,17 @@ class ModelBuilder:
         fix_right: bool = False,
         fix_top: bool = False,
         fix_bottom: bool = False,
-        tri_ke: float = default_tri_ke,
-        tri_ka: float = default_tri_ka,
-        tri_kd: float = default_tri_kd,
-        tri_drag: float = default_tri_drag,
-        tri_lift: float = default_tri_lift,
-        edge_ke: float = default_edge_ke,
-        edge_kd: float = default_edge_kd,
+        tri_ke: float = None,
+        tri_ka: float = None,
+        tri_kd: float = None,
+        tri_drag: float = None,
+        tri_lift: float = None,
+        edge_ke: float = None,
+        edge_kd: float = None,
         add_springs: bool = False,
-        spring_ke: float = default_spring_ke,
-        spring_kd: float = default_spring_kd,
-        particle_radius: float = default_particle_radius,
+        spring_ke: float = None,
+        spring_kd: float = None,
+        particle_radius: float = None,
     ):
         """Helper to create a regular planar cloth grid
 
@@ -3868,6 +3882,16 @@ class ModelBuilder:
             fix_top: Make the top-most edge of particles kinematic
             fix_bottom: Make the bottom-most edge of particles kinematic
         """
+        tri_ke = tri_ke if tri_ke is not None else self.default_tri_ke
+        tri_ka = tri_ka if tri_ka is not None else self.default_tri_ka
+        tri_kd = tri_kd if tri_kd is not None else self.default_tri_kd
+        tri_drag = tri_drag if tri_drag is not None else self.default_tri_drag
+        tri_lift = tri_lift if tri_lift is not None else self.default_tri_lift
+        edge_ke = edge_ke if edge_ke is not None else self.default_edge_ke
+        edge_kd = edge_kd if edge_kd is not None else self.default_edge_kd
+        spring_ke = spring_ke if spring_ke is not None else self.default_spring_ke
+        spring_kd = spring_kd if spring_kd is not None else self.default_spring_kd
+        particle_radius = particle_radius if particle_radius is not None else self.default_particle_radius
 
         def grid_index(x, y, dim_x):
             return y * dim_x + x
@@ -3970,17 +3994,17 @@ class ModelBuilder:
         density: float,
         edge_callback=None,
         face_callback=None,
-        tri_ke: float = default_tri_ke,
-        tri_ka: float = default_tri_ka,
-        tri_kd: float = default_tri_kd,
-        tri_drag: float = default_tri_drag,
-        tri_lift: float = default_tri_lift,
-        edge_ke: float = default_edge_ke,
-        edge_kd: float = default_edge_kd,
+        tri_ke: float = None,
+        tri_ka: float = None,
+        tri_kd: float = None,
+        tri_drag: float = None,
+        tri_lift: float = None,
+        edge_ke: float = None,
+        edge_kd: float = None,
         add_springs: bool = False,
-        spring_ke: float = default_spring_ke,
-        spring_kd: float = default_spring_kd,
-        particle_radius: float = default_particle_radius,
+        spring_ke: float = None,
+        spring_kd: float = None,
+        particle_radius: float = None,
     ):
         """Helper to create a cloth model from a regular triangle mesh
 
@@ -4001,6 +4025,17 @@ class ModelBuilder:
 
             The mesh should be two manifold.
         """
+        tri_ke = tri_ke if tri_ke is not None else self.default_tri_ke
+        tri_ka = tri_ka if tri_ka is not None else self.default_tri_ka
+        tri_kd = tri_kd if tri_kd is not None else self.default_tri_kd
+        tri_drag = tri_drag if tri_drag is not None else self.default_tri_drag
+        tri_lift = tri_lift if tri_lift is not None else self.default_tri_lift
+        edge_ke = edge_ke if edge_ke is not None else self.default_edge_ke
+        edge_kd = edge_kd if edge_kd is not None else self.default_edge_kd
+        spring_ke = spring_ke if spring_ke is not None else self.default_spring_ke
+        spring_kd = spring_kd if spring_kd is not None else self.default_spring_kd
+        particle_radius = particle_radius if particle_radius is not None else self.default_particle_radius
+
         num_tris = int(len(indices) / 3)
 
         start_vertex = len(self.particle_q)
@@ -4078,9 +4113,11 @@ class ModelBuilder:
         cell_z: float,
         mass: float,
         jitter: float,
-        radius_mean: float = default_particle_radius,
+        radius_mean: float = None,
         radius_std: float = 0.0,
     ):
+        radius_mean = radius_mean if radius_mean is not None else self.default_particle_radius
+
         rng = np.random.default_rng(42)
         for z in range(dim_z):
             for y in range(dim_y):
@@ -4115,11 +4152,11 @@ class ModelBuilder:
         fix_right: bool = False,
         fix_top: bool = False,
         fix_bottom: bool = False,
-        tri_ke: float = default_tri_ke,
-        tri_ka: float = default_tri_ka,
-        tri_kd: float = default_tri_kd,
-        tri_drag: float = default_tri_drag,
-        tri_lift: float = default_tri_lift,
+        tri_ke: float = None,
+        tri_ka: float = None,
+        tri_kd: float = None,
+        tri_drag: float = None,
+        tri_lift: float = None,
     ):
         """Helper to create a rectangular tetrahedral FEM grid
 
@@ -4146,6 +4183,11 @@ class ModelBuilder:
             fix_top: Make the top-most edge of particles kinematic
             fix_bottom: Make the bottom-most edge of particles kinematic
         """
+        tri_ke = tri_ke if tri_ke is not None else self.default_tri_ke
+        tri_ka = tri_ka if tri_ka is not None else self.default_tri_ka
+        tri_kd = tri_kd if tri_kd is not None else self.default_tri_kd
+        tri_drag = tri_drag if tri_drag is not None else self.default_tri_drag
+        tri_lift = tri_lift if tri_lift is not None else self.default_tri_lift
 
         start_vertex = len(self.particle_q)
 
@@ -4237,11 +4279,11 @@ class ModelBuilder:
         k_mu: float,
         k_lambda: float,
         k_damp: float,
-        tri_ke: float = default_tri_ke,
-        tri_ka: float = default_tri_ka,
-        tri_kd: float = default_tri_kd,
-        tri_drag: float = default_tri_drag,
-        tri_lift: float = default_tri_lift,
+        tri_ke: float = None,
+        tri_ka: float = None,
+        tri_kd: float = None,
+        tri_drag: float = None,
+        tri_lift: float = None,
     ):
         """Helper to create a tetrahedral model from an input tetrahedral mesh
 
@@ -4256,6 +4298,12 @@ class ModelBuilder:
             k_lambda: The second elastic Lame parameter
             k_damp: The damping stiffness
         """
+        tri_ke = tri_ke if tri_ke is not None else self.default_tri_ke
+        tri_ka = tri_ka if tri_ka is not None else self.default_tri_ka
+        tri_kd = tri_kd if tri_kd is not None else self.default_tri_kd
+        tri_drag = tri_drag if tri_drag is not None else self.default_tri_drag
+        tri_lift = tri_lift if tri_lift is not None else self.default_tri_lift
+
         num_tets = int(len(indices) / 4)
 
         start_vertex = len(self.particle_q)
@@ -4346,16 +4394,22 @@ class ModelBuilder:
         self,
         normal=None,
         offset=0.0,
-        ke: float = default_shape_ke,
-        kd: float = default_shape_kd,
-        kf: float = default_shape_kf,
-        mu: float = default_shape_mu,
-        restitution: float = default_shape_restitution,
+        ke: float = None,
+        kd: float = None,
+        kf: float = None,
+        mu: float = None,
+        restitution: float = None,
     ):
         """
         Creates a ground plane for the world. If the normal is not specified,
         the up_vector of the ModelBuilder is used.
         """
+        ke = ke if ke is not None else self.default_shape_ke
+        kd = kd if kd is not None else self.default_shape_kd
+        kf = kf if kf is not None else self.default_shape_kf
+        mu = mu if mu is not None else self.default_shape_mu
+        restitution = restitution if restitution is not None else self.default_shape_restitution
+
         if normal is None:
             normal = self.up_vector
         self._ground_params = {

--- a/warp/sim/model.py
+++ b/warp/sim/model.py
@@ -1046,6 +1046,8 @@ class Model:
     @property
     def soft_contact_max(self):
         """Maximum number of soft contacts that can be registered"""
+        if self.soft_contact_particle is None:
+            return 0
         return len(self.soft_contact_particle)
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp! If you haven't yet,
please read the contributing guidelines in the CONTRIBUTING.md file.

Please fill the relevant sections in this PR template.

Fields in the Checklist section can be marked after you create and save the Pull Request.
-->

## Category
<!--
Please check all applicable options from the list below (use [x] in Markdown)
-->

- [ ] New feature
- [x] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please explain)

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->
Fix model defaults such that they are assigned within `ModelBuilder` functions instead of in function defs. This allows for users to modify `ModelBuilder.default_*` values. Otherwise, even when users set new values, the functions in `ModelBuilder` would use old values.

Also fix `Model.soft_contact_max` to return 0 when `soft_contact_particle` is None. 

## Changelog
<!--The list in this section will be used creating the changelog for the next release. -->

- Update `Model.soft_contact_max` property
- Update `ModelBuilder`'s `add_joint_revolute()`, `add_joint_prismatic()`, `add_triangle()`,  `add_edge()`, `add_cloth_grid()`, `add_cloth_mesh()`, `add_particle_grid()`, `add_soft_grid()`, `add_soft_mesh()`, `set_ground_plane()`

## Before your PR is "Ready for review"

- [x] Do you agree to the terms under which contributions are accepted as described in Section 9 the Warp [License](https://github.com/NVIDIA/warp/blob/main/LICENSE.md)?
- [x] Have you read the [Contributor Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md)?
- [ ] Have you written any new necessary tests?
- [x] Have you added or updated any necessary documentation?
- [ ] Have you added any files modified by compiling Warp and building the documentation to this PR (.e.g. `stubs.py`, `functions.rst`)?
- [x] Does your code pass `ruff check` and `ruff format --check`?
