### PR TITLE
Fix: Gradients don't propagate through array of structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
   ([GH-1211](https://github.com/NVIDIA/warp/issues/1211)).
 - Fix `@wp.func` losing parameter type information in Pyright/Pylance
   ([GH-1219](https://github.com/NVIDIA/warp/issues/1219)).
+- Fix gradients not propagating through array-of-structs ([GH-1207](https://github.com/NVIDIA/warp/pull/1207)).
 - Fix crashes caused by C++ standard library mismatch on Linux.
 
 ### Documentation

--- a/warp/tests/test_grad_struct_array.py
+++ b/warp/tests/test_grad_struct_array.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import numpy as np
+
+import warp as wp
+from warp.tests.unittest_utils import *
+
+# Test for issue #1174: Gradients not propagating through array of structs
+
+
+# Scalar struct
+@wp.struct
+class ScalarStruct:
+    a: wp.float32
+
+
+# Vec3 struct
+@wp.struct
+class Vec3Struct:
+    v: wp.vec3
+
+
+# Mat22 struct
+@wp.struct
+class Mat22Struct:
+    m: wp.mat22
+
+
+# ===== Scalar Tests =====
+@wp.kernel
+def pack_scalar_struct_kernel(x: wp.array(dtype=wp.float32), y: wp.array(dtype=ScalarStruct)):
+    i = wp.tid()
+    y[i].a = x[i]
+
+
+@wp.kernel
+def loss_from_scalar_struct_kernel(y: wp.array(dtype=ScalarStruct), loss: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    wp.atomic_add(loss, 0, y[i].a)
+
+
+def test_struct_array_gradient_propagation_scalar(_test, device):
+    """Test scalar field gradient propagation with multiple threads (issue #1174)"""
+    with wp.ScopedDevice(device):
+        n = 10
+        x = wp.ones(n, dtype=wp.float32, requires_grad=True)
+        y = wp.zeros(n, dtype=ScalarStruct, requires_grad=True)
+        loss = wp.zeros(1, dtype=wp.float32, requires_grad=True)
+
+        tape = wp.Tape()
+        with tape:
+            wp.launch(kernel=pack_scalar_struct_kernel, dim=n, inputs=[x], outputs=[y])
+            wp.launch(kernel=loss_from_scalar_struct_kernel, dim=n, inputs=[y], outputs=[loss])
+
+        tape.backward(loss=loss)
+
+        # Check that gradients propagate correctly
+        # Each element contributes 1.0 to the loss via atomic_add
+        for i in range(n):
+            assert_np_equal(y.grad.numpy()[i][0], 1.0, tol=1e-5)
+            assert_np_equal(x.grad.numpy()[i], 1.0, tol=1e-5)
+
+
+# ===== Vec3 Tests =====
+@wp.kernel
+def pack_vec3_struct_kernel(x: wp.array(dtype=wp.vec3), y: wp.array(dtype=Vec3Struct)):
+    i = wp.tid()
+    y[i].v = x[i]
+
+
+@wp.kernel
+def loss_from_vec3_struct_kernel(y: wp.array(dtype=Vec3Struct), loss: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    wp.atomic_add(loss, 0, wp.length(y[i].v))
+
+
+def test_struct_array_gradient_propagation_vec3(_test, device):
+    """Test vec3 field gradient propagation with multiple threads (issue #1174)"""
+    with wp.ScopedDevice(device):
+        n = 5
+        x = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3, device=device, requires_grad=True)
+        y = wp.zeros(n, dtype=Vec3Struct, requires_grad=True, device=device)
+        loss = wp.zeros(1, dtype=wp.float32, requires_grad=True, device=device)
+
+        tape = wp.Tape()
+        with tape:
+            wp.launch(kernel=pack_vec3_struct_kernel, dim=n, inputs=[x], outputs=[y], device=device)
+            wp.launch(kernel=loss_from_vec3_struct_kernel, dim=n, inputs=[y], outputs=[loss], device=device)
+
+        tape.backward(loss=loss)
+
+        # Gradient should flow back through struct to x
+        assert x.grad is not None
+        # Non-zero gradients confirm the chain is connected
+        assert np.any(np.abs(x.grad.numpy()) > 1e-6)
+
+
+# ===== Mat22 Tests =====
+@wp.kernel
+def pack_mat22_struct_kernel(x: wp.array(dtype=wp.mat22), y: wp.array(dtype=Mat22Struct)):
+    i = wp.tid()
+    y[i].m = x[i]
+
+
+@wp.kernel
+def loss_from_mat22_struct_kernel(y: wp.array(dtype=Mat22Struct), loss: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    wp.atomic_add(loss, 0, wp.determinant(y[i].m))
+
+
+def test_struct_array_gradient_propagation_mat22(_test, device):
+    """Test mat22 field gradient propagation with multiple threads (issue #1174)"""
+    with wp.ScopedDevice(device):
+        n = 3
+        # Create identity matrices
+        identity = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+        matrices = np.tile(identity, (n, 1, 1))
+
+        x = wp.array(matrices, dtype=wp.mat22, device=device, requires_grad=True)
+        y = wp.zeros(n, dtype=Mat22Struct, requires_grad=True, device=device)
+        loss = wp.zeros(1, dtype=wp.float32, requires_grad=True, device=device)
+
+        tape = wp.Tape()
+        with tape:
+            wp.launch(kernel=pack_mat22_struct_kernel, dim=n, inputs=[x], outputs=[y], device=device)
+            wp.launch(kernel=loss_from_mat22_struct_kernel, dim=n, inputs=[y], outputs=[loss], device=device)
+
+        tape.backward(loss=loss)
+
+        # Gradient should flow back through struct to x
+        assert x.grad is not None
+        # Non-zero gradients confirm the chain is connected
+        assert np.any(np.abs(x.grad.numpy()) > 1e-6)
+
+
+devices = get_test_devices()
+
+
+class TestGradStructArray(unittest.TestCase):
+    pass
+
+
+add_function_test(
+    TestGradStructArray,
+    "test_struct_array_gradient_propagation_scalar",
+    test_struct_array_gradient_propagation_scalar,
+    devices=devices,
+)
+add_function_test(
+    TestGradStructArray,
+    "test_struct_array_gradient_propagation_vec3",
+    test_struct_array_gradient_propagation_vec3,
+    devices=devices,
+)
+add_function_test(
+    TestGradStructArray,
+    "test_struct_array_gradient_propagation_mat22",
+    test_struct_array_gradient_propagation_mat22,
+    devices=devices,
+)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -158,6 +158,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.test_grad import TestGrad
     from warp.tests.test_grad_customs import TestGradCustoms
     from warp.tests.test_grad_debug import TestGradDebug
+    from warp.tests.test_grad_struct_array import TestGradStructArray
     from warp.tests.test_import import TestImport
     from warp.tests.test_indexedarray import TestIndexedArray
     from warp.tests.test_intersect import TestIntersect
@@ -252,6 +253,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestGrad,
         TestGradCustoms,
         TestGradDebug,
+        TestGradStructArray,
         TestHashGrid,
         TestImport,
         TestIndexedArray,


### PR DESCRIPTION
Description
This PR fixes a long-standing bug where gradients fail to propagate backward through array-of-structs in automatic differentiation. The gradient correctly accumulates into the struct array's adjoint but doesn't flow back to the source array.


Problem
When using autodiff with array-of-structs, assignments like y[i].a = x[i] where y is an array of structs would not propagate gradients back to x, even though gradients correctly accumulated into y.grad.

Minimal Example
@wp.struct
class Scalar:
    a: wp.float32
@wp.kernel
def pack_kernel(x: wp.array(dtype=wp.float32), y: wp.array(dtype=Scalar)):
    i = wp.tid()
    y[i].a = x[i]  # Gradient chain broke here
Before fix: x.grad = [0.] ❌
After fix: x.grad = [1.] ✅

Root Cause
In 
warp/_src/codegen.py
, the 
emit_Assign
 function handles struct field assignments by calling the 
store
 builtin, but it failed to generate the reverse-mode adjoint code needed to propagate gradients from the RHS variable back through the struct field reference.

Changes
Modified Files
warp/_src/codegen.py
Added detection for struct array field assignments using type_is_struct()
Added missing adj.add_reverse() call to generate gradient propagation code
Updated warning logic to exclude this case (now differentiable)
warp/tests/test_grad_struct_array.py
 (New File)
Added regression test 
TestGradStructArray
warp/tests/unittest_suites.py
Registered 
TestGradStructArray
 to the default test suite for CI execution
Code Logic
# Check if we're assigning to a struct field in an array element
is_struct_array_field = (
    is_reference(aggregate.type) and
    type_is_struct(aggregate_type)
)
if is_reference(attr.type):
    adj.add_builtin_call("store", [attr, rhs])
    
    # Generate adjoint code to propagate gradients from struct field back to RHS
    if is_struct_array_field and adj.is_differentiable_value_type(strip_reference(rhs.type)):
        adj.add_reverse(f"{rhs.emit_adj()} += {attr.emit_adj()};")
Testing
Added a new test file 
warp/tests/test_grad_struct_array.py
 with the following test case:

def test_struct_array_gradient_propagation(test, device):
    # ... setup x, y, loss ...
    
    tape.backward(loss=loss)
    
    # Check that gradients propagate correctly
    assert_np_equal(y.grad.numpy()[0][0], 1.0, tol=1e-5)
    assert_np_equal(x.grad.numpy()[0], 1.0, tol=1e-5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed autodiff for arrays of structs so gradients now propagate correctly from struct fields (scalars, vectors, matrices) back to inputs and suppressed erroneous nondifferentiability warnings for these cases.

* **Tests**
  * Added end-to-end tests validating gradient propagation through arrays of various struct types across devices and integrated them into the standard test suites.

* **Documentation**
  * Added changelog entry describing the gradient propagation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->