### PR TITLE
Avoid shadowing python builtin in tile matmul example

### DIFF
--- a/docs/modules/tiles.rst
+++ b/docs/modules/tiles.rst
@@ -135,7 +135,7 @@ Example: General Matrix Multiply (GEMM)
         # output tile index
         i, j = wp.tid()
 
-        sum = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+        tile_sum = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
 
         M = A.shape[0]
         N = B.shape[1]
@@ -148,9 +148,9 @@ Example: General Matrix Multiply (GEMM)
             b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(k*TILE_K, j*TILE_N))
 
             # sum += a*b
-            wp.tile_matmul(a, b, sum)
+            wp.tile_matmul(a, b, tile_sum)
 
-        wp.tile_store(C, sum, offset=(i*TILE_M, j*TILE_N))
+        wp.tile_store(C, tile_sum, offset=(i*TILE_M, j*TILE_N))
 
 
 


### PR DESCRIPTION

## Category

- [ ] New feature
- [ ] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Other (please explain)

## Description
In docs, this was rendering a different color than expected because the interpreter picks out `sum` as a builtin. Seen [here](https://nvidia.github.io/warp/modules/tiles.html#example-general-matrix-multiply-gemm)


## Changelog


## Before your PR is "Ready for review"

- [ x] Do you agree to the terms under which contributions are accepted as described in Section 9 the [Warp License](https://github.com/NVIDIA/warp/blob/main/LICENSE.md)?
- [x ] Necessary tests have been added
- [ x] Documentation is up-to-date
- [ x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `stubs.py`, `functions.rst`)
- [ x] Code passes `ruff check` and `ruff format --check`?
