### PR TITLE
Fix SAH CPU Build Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 
 - Fix atomic floating-point min/max operations not returning the old value
   ([GH-1058](https://github.com/NVIDIA/warp/issues/1058)).
+- Fix a bug in CPU BVH construction when using groups for heterogenous edge cases where some groups have <= leaf size primitives ([GH-1111](https://github.com/NVIDIA/warp/issues/1111)).
 
 ## [1.10.1] - 2025-12-01
 


### PR DESCRIPTION
## Description
As identified by #1111, there is a bug in the CPU BVH build when using groups for the specific edge case that one of the groups has <= leaf_size primitives, but the other groups do not. This causes that leaf to be built in-place, and violate the assumption of ascending order of group ids that are being built for the other groups. This PR fixes this bug and adds a test to catch bugs of this nature.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `functions.rst`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPU BVH construction for cases with heterogeneous groups where some groups contain very few primitives, ensuring correct group ordering and stable construction.

* **Tests**
  * Added test coverage validating BVH behavior with heterogeneous and sparse group configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->