### PR TITLE
Fix bvh leaf size and cpu depth check

### DIFF
--- a/warp/native/bvh.cpp
+++ b/warp/native/bvh.cpp
@@ -345,7 +345,7 @@ int TopDownBVHBuilder::build_recursive(BVH& bvh, const vec3* lowers, const vec3*
 
     // If the depth exceeds BVH_QUERY_STACK_SIZE, an out-of-bounds access bug may occur during querying.
     // In that case, we merge the following nodes into a single large leaf node.
-    if (n <= bvh.leaf_size || depth >= BVH_QUERY_STACK_SIZE - 1)
+    if (n <= bvh.leaf_size || depth >= BVH_QUERY_STACK_SIZE)
     {
         bvh.node_lowers[node_index] = make_node(b.lower, start, true);
         bvh.node_uppers[node_index] = make_node(b.upper, end, false);

--- a/warp/native/bvh.h
+++ b/warp/native/bvh.h
@@ -463,8 +463,9 @@ CUDA_CALLABLE inline bool bvh_query_next(bvh_query_t& query, int& index)
         {
             // found leaf, loop through its content primitives
             const int start = left_index;
+            const int end = right_index;
 
-            if (bvh.leaf_size == 1)
+            if (end - start <= 1)
             {
                 int primitive_index = bvh.primitive_indices[start];
                 index = primitive_index;
@@ -472,8 +473,7 @@ CUDA_CALLABLE inline bool bvh_query_next(bvh_query_t& query, int& index)
                 return true;
             }
             else
-            {
-                const int end = right_index;
+            {   
                 int primitive_index = bvh.primitive_indices[start + (query.primitive_counter++)];
 
                 // if already visited the last primitive in the leaf node


### PR DESCRIPTION
## Description
Fixes #1059 by checking for leaf_size of 1 by seeing if the primitive range is <= 1. Also fixes the depth check for the CPU builder to be aligned with the GPU builder.

## Before your PR is "Ready for review"

- [X] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [X] Necessary tests have been added
- [X] Documentation is up-to-date
- [X] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [X] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal spatial acceleration data structure construction and traversal logic for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->