### PR TITLE
Add type imports and overloads for function decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   This fixes a performance regression introduced in Warp 1.6.0 ([GH-758](https://github.com/NVIDIA/warp/issues/758)).
 
 ### Fixed
+
 - Fix crash when radix sort is used on multiple streams, including HashGrids ([GH-950](https://github.com/NVIDIA/warp/issues/950)).
 - Fix `TypeError: Unrecognized type 'tuple[...]'` when using tuple type annotations on Python 3.10. Tuple type hints like `tuple[float, wp.vec3f, wp.vec3f]` now work correctly across all supported Python versions ([GH-959](https://github.com/NVIDIA/warp/issues/959)).
 - Fix tile memory leaks and copy/select/where operations ([GH-777](https://github.com/NVIDIA/warp/pull/777/files))
@@ -30,6 +31,7 @@
 - Fix scaling not being correctly applied to rendered meshes in some cases ([GH-880](https://github.com/NVIDIA/warp/issues/880)).
 - Restore support for older GPU architectures (Maxwell, Pascal, Volta) when building with CUDA 12
   ([GH-966](https://github.com/NVIDIA/warp/issues/966)).
+- Add type imports and overloads for function decorators.
 
 ## [1.9.0] - 2025-09-04
 

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -316,5 +316,6 @@ from warp.builtins import static as static
 from warp.math import *
 
 from . import config as config
+from . import types as types
 
 __version__ = config.version

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -329,6 +329,7 @@ from warp.builtins import static as static
 from warp.math import *
 
 from . import config as config
+from . import types as types
 
 __version__ = config.version
 

--- a/warp/context.py
+++ b/warp/context.py
@@ -48,6 +48,7 @@ from typing import (
     get_args,
     get_origin,
 )
+from typing import overload as _overload
 
 import numpy as np
 
@@ -849,8 +850,15 @@ class Kernel:
 # ----------------------
 
 
-# decorator to register function, @func
-def func(f: Callable | None = None, *, name: str | None = None):
+@_overload
+def func(f: Callable, *, name: str | None = None) -> Function: ...
+@_overload
+def func(*, name: str | None = None) -> Callable[[Callable], Function]: ...
+def func(f: Callable | None = None, *, name: str | None = None) -> Any:
+    """
+    Decorator to register function, @func
+    """
+
     def wrapper(f, *args, **kwargs):
         if name is None:
             key = warp.codegen.make_full_qualified_name(f)
@@ -1066,12 +1074,17 @@ def func_replay(forward_fn):
     return wrapper
 
 
+@_overload
 def kernel(
-    f: Callable | None = None,
-    *,
-    enable_backward: bool | None = None,
-    module: Module | Literal["unique"] | None = None,
-):
+    f: Callable, *, enable_backward: bool | None = None, module: Module | Literal["unique"] | None = None
+) -> Kernel: ...
+@_overload
+def kernel(
+    *, enable_backward: bool | None = None, module: Module | Literal["unique"] | None = None
+) -> Callable[[Callable], Kernel]: ...
+def kernel(
+    f: Callable | None = None, *, enable_backward: bool | None = None, module: Module | Literal["unique"] | None = None
+) -> Any:
     """
     Decorator to register a Warp kernel from a Python function.
     The function must be defined with type annotations for all arguments.
@@ -1141,15 +1154,17 @@ def kernel(
     return wrapper(f)
 
 
-# decorator to register struct, @struct
-def struct(c: type):
+def struct(c: type) -> warp.codegen.Struct:
+    """
+    Decorator to register struct, @struct
+    """
     m = get_module(c.__module__)
     s = warp.codegen.Struct(key=warp.codegen.make_full_qualified_name(c), cls=c, module=m)
     s = functools.update_wrapper(s, c)
     return s
 
 
-def overload(kernel, arg_types=Union[None, Dict[str, Any], List[Any]]):
+def overload(kernel: Kernel | Callable, arg_types: Union[None, Dict[str, Any], List[Any]]):
     """Overload a generic kernel with the given argument types.
 
     Can be called directly or used as a function decorator.


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

This PR improves the type annotations for Warp's function decorators to provide better static type checking support and IDE experience for users.

### Limitations

There are still many functions that are not annotated.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [ ] Code passes formatting and linting checks with `pre-commit run -a`
