### PR TITLE
Simplify Python setup with uv and add pyright stub validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,7 @@ jobs:
           version: "0.8.23"
       
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: '.python-version'
+        run: uv python install
       
       - name: Cache build artifacts
         if: matrix.platform != 'macos'
@@ -137,9 +135,7 @@ jobs:
           version: "0.8.23"
       
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: '.python-version'
+        run: uv python install
       
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
@@ -192,9 +188,7 @@ jobs:
           version: "0.8.23"
       
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: '.python-version'
+        run: uv python install
       
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
@@ -225,9 +219,7 @@ jobs:
         with:
           version: "0.8.23"
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: '.python-version'
+        run: uv python install
       - name: Download Warp binaries
         uses: actions/download-artifact@v4
         with:
@@ -281,9 +273,7 @@ jobs:
         with:
           version: "0.8.23"
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: '.python-version'
+        run: uv python install
       - name: Download native headers
         uses: actions/download-artifact@v4
         with:
@@ -337,3 +327,20 @@ jobs:
           fi
 
           echo "SUCCESS: All symbols are correctly namespaced."
+
+  # Validate that the type stub file (warp/__init__.pyi) passes pyright's type checking.
+  # TODO: Remove continue-on-error once existing pyright issues are resolved.
+  pyright-stubs:
+    runs-on: ubuntu-latest
+    continue-on-error: true  # Allow failures until existing issues are fixed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86
+        with:
+          version: "0.8.23"
+      - name: Set up Python
+        run: uv python install
+      - name: Run pyright on stub file
+        run: uvx pyright warp/__init__.pyi

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -37,9 +37,7 @@ jobs:
         with:
           version: "0.8.23"
       - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: '.python-version'
+        run: uv python install
       - name: Build Warp without CUDA Support
         run: |
           uv run build_lib.py


### PR DESCRIPTION
- Replace actions/setup-python with `uv python install` across workflows
- Add pyright-stubs job to validate warp/__init__.pyi (continue-on-error for now)

<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Add a job for pyright checking of the stubs file.

Remove the use of `setup-python` action in favor of `uv python install`.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use `uv` for Python installation instead of the standard setup action.
  * Added type checking job for stub file validation in the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->