### PR TITLE
Fix Explicit release of temporaries due to ref-cycle in fem.borrow_temporary 

### DIFF
--- a/warp/_src/fem/geometry/adaptive_nanogrid.py
+++ b/warp/_src/fem/geometry/adaptive_nanogrid.py
@@ -417,8 +417,10 @@ class AdaptiveNanogrid(NanogridBase):
                 boundary_face_mask,
             ],
         )
-        boundary_face_indices, _ = utils.masked_indices(boundary_face_mask)
-        self._boundary_face_indices = boundary_face_indices.detach()
+        boundary_face_indices, boundary_face_global_to_local = utils.masked_indices(boundary_face_mask)
+        self._replace_boundary_face_indices(boundary_face_indices.detach())
+        boundary_face_global_to_local.release()
+        boundary_face_mask.release()
 
     def _ensure_stacked_edge_grid(self):
         if self._stacked_edge_grid is None:
@@ -565,6 +567,7 @@ def _build_node_grid(cell_ijk, cell_level, cell_grid: wp.Volume, temporary_store
     node_grid = wp.Volume.allocate_by_voxels(
         cell_nodes.flatten(), voxel_size=cell_grid.get_voxel_size()[0], device=cell_ijk.device
     )
+    cell_nodes.release()
 
     return node_grid
 
@@ -577,6 +580,7 @@ def _build_cell_face_grid(cell_ijk, cell_level, grid: wp.Volume, temporary_store
     face_grid = wp.Volume.allocate_by_voxels(
         cell_faces.flatten(), voxel_size=grid.get_voxel_size()[0], device=cell_ijk.device
     )
+    cell_faces.release()
 
     return face_grid
 
@@ -634,6 +638,9 @@ def _build_completed_face_grid(
     face_grid = wp.Volume.allocate_by_voxels(
         cat_face_ijk.flatten(), voxel_size=cell_face_grid.get_voxel_size(), device=device
     )
+    cat_face_ijk.release()
+    cell_face_ijk.release()
+    additional_face_count.release()
 
     return face_grid
 
@@ -651,6 +658,7 @@ def _build_stacked_face_grid(cell_ijk, cell_level, grid: wp.Volume, temporary_st
     face_grid = wp.Volume.allocate_by_voxels(
         cell_faces.flatten(), voxel_size=grid.get_voxel_size()[0], device=cell_ijk.device
     )
+    cell_faces.release()
 
     return face_grid
 
@@ -668,6 +676,7 @@ def _build_stacked_edge_grid(cell_ijk, cell_level, grid: wp.Volume, temporary_st
     edge_grid = wp.Volume.allocate_by_voxels(
         cell_edges.flatten(), voxel_size=grid.get_voxel_size()[0], device=cell_ijk.device
     )
+    cell_edges.release()
 
     return edge_grid
 


### PR DESCRIPTION
**Context / Problem**

`fem.borrow_temporary()` gives back `warp.cache.Temporary` objects whose `array` attribute self-references the temporary. If we simply drop local references, the buffers keep a ref-cycle and only return to the pool when Python’s GC runs, contributing to situation like this issue in the related Newton repository newton-physics/newton#1042 

**Possible alternatives in my opinion**

1. **Wrap `temporary.array` in a `weakref.proxy`.**  
   - Pro: prevents the ref-cycle entirely; buffers go home as soon as user pointers die.  
   - Con: not backward compatible. Any code that stores `temp.array` or passes it to kernels now receives a proxy, so `wp.launch` can’t infer types (`weakref.ProxyType` shows up as the dtype).

2. **Patch `wp.array` itself (inside Warp) so `array` becomes a property and the temporary installs weakref-backed `release/detach`.**  
   - Pro: fixes the GC issue globally.  
   - Con: still changes the semantics of every `wp.array`: every array-like would be affected even if they never touch `fem.borrow_temporary`.

3. **Explicit release/detach in the whole codebase.**  
   - Keep the current `Temporary` API but audit the Warp library to release or detach buffers.  
   - Benefits: preserves user-facing semantics, keeps changes localized to Warp internals, and makes ownership obvious.  
   - Drawback: requires touching every call site that borrows or stores a temporary.

**Notes**

- Whenever we assign `self.attr = fem.borrow_temporary(...)`, in my changes the **old buffer is released first**.
Even in situation in which the temporary could be returned externally, e.g.:
```
    def fill_arg(self, args: Arg, device):
        args.cell_particle_offsets = self._cell_particle_offsets.to(device)
        args.cell_particle_indices = self._cell_particle_indices.to(device)
        args.particle_fraction = self._particle_fraction.to(device)
        args.particle_coords = self.particle_coords.to(device)
```

 Please correct me if this is not the expected behavior. 

**Still pending**

- Examples and any remaining `fem.integrate()` call sites outside the core solver still need to be changed. I'm going to do a follow-up commit to cover those.  
- Once that pass is done I’ll update this PR; for now the staged changes reflect the core library fixes that motivated the draft.

## Before your PR is "Ready for review"

- [X] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management throughout the finite element module by releasing temporary resources more promptly after use, reducing memory retention and preventing potential leaks during object lifecycle transitions.

* **Performance**
  * Enhanced resource efficiency by implementing systematic cleanup of intermediate computational data structures during rebuilds and operations, resulting in more deterministic memory deallocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->