### PR TITLE
Use Overload of lookupTarget Accepting Triple

### DIFF
--- a/warp/native/clang/clang.cpp
+++ b/warp/native/clang/clang.cpp
@@ -247,7 +247,11 @@ WP_API int wp_compile_cpp(const char* cpp_src, const char *input_file, const cha
     }
 
     std::string error;
+     #if LLVM_VERSION_MAJOR >= 22
+    const llvm::Target* target = llvm::TargetRegistry::lookupTarget(llvm::Triple(target_triple), error);
+    #else
     const llvm::Target* target = llvm::TargetRegistry::lookupTarget(target_triple, error);
+    #endif
 
     const char* CPU = "generic";
     const char* features = "";
@@ -298,7 +302,12 @@ WP_API int wp_compile_cuda(const char* cpp_src, const char *input_file, const ch
     }
 
     std::string error;
+
+    #if LLVM_VERSION_MAJOR >= 22
+    const llvm::Target* target = llvm::TargetRegistry::lookupTarget(llvm::Triple("nvptx64-nvidia-cuda"), error);
+    #else
     const llvm::Target* target = llvm::TargetRegistry::lookupTarget("nvptx64-nvidia-cuda", error);
+    #endif
 
     const char* CPU = "sm_70";
     const char* features = "+ptx75";  // Warp requires CUDA 11.5, which supports PTX ISA 7.5


### PR DESCRIPTION
The overload accepting a llvm::StringRef is deprecated and will be removed once LLVM 22 branches.

<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restores successful C++ and CUDA compilation with LLVM 22+, resolving target detection and code generation issues seen on newer toolchains.
  * Maintains compatibility across older LLVM versions to prevent regressions.

* **Chores**
  * Updated compiler compatibility logic to support LLVM 22+ while preserving behavior on earlier versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->