### PR TITLE
Mesh BVH Ray Query Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   compilation time. Lower levels may improve compile times but reduce run-time performance. It can be configured
   globally, or per-module using `wp.set_module_options({"optimization_level": #})`. Currently it only has an effect
   on GPU modules and only when using CUDA Toolkit 12.9 or newer ([GH-1084](https://github.com/NVIDIA/warp/issues/1084)).
+- Add `wp.mesh_query_ray_anyhit` for ray any-hit queries ([GH-1097](https://github.com/NVIDIA/warp/issues/1097)).
+- Add support for group-aware construction and queries for `wp.Mesh` ([GH-1097](https://github.com/NVIDIA/warp/issues/1097)):
+  - New constructor argument: `groups` for per-face group IDs.
+  - New query overloads: `wp.mesh_query_ray()` and `wp.mesh_query_ray_anyhit()` now accept an optional `root` argument for group-restricted traversal.
+  - Add helper function `wp.mesh_get_group_root()` to retrieve the subtree root for a given group.
 
 ### Removed
 

--- a/docs/modules/functions.rst
+++ b/docs/modules/functions.rst
@@ -5659,6 +5659,22 @@ Geometry
     :param group: The group identifier
 
 
+.. py:function:: mesh_get_group_root(id: uint64, group: int32) -> int
+
+    .. hlist::
+       :columns: 8
+
+       * Kernel
+
+    Get the root of a group in a :class:`Mesh`.
+
+    Returns the root node index for the specified group. If the group does not exist, returns ``-1``
+    (sentinel for the mesh's global root). Pass ``-1`` to mesh queries to traverse from the global root.
+
+    :param id: The mesh identifier
+    :param group: The group identifier
+
+
 .. autoclass:: warp.MeshQueryPoint
    :exclude-members: Var, vars
 .. py:function:: mesh_query_point(id: uint64, point: vec3f, max_dist: float32) -> MeshQueryPoint
@@ -5760,7 +5776,7 @@ Geometry
 
 .. autoclass:: warp.MeshQueryRay
    :exclude-members: Var, vars
-.. py:function:: mesh_query_ray(id: uint64, start: vec3f, dir: vec3f, max_t: float32) -> MeshQueryRay
+.. py:function:: mesh_query_ray(id: uint64, start: vec3f, dir: vec3f, max_t: float32, root: int32) -> MeshQueryRay
 
     .. hlist::
        :columns: 8
@@ -5770,10 +5786,35 @@ Geometry
 
     Computes the closest ray hit on the :class:`Mesh` with identifier ``id``.
 
+    The ``root`` parameter can be obtained using the :func:`mesh_get_group_root` function when creating a grouped mesh.
+    When ``root`` is a valid (>=0) value, the traversal will be confined to the subtree starting from the root.
+    If ``root`` is -1 (default), traversal starts at the mesh's global root.
+
     :param id: The mesh identifier
     :param start: The start point of the ray
     :param dir: The ray direction (should be normalized)
     :param max_t: The maximum distance along the ray to check for intersections
+    :param root: The root node index for grouped BVH queries, or -1 for global root (optional, default: -1)
+
+
+.. py:function:: mesh_query_ray_anyhit(id: uint64, start: vec3f, dir: vec3f, max_t: float32, root: int32) -> bool
+
+    .. hlist::
+       :columns: 8
+
+       * Kernel
+
+    Returns ``True`` immediately upon the first ray hit on the :class:`Mesh` with identifier ``id``.
+
+    The ``root`` parameter can be obtained using the :func:`mesh_get_group_root` function when creating a grouped mesh.
+    When ``root`` is a valid (>=0) value, the traversal will be confined to the subtree starting from the root.
+    If ``root`` is -1 (default), traversal starts at the mesh's global root.
+
+    :param id: The mesh identifier
+    :param start: The start point of the ray
+    :param dir: The ray direction (should be normalized)
+    :param max_t: The maximum distance along the ray to check for intersections
+    :param root: The root node index for grouped BVH queries, or -1 for global root (optional, default: -1)
 
 
 .. autoclass:: warp.MeshQueryAABB

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -3610,6 +3610,18 @@ def bvh_get_group_root(id: uint64, group: int32) -> int:
     ...
 
 @over
+def mesh_get_group_root(id: uint64, group: int32) -> int:
+    """Get the root of a group in a :class:`Mesh`.
+
+    Returns the root node index for the specified group. If the group does not exist, returns ``-1``
+    (sentinel for the mesh's global root). Pass ``-1`` to mesh queries to traverse from the global root.
+
+    :param id: The mesh identifier
+    :param group: The group identifier
+    """
+    ...
+
+@over
 def mesh_query_point(id: uint64, point: vec3f, max_dist: float32) -> MeshQueryPoint:
     """Computes the closest point on the :class:`Mesh` with identifier ``id`` to the given ``point`` in space.
 
@@ -3684,13 +3696,34 @@ def mesh_query_point_sign_winding_number(
     ...
 
 @over
-def mesh_query_ray(id: uint64, start: vec3f, dir: vec3f, max_t: float32) -> MeshQueryRay:
+def mesh_query_ray(id: uint64, start: vec3f, dir: vec3f, max_t: float32, root: int32) -> MeshQueryRay:
     """Computes the closest ray hit on the :class:`Mesh` with identifier ``id``.
+
+    The ``root`` parameter can be obtained using the :func:`mesh_get_group_root` function when creating a grouped mesh.
+    When ``root`` is a valid (>=0) value, the traversal will be confined to the subtree starting from the root.
+    If ``root`` is -1 (default), traversal starts at the mesh's global root.
 
     :param id: The mesh identifier
     :param start: The start point of the ray
     :param dir: The ray direction (should be normalized)
     :param max_t: The maximum distance along the ray to check for intersections
+    :param root: The root node index for grouped BVH queries, or -1 for global root (optional, default: -1)
+    """
+    ...
+
+@over
+def mesh_query_ray_anyhit(id: uint64, start: vec3f, dir: vec3f, max_t: float32, root: int32) -> bool:
+    """Returns ``True`` immediately upon the first ray hit on the :class:`Mesh` with identifier ``id``.
+
+    The ``root`` parameter can be obtained using the :func:`mesh_get_group_root` function when creating a grouped mesh.
+    When ``root`` is a valid (>=0) value, the traversal will be confined to the subtree starting from the root.
+    If ``root`` is -1 (default), traversal starts at the mesh's global root.
+
+    :param id: The mesh identifier
+    :param start: The start point of the ray
+    :param dir: The ray direction (should be normalized)
+    :param max_t: The maximum distance along the ray to check for intersections
+    :param root: The root node index for grouped BVH queries, or -1 for global root (optional, default: -1)
     """
     ...
 

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -5639,6 +5639,22 @@ add_builtin(
 )
 
 add_builtin(
+    "mesh_get_group_root",
+    input_types={"id": uint64, "group": int},
+    value_type=int,
+    group="Geometry",
+    doc="""Get the root of a group in a :class:`Mesh`.
+
+    Returns the root node index for the specified group. If the group does not exist, returns ``-1``
+    (sentinel for the mesh's global root). Pass ``-1`` to mesh queries to traverse from the global root.
+
+    :param id: The mesh identifier
+    :param group: The group identifier""",
+    export=False,
+    is_differentiable=False,
+)
+
+add_builtin(
     "mesh_query_point",
     input_types={
         "id": uint64,
@@ -5924,15 +5940,23 @@ add_builtin(
         "sign": float,
         "normal": vec3,
         "face": int,
+        "root": int,
     },
+    defaults={"root": -1},
     value_type=builtins.bool,
     group="Geometry",
     doc="""Computes the closest ray hit on the :class:`Mesh` with identifier ``id``, returns ``True`` if a hit < ``max_t`` is found.
+
+    The ``root`` parameter can be obtained using the :func:`mesh_get_group_root` function when creating a grouped mesh.
+    When ``root`` is a valid (>=0) value, the traversal will be confined to the subtree starting from the root.
+    If ``root`` is -1 (default), traversal starts at the mesh's global root.
+    The query will only traverse down from that node, limiting traversal to that subtree.
 
     :param id: The mesh identifier
     :param start: The start point of the ray
     :param dir: The ray direction (should be normalized)
     :param max_t: The maximum distance along the ray to check for intersections
+    :param root: The root node index for grouped BVH queries, or -1 for global root
     :param t: Returns the distance of the closest hit along the ray
     :param bary_u: Returns the barycentric u coordinate of the closest hit
     :param bary_v: Returns the barycentric v coordinate of the closest hit
@@ -5950,17 +5974,51 @@ add_builtin(
         "start": vec3,
         "dir": vec3,
         "max_t": float,
+        "root": int,
     },
+    defaults={"root": -1},
     value_type=MeshQueryRay,
     group="Geometry",
     doc="""Computes the closest ray hit on the :class:`Mesh` with identifier ``id``.
 
+    The ``root`` parameter can be obtained using the :func:`mesh_get_group_root` function when creating a grouped mesh.
+    When ``root`` is a valid (>=0) value, the traversal will be confined to the subtree starting from the root.
+    If ``root`` is -1 (default), traversal starts at the mesh's global root.
+
     :param id: The mesh identifier
     :param start: The start point of the ray
     :param dir: The ray direction (should be normalized)
-    :param max_t: The maximum distance along the ray to check for intersections""",
+    :param max_t: The maximum distance along the ray to check for intersections
+    :param root: The root node index for grouped BVH queries, or -1 for global root (optional, default: -1)""",
     require_original_output_arg=True,
     export=False,
+)
+
+add_builtin(
+    "mesh_query_ray_anyhit",
+    input_types={
+        "id": uint64,
+        "start": vec3,
+        "dir": vec3,
+        "max_t": float,
+        "root": int,
+    },
+    defaults={"root": -1},
+    value_type=builtins.bool,
+    group="Geometry",
+    doc="""Returns ``True`` immediately upon the first ray hit on the :class:`Mesh` with identifier ``id``.
+
+    The ``root`` parameter can be obtained using the :func:`mesh_get_group_root` function when creating a grouped mesh.
+    When ``root`` is a valid (>=0) value, the traversal will be confined to the subtree starting from the root.
+    If ``root`` is -1 (default), traversal starts at the mesh's global root.
+
+    :param id: The mesh identifier
+    :param start: The start point of the ray
+    :param dir: The ray direction (should be normalized)
+    :param max_t: The maximum distance along the ray to check for intersections
+    :param root: The root node index for grouped BVH queries, or -1 for global root (optional, default: -1)""",
+    export=False,
+    is_differentiable=False,
 )
 
 add_builtin(

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -3991,6 +3991,7 @@ class Runtime:
                 ctypes.c_int,
                 ctypes.c_int,
                 ctypes.c_int,
+                ctypes.c_void_p,
                 ctypes.c_int,
             ]
 
@@ -4004,6 +4005,7 @@ class Runtime:
                 ctypes.c_int,
                 ctypes.c_int,
                 ctypes.c_int,
+                ctypes.c_void_p,
                 ctypes.c_int,
             ]
 

--- a/warp/native/mesh.cpp
+++ b/warp/native/mesh.cpp
@@ -134,6 +134,7 @@ uint64_t wp_mesh_create_host(
     int num_tris,
     int support_winding_number,
     int constructor_type,
+    int* groups,
     int bvh_leaf_size
 )
 {
@@ -162,7 +163,7 @@ uint64_t wp_mesh_create_host(
     }
     m->average_edge_length = sum / (num_tris * 3);
 
-    wp::bvh_create_host(m->lowers, m->uppers, num_tris, constructor_type, nullptr, bvh_leaf_size, m->bvh);
+    wp::bvh_create_host(m->lowers, m->uppers, num_tris, constructor_type, groups, bvh_leaf_size, m->bvh);
 
     if (support_winding_number) {
         // Let's first compute the sold
@@ -264,6 +265,7 @@ WP_API uint64_t wp_mesh_create_device(
     int num_tris,
     int support_winding_number,
     int constructor_type,
+    int* groups,
     int bvh_leaf_size
 )
 {

--- a/warp/native/mesh.cu
+++ b/warp/native/mesh.cu
@@ -258,6 +258,7 @@ uint64_t wp_mesh_create_device(
     int num_tris,
     int support_winding_number,
     int constructor_type,
+    int* groups,
     int bvh_leaf_size
 )
 {
@@ -303,7 +304,7 @@ uint64_t wp_mesh_create_device(
         (mesh.num_tris, mesh.points, mesh.indices, mesh.lowers, mesh.uppers)
     );
     wp::bvh_create_device(
-        mesh.context, mesh.lowers, mesh.uppers, num_tris, constructor_type, nullptr, bvh_leaf_size, mesh.bvh
+        mesh.context, mesh.lowers, mesh.uppers, num_tris, constructor_type, groups, bvh_leaf_size, mesh.bvh
     );
 
     // we need to overwrite mesh.bvh because it is not initialized when we construct it on device

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -99,6 +99,7 @@ WP_API uint64_t wp_mesh_create_host(
     int num_tris,
     int support_winding_number,
     int constructor_type,
+    int* groups,
     int bvh_leaf_size
 );
 WP_API void wp_mesh_destroy_host(uint64_t id);
@@ -113,6 +114,7 @@ WP_API uint64_t wp_mesh_create_device(
     int num_tris,
     int support_winding_number,
     int constructor_type,
+    int* groups,
     int bvh_leaf_size
 );
 WP_API void wp_mesh_destroy_device(uint64_t id);


### PR DESCRIPTION
## Description
This PR enhances support for specific mesh ray queries that improve performance in downstream rendering applications.

This PR includes:
- Introduce mesh_query_ray_anyhit which is a faster version of mesh_query_ray that can be used to calculate shadows in rendering applications. Shadow calculations only need to know if there exists any hit in the path of the ray.
- Adds groups to mesh API to make grouped mesh BVHs, useful for combining meshes especially for multi-world deformables

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mesh now accepts per-face group IDs; ray queries can be scoped to a group's subtree and an any-hit variant returns on first hit.
  * New helper to get a group's subtree root for scoped queries.

* **Documentation**
  * Docs updated with group/root traversal semantics and examples.

* **Tests**
  * Added tests and kernels validating grouped-mesh queries, any-hit behavior, and brute-force comparisons.

* **Chores**
  * Mesh creation and BVH construction accept and validate group data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->