### PR TITLE
Reduce CPU launch overhead

### DIFF
--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -796,6 +796,9 @@ class Kernel:
         # flag indicating if this kernel belongs to a unique module (set by @wp.kernel decorator)
         self.is_unique_module = False
 
+        # cache for invoke() struct types (avoids dynamic type() calls)
+        self._invoke_cache = {}
+
         if self.module:
             self.module.register_kernel(self)
 
@@ -6618,8 +6621,33 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
 
 # invoke a CPU kernel by passing the parameters as a ctypes structure
 def invoke(kernel, hooks, params: Sequence[Any], adjoint: bool):
-    fields = []
+    # Build cache key from parameter types
+    param_types = tuple(type(p) for p in params[1:])  # skip launch bounds
+    cache_key = (param_types, adjoint)
 
+    cached = kernel._invoke_cache.get(cache_key)
+    if cached is not None:
+        # Fast path: use cached struct types
+        if adjoint:
+            ArgsStruct, AdjArgsStruct, fields, adj_fields = cached
+        else:
+            ArgsStruct, fields = cached
+
+        args = ArgsStruct()
+        for i, field in enumerate(fields):
+            setattr(args, field[0], params[1 + i])
+
+        if not adjoint:
+            hooks.forward(params[0], ctypes.byref(args))
+        else:
+            adj_args = AdjArgsStruct()
+            for i, field in enumerate(adj_fields):
+                setattr(adj_args, field[0], params[1 + len(fields) + i])
+            hooks.backward(params[0], ctypes.byref(args), ctypes.byref(adj_args))
+        return
+
+    # Slow path: build struct types and cache them
+    fields = []
     for i in range(0, len(kernel.adj.args)):
         arg_name = kernel.adj.args[i].label
         field = (arg_name, type(params[1 + i]))  # skip the first argument, which is the launch bounds
@@ -6633,6 +6661,7 @@ def invoke(kernel, hooks, params: Sequence[Any], adjoint: bool):
         setattr(args, name, params[1 + i])
 
     if not adjoint:
+        kernel._invoke_cache[cache_key] = (ArgsStruct, fields)
         hooks.forward(params[0], ctypes.byref(args))
 
     # for adjoint kernels the adjoint arguments are passed through a second struct
@@ -6651,6 +6680,7 @@ def invoke(kernel, hooks, params: Sequence[Any], adjoint: bool):
             name = field[0]
             setattr(adj_args, name, params[1 + len(fields) + i])
 
+        kernel._invoke_cache[cache_key] = (ArgsStruct, AdjArgsStruct, fields, adj_fields)
         hooks.backward(params[0], ctypes.byref(args), ctypes.byref(adj_args))
 
 

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -2470,6 +2470,8 @@ def scalars_equal(a, b):
 
 def types_equal(a, b):
     """Return ``True`` if two Warp types are equal."""
+    if a is b:
+        return True
     return types_equal_generic(a, b, match_generic=False)
 
 


### PR DESCRIPTION
# Reduce CPU kernel launch overhead

CPU runtime for small to medium-sized workloads is currently dominated by `wp.launch()` overhead.
This PR reduces the overhead of `wp.launch()` on CPU by ~65-85%.

## Changes

### 1. Cache `invoke()` struct types on Kernel object
**File:** `warp/_src/context.py`

The `invoke()` function dynamically creates ctypes struct classes using `type()` on every call (~6 µs). This PR caches the struct types in `Kernel._invoke_cache`, keyed by `(param_types, adjoint)`.

### 2. Fast path for `types_equal()`
**File:** `warp/_src/types.py`

Added identity check `if a is b: return True` at the top of `types_equal()`. This avoids expensive comparisons when comparing identical type objects (common case for dtype checks).

## Benchmark

```python
@wp.kernel
def add_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float), c: wp.array(dtype=float)):
    i = wp.tid()
    c[i] = a[i] + b[i]

wp.launch(add_kernel, dim=1, inputs=[a, b, c], device="cpu")
```

**Results (Apple Silicon, CPU — median of 5 runs, 20k iterations each):**

| dim | Before |  After | Before (+record_cmd) |After (+record_cmd) | Speedup |
|------:|-------:|-------:|------:|------:|------:|
| 1 | 11.00 µs |  3.81 µs | 6.73 µs | 1.02 µs | 85% |
| 10 | 11.07 µs | 3.86 µs | 6.80 µs | 1.06 µs | 84% |
| 100 | 11.31 µs | 4.01 µs | 6.99 µs | 1.16 µs | 83% |
| 1,000 | 12.72 µs | 5.37 µs | 8.27 µs | 2.44 µs | 70% |
| 10,000 | 26.35 µs | 18.52 µs | 21.73 µs | 15.29 µs | 30% |
| 100,000 | 156.43 µs | 147.70 µs | 150.73 µs | 142.34 µs | 6% |

- **Before/After**: Standard `wp.launch()` overhead
- **Before/After (+record_cmd)**: Using `wp.launch(..., record_cmd=True)` + `cmd.launch()` for replay

The invoke caching optimization benefits both paths:
- `wp.launch()`: 11.00 → 3.81 µs (~65% faster)
- `record_cmd`: 6.73 → 1.02 µs (~85% faster)

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Kernel launches on CPU are faster on repeated calls by caching and reusing argument structures after the first invocation.
  * Type comparisons are quicker with a new fast-path that immediately succeeds when two references are identical.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->