### PR TITLE
Fix flaky test.

### DIFF
--- a/warp/tests/tile/test_tile_matmul.py
+++ b/warp/tests/tile/test_tile_matmul.py
@@ -159,7 +159,7 @@ def test_tile_transpose_matmul(test, device):
         test_tile_transpose_matmul_kernel, dim=[1], inputs=[input, output], block_dim=TILE_DIM, device=device
     )
 
-    assert_np_equal(output.numpy(), input.numpy().T @ input.numpy())
+    assert_np_equal(output.numpy(), input.numpy().T @ input.numpy(), 1e-6)
 
 
 class TestTileMatmul(unittest.TestCase):


### PR DESCRIPTION

## Description
Fix flaky test:

```
test_tile_transpose_matmul_cpu (__main__.TestTileMatmul.test_tile_transpose_matmul_cpu) ... FAIL                                       
                                                                                                                                       
======================================================================                                                                 
FAIL: test_tile_transpose_matmul_cpu (__main__.TestTileMatmul.test_tile_transpose_matmul_cpu)                                          
----------------------------------------------------------------------                                                                 
Traceback (most recent call last):                                                                                                     
  File "/build/work/166657c01abd3710a2e8396e0f1ea7a055b7/google3/runfiles/google3/third_party/py/warp/tests/unittest_utils.py", line 25
6, in test_func                                                                                                                        
    func(self, device, **kwargs)                                                                                                       
  File "/build/work/166657c01abd3710a2e8396e0f1ea7a055b7/google3/runfiles/google3/third_party/py/warp/tests/tile/test_tile_matmul.py", 
line 162, in test_tile_transpose_matmul                                                                                                
    assert_np_equal(output.numpy(), input.numpy().T @ input.numpy())                                                                   
  File "/build/work/166657c01abd3710a2e8396e0f1ea7a055b7/google3/runfiles/google3/third_party/py/warp/tests/unittest_utils.py", line 24
7, in assert_np_equal                                                                                                                  
    np.testing.assert_array_equal(result, expect)                                                                                      
  File "/build/work/166657c01abd3710a2e8396e0f1ea7a055b7/google3/runfiles/google3/third_party/py/numpy/testing/_private/utils.py", line
 1061, in assert_array_equal                                                                                                           
    assert_array_compare(operator.__eq__, actual, desired, err_msg=err_msg,                                                            
  File "/build/work/166657c01abd3710a2e8396e0f1ea7a055b7/google3/runfiles/google3/third_party/py/numpy/testing/_private/utils.py", line
 926, in assert_array_compare                                                                                                          
    raise AssertionError(msg)                                                                                                          
AssertionError:                                                                                                                        
Arrays are not equal                                               
                                                                                                                                       
Mismatched elements: 2 / 16 (12.5%)                                                                                                    
Max absolute difference among violations: 1.1920929e-07                                                                                
Max relative difference among violations: 6.585429e-08                                                                                 
 ACTUAL: array([[2.199484, 2.016202, 1.81212 , 2.577893],                                                                              
       [2.016202, 2.689484, 1.810198, 2.660469],                                                                                       
       [1.81212 , 1.810198, 2.331157, 2.405685],                                                                                       
       [2.577893, 2.660469, 2.405685, 4.038987]], dtype=float32)                                                                       
 DESIRED: array([[2.199484, 2.016202, 1.81212 , 2.577893],                                                                             
       [2.016202, 2.689484, 1.810198, 2.660469],                                                                                       
       [1.81212 , 1.810198, 2.331157, 2.405685],                                                                                       
       [2.577893, 2.660469, 2.405685, 4.038987]], dtype=float32)         
```

## Before your PR is "Ready for review"

- [ x ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [ x ] Code passes formatting and linting checks with `pre-commit run -a`
