### PR TITLE
Use centroids for SAH partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add more examples to `Tiles and SIMT code` documentation, demonstrating caveats when switching between the CPU and GPU and using `wp.tile()` ([GH-1042](https://github.com/NVIDIA/warp/issues/1042)).
 - Add support for `int64` and `uint64` key types to `wp.tile_sort()` ([GH-1089](https://github.com/NVIDIA/warp/issues/1089)).
 - Add `wp.tile_scan_max_inclusive()` and `wp.tile_scan_min_inclusive()` for cumulative maximum and minimum operations across tiles ([GH-1090](https://github.com/NVIDIA/warp/issues/1090)).
+- Changed BVH SAH constructor to use centroids instead of bounds to determine partition axis, improving build quality and traversal performance in some scenarios ([GH-1102](https://github.com/NVIDIA/warp/issues/1102)).
 
 ### Removed
 

--- a/warp/native/bvh.cpp
+++ b/warp/native/bvh.cpp
@@ -392,15 +392,20 @@ float TopDownBVHBuilder::partition_sah_indices(const vec3* lowers, const vec3* u
     assert(end - start >= 2);
 
     int n = end - start;
-    vec3 edges = range_bounds.edges();
 
-    bounds3 b = calc_bounds(lowers, uppers, indices, start, end);
-
+    bounds3 centroid_bounds;
+    for (int i = start; i < end; ++i)
+    {
+        vec3 item_center = 0.5f * (lowers[indices[i]] + uppers[indices[i]]);
+        centroid_bounds.add_point(item_center);
+    }
+    vec3 edges = centroid_bounds.edges();
+    
     split_axis = longest_axis(edges);
 
     // compute each bucket
-    float range_start = b.lower[split_axis];
-    float range_end = b.upper[split_axis];
+    float range_start = centroid_bounds.lower[split_axis];
+    float range_end = centroid_bounds.upper[split_axis];
 
     // Guard against zero extent along the split axis to avoid division-by-zero
     if (range_end <= range_start)


### PR DESCRIPTION
This PR improves the quality of SAH BVH builds by using centroids rather than the full bounds when deciding which axis to split along. Elongated bounds can bias the axis choice, using centroids avoid this.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * BVH partitioning now selects split axis using object centroids instead of bounds, yielding improved build quality and traversal performance in some scenarios.
  * Added a guard to robustly handle degenerate/zero-range partition cases and avoid invalid split points.

* **Documentation**
  * Changelog updated to note the behavioral change in BVH SAH partitioning (no public API signature change).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->