### PR TITLE
Prevent FFI ctypes callback garbage collection via instance caching.

### DIFF
--- a/warp/jax_experimental/ffi.py
+++ b/warp/jax_experimental/ffi.py
@@ -512,6 +512,7 @@ class FfiCallable:
 
         return None
 
+
 # Holders for the custom callbacks to keep them alive.
 _FFI_CALLABLE_REGISTRY: dict[str, FfiCallable] = {}
 _FFI_KERNEL_REGISTRY: dict[str, FfiKernel] = {}

--- a/warp/jax_experimental/ffi.py
+++ b/warp/jax_experimental/ffi.py
@@ -14,9 +14,10 @@
 # limitations under the License.
 
 import ctypes
+import threading
 import traceback
 from typing import Callable
-import threading
+
 import jax
 
 import warp as wp
@@ -553,8 +554,8 @@ def jax_kernel(kernel, num_outputs=1, vmap_method="broadcast_all", launch_dims=N
 
     with _FFI_REGISTRY_LOCK:
         if key not in _FFI_KERNEL_REGISTRY:
-           new_kernel = FfiKernel(kernel, num_outputs, vmap_method, launch_dims, output_dims)
-           _FFI_KERNEL_REGISTRY[key]  = new_kernel
+            new_kernel = FfiKernel(kernel, num_outputs, vmap_method, launch_dims, output_dims)
+            _FFI_KERNEL_REGISTRY[key] = new_kernel
 
     return _FFI_KERNEL_REGISTRY[key]
 
@@ -611,6 +612,7 @@ def jax_callable(
 # func(inputs, outputs, attrs, ctx)
 #
 ###############################################################################
+
 
 def register_ffi_callback(name: str, func: Callable, graph_compatible: bool = True) -> None:
     """Create a JAX callback from a Python function.

--- a/warp/jax_experimental/ffi.py
+++ b/warp/jax_experimental/ffi.py
@@ -16,7 +16,7 @@
 import ctypes
 import traceback
 from typing import Callable
-
+import threading
 import jax
 
 import warp as wp
@@ -25,68 +25,6 @@ from warp.jax import get_jax_device
 from warp.types import array_t, launch_bounds_t, strides_from_shape, type_to_warp
 
 from .xla_ffi import *
-
-
-def jax_kernel(kernel, num_outputs=1, vmap_method="broadcast_all", launch_dims=None, output_dims=None):
-    """Create a JAX callback from a Warp kernel.
-
-    NOTE: This is an experimental feature under development.
-
-    Args:
-        kernel: The Warp kernel to launch.
-        num_outputs: Optional. Specify the number of output arguments if greater than 1.
-        vmap_method: Optional. String specifying how the callback transforms under ``vmap()``.
-                     This argument can also be specified for individual calls.
-        launch_dims: Optional. Specify the default kernel launch dimensions. If None, launch
-                     dimensions are inferred from the shape of the first array argument.
-                     This argument can also be specified for individual calls.
-        output_dims: Optional. Specify the default dimensions of output arrays.  If None, output
-                     dimensions are inferred from the launch dimensions.
-                     This argument can also be specified for individual calls.
-
-    Limitations:
-        - All kernel arguments must be contiguous arrays or scalars.
-        - Scalars must be static arguments in JAX.
-        - Input arguments are followed by output arguments in the Warp kernel definition.
-        - There must be at least one output argument.
-        - Only the CUDA backend is supported.
-    """
-
-    return FfiKernel(kernel, num_outputs, vmap_method, launch_dims, output_dims)
-
-
-def jax_callable(
-    func: Callable,
-    num_outputs: int = 1,
-    graph_compatible: bool = True,
-    vmap_method: str = "broadcast_all",
-    output_dims=None,
-):
-    """Create a JAX callback from an annotated Python function.
-
-    The Python function arguments must have type annotations like Warp kernels.
-
-    NOTE: This is an experimental feature under development.
-
-    Args:
-        func: The Python function to call.
-        num_outputs: Optional. Specify the number of output arguments if greater than 1.
-        graph_compatible: Optional. Whether the function can be called during CUDA graph capture.
-        vmap_method: Optional. String specifying how the callback transforms under ``vmap()``.
-            This argument can also be specified for individual calls.
-        output_dims: Optional. Specify the default dimensions of output arrays.
-            If ``None``, output dimensions are inferred from the launch dimensions.
-            This argument can also be specified for individual calls.
-
-    Limitations:
-        - All kernel arguments must be contiguous arrays or scalars.
-        - Scalars must be static arguments in JAX.
-        - Input arguments are followed by output arguments in the Warp kernel definition.
-        - There must be at least one output argument.
-        - Only the CUDA backend is supported.
-    """
-
-    return FfiCallable(func, num_outputs, graph_compatible, vmap_method, output_dims)
 
 
 class FfiArg:
@@ -574,6 +512,97 @@ class FfiCallable:
 
         return None
 
+# Holders for the custom callbacks to keep them alive.
+_FFI_CALLABLE_REGISTRY: dict[str, FfiCallable] = {}
+_FFI_KERNEL_REGISTRY: dict[str, FfiKernel] = {}
+_FFI_REGISTRY_LOCK = threading.Lock()
+
+
+def jax_kernel(kernel, num_outputs=1, vmap_method="broadcast_all", launch_dims=None, output_dims=None):
+    """Create a JAX callback from a Warp kernel.
+
+    NOTE: This is an experimental feature under development.
+
+    Args:
+        kernel: The Warp kernel to launch.
+        num_outputs: Optional. Specify the number of output arguments if greater than 1.
+        vmap_method: Optional. String specifying how the callback transforms under ``vmap()``.
+                     This argument can also be specified for individual calls.
+        launch_dims: Optional. Specify the default kernel launch dimensions. If None, launch
+                     dimensions are inferred from the shape of the first array argument.
+                     This argument can also be specified for individual calls.
+        output_dims: Optional. Specify the default dimensions of output arrays.  If None, output
+                     dimensions are inferred from the launch dimensions.
+                     This argument can also be specified for individual calls.
+
+    Limitations:
+        - All kernel arguments must be contiguous arrays or scalars.
+        - Scalars must be static arguments in JAX.
+        - Input arguments are followed by output arguments in the Warp kernel definition.
+        - There must be at least one output argument.
+        - Only the CUDA backend is supported.
+    """
+    key = (
+        kernel.func,
+        num_outputs,
+        vmap_method,
+        tuple(launch_dims) if launch_dims else launch_dims,
+        tuple(sorted(output_dims.items())) if output_dims else output_dims,
+    )
+
+    with _FFI_REGISTRY_LOCK:
+        if key not in _FFI_KERNEL_REGISTRY:
+           new_kernel = FfiKernel(kernel, num_outputs, vmap_method, launch_dims, output_dims)
+           _FFI_KERNEL_REGISTRY[key]  = new_kernel
+
+    return _FFI_KERNEL_REGISTRY[key]
+
+
+def jax_callable(
+    func: Callable,
+    num_outputs: int = 1,
+    graph_compatible: bool = True,
+    vmap_method: str = "broadcast_all",
+    output_dims=None,
+):
+    """Create a JAX callback from an annotated Python function.
+
+    The Python function arguments must have type annotations like Warp kernels.
+
+    NOTE: This is an experimental feature under development.
+
+    Args:
+        func: The Python function to call.
+        num_outputs: Optional. Specify the number of output arguments if greater than 1.
+        graph_compatible: Optional. Whether the function can be called during CUDA graph capture.
+        vmap_method: Optional. String specifying how the callback transforms under ``vmap()``.
+            This argument can also be specified for individual calls.
+        output_dims: Optional. Specify the default dimensions of output arrays.
+            If ``None``, output dimensions are inferred from the launch dimensions.
+            This argument can also be specified for individual calls.
+
+    Limitations:
+        - All kernel arguments must be contiguous arrays or scalars.
+        - Scalars must be static arguments in JAX.
+        - Input arguments are followed by output arguments in the Warp kernel definition.
+        - There must be at least one output argument.
+        - Only the CUDA backend is supported.
+    """
+    key = (
+        func,
+        num_outputs,
+        graph_compatible,
+        vmap_method,
+        tuple(sorted(output_dims.items())) if output_dims else output_dims,
+    )
+
+    with _FFI_REGISTRY_LOCK:
+        if key not in _FFI_CALLABLE_REGISTRY:
+            new_callable = FfiCallable(func, num_outputs, graph_compatible, vmap_method, output_dims)
+            _FFI_CALLABLE_REGISTRY[key] = new_callable
+
+    return _FFI_CALLABLE_REGISTRY[key]
+
 
 ###############################################################################
 #
@@ -581,10 +610,6 @@ class FfiCallable:
 # func(inputs, outputs, attrs, ctx)
 #
 ###############################################################################
-
-# Holder for the custom callbacks to keep them alive.
-ffi_callbacks = {}
-
 
 def register_ffi_callback(name: str, func: Callable, graph_compatible: bool = True) -> None:
     """Create a JAX callback from a Python function.
@@ -644,7 +669,8 @@ def register_ffi_callback(name: str, func: Callable, graph_compatible: bool = Tr
 
     FFI_CCALLFUNC = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.POINTER(XLA_FFI_CallFrame))
     callback_func = FFI_CCALLFUNC(ffi_callback)
-    ffi_callbacks[name] = callback_func
+    with _FFI_REGISTRY_LOCK:
+        _FFI_CALLABLE_REGISTRY[name] = callback_func
     ffi_ccall_address = ctypes.cast(callback_func, ctypes.c_void_p)
     ffi_capsule = jax.ffi.pycapsule(ffi_ccall_address.value)
     jax.ffi.register_ffi_target(name, ffi_capsule, platform="CUDA")


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Category

- [ ] New feature
- [x] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please explain)

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Intermittent segfaults were occurring in JAX FFI custom calls. Investigation traced this to the `ctypes.CFUNCTYPE` callback
object being prematurely garbage collected by Python. This left JAX's FFI registry with a dangling C function pointer, leading to crashes. 


## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `stubs.py`, `functions.rst`)
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
