### PR TITLE
Fix verbose flag in `capture_debug_dot_print` function

### DIFF
--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -7827,7 +7827,7 @@ def capture_end(device: DeviceLike = None, stream: Stream | None = None) -> Grap
     return graph
 
 
-def capture_debug_dot_print(graph: Graph, path: str, verbose: bool = False):
+def capture_debug_dot_print(graph: Graph, path: str, verbose: bool = True):
     """Export a CUDA graph to a DOT file for visualization
 
     Args:
@@ -7835,7 +7835,7 @@ def capture_debug_dot_print(graph: Graph, path: str, verbose: bool = False):
         path: Path to save the DOT file
         verbose: Whether to include additional debug information in the output
     """
-    if not runtime.core.wp_capture_debug_dot_print(graph.graph, path.encode(), 0 if verbose else 1):
+    if not runtime.core.wp_capture_debug_dot_print(graph.graph, path.encode(), 1 if verbose else 0):
         raise RuntimeError(f"Graph debug dot print error: {runtime.get_error_string()}")
 
 


### PR DESCRIPTION
<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/user_guide/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

Correct verbose flag in `capture_debug_dot_print` function. Default value of `verbose` is changed to keep the default behavior consistent.

## Before your PR is "Ready for review"

- [x] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [ ] Necessary tests have been added
- [x] Documentation is up-to-date
- [x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`