### PR TITLE
Allow NVRTC compilation without CUDA driver (GH-1085, GH-1187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 
 ### Changed
 
+- Allow NVRTC compilation without a CUDA driver, enabling `wp.compile_aot_module()` to produce
+  PTX/CUBIN during Docker image builds where no GPU is available
+  ([GH-1085](https://github.com/NVIDIA/warp/issues/1085)).
 - Enable "shared" tile allocations on the stack for all CPU architectures, by defaulting
   `wp.config.enable_tiles_in_stack_memory` to `True`. ([GH-1032](https://github.com/NVIDIA/warp/issues/1032)).
 - Relax the integer types expected when indexing vectors and matrices
@@ -43,6 +46,8 @@
   ([GH-1211](https://github.com/NVIDIA/warp/issues/1211)).
 
 ### Documentation
+
+- Document ahead-of-time CUDA compilation without a driver (Docker build workflow).
 
 ## [1.11.1] - 2026-02-01
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -4917,6 +4917,7 @@ class Runtime:
 
         self.cuda_devices = []
         self.cuda_primary_devices = []
+        self.nvrtc_supported_archs = set()
 
         cuda_device_count = 0
 
@@ -4943,17 +4944,15 @@ class Runtime:
                 # we can't rely on minor version compatibility, so the driver can't be older than the toolkit
                 self.min_driver_version = self.toolkit_version
 
-            # determine if the installed driver is sufficient
-            if self.driver_version is not None and self.driver_version >= self.min_driver_version:
-                # get all architectures supported by NVRTC
-                num_archs = self.core.wp_nvrtc_supported_arch_count()
-                if num_archs > 0:
-                    archs = (ctypes.c_int * num_archs)()
-                    self.core.wp_nvrtc_supported_archs(archs)
-                    self.nvrtc_supported_archs = set(archs)
-                else:
-                    self.nvrtc_supported_archs = set()
+            # NVRTC is statically linked — arch query works without a driver
+            num_archs = self.core.wp_nvrtc_supported_arch_count()
+            if num_archs > 0:
+                archs = (ctypes.c_int * num_archs)()
+                self.core.wp_nvrtc_supported_archs(archs)
+                self.nvrtc_supported_archs = set(archs)
 
+            # device enumeration requires the CUDA driver
+            if self.driver_version is not None and self.driver_version >= self.min_driver_version:
                 # get CUDA device count
                 cuda_device_count = self.core.wp_cuda_device_get_count()
 
@@ -4968,9 +4967,6 @@ class Runtime:
                 # count known non-primary contexts on each physical device so we can
                 # give them reasonable aliases (e.g., "cuda:0.0", "cuda:0.1")
                 self.cuda_custom_context_count = [0] * cuda_device_count
-            else:
-                # driver is insufficient, no NVRTC architectures supported
-                self.nvrtc_supported_archs = set()
 
         # set default device
         if cuda_device_count > 0:
@@ -4998,9 +4994,12 @@ class Runtime:
             except ValueError:
                 pass  # no eligible NVRTC-supported arch ≥ default, retain existing
         else:
-            # CUDA not available
             self.set_default_device("cpu")
-            self.default_ptx_arch = None
+            if self.nvrtc_supported_archs:
+                # NVRTC available but no devices/driver — enable offline compilation
+                self.default_ptx_arch = warp.config.ptx_target_arch if warp.config.ptx_target_arch is not None else 75
+            else:
+                self.default_ptx_arch = None
 
         # initialize kernel cache
         warp._src.build.init_kernel_cache(warp.config.kernel_cache_dir)
@@ -5029,7 +5028,13 @@ class Runtime:
                     # Warp was compiled without CUDA support
                     greeting.append("   CUDA not enabled in this build")
                 elif self.driver_version is None:
-                    greeting.append("   CUDA driver not found or failed to initialize")
+                    if self.nvrtc_supported_archs:
+                        greeting.append(
+                            f"   CUDA Toolkit {self.toolkit_version[0]}.{self.toolkit_version[1]}"
+                            ", CUDA driver not available (NVRTC compilation available)"
+                        )
+                    else:
+                        greeting.append("   CUDA driver not found or failed to initialize")
                 elif self.driver_version < self.min_driver_version:
                     # insufficient CUDA driver version
                     greeting.append(

--- a/warp/native/cuda_util.cpp
+++ b/warp/native/cuda_util.cpp
@@ -177,7 +177,8 @@ bool init_cuda_driver()
     static HMODULE hCudaDriver = LoadLibraryA("nvcuda.dll");
     if (hCudaDriver == NULL) {
         fprintf(
-            stderr, "Warp CUDA warning: Could not find or load the NVIDIA CUDA driver. Proceeding in CPU-only mode.\n"
+            stderr,
+            "Warp CUDA warning: Could not find or load the NVIDIA CUDA driver. GPU execution will not be available.\n"
         );
         return false;
     }
@@ -190,7 +191,8 @@ bool init_cuda_driver()
         if (hCudaDriver == NULL) {
             fprintf(
                 stderr,
-                "Warp CUDA warning: Could not find or load the NVIDIA CUDA driver. Proceeding in CPU-only mode.\n"
+                "Warp CUDA warning: Could not find or load the NVIDIA CUDA driver. GPU execution will not be "
+                "available.\n"
             );
             return false;
         }


### PR DESCRIPTION
## Summary

Decouple the NVRTC architecture query from the CUDA driver version gate so that `wp.compile_aot_module(module, arch=75)` works when no driver or GPU is present (e.g. during Docker image builds).

NVRTC is statically linked into `warp.so` and does not need the driver, so the arch query and offline compilation can proceed independently.

### Changes

- **`warp/_src/context.py`**: Move NVRTC arch query before the driver gate; set `default_ptx_arch` when NVRTC is available but no devices; update greeting message for no-driver-but-NVRTC case
- **`warp/native/cuda_util.cpp`**: Change misleading "Proceeding in CPU-only mode" to "GPU execution will not be available"
- **`warp/tests/aot/test_module_aot.py`**: Add `test_module_compile_deviceless_ptx` exercising AOT compilation with explicit arch and no device
- **`docs/deep_dive/codegen.rst`**: Document the Docker build workflow for driverless NVRTC compilation

### User workflow

```dockerfile
FROM nvidia/cuda:12.8.0-devel-ubuntu24.04
RUN pip install warp-lang
COPY my_compile_script.py .
RUN python my_compile_script.py  # no GPU needed
```

```python
import warp as wp

@wp.kernel
def my_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float)):
    i = wp.tid()
    b[i] = a[i] * 2.0

wp.compile_aot_module(__name__, arch=[75, 80, 86, 90], module_dir="/app/warp_cache")
```

At runtime with `--gpus`, the pre-compiled PTX/CUBIN is loaded from cache.

Closes #1085
Closes #1187

## Test plan

- [x] All 21 AOT tests pass locally (with GPU)
- [x] Docker test passes in `python:3.12-slim` container (no CUDA driver, no GPU) — NVRTC produces `.cubin`
- [x] Docs build succeeds with no warnings
- [x] All pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warp can compile CUDA kernels without a CUDA driver, enabling offline ahead-of-time compilation (useful for Docker builds).

* **Documentation**
  * Added step-by-step examples and a Dockerfile for compiling CUDA kernels in Docker without driver dependencies and guidance for no-GPU scenarios.

* **Tests**
  * Added test coverage for ahead-of-time PTX compilation when no CUDA device/driver is present.

* **Clarification**
  * Startup and warning messages updated to reflect NVRTC availability even when a CUDA driver is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->