### PR TITLE
Fix MJX-Warp FFI Multi-GPU Deadlock

### DIFF
--- a/warp/_src/jax_experimental/ffi.py
+++ b/warp/_src/jax_experimental/ffi.py
@@ -681,11 +681,13 @@ class FfiCallable:
 
                 cuda_stream = get_stream_from_callframe(call_frame.contents)
 
+                device_ordinal = get_device_ordinal_from_callframe(call_frame.contents)
+
                 if self.graph_mode == GraphMode.WARP:
                     # check if we already captured an identical call
                     ip = [inputs[i].contents.data for i in self.array_input_indices]
                     op = [outputs[i].contents.data for i in self.array_output_indices]
-                    capture_key = hash((call_id, *ip, *op))
+                    capture_key = hash((device_ordinal, call_id, *ip, *op))
                     capture = self.captures.get(capture_key)
 
                     # launch existing graph


### PR DESCRIPTION
Problem
In multi-GPU environments using jax.pmap, identical virtual addresses can be assigned to buffers on different devices. The MJX-Warp FFI graph cache used:

capture_key = hash((call_id, *buffer_pointers))
This led to cache collisions where a CUDA graph captured on one device was incorrectly retrieved and launched on another device, causing silent deadlocks after ~10M training steps.

Root Cause
Memory addresses are only unique per-device, not globally:

Device 0 allocates buffer at 0x7f1234567890
Device 1 allocates different buffer at same virtual address 0x7f1234567890
Both hash to identical cache key → cross-device graph launch → deadlock
Solution
Include device_ordinal in the cache key hash:

device_ordinal = get_device_ordinal_from_callframe(call_frame.contents)
capture_key = hash((device_ordinal, call_id, *buffer_pointers))
This ensures CUDA graphs are cached uniquely per device, preventing cross-device launch conflicts.

Changes
File: 
warp/_src/jax_experimental/ffi.py

Line 684 - Added: Extract device ordinal from call frame
Line 690 - Modified: Include device_ordinal in cache key hash


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CUDA GPU graph capture now differentiates captures by device, preventing cross-device cache mix-ups and improving correctness and reuse when running on multiple GPUs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->