### PR TITLE
Add alpha and beta scalings to tile_matmul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   ([GH-1018](https://github.com/NVIDIA/warp/issues/1018)).
 - Add automatic differentiation support with `jax_kernel(enable_backward=True)`
   ([GH-912](https://github.com/NVIDIA/warp/pull/912), [GH-515](https://github.com/NVIDIA/warp/issues/515)).
+- Add alpha and beta scalings to `wp.tile_matmul()` ([GH-1023](https://github.com/NVIDIA/warp/pull/1023)).
 
 ### Removed
 

--- a/docs/modules/functions.rst
+++ b/docs/modules/functions.rst
@@ -2816,7 +2816,7 @@ Tile Primitives
     Add a square matrix and a diagonal matrix 'd' represented as a 1D tile
 
 
-.. py:function:: tile_matmul(a: Tile[Float,Tuple[int, int]], b: Tile[Float,Tuple[int, int]], out: Tile[Float,Tuple[int, int]]) -> None
+.. py:function:: tile_matmul(a: Tile[Float,Tuple[int, int]], b: Tile[Float,Tuple[int, int]], out: Tile[Float,Tuple[int, int]], alpha: Float, beta: Float) -> None
 
     .. hlist::
        :columns: 8
@@ -2824,7 +2824,7 @@ Tile Primitives
        * Kernel
        * Differentiable
 
-    Computes the matrix product and accumulates ``out += a*b``.
+    Computes the matrix product and accumulates ``out = alpha * a*b + beta * out``.
 
     Supported datatypes are:
         * fp16, fp32, fp64 (real)
@@ -2833,13 +2833,17 @@ Tile Primitives
     All input and output tiles must have the same datatype. Tile data will automatically be migrated
     to shared memory if necessary and will use TensorCore operations when available.
 
+    Note that computing the adjoints of alpha and beta are not yet supported.
+
     :param a: A tile with ``shape=(M, K)``
     :param b: A tile with ``shape=(K, N)``
     :param out: A tile with ``shape=(M, N)``
+    :param alpha: Scaling factor (default 1.0)
+    :param beta: Accumulator factor (default 1.0)
     
 
 
-.. py:function:: tile_matmul(a: Tile[Float,Tuple[int, int]], b: Tile[Float,Tuple[int, int]]) -> Tile[Float,Tuple[int, int]]
+.. py:function:: tile_matmul(a: Tile[Float,Tuple[int, int]], b: Tile[Float,Tuple[int, int]], alpha: Float) -> Tile[Float,Tuple[int, int]]
     :noindex:
     :nocontentsentry:
 
@@ -2849,7 +2853,7 @@ Tile Primitives
        * Kernel
        * Differentiable
 
-    Computes the matrix product ``out = a*b``.
+    Computes the matrix product ``out = alpha * a*b``.
 
     Supported datatypes are:
         * fp16, fp32, fp64 (real)
@@ -2858,8 +2862,11 @@ Tile Primitives
     Both input tiles must have the same datatype. Tile data will automatically be migrated
     to shared memory if necessary and will use TensorCore operations when available.
 
+    Note that computing the adjoints of alpha is not yet supported.
+
     :param a: A tile with ``shape=(M, K)``
     :param b: A tile with ``shape=(K, N)``
+    :param alpha: Scaling factor (default 1.0)
     :returns: A tile with ``shape=(M, N)``
     
 

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -5390,8 +5390,14 @@ def tile_diag_add(a: Tile[Any, Tuple[int, int]], d: Tile[Any, Tuple[int]]) -> Ti
     ...
 
 @over
-def tile_matmul(a: Tile[Float, Tuple[int, int]], b: Tile[Float, Tuple[int, int]], out: Tile[Float, Tuple[int, int]]):
-    """Computes the matrix product and accumulates ``out += a*b``.
+def tile_matmul(
+    a: Tile[Float, Tuple[int, int]],
+    b: Tile[Float, Tuple[int, int]],
+    out: Tile[Float, Tuple[int, int]],
+    alpha: Float,
+    beta: Float,
+):
+    """Computes the matrix product and accumulates ``out = alpha * a*b + beta * out``.
 
     Supported datatypes are:
         * fp16, fp32, fp64 (real)
@@ -5400,16 +5406,22 @@ def tile_matmul(a: Tile[Float, Tuple[int, int]], b: Tile[Float, Tuple[int, int]]
     All input and output tiles must have the same datatype. Tile data will automatically be migrated
     to shared memory if necessary and will use TensorCore operations when available.
 
+    Note that computing the adjoints of alpha and beta are not yet supported.
+
     :param a: A tile with ``shape=(M, K)``
     :param b: A tile with ``shape=(K, N)``
     :param out: A tile with ``shape=(M, N)``
+    :param alpha: Scaling factor (default 1.0)
+    :param beta: Accumulator factor (default 1.0)
 
     """
     ...
 
 @over
-def tile_matmul(a: Tile[Float, Tuple[int, int]], b: Tile[Float, Tuple[int, int]]) -> Tile[Float, Tuple[int, int]]:
-    """Computes the matrix product ``out = a*b``.
+def tile_matmul(
+    a: Tile[Float, Tuple[int, int]], b: Tile[Float, Tuple[int, int]], alpha: Float
+) -> Tile[Float, Tuple[int, int]]:
+    """Computes the matrix product ``out = alpha * a*b``.
 
     Supported datatypes are:
         * fp16, fp32, fp64 (real)
@@ -5418,8 +5430,11 @@ def tile_matmul(a: Tile[Float, Tuple[int, int]], b: Tile[Float, Tuple[int, int]]
     Both input tiles must have the same datatype. Tile data will automatically be migrated
     to shared memory if necessary and will use TensorCore operations when available.
 
+    Note that computing the adjoints of alpha is not yet supported.
+
     :param a: A tile with ``shape=(M, K)``
     :param b: A tile with ``shape=(K, N)``
+    :param alpha: Scaling factor (default 1.0)
     :returns: A tile with ``shape=(M, N)``
 
     """

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -1256,6 +1256,9 @@ class Adjoint:
         if isinstance(var, int):
             return adj.add_constant(var)
 
+        if isinstance(var, float):
+            return adj.add_constant(var)
+
         if var.label is None:
             return adj.add_var(var.type, var.constant)
 

--- a/warp/tests/tile/test_tile_cholesky.py
+++ b/warp/tests/tile/test_tile_cholesky.py
@@ -370,8 +370,7 @@ def test_tile_cholesky_block_cholesky(test, device):
             for j in range(0, k, BLOCK_SIZE):
                 L_block = wp.tile_load(L, shape=(BLOCK_SIZE, BLOCK_SIZE), offset=(k, j))
                 L_block_T = wp.tile_transpose(L_block)
-                L_L_T_block = wp.tile_matmul(L_block, L_block_T)
-                A_kk_tile -= L_L_T_block
+                wp.tile_matmul(L_block, L_block_T, A_kk_tile, alpha=-1.0)
 
             # Compute the Cholesky factorization for the block
             # print(A_kk_tile)
@@ -386,8 +385,7 @@ def test_tile_cholesky_block_cholesky(test, device):
                     L_tile = wp.tile_load(L, shape=(BLOCK_SIZE, BLOCK_SIZE), offset=(i, j))
                     L_2_tile = wp.tile_load(L, shape=(BLOCK_SIZE, BLOCK_SIZE), offset=(k, j))
                     L_T_tile = wp.tile_transpose(L_2_tile)
-                    L_L_T_tile = wp.tile_matmul(L_tile, L_T_tile)
-                    A_ik_tile -= L_L_T_tile
+                    wp.tile_matmul(L_tile, L_T_tile, A_ik_tile, alpha=-1.0)
 
                 A_ik_T_tile = wp.tile_transpose(A_ik_tile)
                 sol_T_tile = wp.tile_lower_solve(L_kk_tile, A_ik_T_tile)
@@ -414,8 +412,7 @@ def test_tile_cholesky_block_cholesky(test, device):
             for j in range(0, i, BLOCK_SIZE):
                 L_block = wp.tile_load(L, shape=(BLOCK_SIZE, BLOCK_SIZE), offset=(i, j))
                 y_block = wp.tile_load(scratch, shape=(BLOCK_SIZE, 1), offset=(j, 0))
-                Ly_block = wp.tile_matmul(L_block, y_block)
-                rhs_tile -= Ly_block
+                wp.tile_matmul(L_block, y_block, rhs_tile, alpha=-1.0)
             L_tile = wp.tile_load(L, shape=(BLOCK_SIZE, BLOCK_SIZE), offset=(i, i))
             y_tile = wp.tile_lower_solve(L_tile, rhs_tile)
             wp.tile_store(scratch, y_tile, offset=(i, 0))
@@ -429,8 +426,7 @@ def test_tile_cholesky_block_cholesky(test, device):
                 L_tile = wp.tile_load(L, shape=(BLOCK_SIZE, BLOCK_SIZE), offset=(j, i_start))
                 L_T_tile = wp.tile_transpose(L_tile)
                 x_tile = wp.tile_load(x, shape=(BLOCK_SIZE, 1), offset=(j, 0))
-                L_T_x_tile = wp.tile_matmul(L_T_tile, x_tile)
-                rhs_tile -= L_T_x_tile
+                wp.tile_matmul(L_T_tile, x_tile, rhs_tile, alpha=-1.0)
             L_tile = wp.tile_load(L, shape=(BLOCK_SIZE, BLOCK_SIZE), offset=(i_start, i_start))
             x_tile = wp.tile_upper_solve(wp.tile_transpose(L_tile), rhs_tile)
             wp.tile_store(x, x_tile, offset=(i_start, 0))


### PR DESCRIPTION
## Description
This PR adds alpha and beta scalings to `tile_matmul` as in the [cublasdx API](https://docs.nvidia.com/cuda/cublasdx/using_cublasdx.html). The main motivation is to generalize the `tile_matmul` API with the aim to reduce the number of operations and shared memory of otherwise necessary operations. For example, in the tile_block_cholesky example
```diff
@@ -78,8 +78,7 @@ def blocked_cholesky_kernel(
                 for j in range(0, k, block_size):
                     L_block = wp.tile_load(L, shape=(block_size, block_size), offset=(k, j))
                     L_block_T = wp.tile_transpose(L_block)
-                    L_L_T_block = wp.tile_matmul(L_block, L_block_T)
-                    A_kk_tile -= L_L_T_block
+                    wp.tile_matmul(L_block, L_block_T, A_kk_tile, alpha=-1.0)
```
this reduces shared memory usage (`L_L_T_block` doesn't exist) and fuses the subtraction.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - tile_matmul adds alpha and beta scalars: out = alpha*(A @ B) + beta*out (defaults 1.0); supports in-place scaled matmul.

- **Documentation**
  - API docs and overloads updated to describe alpha/beta, defaults, semantics, and note adjoint support is not yet available.

- **Examples**
  - Cholesky example simplified to use tile_matmul(alpha=-1.0) for in-place subtraction.

- **Tests**
  - Tests updated for alpha/beta forward behavior and adjusted gradient expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->