### PR TITLE
Add wp.print_diagnostics() for environment snapshots (GH-1221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
   Supported on `Grid2D`, `Grid3D`, and `Nanogrid` geometries ([GH-1208](https://github.com/NVIDIA/warp/issues/1208)).
 - Add support for JAX vmap with FFI `jax_kernel()` and `jax_callable()`
   ([GH-859](https://github.com/NVIDIA/warp/issues/859)).
+- Add `wp.print_diagnostics()` to display a comprehensive snapshot of the Warp build and runtime
+  environment, including software versions, CUDA info, build flags, and devices. Returns a dictionary
+  for programmatic access ([GH-1221](https://github.com/NVIDIA/warp/issues/1221)).
 
 ### Removed
 

--- a/build_lib.py
+++ b/build_lib.py
@@ -583,6 +583,8 @@ def main(argv: list[str] | None = None) -> int:
         else:
             # Clear kernel cache in subprocess (ensures fresh import of updated config.py)
             print("Clearing kernel cache...")
+            sys.stdout.flush()
+            sys.stderr.flush()
             result = subprocess.run(
                 [
                     sys.executable,
@@ -594,6 +596,21 @@ def main(argv: list[str] | None = None) -> int:
             )
             if result.returncode != 0:
                 print(f"Warning: Failed to clear kernel cache (exit code {result.returncode})")
+
+            # Flush build output before printing diagnostics so log ordering is correct
+            sys.stdout.flush()
+            sys.stderr.flush()
+
+            # Print build diagnostics (subprocess ensures fresh import of rebuilt libraries)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import warp; warp.print_diagnostics()",
+                ],
+                cwd=base_path,
+                check=False,
+            )
     except Exception as e:
         print(f"Unable to clear kernel cache: {e}")
 

--- a/docs/api_reference/warp.rst
+++ b/docs/api_reference/warp.rst
@@ -245,6 +245,7 @@ Runtime
    init
    is_cpu_available
    is_cuda_available
+   print_diagnostics
 
 Kernel Programming
 ------------------

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -210,6 +210,8 @@ from warp._src.context import is_cuda_available as is_cuda_available
 from warp._src.build import clear_kernel_cache as clear_kernel_cache
 from warp._src.build import clear_lto_cache as clear_lto_cache
 
+from warp._src.context import print_diagnostics as print_diagnostics
+
 
 # category: Kernel Programming
 

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -156,6 +156,8 @@ from warp._src.context import is_cuda_available as is_cuda_available
 from warp._src.build import clear_kernel_cache as clear_kernel_cache
 from warp._src.build import clear_lto_cache as clear_lto_cache
 
+from warp._src.context import print_diagnostics as print_diagnostics
+
 from warp._src.codegen import WarpCodegenAttributeError as WarpCodegenAttributeError
 from warp._src.codegen import WarpCodegenError as WarpCodegenError
 from warp._src.codegen import WarpCodegenIndexError as WarpCodegenIndexError

--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -618,7 +618,7 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str
             cpp_flags += ' /D "WP_VERIFY_FP"'
 
         if args.fast_math:
-            cpp_flags += " /fp:fast"
+            cpp_flags += ' /fp:fast /D "WP_FAST_MATH"'
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as executor:
             futures, wall_clock = [], time.perf_counter_ns()
@@ -721,7 +721,7 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str
             cpp_flags += " -DWP_VERIFY_FP"
 
         if args.fast_math:
-            cpp_flags += " -ffast-math"
+            cpp_flags += " -ffast-math -DWP_FAST_MATH"
 
         ld_inputs = []
 

--- a/warp/native/clang/clang.cpp
+++ b/warp/native/clang/clang.cpp
@@ -526,6 +526,13 @@ WP_API uint64_t wp_lookup(const char* dll_name, const char* function_name)
 
 WP_API const char* wp_warp_clang_version() { return WP_VERSION_STRING; }
 
+WP_API const char* wp_llvm_version()
+{
+    static char version[64];
+    snprintf(version, sizeof(version), "%d.%d.%d", LLVM_VERSION_MAJOR, LLVM_VERSION_MINOR, LLVM_VERSION_PATCH);
+    return version;
+}
+
 }  // extern "C"
 
 }  // namespace wp

--- a/warp/native/volume.cpp
+++ b/warp/native/volume.cpp
@@ -508,3 +508,13 @@ void wp_volume_get_tiles_device(uint64_t id, void* buf) { }
 void wp_volume_get_voxels_device(uint64_t id, void* buf) { }
 
 #endif
+
+const char* wp_nanovdb_version()
+{
+    static char version[64];
+    snprintf(
+        version, sizeof(version), "%d.%d.%d", PNANOVDB_MAJOR_VERSION_NUMBER, PNANOVDB_MINOR_VERSION_NUMBER,
+        PNANOVDB_PATCH_VERSION_NUMBER
+    );
+    return version;
+}

--- a/warp/native/warp.cpp
+++ b/warp/native/warp.cpp
@@ -163,6 +163,39 @@ int wp_is_mathdx_enabled() { return int(WP_ENABLE_MATHDX); }
 
 int wp_is_debug_enabled() { return int(WP_ENABLE_DEBUG); }
 
+const char* wp_host_compiler_version()
+{
+    static char version[128];
+#if defined(_MSC_VER)
+    snprintf(version, sizeof(version), "MSVC %d.%d", _MSC_VER / 100, _MSC_VER % 100);
+#elif defined(__GNUC__) && !defined(__clang__)
+    snprintf(version, sizeof(version), "GCC %d.%d.%d", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+#elif defined(__clang__)
+    snprintf(version, sizeof(version), "Clang %d.%d.%d", __clang_major__, __clang_minor__, __clang_patchlevel__);
+#else
+    snprintf(version, sizeof(version), "unknown");
+#endif
+    return version;
+}
+
+int wp_is_verify_fp_enabled()
+{
+#ifdef WP_VERIFY_FP
+    return 1;
+#else
+    return 0;
+#endif
+}
+
+int wp_is_fast_math_enabled()
+{
+#ifdef WP_FAST_MATH
+    return 1;
+#else
+    return 0;
+#endif
+}
+
 void* wp_alloc_host(size_t s)
 {
     // increase CPU array alignment for compatibility with other libs, e.g., JAX, XLA, Eigen.
@@ -1068,5 +1101,8 @@ WP_API void wp_cuda_graphics_unregister_resource(void* context, void* resource) 
 WP_API void wp_cuda_timing_begin(int flags) { }
 WP_API int wp_cuda_timing_get_result_count() { return 0; }
 WP_API void wp_cuda_timing_end(timing_result_t* results, int size) { }
+
+WP_API const char* wp_libmathdx_version() { return ""; }
+WP_API int wp_nvrtc_version() { return 0; }
 
 #endif  // !WP_ENABLE_CUDA

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -1879,6 +1879,24 @@ int wp_cuda_driver_version()
 
 int wp_cuda_toolkit_version() { return CUDA_VERSION; }
 
+int wp_nvrtc_version()
+{
+    int major = 0, minor = 0;
+    nvrtcVersion(&major, &minor);
+    return major * 1000 + minor * 10;
+}
+
+const char* wp_libmathdx_version()
+{
+#if WP_ENABLE_MATHDX
+    static char version[64];
+    snprintf(version, sizeof(version), "%d.%d.%d", LIBMATHDX_VER_MAJOR, LIBMATHDX_VER_MINOR, LIBMATHDX_VER_PATCH);
+    return version;
+#else
+    return "";
+#endif
+}
+
 bool wp_cuda_driver_is_initialized() { return is_cuda_driver_initialized(); }
 
 int wp_nvrtc_supported_arch_count()

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -446,6 +446,13 @@ WP_API int wp_cuda_toolkit_version();  // CUDA Toolkit version used to build War
 WP_API const char* wp_version();  // Warp native library version string
 WP_API bool wp_cuda_driver_is_initialized();
 
+WP_API const char* wp_nanovdb_version();  // NanoVDB version string
+WP_API const char* wp_host_compiler_version();  // Host C++ compiler version
+WP_API const char* wp_libmathdx_version();  // libmathdx version (empty if not built with MathDx)
+WP_API int wp_nvrtc_version();  // NVRTC version (encoded as major*1000 + minor*10)
+WP_API int wp_is_verify_fp_enabled();  // Whether native lib was built with WP_VERIFY_FP
+WP_API int wp_is_fast_math_enabled();  // Whether native lib was built with fast math
+
 WP_API int wp_nvrtc_supported_arch_count();
 WP_API void wp_nvrtc_supported_archs(int* archs);
 

--- a/warp/tests/test_diagnostics.py
+++ b/warp/tests/test_diagnostics.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import warp as wp
+from warp._src.context import (
+    get_host_compiler_version,
+    get_libmathdx_version,
+    get_llvm_version,
+    get_nanovdb_version,
+    get_nvrtc_version,
+)
+
+
+class TestDiagnostics(unittest.TestCase):
+    """Tests for wp.print_diagnostics() and related version query functions."""
+
+    def test_print_diagnostics_returns_dict(self):
+        info = wp.print_diagnostics()
+        self.assertIsInstance(info, dict)
+
+    def test_print_diagnostics_has_required_keys(self):
+        info = wp.print_diagnostics()
+        required_keys = [
+            "warp_python",
+            "warp_native",
+            "warp_clang",
+            "llvm",
+            "numpy",
+            "python",
+            "platform",
+            "cuda_enabled",
+            "cuda_toolkit",
+            "cuda_driver",
+            "nvrtc",
+            "cuda_compatibility",
+            "mathdx_enabled",
+            "libmathdx",
+            "nanovdb",
+            "host_compiler",
+            "debug",
+            "verify_fp",
+            "fast_math",
+            "devices",
+        ]
+        for key in required_keys:
+            self.assertIn(key, info, f"Missing key: {key}")
+
+    def test_print_diagnostics_version_strings(self):
+        info = wp.print_diagnostics()
+        self.assertIsInstance(info["warp_python"], str)
+        self.assertRegex(info["warp_python"], r"^\d+\.\d+\.\d+")
+        self.assertIsInstance(info["warp_native"], str)
+        self.assertRegex(info["warp_native"], r"^\d+\.\d+\.\d+")
+        self.assertIsInstance(info["numpy"], str)
+        self.assertIsInstance(info["python"], str)
+        self.assertIsInstance(info["platform"], str)
+
+    def test_print_diagnostics_build_flags(self):
+        info = wp.print_diagnostics()
+        self.assertIsInstance(info["debug"], bool)
+        self.assertIsInstance(info["verify_fp"], bool)
+        self.assertIsInstance(info["fast_math"], bool)
+
+    def test_print_diagnostics_devices(self):
+        info = wp.print_diagnostics()
+        devices = info["devices"]
+        self.assertIsInstance(devices, list)
+        self.assertGreaterEqual(len(devices), 1)
+        # CPU device should always be present
+        self.assertEqual(devices[0]["alias"], "cpu")
+
+    def test_print_diagnostics_cuda_device_structure(self):
+        info = wp.print_diagnostics()
+        devices = info["devices"]
+        if wp.is_cuda_available():
+            self.assertGreaterEqual(len(devices), 2, "CUDA available but no CUDA device in list")
+            cuda_dev = devices[1]
+            self.assertRegex(cuda_dev["arch"], r"^sm_\d+$")
+            self.assertIsInstance(cuda_dev["sm_count"], int)
+            self.assertGreater(cuda_dev["sm_count"], 0)
+            self.assertIsInstance(cuda_dev["memory_gb"], float)
+            self.assertIsInstance(cuda_dev["mempool_enabled"], bool)
+            self.assertRegex(cuda_dev["pci_bus_id"], r"^[0-9A-F]+:[0-9A-F]+:[0-9A-F]+$")
+
+    def test_nanovdb_version(self):
+        version = get_nanovdb_version()
+        self.assertIsInstance(version, str)
+        self.assertRegex(version, r"^\d+\.\d+\.\d+$")
+
+    def test_host_compiler_version(self):
+        version = get_host_compiler_version()
+        self.assertIsInstance(version, str)
+        self.assertNotEqual(version, "unknown")
+
+    def test_llvm_version(self):
+        version = get_llvm_version()
+        self.assertIsInstance(version, str)
+        # LLVM should be available since warp-clang is loaded
+        self.assertRegex(version, r"^\d+\.\d+\.\d+$")
+
+    def test_nvrtc_version(self):
+        version = get_nvrtc_version()
+        # NVRTC may be statically linked even without a GPU present at runtime,
+        # so we only validate the shape when a version is returned.
+        if version is not None:
+            self.assertIsInstance(version, tuple)
+            self.assertEqual(len(version), 2)
+            self.assertGreater(version[0], 0)
+
+    def test_libmathdx_version(self):
+        version = get_libmathdx_version()
+        self.assertIsInstance(version, str)
+        # If MathDx is enabled, version should be a valid version string
+        if version:
+            self.assertRegex(version, r"^\d+\.\d+\.\d+$")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -142,6 +142,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.test_ctypes import TestCTypes
     from warp.tests.test_dense import TestDense
     from warp.tests.test_devices import TestDevices
+    from warp.tests.test_diagnostics import TestDiagnostics
     from warp.tests.test_examples import (
         TestCoreExamples,
         TestFemDiffusionExamples,
@@ -235,6 +236,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestCTypes,
         TestDense,
         TestDevices,
+        TestDiagnostics,
         TestDLPack,
         TestCoreExamples,
         TestFemDiffusionExamples,


### PR DESCRIPTION
## Summary

- Add `wp.print_diagnostics()` that prints and returns a comprehensive snapshot of the Warp build and runtime environment — software versions, CUDA info, library versions, build flags, and device details
- Add native query functions: `wp_nanovdb_version`, `wp_host_compiler_version`, `wp_libmathdx_version`, `wp_nvrtc_version`, `wp_llvm_version`, `wp_is_verify_fp_enabled`, `wp_is_fast_math_enabled`
- Add `WP_FAST_MATH` preprocessor define when building with `--fast-math`
- Call `print_diagnostics()` at the end of the build process in `build_lib.py`

## Example output

```
>>> import warp as wp
>>> wp.print_diagnostics()
Software
  Warp (package):   1.12.0.dev0
  Warp (core):      1.12.0.dev0
  warp-clang:       1.12.0.dev0 (LLVM 18.1.3)
  NumPy:            2.4.1
  Python:           3.12.3 (main, Jan 22 2026, 20:57:42) [GCC 13.3.0]
  Platform:         Linux-6.8.0-94-generic-x86_64-with-glibc2.39

CUDA
  Enabled:          True
  Toolkit:          13.1
  Driver:           13.1
  NVRTC:            13.1
  Forward compat:   False

Libraries
  MathDx:           0.3.0
  NanoVDB:          32.8.0

Build
  Compiler:         GCC 11.5.0
  Debug:            False
  Verify FP:        False
  Fast math:        False

Devices
  cpu
    Name:             x86_64
  cuda:0
    Name:             NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition
    Memory:           95.0 GiB
    Arch:             sm_120
    SMs:              188
    PCI:              00000000:1A:00
    Mempool:          enabled
```

## Test plan

- [x] `uv run warp/tests/test_diagnostics.py` — 11 tests covering dict keys, version formats, build flags, device structure, and individual getters
- [x] `uv run python -c "import warp; warp.print_diagnostics()"` — manual verification of output format
- [ ] Verify `uv run build_lib.py --quick` prints diagnostics after build
- [ ] Verify no regressions in `uv run warp/tests/test_version.py`

Closes GH-1221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added diagnostics API: wp.print_diagnostics() returns a dictionary snapshot of build/runtime info (versions, CUDA details, build flags, devices).
  * Added version query helpers: wp.get_llvm_version(), wp.get_nanovdb_version(), wp.get_host_compiler_version(), wp.get_libmathdx_version(), wp.get_nvrtc_version().

* **Documentation**
  * Exposed print_diagnostics() in the public API reference.

* **Tests**
  * Added comprehensive diagnostics test suite validating structure and contents of diagnostics data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->