### PR TITLE
Fix FfiCallable to skip 'return' argument in FFI callback registration (GH-893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### Fixed
 
+- Fix FfiCallable to skip 'return' argument in FFI callback registration ([GH-893](https://github.com/NVIDIA/warp/issues/893)).
 - Fix calling user functions from Python scope not working with array parameters.
 - Fix an off-by-one error in marching cubes output coordinates to align with the `scikit-image` convention
   ([GH-324](https://github.com/NVIDIA/warp/issues/324)).

--- a/warp/jax_experimental/ffi.py
+++ b/warp/jax_experimental/ffi.py
@@ -381,6 +381,7 @@ class FfiCallable:
             if arg_name == "return":
                 if arg_type is not None:
                     raise TypeError("Function must not return a value")
+                continue
             else:
                 arg = FfiArg(arg_name, arg_type, arg_name in in_out_argnames)
                 if arg_name in in_out_argnames:


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Fix FfiCallable to skip 'return' argument in FFI callback registration (GH-893)

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`
