### PR TITLE
Updated OpenGL rendering example to remove the distutils import

### DIFF
--- a/warp/examples/core/example_render_opengl.py
+++ b/warp/examples/core/example_render_opengl.py
@@ -441,28 +441,27 @@ class Example:
 
 if __name__ == "__main__":
     import argparse
-    import distutils.util
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--device", type=str, default=None, help="Override the default Warp device.")
     parser.add_argument("--num_tiles", type=int, default=4, help="Number of viewports to render in a single frame.")
     parser.add_argument(
         "--show_plot",
-        type=lambda x: bool(distutils.util.strtobool(x.strip())),
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Display the pixels in an additional matplotlib figure.",
     )
     parser.add_argument("--render_mode", type=str, choices=("depth", "rgb"), default="depth", help="")
     parser.add_argument(
         "--split_up_tiles",
-        type=lambda x: bool(distutils.util.strtobool(x.strip())),
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Whether to split tiles into subplots when --show_plot is True.",
     )
     parser.add_argument("--custom_tile_arrangement", action="store_true", help="Apply custom tile arrangement.")
     parser.add_argument(
         "--use_imgui",
-        type=lambda x: bool(distutils.util.strtobool(x.strip())),
+        action=argparse.BooleanOptionalAction,
         default=True,
         help="Enable or disable the ImGui window.",
     )


### PR DESCRIPTION
Updated OpenGL rendering example to remove the distutils import and replace the functionality with the BooleanOptionalAction.

Closes #1204 

<!--
Thank you for contributing to NVIDIA Warp!

See the contribution guide: https://nvidia.github.io/warp/user_guide/contribution_guide.html

Please fill the relevant sections.

Checkboxes can also be marked after you submit the PR.
-->

## Description
<!--
Please add a description of what this PR aims to accomplish. 
Existing issues may be reference using a special keyword, e.g. Closes #10
Include any limitations or non-handled areas in the changes.
-->

## Before your PR is "Ready for review"

- [x ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x ] Necessary tests have been added
- [ x] Documentation is up-to-date
- [ x] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [ x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command-line boolean flags for show_plot, split_up_tiles, and use_imgui now support both positive and negative forms (e.g., --flag and --no-flag), making CLI usage more consistent and user-friendly while preserving existing defaults and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->