### PR TITLE
Add support for `ast.IfExp` in kernels

### DIFF
--- a/warp/tests/test_conditional.py
+++ b/warp/tests/test_conditional.py
@@ -59,6 +59,28 @@ def test_conditional_if_else_nested():
 
 
 @wp.kernel
+def test_conditional_ifexp():
+    a = 0.5
+    b = 2.0
+
+    c = 1.0 if a > b else -1.0
+
+    wp.expect_eq(c, -1.0)
+
+
+@wp.kernel
+def test_conditional_ifexp_nested():
+    a = 1.0
+    b = 2.0
+
+    c = 3.0 if a > b else 6.0
+    d = 4.0 if a > b else 7.0
+    e = 1.0 if (a > b and c > d) else (-1.0 if a > b else (2.0 if c > d else -2.0))
+
+    wp.expect_eq(e, -2.0)
+
+
+@wp.kernel
 def test_boolean_and():
     a = 1.0
     b = 2.0
@@ -231,6 +253,8 @@ class TestConditional(unittest.TestCase):
 
 add_kernel_test(TestConditional, kernel=test_conditional_if_else, dim=1, devices=devices)
 add_kernel_test(TestConditional, kernel=test_conditional_if_else_nested, dim=1, devices=devices)
+add_kernel_test(TestConditional, kernel=test_conditional_ifexp, dim=1, devices=devices)
+add_kernel_test(TestConditional, kernel=test_conditional_ifexp_nested, dim=1, devices=devices)
 add_kernel_test(TestConditional, kernel=test_boolean_and, dim=1, devices=devices)
 add_kernel_test(TestConditional, kernel=test_boolean_or, dim=1, devices=devices)
 add_kernel_test(TestConditional, kernel=test_boolean_compound, dim=1, devices=devices)

--- a/warp/tests/test_conditional.py
+++ b/warp/tests/test_conditional.py
@@ -81,6 +81,26 @@ def test_conditional_ifexp_nested():
 
 
 @wp.kernel
+def test_conditional_ifexp_constant():
+    a = 1.0 if False else -1.0
+    b = 2.0 if 123 else -2.0
+
+    wp.expect_eq(a, -1.0)
+    wp.expect_eq(b, 2.0)
+
+
+@wp.kernel
+def test_conditional_ifexp_constant_nested():
+    a = 1.0 if False else (2.0 if True else 3.0)
+    b = 4.0 if 0 else (5.0 if 0 else (6.0 if False else 7.0))
+    c = 8.0 if False else (9.0 if False else (10.0 if 321 else 11.0))
+
+    wp.expect_eq(a, 2.0)
+    wp.expect_eq(b, 7.0)
+    wp.expect_eq(c, 10.0)
+
+
+@wp.kernel
 def test_boolean_and():
     a = 1.0
     b = 2.0
@@ -255,6 +275,8 @@ add_kernel_test(TestConditional, kernel=test_conditional_if_else, dim=1, devices
 add_kernel_test(TestConditional, kernel=test_conditional_if_else_nested, dim=1, devices=devices)
 add_kernel_test(TestConditional, kernel=test_conditional_ifexp, dim=1, devices=devices)
 add_kernel_test(TestConditional, kernel=test_conditional_ifexp_nested, dim=1, devices=devices)
+add_kernel_test(TestConditional, kernel=test_conditional_ifexp_constant, dim=1, devices=devices)
+add_kernel_test(TestConditional, kernel=test_conditional_ifexp_constant_nested, dim=1, devices=devices)
 add_kernel_test(TestConditional, kernel=test_boolean_and, dim=1, devices=devices)
 add_kernel_test(TestConditional, kernel=test_boolean_or, dim=1, devices=devices)
 add_kernel_test(TestConditional, kernel=test_boolean_compound, dim=1, devices=devices)


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Category
<!--
Please check all applicable options from the list below (use [x] in Markdown)
-->

- [x] New feature
- [ ] Bugfix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (please explain)

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Adds support for Python's `ast.IfExp` in kernels. The codegen node visitor is modified to handle `ast.IfExp` by generating regular if statements.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `stubs.py`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`
