### PR TITLE
Fix GitHub security alerts for CI permissions and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ on:
   schedule: # Schedule workflow only runs on the default branch
     - cron: "45 9 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   build-warp:
     runs-on: ${{ matrix.os }}

--- a/uv.lock
+++ b/uv.lock
@@ -3090,7 +3090,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.35.4"
+version = "20.36.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -3100,9 +3100,9 @@ dependencies = [
     { name = "platformdirs", version = "4.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/28/e6f1a6f655d620846bd9df527390ecc26b3805a0c5989048c210e22c5ca9/virtualenv-20.35.4.tar.gz", hash = "sha256:643d3914d73d3eeb0c552cbb12d7e82adf0e504dbf86a3182f8771a153a1971c", size = 6028799, upload-time = "2025-10-29T06:57:40.511Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/0c/c05523fa3181fdf0c9c52a6ba91a23fbf3246cc095f26f6516f9c60e6771/virtualenv-20.35.4-py3-none-any.whl", hash = "sha256:c21c9cede36c9753eeade68ba7d523529f228a403463376cf821eaae2b650f1b", size = 6005095, upload-time = "2025-10-29T06:57:37.598Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add top-level `permissions: contents: read` to `ci.yml` to restrict default `GITHUB_TOKEN` scope on push/schedule/workflow_dispatch triggers (matches existing pattern in `pr.yml`)
- Upgrade `virtualenv` 20.35.4 → 20.36.1 to resolve Dependabot security alert

## Notes
- `filelock` 3.19.1 remains pinned only for the Python < 3.10 resolution because filelock 3.20.3+ requires Python ≥ 3.10. The ≥ 3.10 resolution already uses 3.20.3.
- When `ci.yml` is called via `workflow_call` from `pr.yml`, the effective permissions are the intersection of caller and callee — both declare `contents: read`, so no regression.

## Test plan
- [x] CI workflow runs successfully with the new permissions block
- [x] `uv lock --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI workflow permissions by granting the automation read-only access to repository contents (least-privilege).
  * Confirmed no behavioral changes to existing jobs or steps; this change only restricts/clarifies workflow permissions for safer automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->