### PR TITLE
example_tile_filtering.py is cuda-only

### DIFF
--- a/warp/tests/test_examples.py
+++ b/warp/tests/test_examples.py
@@ -435,7 +435,7 @@ add_example_test(
 add_example_test(
     TestTileExamples,
     name="tile.example_tile_filtering",
-    devices=test_devices,
+    devices=cuda_test_devices,
     test_options={"headless": True},
 )
 add_example_test(


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated example execution to operate within a device-scoped context.

* **Tests**
  * Modified example test configuration to run on GPU hardware targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->