### PR TITLE
Support @property getters for warp.struct

### DIFF
--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -460,6 +460,7 @@ class Struct:
         self.cls = cls
         self.module = module
         self.vars: dict[str, Var] = {}
+        self.properties: dict[str, warp._src.context.Function] = {}
 
         if isinstance(self.cls, Sequence):
             raise RuntimeError("Warp structs must be defined as base classes")
@@ -482,6 +483,12 @@ class Struct:
                     warp.init()
                 fields.append((label, var.type._type_))
 
+        # Collect properties, but postpone Function creation until after native_name is set
+        property_members = []
+        for name, item in inspect.getmembers(self.cls):
+            if isinstance(item, property):
+                property_members.append((name, item))
+
         class StructType(ctypes.Structure):
             # if struct is empty, add a dummy field to avoid launch errors on CPU device ("ffi_prep_cif failed")
             _fields_ = fields or [("_dummy_", ctypes.c_byte)]
@@ -502,11 +509,50 @@ class Struct:
             if isinstance(type_hint, Struct):
                 ch.update(type_hint.hash)
 
-        self.hash = ch.digest()
+        # Hash property names (to ensure layout/identity stability if names change)
+        for name, _ in property_members:
+            ch.update(bytes(name, "utf-8"))
 
+        self.hash = ch.digest()
         # generate unique identifier for structs in native code
         hash_suffix = f"{self.hash.hex()[:8]}"
         self.native_name = f"{self.key}_{hash_suffix}"
+
+        # Extract properties and create Functions
+        # self.native_name is now defined, so Function() can resolve 'self' type code.
+        for name, item in property_members:
+            # We currently support only getters
+            if item.fset is not None:
+                raise TypeError("Struct properties with setters are not supported")
+            if item.fdel is not None:
+                raise TypeError("Struct properties with deleters are not supported")
+            getter = item.fget
+            # We need to add 'self' as the first argument, with the type of the struct itself.
+            # This allows overload resolution to match the struct instance to the 'self' argument.
+            if not hasattr(getter, "__annotations__"):
+                getter.__annotations__ = {}
+
+            # Find the name of the first argument (conventionally 'self')
+            argspec = get_full_arg_spec(getter)
+            if len(argspec.args) > 0:
+                self_arg = argspec.args[0]
+                getter.__annotations__[self_arg] = self
+
+            # Create the Warp Function.
+            # We pass 'func=getter' so that input_types and return_types are inferred.
+            # We set 'namespace=""' and a unique 'native_func' to generate a free function
+            # in C++ that takes the struct as the first argument (e.g., StructName_propName(struct_inst)).
+            p_func = warp._src.context.Function(
+                func=getter,
+                key=f"{self.key}.{name}",
+                namespace="",
+                module=module,
+            )
+
+            # Ensure the C++ function name is unique and predictable
+            p_func.native_func = f"{self.native_name}_{name}"
+
+            self.properties[name] = p_func
 
         # create default constructor (zero-initialize)
         self.default_constructor = warp._src.context.Function(
@@ -2259,6 +2305,11 @@ class Adjoint:
                     return adj.add_builtin_call("transform_get_translation", [aggregate])
                 else:
                     return adj.add_builtin_call("transform_get_rotation", [aggregate])
+
+            elif isinstance(aggregate_type, Struct) and node.attr in aggregate_type.properties:
+                # property access
+                prop = aggregate_type.properties[node.attr]
+                return adj.add_call(prop, (aggregate,), {}, {})
 
             else:
                 attr_var = aggregate_type.vars[node.attr]

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -531,18 +531,16 @@ class Struct:
             getter = item.fget
             # We need to add 'self' as the first argument, with the type of the struct itself.
             # This allows overload resolution to match the struct instance to the 'self' argument.
-            # Copy annotations to avoid mutating the original function
-            annotations = dict(getattr(getter, "__annotations__", {}))
-
+            if not hasattr(getter, "__annotations__"):
+                getter.__annotations__ = {}
 
             # Find the name of the first argument (conventionally 'self')
             argspec = get_full_arg_spec(getter)
-            
+
             if len(argspec.args) == 0:
                 raise TypeError(f"Struct property '{name}' must have at least one argument (self)")
             self_arg = argspec.args[0]
-            annotations[self_arg] = self
-            getter.__annotations__ = annotations
+            getter.__annotations__[self_arg] = self
 
             # Create the Warp Function.
             # We pass 'func=getter' so that input_types and return_types are inferred.


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description

Add support for `@property` in `warp.struct`.
Allows user to define property getters in the warp.struct. The properties are converted into warp functions at the codegen step.

Closes #1152 

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only properties on structs can be defined and accessed as first-class members; struct metadata now exposes property functions.

* **Bug Fixes / Behavior**
  * Struct attribute reads dispatch to property implementations instead of direct field access.
  * Setters/deleters for struct properties are disallowed and will raise an error.

* **Tests**
  * Added tests validating property reads on structs and rejecting property setters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->