### PR TITLE
added JAX interop adjoint support using FFI

### DIFF
--- a/docs/modules/interoperability.rst
+++ b/docs/modules/interoperability.rst
@@ -953,6 +953,141 @@ and it can also be passed to each call::
         ...
 
 
+Automatic Differentiation (AD) for Warp kernels in JAX
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Warp kernels can be given JAX gradients using a convenience wrapper that wires a custom VJP around a kernel and its adjoint.
+
+.. autofunction:: warp.jax_experimental.ffi.jax_ad_kernel
+
+Basic example (one output, static scalar argument)::
+
+    import jax
+    import jax.numpy as jnp
+
+    import warp as wp
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_sum_square(
+        a: wp.array(dtype=float),
+        b: wp.array(dtype=float),
+        s: float,
+        out: wp.array(dtype=float),
+    ):
+        tid = wp.tid()
+        out[tid] = (a[tid] * s + b[tid]) ** 2.0
+
+    # s is a scalar and must be static in JAX; mark it explicitly
+    jax_scale = jax_ad_kernel(scale_sum_square, num_outputs=1, static_argnames=("s",))
+
+    @jax.jit
+    def loss(a, b, s):
+        (out,) = jax_scale(a, b, s)
+        return jnp.sum(out)
+
+    n = 16
+    a = jnp.arange(n, dtype=jnp.float32)
+    b = jnp.ones(n, dtype=jnp.float32)
+    s = 2.0
+
+    # gradients w.r.t. array inputs
+    da, db = jax.grad(loss, argnums=(0, 1))(a, b, s)
+    print(da, db)
+
+Multiple outputs::
+
+    @wp.kernel
+    def multi_output(
+        a: wp.array(dtype=float),
+        b: wp.array(dtype=float),
+        s: float,
+        c: wp.array(dtype=float),
+        d: wp.array(dtype=float),
+    ):
+        tid = wp.tid()
+        c[tid] = a[tid] ** 2.0
+        d[tid] = a[tid] * b[tid] * s
+
+    jax_multi = jax_ad_kernel(multi_output, num_outputs=2, static_argnames=("s",))
+
+    def caller(fn, a, b, s):
+        c, d = fn(a, b, s)
+        return jnp.sum(c + d)
+
+    # differentiate a batched scalar objective over two inputs
+    da, db = jax.grad(lambda a, b, s: caller(jax_multi, a, b, s), argnums=(0, 1))(a, b, s)
+    print(da, db)
+
+Vector and matrix arrays also work. Inner component dimensions are packed in the JAX array and handled automatically::
+
+    @wp.kernel
+    def scale_vec2(a: wp.array(dtype=wp.vec2), s: float, out: wp.array(dtype=wp.vec2)):
+        tid = wp.tid()
+        out[tid] = a[tid] * s
+
+    jax_vec = jax_ad_kernel(scale_vec2, num_outputs=1, static_argnames=("s",))
+
+    @jax.jit
+    def vec_loss(a, s):
+        (out,) = jax_vec(a, s)
+        return jnp.sum(out)
+
+    a2 = jnp.arange(10, dtype=jnp.float32).reshape((5, 2))  # vec2 payload shape
+    (da2,) = jax.grad(vec_loss, argnums=(0,))(a2, 3.0)
+    print(da2)
+
+Notes
+.....
+
+- Scalar inputs must be static in JAX. By default, :func:`jax_ad_kernel` auto-detects scalars, but you can
+  specify them explicitly via ``static_argnames``.
+- Gradients are returned for differentiable array inputs (static scalars are excluded from the gradient tuple).
+- CUDA backend is required.
+
+
+VMAP with gradients
+...................
+
+The AD wrapper works under :func:`jax.vmap` using the same batching semantics as forward-only calls.
+Leading batch axes are supported without changing the kernel's launch dimensions.
+
+There are three options for ``vmap_method``:
+
+- ``"sequential"``: lowers to a :func:`jax.lax.scan`; most general, least parallel.
+- ``"broadcast_all"`` (default): assumes the kernel can handle broadcasted batch axes; best for data-parallel batches.
+- ``"expand_dims"``: expands a new leading axis per-batched argument; use only if your kernel semantics require it.
+
+Per-sample batched gradients with broadcasting::
+
+    # same scale_sum_square kernel and jax_scale from above, but ensure vmap-friendly method
+    jax_scale = jax_ad_kernel(scale_sum_square, num_outputs=1, static_argnames=("s",), vmap_method="broadcast_all")
+
+    def per_sample_loss(a, b):
+        (out,) = jax_scale(a, b, 2.0)
+        return jnp.sum(out)
+
+    B, N = 4, 12
+    A = jnp.arange(B * N, dtype=jnp.float32).reshape((B, N))
+    Bv = jnp.ones((B, N), dtype=jnp.float32)
+
+    # map batch axis on both inputs
+    dA, dB = jax.vmap(jax.grad(per_sample_loss, argnums=(0, 1)), in_axes=(0, 0))(A, Bv)
+    print(dA.shape, dB.shape)  # (B, N), (B, N)
+
+When one input is shared across the batch, use ``in_axes=(0, None)`` (or pass a constant inside the mapped function)::
+
+    shared = jnp.ones((N,), dtype=jnp.float32)
+    dA_shared, dB_shared = jax.vmap(jax.grad(per_sample_loss, argnums=(0, 1)), in_axes=(0, None))(A, shared)
+    print(dA_shared.shape, dB_shared.shape)  # (B, N), (N,)
+
+Constraints and tips:
+
+- Kernel arguments must be contiguous arrays or scalars. Scalars must be static in JAX (pass via ``static_argnames`` or use Python constants).
+- Only the CUDA backend is supported.
+- For vector/matrix arrays, specify Warp dtypes (e.g., ``wp.vec2``); JAX inner component dimensions are derived automatically.
+
+
 Calling Annotated Python Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/warp/jax_experimental/__init__.py
+++ b/warp/jax_experimental/__init__.py
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 from .custom_call import jax_kernel
+from .ffi import jax_ad_kernel

--- a/warp/jax_experimental/ffi.py
+++ b/warp/jax_experimental/ffi.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import ctypes
+import inspect
 import threading
 import traceback
 from enum import IntEnum
@@ -173,14 +174,14 @@ class FfiKernel:
                     raise TypeError(
                         f"Invalid data type for array argument '{input_arg.name}', expected {input_arg.jax_scalar_type}, got {input_value.dtype}"
                     )
-                # check ndim
-                if input_value.ndim != input_arg.jax_ndim:
+                # allow leading batch dims under vmap; require trailing dtype dims to match
+                if input_value.ndim < input_arg.jax_ndim:
                     raise TypeError(
-                        f"Invalid dimensionality for array argument '{input_arg.name}', expected {input_arg.jax_ndim} dimensions, got {input_value.ndim}"
+                        f"Invalid dimensionality for array argument '{input_arg.name}', expected at least {input_arg.jax_ndim} dimensions, got {input_value.ndim}"
                     )
-                # check inner dims
+                # check inner (dtype) dims at the end
                 for d in range(input_arg.dtype_ndim):
-                    if input_value.shape[input_arg.type.ndim + d] != input_arg.dtype_shape[d]:
+                    if input_value.shape[-input_arg.dtype_ndim + d] != input_arg.dtype_shape[d]:
                         raise TypeError(
                             f"Invalid inner dimensions for array argument '{input_arg.name}', expected {input_arg.dtype_shape}, got {input_value.shape[-input_arg.dtype_ndim :]}"
                         )
@@ -193,7 +194,7 @@ class FfiKernel:
 
             # append in-out arg to output types
             if input_arg.in_out:
-                out_types.append(get_jax_output_type(input_arg, input_value.shape))
+                out_types.append(get_jax_output_type(input_arg, get_warp_shape(input_arg, input_value.shape)))
 
         # launch dimensions
         if launch_dims is None:
@@ -455,14 +456,14 @@ class FfiCallable:
                     raise TypeError(
                         f"Invalid data type for array argument '{input_arg.name}', expected {input_arg.jax_scalar_type}, got {input_value.dtype}"
                     )
-                # check ndim
-                if input_value.ndim != input_arg.jax_ndim:
+                # allow leading batch dims under vmap; require trailing dtype dims to match
+                if input_value.ndim < input_arg.jax_ndim:
                     raise TypeError(
-                        f"Invalid dimensionality for array argument '{input_arg.name}', expected {input_arg.jax_ndim} dimensions, got {input_value.ndim}"
+                        f"Invalid dimensionality for array argument '{input_arg.name}', expected at least {input_arg.jax_ndim} dimensions, got {input_value.ndim}"
                     )
-                # check inner dims
+                # check inner (dtype) dims at the end
                 for d in range(input_arg.dtype_ndim):
-                    if input_value.shape[input_arg.type.ndim + d] != input_arg.dtype_shape[d]:
+                    if input_value.shape[-input_arg.dtype_ndim + d] != input_arg.dtype_shape[d]:
                         raise TypeError(
                             f"Invalid inner dimensions for array argument '{input_arg.name}', expected {input_arg.dtype_shape}, got {input_value.shape[-input_arg.dtype_ndim :]}"
                         )
@@ -475,7 +476,7 @@ class FfiCallable:
 
             # append in-out arg to output types
             if input_arg.in_out:
-                out_types.append(get_jax_output_type(input_arg, input_value.shape))
+                out_types.append(get_jax_output_type(input_arg, get_warp_shape(input_arg, input_value.shape)))
 
         # output shapes
         if isinstance(output_dims, dict):
@@ -591,8 +592,25 @@ class FfiCallable:
             for i, arg in enumerate(self.input_args):
                 if arg.is_array:
                     buffer = inputs[i].contents
-                    shape = buffer.dims[: buffer.rank - arg.dtype_ndim]
-                    arr = wp.array(ptr=buffer.data, dtype=arg.type.dtype, shape=shape, device=device)
+                    # Collapse leading batch dimensions so Warp sees only the declared warp_ndim
+                    jax_rank = buffer.rank - arg.dtype_ndim
+                    dims_jax = buffer.dims[:jax_rank]
+                    warp_ndim = arg.type.ndim
+                    if jax_rank < warp_ndim:
+                        raise RuntimeError(
+                            f"Argument '{arg.name}' expects {warp_ndim} dimension(s) but the passed array has {jax_rank} dimension(s)."
+                        )
+                    if jax_rank == warp_ndim:
+                        collapsed_shape = dims_jax
+                    else:
+                        # collapse all leading (batch) dims into the first warp dimension
+                        batch_prod = 1
+                        for d in dims_jax[: jax_rank - warp_ndim]:
+                            batch_prod *= d
+                        warp_dims = list(dims_jax[jax_rank - warp_ndim :])
+                        warp_dims[0] = warp_dims[0] * batch_prod
+                        collapsed_shape = tuple(warp_dims)
+                    arr = wp.array(ptr=buffer.data, dtype=arg.type.dtype, shape=collapsed_shape, device=device)
                     arg_list.append(arr)
                 else:
                     # scalar argument, get stashed value
@@ -602,8 +620,24 @@ class FfiCallable:
             # pure output args (skip in-out FFI buffers)
             for i, arg in enumerate(self.output_args):
                 buffer = outputs[i + self.num_in_out].contents
-                shape = buffer.dims[: buffer.rank - arg.dtype_ndim]
-                arr = wp.array(ptr=buffer.data, dtype=arg.type.dtype, shape=shape, device=device)
+                # Collapse leading batch dimensions so Warp sees only the declared warp_ndim
+                jax_rank = buffer.rank - arg.dtype_ndim
+                dims_jax = buffer.dims[:jax_rank]
+                warp_ndim = arg.type.ndim
+                if jax_rank < warp_ndim:
+                    raise RuntimeError(
+                        f"Output argument '{arg.name}' expects {warp_ndim} dimension(s) but the passed array has {jax_rank} dimension(s)."
+                    )
+                if jax_rank == warp_ndim:
+                    collapsed_shape = dims_jax
+                else:
+                    batch_prod = 1
+                    for d in dims_jax[: jax_rank - warp_ndim]:
+                        batch_prod *= d
+                    warp_dims = list(dims_jax[jax_rank - warp_ndim :])
+                    warp_dims[0] = warp_dims[0] * batch_prod
+                    collapsed_shape = tuple(warp_dims)
+                arr = wp.array(ptr=buffer.data, dtype=arg.type.dtype, shape=collapsed_shape, device=device)
                 arg_list.append(arr)
 
             # call the Python function with reconstructed arguments
@@ -823,6 +857,229 @@ def register_ffi_callback(name: str, func: Callable, graph_compatible: bool = Tr
     jax.ffi.register_ffi_target(name, ffi_capsule, platform="CUDA")
 
 
+def jax_ad_kernel(kernel, num_outputs=1, static_argnames=None, vmap_method: Optional[str] = "broadcast_all"):
+    """Create a JAX-callable from a Warp kernel with a custom VJP.
+
+    Args:
+        kernel: The Warp kernel to wrap.
+        num_outputs: Number of output arrays produced by the kernel.
+        static_argnames: Optional iterable of argument names that should be treated
+            as static (non-differentiable) in JAX. If None, scalar (non-array) inputs
+            are treated as static by default.
+        vmap_method: How the callback transforms under jax.vmap.
+
+    Returns:
+        A JAX-callable function that can be used inside jax.jit and differentiated with jax.grad.
+    """
+
+    # Infer the original kernel signature (names and annotations)
+    signature = inspect.signature(kernel.func)
+
+    # Positional-or-keyword parameters only
+    parameters = [p for p in signature.parameters.values() if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD]
+    parameter_count = len(parameters)
+    num_inputs = parameter_count - num_outputs
+
+    # Determine static argument indices
+    static_args: list[int] = []
+    if static_argnames is not None:
+        name_set = set(static_argnames)
+        for i, p in enumerate(parameters[:num_inputs]):
+            if p.name in name_set:
+                static_args.append(i)
+    else:
+        # Default heuristic: non-array inputs (e.g., scalars) are static
+        for i, p in enumerate(parameters[:num_inputs]):
+            ann = p.annotation
+            try:
+                is_array = isinstance(ann, wp.array)
+            except Exception:
+                is_array = False
+            if not is_array:
+                static_args.append(i)
+
+    static_args = sorted(set(static_args))
+
+    # Forward kernel wrapper: simply launches the kernel
+    def fwd_kernel_wrapper(*args):
+        # args are Warp arrays/scalars reconstructed via FFI in jax_callable
+        wp.launch(kernel, dim=args[0].shape, inputs=args[:-num_outputs], outputs=args[-num_outputs:])
+
+    # Expose the kernel signature to the wrapper so type annotations flow through
+    fwd_kernel_wrapper.__signature__ = signature
+
+    # JAX forward callable using FFI
+    jax_fwd_kernel = jax_callable(fwd_kernel_wrapper, num_outputs=num_outputs, vmap_method=vmap_method)
+
+    # Backward wrapper: launches adjoint with provided output gradients
+    def bwd_kernel_wrapper(*args):
+        # Args: inputs ++ outputs ++ out-grads ++ in-grads-without-statics
+        assert len(args) == 2 * parameter_count - len(static_args)
+
+        inputs = list(args[:num_inputs])
+        outputs = list(args[num_inputs:parameter_count])
+        grad_out = list(args[parameter_count : parameter_count + num_outputs])
+        grad_in = list(args[parameter_count + num_outputs :])
+
+        # Insert placeholders for static arg grads to satisfy Warp's adjoint signature
+        for i in static_args:
+            grad_in.insert(i, inputs[i])
+
+        # Ensure gradient input buffers are zero-initialized before accumulation
+        try:
+            for gi in grad_in:
+                if isinstance(gi, wp.array):
+                    gi.zero_()
+        except Exception:
+            pass
+
+        # Launch adjoint
+        wp.launch(
+            kernel,
+            dim=inputs[0].shape,
+            inputs=inputs,
+            outputs=outputs,
+            adj_inputs=grad_in,
+            adj_outputs=grad_out,
+            adjoint=True,
+        )
+
+    # Build the backward wrapper signature expected by jax_callable
+    # Inputs to the backward function are: inputs, outputs, output grads
+    bwd_input_params = parameters[:num_inputs]
+    bwd_output_params = parameters[num_inputs:parameter_count]
+    bwd_grad_output_params = [
+        inspect.Parameter(
+            p.name + "__vjp",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            default=p.default,
+            annotation=p.annotation,
+        )
+        for p in bwd_output_params
+    ]
+
+    # Outputs of backward are gradients for differentiable inputs (exclude statics)
+    bwd_grad_input_params = [
+        inspect.Parameter(
+            p.name + "__vjp",
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            default=p.default,
+            annotation=p.annotation,
+        )
+        for p in bwd_input_params
+    ]
+    for i in reversed(static_args):
+        del bwd_grad_input_params[i]
+
+    bwd_signature = bwd_input_params + bwd_output_params + bwd_grad_output_params + bwd_grad_input_params
+    bwd_kernel_wrapper.__signature__ = inspect.Signature(bwd_signature)
+
+    jax_bwd_kernel = jax_callable(
+        bwd_kernel_wrapper,
+        num_outputs=len(bwd_input_params) - len(static_args),
+        vmap_method=vmap_method,
+    )
+
+    # Names of gradient outputs corresponding to differentiable inputs
+    differentiable_input_indices = [i for i in range(num_inputs) if i not in static_args]
+    differentiable_input_names = [parameters[i].name for i in differentiable_input_indices]
+
+    # Define custom VJP wrappers
+    def fwd_function(*args):
+        outputs = jax_fwd_kernel(*args)
+        non_static_inputs = list(args)
+        for i in reversed(static_args):
+            del non_static_inputs[i]
+        if num_outputs == 1:
+            if isinstance(outputs, (list, tuple)):
+                outputs_tuple = (outputs[0],)
+            else:
+                outputs_tuple = (outputs,)
+        else:
+            outputs_tuple = tuple(outputs) if isinstance(outputs, (list, tuple)) else (outputs,)
+        return outputs, (tuple(non_static_inputs), outputs_tuple)
+
+    def bwd_function(*bwd_args):
+        # Layout: (*nondiff_values, residuals, *grad_out)
+        nondiff_vals = list(bwd_args[: len(static_args)])
+        residuals = bwd_args[len(static_args)]
+        grad_out_args = bwd_args[len(static_args) + 1 :]
+
+        non_static_inputs, output_vals_tuple = residuals
+
+        # Reconstruct full input list including static values at correct indices
+        input_vals = list(non_static_inputs)
+        for i, v in zip(static_args, nondiff_vals):
+            input_vals.insert(i, v)
+
+        # Call the adjoint launcher
+        if num_outputs > 1:
+            if len(grad_out_args) == 1 and isinstance(grad_out_args[0], (list, tuple)):
+                grad_out_tuple = tuple(grad_out_args[0])
+            else:
+                grad_out_tuple = tuple(grad_out_args)
+        else:
+            go = grad_out_args[0]
+            if isinstance(go, (list, tuple)):
+                grad_out_tuple = (go[0],)
+            else:
+                grad_out_tuple = (go,)
+        bwd_call_args = list(input_vals) + list(output_vals_tuple) + list(grad_out_tuple)
+
+        # Provide output dims mapping in warp dims (exclude batch and dtype trailing dims)
+        # so that vmap can broadcast batch dims externally.
+        out_dims_map = {}
+        # Build a quick lookup of parameter annotations by name
+        param_ann = {p.name: p.annotation for p in parameters[:num_inputs]}
+        for name, val in zip(differentiable_input_names, non_static_inputs):
+            ann = param_ann.get(name)
+            if ann is None:
+                continue
+            try:
+                is_array_ann = isinstance(ann, wp.array)
+            except Exception:
+                is_array_ann = False
+            if not is_array_ann:
+                continue
+            # Determine dtype_ndim from annotation
+            dtype_ndim = 0
+            try:
+                if hasattr(ann.dtype, "_wp_scalar_type_"):
+                    dtype_ndim = len(ann.dtype._shape_)
+            except Exception:
+                pass
+            warp_ndim = getattr(ann, "ndim", 0)
+            vshape = tuple(val.shape)
+            if warp_ndim == 0:
+                # scalar value: no gradient array expected
+                continue
+            if dtype_ndim > 0:
+                # remove trailing dtype dims then take last warp_ndim dims
+                core_rank = max(0, len(vshape) - dtype_ndim)
+                warp_dims = vshape[max(0, core_rank - warp_ndim) : core_rank]
+            else:
+                warp_dims = vshape[-warp_ndim:]
+            out_dims_map[f"{name}__vjp"] = tuple(warp_dims)
+
+        non_static_input_grads = jax_bwd_kernel(*bwd_call_args, output_dims=out_dims_map)
+        return tuple(non_static_input_grads)
+
+    jax_func = jax.custom_vjp(jax_fwd_kernel, nondiff_argnums=tuple(static_args))
+    jax_func.defvjp(fwd_function, bwd_function)
+
+    # If static scalar args are present, wrap with jitted callable that marks them static
+    if static_args:
+        static_names = [parameters[i].name for i in static_args]
+
+        def _user_callable(*args):
+            return jax_func(*args)
+
+        _user_callable.__signature__ = signature
+        return jax.jit(_user_callable, static_argnames=tuple(static_names))
+
+    return jax_func
+
+
 ###############################################################################
 #
 # Utilities
@@ -859,7 +1116,7 @@ def get_jax_output_type(arg, dims):
         # vector/matrix array
         if ndim == arg.warp_ndim:
             return jax.ShapeDtypeStruct((*dims, *arg.dtype_shape), arg.jax_scalar_type)
-        elif ndim == arg.jax_ndim:
+        elif ndim >= arg.jax_ndim:
             # make sure inner dimensions match
             inner_dims = dims[-arg.dtype_ndim :]
             for i in range(arg.dtype_ndim):
@@ -870,6 +1127,6 @@ def get_jax_output_type(arg, dims):
             raise ValueError(f"Invalid output dimensions for argument '{arg.name}': {dims}")
     else:
         # scalar array
-        if ndim != arg.warp_ndim:
+        if ndim < arg.warp_ndim:
             raise ValueError(f"Invalid output dimensions for argument '{arg.name}': {dims}")
         return jax.ShapeDtypeStruct(dims, arg.jax_scalar_type)

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -308,6 +308,533 @@ def test_jax_kernel_launch_dims(test, device):
     assert_np_equal(result_2d, expected_2d)
 
 
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_simple(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_sum_square_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float), s: float, c: wp.array(dtype=float)):
+        tid = wp.tid()
+        c[tid] = (a[tid] * s + b[tid]) ** 2.0
+
+    jax_func = jax_ad_kernel(scale_sum_square_kernel, num_outputs=1, static_argnames=("s",), vmap_method="sequential")
+
+    from functools import partial
+
+    @partial(jax.jit, static_argnames=["s"])
+    def loss(a, b, s):
+        out = jax_func(a, b, s)[0]
+        return jp.sum(out)
+
+    n = 16
+    a = jp.arange(n, dtype=jp.float32)
+    b = jp.ones(n, dtype=jp.float32)
+    s = 2.0
+
+    with jax.default_device(wp.device_to_jax(device)):
+        da, db = jax.grad(loss, argnums=(0, 1))(a, b, s)
+
+    # reference gradients
+    # d/da sum((a*s + b)^2) = sum(2*(a*s + b) * s)
+    # d/db sum((a*s + b)^2) = sum(2*(a*s + b))
+    a_np = np.arange(n, dtype=np.float32)
+    b_np = np.ones(n, dtype=np.float32)
+    ref_da = 2.0 * (a_np * s + b_np) * s
+    ref_db = 2.0 * (a_np * s + b_np)
+
+    assert_np_equal(np.asarray(da), ref_da)
+    assert_np_equal(np.asarray(db), ref_db)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_multi_output(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def multi_output_kernel(
+        a: wp.array(dtype=float), b: wp.array(dtype=float), s: float, c: wp.array(dtype=float), d: wp.array(dtype=float)
+    ):
+        tid = wp.tid()
+        c[tid] = a[tid] ** 2.0
+        d[tid] = a[tid] * b[tid] * s
+
+    jax_func = jax_ad_kernel(multi_output_kernel, num_outputs=2, static_argnames=("s",))
+
+    def caller(fn, a, b, s):
+        c, d = fn(a, b, s)
+        return jp.sum(c + d)
+
+    @jax.jit
+    def grads(a, b, s):
+        # mark s as static in the inner call via partial to avoid hashing
+        def _inner(a, b, s):
+            return caller(jax_func, a, b, s)
+
+        return jax.grad(lambda a, b: _inner(a, b, 2.0), argnums=(0, 1))(a, b)
+
+    n = 16
+    a = jp.arange(n, dtype=jp.float32)
+    b = jp.ones(n, dtype=jp.float32)
+    s = 2.0
+
+    with jax.default_device(wp.device_to_jax(device)):
+        da, db = grads(a, b, s)
+
+    a_np = np.arange(n, dtype=np.float32)
+    b_np = np.ones(n, dtype=np.float32)
+    # d/da sum(c+d) = 2*a + b*s
+    ref_da = 2.0 * a_np + b_np * s
+    # d/db sum(c+d) = a*s
+    ref_db = a_np * s
+
+    assert_np_equal(np.asarray(da), ref_da)
+    assert_np_equal(np.asarray(db), ref_db)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vec2(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_vec_kernel(a: wp.array(dtype=wp.vec2), s: float, out: wp.array(dtype=wp.vec2)):
+        tid = wp.tid()
+        out[tid] = a[tid] * s
+
+    jax_func = jax_ad_kernel(scale_vec_kernel, num_outputs=1, static_argnames=("s",))
+
+    from functools import partial
+
+    @partial(jax.jit, static_argnames=("s",))
+    def loss(a, s):
+        out = jax_func(a, s)[0]
+        return jp.sum(out)
+
+    n = 10
+    a = jp.arange(n, dtype=jp.float32).reshape((n // 2, 2))
+    s = 3.0
+
+    with jax.default_device(wp.device_to_jax(device)):
+        (da,) = jax.grad(loss, argnums=(0,))(a, s)
+
+    # d/da sum(a*s) = s
+    ref = np.full_like(np.asarray(a), s)
+    assert_np_equal(np.asarray(da), ref)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_2d(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def add_one_2d(a: wp.array2d(dtype=float), out: wp.array2d(dtype=float)):
+        i, j = wp.tid()
+        out[i, j] = a[i, j] + 1.0
+
+    jax_func = jax_ad_kernel(add_one_2d, num_outputs=1)
+
+    @jax.jit
+    def loss(a):
+        out = jax_func(a)[0]
+        return jp.sum(out)
+
+    n, m = 8, 6
+    a = jp.arange(n * m, dtype=jp.float32).reshape((n, m))
+
+    with jax.default_device(wp.device_to_jax(device)):
+        (da,) = jax.grad(loss, argnums=(0,))(a)
+
+    ref = np.ones((n, m), dtype=np.float32)
+    assert_np_equal(np.asarray(da), ref)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_mat22(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_mat_kernel(a: wp.array(dtype=wp.mat22), s: float, out: wp.array(dtype=wp.mat22)):
+        tid = wp.tid()
+        out[tid] = a[tid] * s
+
+    jax_func = jax_ad_kernel(scale_mat_kernel, num_outputs=1, static_argnames=("s",))
+
+    from functools import partial
+
+    @partial(jax.jit, static_argnames=("s",))
+    def loss(a, s):
+        out = jax_func(a, s)[0]
+        return jp.sum(out)
+
+    n = 12  # must be divisible by 4 for 2x2 matrices
+    a = jp.arange(n, dtype=jp.float32).reshape((n // 4, 2, 2))
+    s = 2.5
+
+    with jax.default_device(wp.device_to_jax(device)):
+        (da,) = jax.grad(loss, argnums=(0,))(a, s)
+
+    ref = np.full((n // 4, 2, 2), s, dtype=np.float32)
+    assert_np_equal(np.asarray(da), ref)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vmap_simple(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_sum_square_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float), s: float, c: wp.array(dtype=float)):
+        tid = wp.tid()
+        c[tid] = (a[tid] * s + b[tid]) ** 2.0
+
+    jax_func = jax_ad_kernel(scale_sum_square_kernel, num_outputs=1, static_argnames=("s",))
+
+    # per-sample loss; close over static scalar s to avoid vmap over statics
+    def per_sample_loss(a, b):
+        out = jax_func(a, b, 2.0)[0]
+        return jp.sum(out)
+
+    B, N = 4, 12
+    a = jp.arange(B * N, dtype=jp.float32).reshape((B, N))
+    b = jp.ones((B, N), dtype=jp.float32)
+
+    with jax.default_device(wp.device_to_jax(device)):
+        da, db = jax.vmap(jax.grad(per_sample_loss, argnums=(0, 1)), in_axes=(0, 0))(a, b)
+
+    a_np = np.arange(B * N, dtype=np.float32).reshape((B, N))
+    b_np = np.ones((B, N), dtype=np.float32)
+    s = 2.0
+    ref_da = 2.0 * (a_np * s + b_np) * s
+    ref_db = 2.0 * (a_np * s + b_np)
+
+    assert_np_equal(np.asarray(da), ref_da)
+    assert_np_equal(np.asarray(db), ref_db)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vmap_vec2(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_vec_kernel(a: wp.array(dtype=wp.vec2), s: float, out: wp.array(dtype=wp.vec2)):
+        tid = wp.tid()
+        out[tid] = a[tid] * s
+
+    jax_func = jax_ad_kernel(scale_vec_kernel, num_outputs=1, static_argnames=("s",), vmap_method="sequential")
+
+    def per_sample_loss(a):
+        out = jax_func(a, 2.0)[0]
+        return jp.sum(out)
+
+    B = 3
+    n = 8
+    a = jp.arange(B * n, dtype=jp.float32).reshape((B, n // 2, 2))
+
+    with jax.default_device(wp.device_to_jax(device)):
+        (da,) = jax.vmap(jax.grad(per_sample_loss, argnums=(0,)), in_axes=(0,))(a)
+
+    ref = np.full((B, n // 2, 2), 2.0, dtype=np.float32)
+    assert_np_equal(np.asarray(da), ref)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vmap_multi_output(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def multi_output_kernel(
+        a: wp.array(dtype=float), b: wp.array(dtype=float), s: float, c: wp.array(dtype=float), d: wp.array(dtype=float)
+    ):
+        tid = wp.tid()
+        c[tid] = a[tid] ** 2.0
+        d[tid] = a[tid] * b[tid] * s
+
+    jax_func = jax_ad_kernel(multi_output_kernel, num_outputs=2, static_argnames=("s",), vmap_method="sequential")
+
+    def per_sample_loss(a, b):
+        c, d = jax_func(a, b, 2.0)
+        return jp.sum(c + d)
+
+    B, n = 2, 12
+    a = jp.arange(B * n, dtype=jp.float32).reshape((B, n))
+    b = jp.ones((B, n), dtype=jp.float32)
+
+    with jax.default_device(wp.device_to_jax(device)):
+        da, db = jax.vmap(jax.grad(per_sample_loss, argnums=(0, 1)), in_axes=(0, 0))(a, b)
+
+    a_np = np.arange(B * n, dtype=np.float32).reshape((B, n))
+    b_np = np.ones((B, n), dtype=np.float32)
+    s = 2.0
+    ref_da = 2.0 * a_np + b_np * s
+    ref_db = a_np * s
+
+    assert_np_equal(np.asarray(da), ref_da)
+    assert_np_equal(np.asarray(db), ref_db)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vmap_broadcast_all_simple(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_sum_square_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float), s: float, c: wp.array(dtype=float)):
+        tid = wp.tid()
+        c[tid] = (a[tid] * s + b[tid]) ** 2.0
+
+    jax_func = jax_ad_kernel(
+        scale_sum_square_kernel, num_outputs=1, static_argnames=("s",), vmap_method="broadcast_all"
+    )
+
+    def per_sample_loss(a, b):
+        out = jax_func(a, b, 2.0)[0]
+        return jp.sum(out)
+
+    B, N = 3, 10
+    a = jp.arange(B * N, dtype=jp.float32).reshape((B, N))
+    b = jp.ones((B, N), dtype=jp.float32)
+
+    with jax.default_device(wp.device_to_jax(device)):
+        da, db = jax.vmap(jax.grad(per_sample_loss, argnums=(0, 1)), in_axes=(0, 0))(a, b)
+
+    a_np = np.arange(B * N, dtype=np.float32).reshape((B, N))
+    b_np = np.ones((B, N), dtype=np.float32)
+    s = 2.0
+    ref_da = 2.0 * (a_np * s + b_np) * s
+    ref_db = 2.0 * (a_np * s + b_np)
+
+    assert_np_equal(np.asarray(da), ref_da)
+    assert_np_equal(np.asarray(db), ref_db)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vmap_expand_dims_simple(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_sum_square_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float), s: float, c: wp.array(dtype=float)):
+        tid = wp.tid()
+        c[tid] = (a[tid] * s + b[tid]) ** 2.0
+
+    jax_func = jax_ad_kernel(
+        scale_sum_square_kernel, num_outputs=1, static_argnames=("s",), vmap_method="broadcast_all"
+    )
+
+    def per_sample_loss(a, b):
+        out = jax_func(a, b, 2.0)[0]
+        return jp.sum(out)
+
+    B, N = 2, 9
+    a = jp.arange(B * N, dtype=jp.float32).reshape((B, N))
+    b = jp.ones((B, N), dtype=jp.float32)
+
+    with jax.default_device(wp.device_to_jax(device)):
+        da, db = jax.vmap(jax.grad(per_sample_loss, argnums=(0, 1)), in_axes=(0, 0))(a, b)
+
+    a_np = np.arange(B * N, dtype=np.float32).reshape((B, N))
+    b_np = np.ones((B, N), dtype=np.float32)
+    s = 2.0
+    ref_da = 2.0 * (a_np * s + b_np) * s
+    ref_db = 2.0 * (a_np * s + b_np)
+
+    assert_np_equal(np.asarray(da), ref_da)
+    assert_np_equal(np.asarray(db), ref_db)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vmap_broadcast_mismatched_inputs(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_sum_square_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float), s: float, c: wp.array(dtype=float)):
+        tid = wp.tid()
+        c[tid] = (a[tid] * s + b[tid]) ** 2.0
+
+    jax_func = jax_ad_kernel(
+        scale_sum_square_kernel, num_outputs=1, static_argnames=("s",), vmap_method="broadcast_all"
+    )
+
+    def per_sample_loss(a, b):
+        out = jax_func(a, b, 1.5)[0]
+        return jp.sum(out)
+
+    B, N = 3, 8
+    a = jp.arange(B * N, dtype=jp.float32).reshape((B, N))
+    b = jp.ones((N,), dtype=jp.float32)
+
+    with jax.default_device(wp.device_to_jax(device)):
+        da, db = jax.vmap(jax.grad(per_sample_loss, argnums=(0, 1)), in_axes=(0, None))(a, b)
+
+    a_np = np.arange(B * N, dtype=np.float32).reshape((B, N))
+    b_np = np.ones((N,), dtype=np.float32)
+    s = 1.5
+    ref_da = 2.0 * (a_np * s + b_np) * s
+    ref_db = 2.0 * (a_np * s + b_np)
+
+    assert_np_equal(np.asarray(da), ref_da)
+    assert_np_equal(np.asarray(db), ref_db)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vmap_double_batch(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_sum_square_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float), s: float, c: wp.array(dtype=float)):
+        tid = wp.tid()
+        c[tid] = (a[tid] * s + b[tid]) ** 2.0
+
+    jax_func = jax_ad_kernel(
+        scale_sum_square_kernel, num_outputs=1, static_argnames=("s",), vmap_method="broadcast_all"
+    )
+
+    def per_elem_loss(a, b):
+        out = jax_func(a, b, 2.0)[0]
+        return jp.sum(out)
+
+    B, M, N = 2, 3, 6
+    a = jp.arange(B * M * N, dtype=jp.float32).reshape((B, M, N))
+    b = jp.ones((B, M, N), dtype=jp.float32)
+
+    with jax.default_device(wp.device_to_jax(device)):
+        grad_fun = jax.vmap(jax.vmap(jax.grad(per_elem_loss, argnums=(0, 1))))
+        da, db = grad_fun(a, b)
+
+    a_np = np.arange(B * M * N, dtype=np.float32).reshape((B, M, N))
+    b_np = np.ones((B, M, N), dtype=np.float32)
+    s = 2.0
+    ref_da = 2.0 * (a_np * s + b_np) * s
+    ref_db = 2.0 * (a_np * s + b_np)
+
+    assert_np_equal(np.asarray(da), ref_da)
+    assert_np_equal(np.asarray(db), ref_db)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vmap_2d_broadcast_all(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_2d(a: wp.array2d(dtype=float), s: float, out: wp.array2d(dtype=float)):
+        i, j = wp.tid()
+        out[i, j] = a[i, j] * s
+
+    jax_func = jax_ad_kernel(scale_2d, num_outputs=1, static_argnames=("s",), vmap_method="broadcast_all")
+
+    def per_sample_loss(a):
+        out = jax_func(a, 3.0)[0]
+        return jp.sum(out)
+
+    B, H, W = 2, 4, 5
+    a = jp.arange(B * H * W, dtype=jp.float32).reshape((B, H, W))
+
+    with jax.default_device(wp.device_to_jax(device)):
+        (da,) = jax.vmap(jax.grad(per_sample_loss, argnums=(0,)), in_axes=(0,))(a)
+
+    ref = np.full((B, H, W), 3.0, dtype=np.float32)
+    assert_np_equal(np.asarray(da), ref)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_vmap_2d_expand_dims(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def add_one_2d(a: wp.array2d(dtype=float), out: wp.array2d(dtype=float)):
+        i, j = wp.tid()
+        out[i, j] = a[i, j] + 1.0
+
+    jax_func = jax_ad_kernel(add_one_2d, num_outputs=1, vmap_method="broadcast_all")
+
+    def per_sample_loss(a):
+        out = jax_func(a)[0]
+        return jp.sum(out)
+
+    B, H, W = 2, 3, 4
+    a = jp.arange(B * H * W, dtype=jp.float32).reshape((B, H, W))
+
+    with jax.default_device(wp.device_to_jax(device)):
+        (da,) = jax.vmap(jax.grad(per_sample_loss, argnums=(0,)), in_axes=(0,))(a)
+
+    ref = np.ones((B, H, W), dtype=np.float32)
+    assert_np_equal(np.asarray(da), ref)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 4, 31), "Jax version too old for FFI custom_vjp")
+def test_jax_ad_kernel_auto_static_argnames(test, device):
+    import jax
+    import jax.numpy as jp
+
+    from warp.jax_experimental.ffi import jax_ad_kernel
+
+    @wp.kernel
+    def scale_sum_square_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float), s: float, c: wp.array(dtype=float)):
+        tid = wp.tid()
+        c[tid] = (a[tid] * s + b[tid]) ** 2.0
+
+    # Omit static_argnames to exercise auto-detection of scalar statics
+    jax_func = jax_ad_kernel(scale_sum_square_kernel, num_outputs=1)
+
+    def loss(a, b, s):
+        out = jax_func(a, b, s)[0]
+        return jp.sum(out)
+
+    n = 20
+    a = jp.arange(n, dtype=jp.float32)
+    b = jp.ones(n, dtype=jp.float32)
+    s = 1.5
+
+    with jax.default_device(wp.device_to_jax(device)):
+        da, db = jax.grad(loss, argnums=(0, 1))(a, b, s)
+
+    a_np = np.arange(n, dtype=np.float32)
+    b_np = np.ones(n, dtype=np.float32)
+    ref_da = 2.0 * (a_np * s + b_np) * s
+    ref_db = 2.0 * (a_np * s + b_np)
+
+    assert_np_equal(np.asarray(da), ref_da)
+    assert_np_equal(np.asarray(db), ref_db)
+
+
 class TestJax(unittest.TestCase):
     pass
 
@@ -359,6 +886,81 @@ try:
 
         add_function_test(
             TestJax, "test_jax_kernel_launch_dims", test_jax_kernel_launch_dims, devices=jax_compatible_cuda_devices
+        )
+
+        add_function_test(
+            TestJax, "test_jax_ad_kernel_simple", test_jax_ad_kernel_simple, devices=jax_compatible_cuda_devices
+        )
+
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_multi_output",
+            test_jax_ad_kernel_multi_output,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax, "test_jax_ad_kernel_vec2", test_jax_ad_kernel_vec2, devices=jax_compatible_cuda_devices
+        )
+        add_function_test(TestJax, "test_jax_ad_kernel_2d", test_jax_ad_kernel_2d, devices=jax_compatible_cuda_devices)
+        add_function_test(
+            TestJax, "test_jax_ad_kernel_mat22", test_jax_ad_kernel_mat22, devices=jax_compatible_cuda_devices
+        )
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_vmap_simple",
+            test_jax_ad_kernel_vmap_simple,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_auto_static_argnames",
+            test_jax_ad_kernel_auto_static_argnames,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax, "test_jax_ad_kernel_vmap_vec2", test_jax_ad_kernel_vmap_vec2, devices=jax_compatible_cuda_devices
+        )
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_vmap_multi_output",
+            test_jax_ad_kernel_vmap_multi_output,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_vmap_broadcast_all_simple",
+            test_jax_ad_kernel_vmap_broadcast_all_simple,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_vmap_expand_dims_simple",
+            test_jax_ad_kernel_vmap_expand_dims_simple,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_vmap_broadcast_mismatched_inputs",
+            test_jax_ad_kernel_vmap_broadcast_mismatched_inputs,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_vmap_double_batch",
+            test_jax_ad_kernel_vmap_double_batch,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_vmap_2d_broadcast_all",
+            test_jax_ad_kernel_vmap_2d_broadcast_all,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_jax_ad_kernel_vmap_2d_expand_dims",
+            test_jax_ad_kernel_vmap_2d_expand_dims,
+            devices=jax_compatible_cuda_devices,
         )
 
 except Exception as e:


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
-->

Added JAX interop adjoint support using FFI. Also added support for static inputs (with auto-detection), vmap, multi-output with AD. Fixed some bugs related to vmap for the forward pass. 

This is a new area for me, so there may be some oddities or poor decisions, but all tests pass. We may need to discuss any missing features and whether this is the way the user intends to use it.

This work is inspired by and thanks to J. Sevcik
https://gist.github.com/jaro-sevcik/893ffb891564dfc7617c8f12f3c2d1d2

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`
