### PR TITLE
Pass arguments to CPU kernels through a struct (#356)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,10 +281,10 @@ jobs:
         if: always()
 
   test-warp-macos:
-    runs-on: macos-13
+    runs-on: macos-latest
     needs: build-warp-macos
     env:
-      OS: macos-13
+      OS: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   ([GH-854](https://github.com/NVIDIA/warp/issues/854)).
 - Use an extended-length default cache path on Windows  to prevent build errors
   ([GH-870](https://github.com/NVIDIA/warp/issues/870)).
+- Arguments for CPU kernels are now passed as a pointer to a structure to avoid a bug in the ARM64 calling convention
+  implementation of the libffi library ([GH-356](https://github.com/NVIDIA/warp/issues/356)).
 
 ### Fixed
 

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -756,6 +756,7 @@ def test_multiple_return_values(test, device):
         test_multiple_return_values_quat_to_axis_angle_kernel,
         dim=1,
         inputs=(q, expected_axis, expected_angle),
+        device=device,
     )
 
     # fmt: off


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
This avoids a bug in libffi for ARM64 when passing many arguments of various types.

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
