### PR TITLE
Fix bsr_get_diag zero fill for missing blocks

### DIFF
--- a/warp/_src/sparse.py
+++ b/warp/_src/sparse.py
@@ -1261,6 +1261,7 @@ def bsr_get_diag(A: BsrMatrixOrExpression[BlockType], out: Array[BlockType] | No
             raise ValueError(f"Output array must reside on device {A.values.device}, got {out.device}")
         if out.shape[0] < dim:
             raise ValueError(f"Output array must be of length at least {dim}, got {out.shape[0]}")
+        out.zero_()
 
     wp.launch(
         kernel=_bsr_get_diag_kernel,

--- a/warp/tests/test_sparse.py
+++ b/warp/tests/test_sparse.py
@@ -241,6 +241,11 @@ def test_bsr_get_set_diag(test, device):
     assert_np_equal(diag_np[2], vals_np[4], tol=0.00001)
     assert_np_equal(diag_np[3], vals_np[3], tol=0.00001)
 
+    # Passing out should produce the same result as allocating internally.
+    sentinel = wp.full(shape=(nrow,), value=bsr.values.dtype(7.0), dtype=bsr.values.dtype, device=device)
+    bsr_get_diag(bsr, out=sentinel)
+    assert_np_equal(diag_np, sentinel.numpy(), tol=0.00001)
+
     # Test set_diag/get_diag round-trips with various block types
 
     # Array of blocks


### PR DESCRIPTION
## Description
To my understanding, `bsr_get_diag` should produce the same result whether or not an `out` array is provided. Previously, when `out` was passed, it was not zero-initialized, causing missing diagonal blocks to retain whatever values were already in `out` instead of being set to 0.0. This PR fixes that and adds a regression test.

## Before your PR is "Ready for review"

- [X] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [X] Necessary tests have been added
- [X] Documentation is up-to-date
- [X] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [X] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `bsr_get_diag()` to properly initialize output buffers when provided by users, ensuring correct results when writing diagonal blocks to an external buffer.

* **Tests**
  * Added test coverage validating output buffer behavior for the diagonal extraction function.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->