### PR TITLE
Fix @wp.func type inference for Pyright/Pylance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixed
 
+- Fix `@wp.func` decorated functions showing generic `_Wrapped` types in Pyright/Pylance instead of their actual
+  signatures on Python 3.10+ ([GH-1163](https://github.com/NVIDIA/warp/issues/1163)).
 - Fix `--llvm-path` build option to use existing LLVM installation when building `warp-clang` library instead of
   downloading from packman.
 - Fix excessive memory usage in CUDA graphs with multiple allocations/deallocations

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -46,6 +46,17 @@ from typing import (
     get_args,
     get_origin,
 )
+from typing import (
+    overload as typing_overload,
+)
+
+try:
+    from typing import ParamSpec
+except ImportError:
+    # Python 3.9 - ParamSpec not available, use TypeVar as fallback
+    def ParamSpec(name):
+        return TypeVar(name)
+
 
 import numpy as np
 
@@ -857,8 +868,31 @@ class Kernel:
 
 # ----------------------
 
+# Type variables for the @func decorator overloads below.
+# Using ParamSpec preserves the decorated function's signature for static type checkers,
+# so IDEs show the original parameters instead of generic (*args, **kwargs).
+# Note: ParamSpec requires Python 3.10+; on 3.9 this falls back to TypeVar.
+_FuncParams = ParamSpec("_FuncParams")
+_FuncReturn = TypeVar("_FuncReturn")
 
-# decorator to register function, @func
+
+@typing_overload
+def func(f: Callable[_FuncParams, _FuncReturn]) -> Callable[_FuncParams, _FuncReturn]:
+    """Register a Warp function (bare decorator: ``@wp.func``)."""
+    ...
+
+
+@typing_overload
+def func(
+    f: None = None,
+    *,
+    name: str | None = None,
+    module: Module | Literal["unique"] | str | None = None,
+) -> Callable[[Callable[_FuncParams, _FuncReturn]], Callable[_FuncParams, _FuncReturn]]:
+    """Register a Warp function (decorator with arguments: ``@wp.func(...)``)."""
+    ...
+
+
 def func(
     f: Callable | None = None,
     *,


### PR DESCRIPTION
## Description

Fixes #1163

Functions decorated with `@wp.func` were showing generic `_Wrapped[..., Unknown, ...]` types in static type checkers (Pyright, Pylance) instead of their actual signatures. This broke IDE autocompletion and hover information for some `@wp.func` decorated functions (`@wp.func` in the same file seemed to be okay).

## Changes

- Add `@overload` signatures with `ParamSpec` to the `func` decorator in `warp/_src/context.py`
- Add unit tests to verify the fix without requiring Pyright installation

## Before

Hovering over `@wp.func` decorated functions in VS Code/Cursor shows:

```
Type of "bsr_row_index" is "((f: Unknown, ...) -> _Wrapped[..., Unknown, ..., Unknown]) | _Wrapped[..., Unknown, ..., Unknown]"
```

## After

```
Type of "bsr_row_index" is "(offsets: array[int], row_count: int, block_index: int) -> int"
```

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decorated function signatures so type checkers and IDEs display accurate parameter lists and return types on Python 3.10+.

* **Tests**
  * Added tests to verify overloads, signature preservation, and runtime reflection on decorated functions.

* **Documentation**
  * Updated changelog to document the signature/display fix for Python 3.10+.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->