### PR TITLE
Add external resource interoperability

### DIFF
--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -82,6 +82,7 @@ from warp.context import capture_begin, capture_end, capture_launch
 from warp.context import Kernel, Function, Launch
 from warp.context import Stream, get_stream, set_stream, wait_stream, synchronize_stream
 from warp.context import Event, record_event, wait_event, synchronize_event, get_event_elapsed_time
+from warp.context import ExternalMemoryBuffer, ExternalSemaphore, signal_external_semaphore, wait_external_semaphore
 from warp.context import RegisteredGLBuffer
 from warp.context import is_mempool_supported, is_mempool_enabled, set_mempool_enabled
 from warp.context import (

--- a/warp/native/warp.cpp
+++ b/warp/native/warp.cpp
@@ -1076,6 +1076,15 @@ WP_API void cuda_graphics_device_ptr_and_size(void* context, void* resource, uin
 WP_API void* cuda_graphics_register_gl_buffer(void* context, uint32_t gl_buffer, unsigned int flags) { return NULL; }
 WP_API void cuda_graphics_unregister_resource(void* context, void* resource) {}
 
+WP_API void* cuda_import_external_memory(void* context, unsigned int type, void* handle, uint64_t size, unsigned int flags) { return NULL}
+WP_API void cuda_destroy_external_memory(void* context, void* external_memory) {}
+WP_API void cuda_external_memory_get_mapped_buffer(void* context, void* external_memory, uint64_t offset, uint64_t size, unsigned int flags, uint64_t* ptr) {}
+
+WP_API void* cuda_import_external_semaphore(void* context, unsigned int type, void* handle, unsigned int flags) { return NULL }
+WP_API void cuda_destroy_external_semaphore(void* context, void* external_semaphore) {}
+WP_API void cuda_signal_external_semaphore_async(void* context, void* external_semaphore, uint64_t value, void* stream) {}
+WP_API void cuda_wait_external_semaphore_async(void* context, void* external_semaphore, uint64_t value, void* stream) {}
+
 WP_API void cuda_timing_begin(int flags) {}
 WP_API int cuda_timing_get_result_count() { return 0; }
 WP_API void cuda_timing_end(timing_result_t* results, int size) {}

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -370,6 +370,16 @@ extern "C"
     WP_API void* cuda_graphics_register_gl_buffer(void* context, uint32_t gl_buffer, unsigned int flags);
     WP_API void cuda_graphics_unregister_resource(void* context, void* resource);
 
+    // external resource interoperability
+    WP_API void* cuda_import_external_memory(void* context, unsigned int type, void* handle, uint64_t size, unsigned int flags);
+    WP_API void cuda_destroy_external_memory(void* context, void* external_memory);
+    WP_API void cuda_external_memory_get_mapped_buffer(void* context, void* external_memory, uint64_t offset, uint64_t size, unsigned int flags, uint64_t* ptr);
+
+    WP_API void* cuda_import_external_semaphore(void* context, unsigned int type, void* handle, unsigned int flags);
+    WP_API void cuda_destroy_external_semaphore(void* context, void* external_semaphore);
+    WP_API void cuda_signal_external_semaphore_async(void* context, void* external_semaphore, uint64_t value, void* stream);
+    WP_API void cuda_wait_external_semaphore_async(void* context, void* external_semaphore, uint64_t value, void* stream);
+
     // CUDA timing
     WP_API void cuda_timing_begin(int flags);
     WP_API int cuda_timing_get_result_count();


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Category
<!--
Please check all applicable options from the list below (use [x] in Markdown)
-->

- [x] New feature
- [ ] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please explain)

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Hi, this PR adds support for the [External Resource Interoperability API](https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__EXTRES__INTEROP.html) for interoperability between Cuda and other graphics APIs such as Vulkan, D3D12 and D3D11.

PR is functional and tested on windows with Vulkan, some docs are missing and some cleanup might be needed. If there is interest in merging something like this I am more than happy to complete this.

~ Dario

## Changelog
<!--This will help inform the creation of the changelog for the next release.-->

- Expose External Resource Interoperability API through `ExternalSemaphore` and `ExternalMemoryBuffer`

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution
adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `stubs.py`, `functions.rst`)
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
