### PR TITLE
Add device ordinal XLA plumbing

### DIFF
--- a/warp/jax_experimental/xla_ffi.py
+++ b/warp/jax_experimental/xla_ffi.py
@@ -379,6 +379,24 @@ class XLA_FFI_Stream_Get_Args(ctypes.Structure):
 XLA_FFI_Stream_Get = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.POINTER(XLA_FFI_Stream_Get_Args))
 
 
+# struct XLA_FFI_DeviceOrdinal_Get {
+#   size_t struct_size;
+#   XLA_FFI_Extension_Base* extension_start;
+#   XLA_FFI_ExecutionContext* ctx;
+#   int32_t device_ordinal;  // out
+# };
+class XLA_FFI_DeviceOrdinal_Get_Args(ctypes.Structure):
+    _fields_ = (
+        ("struct_size", ctypes.c_size_t),
+        ("extension_start", ctypes.POINTER(XLA_FFI_Extension_Base)),
+        ("ctx", ctypes.c_void_p),  # XLA_FFI_ExecutionContext*
+        ("device_ordinal", ctypes.c_int32),
+    )  # // out
+
+
+XLA_FFI_DeviceOrdinal_Get = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.POINTER(XLA_FFI_DeviceOrdinal_Get_Args))
+
+
 # struct XLA_FFI_Api {
 #   size_t struct_size;
 #   XLA_FFI_Extension_Base* extension_start;
@@ -402,6 +420,8 @@ XLA_FFI_Stream_Get = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.POINTER(XLA_FFI_St
 #   _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Future_Create);
 #   _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Future_SetAvailable);
 #   _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Future_SetError);
+#   _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_RunId_Get);
+#   _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_DeviceOrdinal_Get);
 # };
 class XLA_FFI_Api(ctypes.Structure):
     _fields_ = (
@@ -425,6 +445,9 @@ class XLA_FFI_Api(ctypes.Structure):
         ("XLA_FFI_Future_Create", ctypes.c_void_p),  # XLA_FFI_Future_Create
         ("XLA_FFI_Future_SetAvailable", ctypes.c_void_p),  # XLA_FFI_Future_SetAvailable
         ("XLA_FFI_Future_SetError", ctypes.c_void_p),  # XLA_FFI_Future_SetError
+        # TODO(chaserileyroberts): Make this return the correct value and not a c_void_p.
+        ("XLA_FFI_RunId_Get", ctypes.c_void_p),  # XLA_FFI_RunId_Get
+        ("XLA_FFI_DeviceOrdinal_Get", XLA_FFI_DeviceOrdinal_Get),  # XLA_FFI_DeviceOrdinal_Get
     )
 
 
@@ -568,6 +591,15 @@ def get_stream_from_callframe(call_frame):
     api.contents.XLA_FFI_Stream_Get(get_stream_args)
     # TODO check result
     return get_stream_args.stream
+
+
+def get_device_ordinal_from_callframe(call_frame):
+    api = call_frame.api
+    get_device_args = XLA_FFI_DeviceOrdinal_Get_Args(
+        ctypes.sizeof(XLA_FFI_DeviceOrdinal_Get_Args), ctypes.POINTER(XLA_FFI_Extension_Base)(), call_frame.ctx, 0
+    )
+    api.contents.XLA_FFI_DeviceOrdinal_Get(get_device_args)
+    return get_device_args.device_ordinal
 
 
 _dtype_from_ffi = {


### PR DESCRIPTION
## Description

This PR fixes failures related to using Warp within a `jax.pmap` or a `jax.shard_map`. The main issue was that JAX would initiate the Warp callback from multiple threads targeting different devices, but the device Warp would target was always the default one. To fix this, we hookup `XLA_FFI_DeviceOrdinal_Get` to `xla_ffi.py`, and plumb that value to the warp device context so that JAX and Warp would each target the same device on each callback. 

Since the device Warp uses is dependent on a global context, JAX calling the FFI callable from multiple threads would smash this value and cause errors. To fix this, we include a threading lock before entering the context. We may consider making the device context value a thread local instead of a program global one instead.  

## Before your PR is "Ready for review"

- [ x ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ x ] Necessary tests have been added
- [ x ] Documentation is up-to-date
- [ x ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [ x ] Code passes formatting and linting checks with `pre-commit run -a`
