### PR TITLE
Fix wp.static() capturing global variables instead of loop variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 - Fix `@wp.func` decorated functions showing generic `_Wrapped` types in Pyright/Pylance instead of their actual
   signatures on Python 3.10+ ([GH-1163](https://github.com/NVIDIA/warp/issues/1163)).
+- Fix `wp.static()` incorrectly capturing global Python variables instead of loop variables when used inside for-loops
+  in kernels ([GH-1139](https://github.com/NVIDIA/warp/issues/1139)).
 - Fix `--llvm-path` build option to use existing LLVM installation when building `warp-clang` library instead of
   downloading from packman.
 - Fix excessive memory usage in CUDA graphs with multiple allocations/deallocations


### PR DESCRIPTION
When a global Python variable had the same name as a kernel for-loop variable, wp.static() incorrectly used the global value. The fix tracks loop variables during AST traversal and defers wp.static() evaluation when the expression references a loop variable.

Fixes GH-1139

<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/modules/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * wp.static() no longer captures global variables instead of loop variables; loop-local variables in for-loops are now respected, including in nested and shadowed cases.

* **Tests**
  * Added tests validating wp.static() with simple loops, expressions, nested loops, and reused loop-variable names to ensure correct behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->