### PR TITLE
fix debugging docs on disabling kernel caching

### DIFF
--- a/docs/user_guide/debugging.rst
+++ b/docs/user_guide/debugging.rst
@@ -114,7 +114,7 @@ Step-Through Debugging
 
 It is possible to attach IDE debuggers such as Visual Studio to Warp processes to step through generated kernel code.
 Users should first compile the kernels in debug mode by setting::
-   
+
     wp.config.mode = "debug"
 
 This setting ensures that line numbers, and debug symbols are generated correctly. After launching the Python process,
@@ -170,9 +170,9 @@ for each module that was compiled at runtime.
 The name of each folder ends with a hexadecimal hash constructed from the module contents to avoid potential
 conflicts when using multiple processes and to support the caching of runtime-defined kernels.
 
-If an bug with Warp's kernel caching logic is suspected, kernel caching can be disabled by setting::
+If a bug with Warp's kernel caching logic is suspected, kernel caching can be disabled by setting::
 
-    wp.config.cache_kernels = True
+    wp.config.cache_kernels = False
 
 CUDA Error Verification
 -----------------------


### PR DESCRIPTION
## Description
Fix debugging documentation on kernel caching.

<img width="725" height="160" alt="image" src="https://github.com/user-attachments/assets/a034742b-4ffe-4432-a413-7056b6ff1990" />

## Before your PR is "Ready for review"

- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [ ] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected grammar in the debugging guide.
  * Updated kernel cache configuration docs to show the default as disabled.
  * Applied the cache-default update consistently across generated-code examples.
  * Minor whitespace/formatting improvements in the Step-Through Debugging section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->