### PR TITLE
reduce cuda api overhead for launch

### DIFF
--- a/warp/context.py
+++ b/warp/context.py
@@ -5707,7 +5707,7 @@ class Launch:
 
             # If the stream is capturing, we retain the CUDA module so that it doesn't get unloaded
             # before the captured graph is released.
-            if runtime.core.cuda_stream_is_capturing(stream.cuda_stream):
+            if len(runtime.captures) > 0 and runtime.core.cuda_stream_is_capturing(stream.cuda_stream):
                 capture_id = runtime.core.cuda_stream_get_capture_id(stream.cuda_stream)
                 graph = runtime.captures.get(capture_id)
                 if graph is not None:
@@ -5897,7 +5897,7 @@ def launch(
 
             # If the stream is capturing, we retain the CUDA module so that it doesn't get unloaded
             # before the captured graph is released.
-            if runtime.core.cuda_stream_is_capturing(stream.cuda_stream):
+            if len(runtime.captures) > 0 and runtime.core.cuda_stream_is_capturing(stream.cuda_stream):
                 capture_id = runtime.core.cuda_stream_get_capture_id(stream.cuda_stream)
                 graph = runtime.captures.get(capture_id)
                 if graph is not None:


### PR DESCRIPTION
## Description

This PR short circuits an unnecessary cuda api call when launching a kernel. This can improve performance in the case the kernel run time is tiny.

This is the profile before:
![image](https://github.com/user-attachments/assets/497d2dd3-dbf7-485e-8f9f-421fb24aabbf)
and after:
![image](https://github.com/user-attachments/assets/4a1a1e67-0ff9-4412-989e-6e4ebf4464e0)

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `stubs.py`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`
