### PR TITLE
Migrate deprecated call to JAX's register_custom_call_target with the updated version

### DIFF
--- a/warp/jax_experimental/custom_call.py
+++ b/warp/jax_experimental/custom_call.py
@@ -262,7 +262,10 @@ def _create_jax_warp_primitive():
     capsule = PyCapsule_New(ccall_address.value, b"xla._CUSTOM_CALL_TARGET", PyCapsule_Destructor(0))
 
     # Register the callback in XLA.
-    jax.lib.xla_client.register_custom_call_target("warp_call", capsule, platform="gpu")
+    try:
+        jax.ffi.register_ffi_target("warp_call", capsule, platform="gpu", api_version=0)
+    except AttributeError:
+        jax.lib.xla_client.register_custom_call_target("warp_call", capsule, platform="gpu")
 
     def default_layout(shape):
         return range(len(shape) - 1, -1, -1)


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Category
<!--
Please check all applicable options from the list below (use [x] in Markdown)
-->

- [ ] New feature
- [x] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please explain)

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

The `jaxlib.xla_xlient.register_custom_call_target` function is deprecated in favor of the similar function under `jax.ffi`: https://docs.jax.dev/en/latest/_autosummary/jax.ffi.register_ffi_target.html

By explicitly setting `api_version=0`, this should have no affect on behavior.

## Changelog
<!--This will help inform the creation of the changelog for the next release.-->

N/A

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution
adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `stubs.py`, `functions.rst`)
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
