### PR TITLE
Add inplace variants of cholesky and triangular solve operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Mesh queries: `wp.mesh_query_aabb_tiled()` and `wp.mesh_query_aabb_next_tiled()`
   - Aliases with `tile_*` prefix are also available for all functions.
 - Add alpha and beta scalings to `wp.tile_matmul()` ([GH-1023](https://github.com/NVIDIA/warp/pull/1023)).
+- Add `wp.tile_cholesky_inplace()`, `wp.tile_cholesky_solve_inplace()`, `wp.tile_lower_solve_inplace()` and `wp.tile_upper_solve_inplace()` ([GH-1025](https://github.com/NVIDIA/warp/pull/1025)).
 
 ### Removed
 

--- a/docs/modules/functions.rst
+++ b/docs/modules/functions.rst
@@ -2967,7 +2967,7 @@ Tile Primitives
     
 
 
-.. py:function:: tile_fft(inout: Tile[Vector[2,Float],Tuple[int, int]]) -> Tile[Vector[2,Float],Tuple[int, int]]
+.. py:function:: tile_fft(inout: Tile[Vector[2,Float],Tuple[int, int]]) -> None
 
     .. hlist::
        :columns: 8
@@ -2986,7 +2986,7 @@ Tile Primitives
     :param inout: The input/output tile
 
 
-.. py:function:: tile_ifft(inout: Tile[Vector[2,Float],Tuple[int, int]]) -> Tile[Vector[2,Float],Tuple[int, int]]
+.. py:function:: tile_ifft(inout: Tile[Vector[2,Float],Tuple[int, int]]) -> None
 
     .. hlist::
        :columns: 8
@@ -3028,7 +3028,30 @@ Tile Primitives
     :returns L: A square, lower triangular, matrix, such that LL^T = A
 
 
-.. py:function:: tile_cholesky_solve(L: Tile[Float,Tuple[int, int]], y: Tile[Float,Tuple[int]]) -> None
+.. py:function:: tile_cholesky_inplace(A: Tile[Float,Tuple[int, int]]) -> None
+
+    .. hlist::
+       :columns: 8
+
+       * Kernel
+
+    Compute the Cholesky factorization L of a matrix A.
+    L is lower triangular and satisfies LL^T = A.
+
+    Only the lower triangular portion of A is used for the decomposition;
+    the upper triangular part may be left unspecified.
+
+    Note: This inplace variant does not support automatic differentiation (adjoint computation),
+    but offers improved performance and uses half the shared memory compared to the standard version.
+
+    Supported datatypes are:
+        * float32
+        * float64
+
+    :param A: A square, symmetric positive-definite, matrix. Only the lower triangular part of A is replaced by L, such that LL^T = A; the upper part is untouched.
+
+
+.. py:function:: tile_cholesky_solve(L: Tile[Float,Tuple[int, int]], y: Tile[Float,Tuple[int]]) -> Tile[Float,Tuple[int]]
 
     .. hlist::
        :columns: 8
@@ -3046,6 +3069,26 @@ Tile Primitives
     :param L: A square, lower triangular, matrix, such that LL^T = A
     :param y: A 1D or 2D tile of length M
     :returns x: A tile of the same shape as y such that LL^T x = y
+
+
+.. py:function:: tile_cholesky_solve_inplace(L: Tile[Float,Tuple[int, int]], y: Tile[Float,Tuple[int]]) -> None
+
+    .. hlist::
+       :columns: 8
+
+       * Kernel
+
+    With L such that LL^T = A, solve for x in Ax = y by overwriting y with x
+
+    Note: This inplace variant does not support automatic differentiation (adjoint computation),
+    but avoids allocating shared memory for the output x by reusing y's memory.
+
+    Supported datatypes are:
+        * float32
+        * float64
+
+    :param L: A square, lower triangular, matrix, such that LL^T = A
+    :param y: A 1D or 2D tile of length M that gets overwritten by x where LL^T x = y
 
 
 .. py:function:: tile_lower_solve(L: Tile[Float,Tuple[int, int]], y: Tile[Float,Tuple[int]]) -> Tile[Float,Tuple[int]]
@@ -3070,6 +3113,28 @@ Tile Primitives
     :returns z: A tile of the same shape as y such that Lz = y
 
 
+.. py:function:: tile_lower_solve_inplace(L: Tile[Float,Tuple[int, int]], y: Tile[Float,Tuple[int]]) -> None
+
+    .. hlist::
+       :columns: 8
+
+       * Kernel
+
+    Solve for z in Lz = y, where L is a lower triangular matrix by overwriting y with z.
+
+    This performs general forward substitution for a lower triangular system inplace.
+
+    Note: This inplace variant does not support automatic differentiation (adjoint computation),
+    but avoids allocating shared memory for the output z by reusing y's memory.
+
+    Supported datatypes are:
+        * float32
+        * float64
+
+    :param L: A square, non-singular, lower triangular matrix
+    :param y: A 1D or 2D tile with compatible shape that gets overwritten by z where Lz = y
+
+
 .. py:function:: tile_upper_solve(U: Tile[Float,Tuple[int, int]], z: Tile[Float,Tuple[int]]) -> Tile[Float,Tuple[int]]
 
     .. hlist::
@@ -3077,7 +3142,7 @@ Tile Primitives
 
        * Kernel
 
-    Solve for x in U x = z, where U is an upper triangular matrix.
+    Solve for x in Ux = z, where U is an upper triangular matrix.
 
     This performs general back substitution for upper triangular systems.
 
@@ -3090,6 +3155,28 @@ Tile Primitives
     :param U: A square, non-singular, upper triangular matrix
     :param z: A 1D or 2D tile with compatible shape
     :returns x: A tile of the same shape as z such that U x = z
+
+
+.. py:function:: tile_upper_solve_inplace(U: Tile[Float,Tuple[int, int]], z: Tile[Float,Tuple[int]]) -> None
+
+    .. hlist::
+       :columns: 8
+
+       * Kernel
+
+    Solve for x in Ux = z, where U is an upper triangular matrix by overwriting z with x.
+
+    This performs general back substitution for upper triangular systems inplace.
+
+    Note: This inplace variant does not support automatic differentiation (adjoint computation),
+    but avoids allocating shared memory for the output x by reusing z's memory.
+
+    Supported datatypes are:
+        * float32
+        * float64
+
+    :param U: A square, non-singular, upper triangular matrix
+    :param z: A 1D or 2D tile with compatible shape that gets overwritten by x where Ux = z
 
 
 

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -5645,7 +5645,7 @@ def tile_matmul(
     ...
 
 @over
-def tile_fft(inout: Tile[Vector[2, Float], Tuple[int, int]]) -> Tile[Vector[2, Float], Tuple[int, int]]:
+def tile_fft(inout: Tile[Vector[2, Float], Tuple[int, int]]):
     """Compute the forward FFT along the second dimension of a 2D tile of data.
 
     This function cooperatively computes the forward FFT on a tile of data inplace, treating each row individually.
@@ -5660,7 +5660,7 @@ def tile_fft(inout: Tile[Vector[2, Float], Tuple[int, int]]) -> Tile[Vector[2, F
     ...
 
 @over
-def tile_ifft(inout: Tile[Vector[2, Float], Tuple[int, int]]) -> Tile[Vector[2, Float], Tuple[int, int]]:
+def tile_ifft(inout: Tile[Vector[2, Float], Tuple[int, int]]):
     """Compute the inverse FFT along the second dimension of a 2D tile of data.
 
     This function cooperatively computes the inverse FFT on a tile of data inplace, treating each row individually.
@@ -5694,7 +5694,26 @@ def tile_cholesky(A: Tile[Float, Tuple[int, int]]) -> Tile[Float, Tuple[int, int
     ...
 
 @over
-def tile_cholesky_solve(L: Tile[Float, Tuple[int, int]], y: Tile[Float, Tuple[int]]):
+def tile_cholesky_inplace(A: Tile[Float, Tuple[int, int]]):
+    """Compute the Cholesky factorization L of a matrix A.
+    L is lower triangular and satisfies LL^T = A.
+
+    Only the lower triangular portion of A is used for the decomposition;
+    the upper triangular part may be left unspecified.
+
+    Note: This inplace variant does not support automatic differentiation (adjoint computation),
+    but offers improved performance and uses half the shared memory compared to the standard version.
+
+    Supported datatypes are:
+        * float32
+        * float64
+
+    :param A: A square, symmetric positive-definite, matrix. Only the lower triangular part of A is replaced by L, such that LL^T = A; the upper part is untouched.
+    """
+    ...
+
+@over
+def tile_cholesky_solve(L: Tile[Float, Tuple[int, int]], y: Tile[Float, Tuple[int]]) -> Tile[Float, Tuple[int]]:
     """With L such that LL^T = A, solve for x in Ax = y
 
     Note that computing the adjoint is not yet supported.
@@ -5706,6 +5725,22 @@ def tile_cholesky_solve(L: Tile[Float, Tuple[int, int]], y: Tile[Float, Tuple[in
     :param L: A square, lower triangular, matrix, such that LL^T = A
     :param y: A 1D or 2D tile of length M
     :returns x: A tile of the same shape as y such that LL^T x = y
+    """
+    ...
+
+@over
+def tile_cholesky_solve_inplace(L: Tile[Float, Tuple[int, int]], y: Tile[Float, Tuple[int]]):
+    """With L such that LL^T = A, solve for x in Ax = y by overwriting y with x
+
+    Note: This inplace variant does not support automatic differentiation (adjoint computation),
+    but avoids allocating shared memory for the output x by reusing y's memory.
+
+    Supported datatypes are:
+        * float32
+        * float64
+
+    :param L: A square, lower triangular, matrix, such that LL^T = A
+    :param y: A 1D or 2D tile of length M that gets overwritten by x where LL^T x = y
     """
     ...
 
@@ -5728,8 +5763,26 @@ def tile_lower_solve(L: Tile[Float, Tuple[int, int]], y: Tile[Float, Tuple[int]]
     ...
 
 @over
+def tile_lower_solve_inplace(L: Tile[Float, Tuple[int, int]], y: Tile[Float, Tuple[int]]):
+    """Solve for z in Lz = y, where L is a lower triangular matrix by overwriting y with z.
+
+    This performs general forward substitution for a lower triangular system inplace.
+
+    Note: This inplace variant does not support automatic differentiation (adjoint computation),
+    but avoids allocating shared memory for the output z by reusing y's memory.
+
+    Supported datatypes are:
+        * float32
+        * float64
+
+    :param L: A square, non-singular, lower triangular matrix
+    :param y: A 1D or 2D tile with compatible shape that gets overwritten by z where Lz = y
+    """
+    ...
+
+@over
 def tile_upper_solve(U: Tile[Float, Tuple[int, int]], z: Tile[Float, Tuple[int]]) -> Tile[Float, Tuple[int]]:
-    """Solve for x in U x = z, where U is an upper triangular matrix.
+    """Solve for x in Ux = z, where U is an upper triangular matrix.
 
     This performs general back substitution for upper triangular systems.
 
@@ -5742,6 +5795,24 @@ def tile_upper_solve(U: Tile[Float, Tuple[int, int]], z: Tile[Float, Tuple[int]]
     :param U: A square, non-singular, upper triangular matrix
     :param z: A 1D or 2D tile with compatible shape
     :returns x: A tile of the same shape as z such that U x = z
+    """
+    ...
+
+@over
+def tile_upper_solve_inplace(U: Tile[Float, Tuple[int, int]], z: Tile[Float, Tuple[int]]):
+    """Solve for x in Ux = z, where U is an upper triangular matrix by overwriting z with x.
+
+    This performs general back substitution for upper triangular systems inplace.
+
+    Note: This inplace variant does not support automatic differentiation (adjoint computation),
+    but avoids allocating shared memory for the output x by reusing z's memory.
+
+    Supported datatypes are:
+        * float32
+        * float64
+
+    :param U: A square, non-singular, upper triangular matrix
+    :param z: A 1D or 2D tile with compatible shape that gets overwritten by x where Ux = z
     """
     ...
 

--- a/warp/native/tile.h
+++ b/warp/native/tile.h
@@ -3278,7 +3278,7 @@ inline CUDA_CALLABLE void scalar_matmul(const StorageA& A, const StorageB& B, St
 template <typename TileA, typename TileL>
 inline CUDA_CALLABLE void scalar_cholesky(TileA& A, TileL& L)
 {
-    using T = typename TileA::Type;    
+    using T = typename TileA::Type;
     constexpr int n = TileA::Layout::Shape::dim(1);
 
     for (int j=0; j < n; ++j)
@@ -3612,14 +3612,69 @@ CUDA_CALLABLE TileL& tile_cholesky(Fwd fun_forward, TileA& A, TileL& L)
     return L;
 }
 
+template <typename Fwd, typename TileA>
+void tile_cholesky_inplace(Fwd fun_forward, TileA& A)
+{
+    static_assert(TileA::Layout::Shape::N == 2, "Expected TileA::Layout::Shape::N == 2");
+    static_assert(TileA::Layout::Shape::dim(0) == TileA::Layout::Shape::dim(1), "Expected TileA to be square");
+
+#if !defined(__CUDA_ARCH__) || WP_ENABLE_MATHDX == 0
+
+    partitioned_gemm::scalar_cholesky(A, A);
+
+#else
+
+    // TODO: for batched Cholesky, need one info per batch
+    __shared__ int info[1];
+
+    if (WP_TILE_THREAD_IDX == 0) {
+        info[0] = 0;
+    }
+
+    // Call cholesky on A
+    WP_TILE_SYNC();
+    
+    fun_forward(A.data.ptr, info);
+    
+    WP_TILE_SYNC();
+
+    // TODO: for batched Cholesky, check all batches
+#if defined(_DEBUG)    
+    if (WP_TILE_THREAD_IDX == 0 && info[0] != 0) {
+        printf("Non-zero status in Cholesky factorization, got %d\n", info[0]);
+    }
+#endif
+
+    // Zero-out the upper triangular part of L
+
+    WP_PRAGMA_UNROLL
+    for (int i=WP_TILE_THREAD_IDX; i < TileA::Layout::Size; i += WP_TILE_BLOCK_DIM)
+    {
+        auto c = TileA::Layout::coord_from_linear(i);
+        
+        if(c[0] < c[1]) 
+            A.data(c) = 0.0;
+    }
+
+    WP_TILE_SYNC();
+
+#endif
+}
+
 #define adj_tile_cholesky(function_name, A, L, \
                           adj_function_name, adj_A, adj_L, adj_ret) \
     do { \
         assert(false); \
     } while (0)
 
-template <typename Fwd, typename TileL, typename TileX, typename TileY>
-TileY& tile_cholesky_solve(Fwd fun_forward, TileL& L, TileX& Y, TileY& X)
+#define adj_tile_cholesky_inplace(function_name, A, \
+                                  adj_function_name, adj_A) \
+    do { \
+        assert(false); \
+    } while (0)
+
+template <typename Fwd, typename TileL, typename TileY, typename TileX>
+TileX& tile_cholesky_solve(Fwd fun_forward, TileL& L, TileY& Y, TileX& X)
 {       
     // Copy y to x
 
@@ -3644,15 +3699,34 @@ TileY& tile_cholesky_solve(Fwd fun_forward, TileL& L, TileX& Y, TileY& X)
     return X;
 }
 
+template <typename Fwd, typename TileL, typename TileY>
+void tile_cholesky_solve_inplace(Fwd fun_forward, TileL& L, TileY& Y)
+{
+#if !defined(__CUDA_ARCH__) || WP_ENABLE_MATHDX == 0
+
+    partitioned_gemm::scalar_cholesky_solve(L, Y, Y);
+
+#else
+
+    // Call cholesky solve on L & y
+    fun_forward(L.data.ptr, Y.data.ptr); \
+
+    WP_TILE_SYNC();
+    
+#endif
+}
+
 #define adj_tile_cholesky_solve(function_name, L, Y, X, \
                                 adj_function_name, adj_L, adj_Y, adj_X, adj_ret) \
     do { \
         assert(false); \
     } while (0)
 
-
-
-
+#define adj_tile_cholesky_solve_inplace(function_name, L, Y, \
+                                        adj_function_name, adj_L, adj_Y) \
+    do { \
+        assert(false); \
+    } while (0)
 
 
 template <typename Fwd, typename TileL, typename TileY, typename TileZ>
@@ -3680,12 +3754,37 @@ TileZ& tile_lower_solve(Fwd fun_forward, TileL& L, TileY& y, TileZ& z)
     return z;
 }
 
+template <typename Fwd, typename TileL, typename TileY>
+void tile_lower_solve_inplace(Fwd fun_forward, TileL& L, TileY& y)
+{
+#if !defined(__CUDA_ARCH__) || WP_ENABLE_MATHDX == 0
+    
+    partitioned_gemm::scalar_cholesky_forward_substitution(L, y, y);
+
+#else
+
+    // Call cholesky solve on L & y
+
+    WP_TILE_SYNC();
+    
+    fun_forward(L.data.ptr, y.data.ptr);
+
+    WP_TILE_SYNC();
+    
+#endif
+}
+
 #define adj_tile_lower_solve(function_name, L, y, z, \
                              adj_function_name, adj_L, adj_y, adj_z, adj_ret) \
     do { \
         assert(false); \
     } while (0)
-		
+
+#define adj_tile_lower_solve_inplace(function_name, L, y, \
+                                     adj_function_name, adj_L, adj_y) \
+    do { \
+        assert(false); \
+    } while (0)		
 	
 
 template <typename Fwd, typename TileU, typename TileZ, typename TileX>
@@ -3714,16 +3813,40 @@ TileX& tile_upper_solve(Fwd fun_forward, TileU& U, TileZ& z, TileX& x)
     return x;
 }
 
+template <typename Fwd, typename TileU, typename TileZ>
+void tile_upper_solve_inplace(Fwd fun_forward, TileU& U, TileZ& z)
+{
+
+#if !defined(__CUDA_ARCH__) || WP_ENABLE_MATHDX == 0
+
+    auto L = tile_transpose(U);
+    partitioned_gemm::scalar_cholesky_back_substitution(L, z);
+
+#else
+
+    // Call cholesky solve on U & z
+
+    WP_TILE_SYNC();
+    
+    fun_forward(U.data.ptr, z.data.ptr);
+
+    WP_TILE_SYNC();
+    
+#endif
+}
+
 #define adj_tile_upper_solve(function_name, U, z, x, \
                              adj_function_name, adj_U, adj_z, adj_x, adj_ret) \
     do { \
         assert(false); \
     } while (0)
 
+#define adj_tile_upper_solve_inplace(function_name, U, z, \
+                                     adj_function_name, adj_U, adj_z) \
+    do { \
+        assert(false); \
+    } while (0)
 
-
-
-    
 
 template <typename Tile>
 inline CUDA_CALLABLE auto tile_transpose(Tile& t)


### PR DESCRIPTION
## Description

This PR introduces inplace variants of `wp.tile_cholesky()`, `wp.tile_cholesky_solve()`, `wp.tile_lower_solve()` and `wp.tile_upper_solve()`. In a similar spirit to https://github.com/NVIDIA/warp/pull/1023, this can can reduce the used shared memory in a kernel.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-place tile operations for Cholesky, triangular solves, and FFT/IFFT to enable overwriting inputs and reduce memory use.

* **Documentation**
  * Public API docs updated to describe in-place semantics, supported datatypes, and clarified solve notation.

* **Tests**
  * New tests validating in-place Cholesky, forward/back substitution, and multi‑RHS scenarios.

* **Refactor**
  * Examples and kernels updated to use in-place variants, removing intermediate temporaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->