### PR TITLE
Add texture mipmap support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,7 @@ dout = "dout"
 iy = "iy"
 nd = "nd"
 transformd = "transformd"
+lod = "lod"
 
 [tool.typos.default.extend-identifiers]
 CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN = "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN"

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -4672,7 +4672,7 @@ def volume_world_to_index_dir(id: uint64, xyz: vec3f) -> vec3f:
     ...
 
 @over
-def texture_sample(tex: Texture2D, uv: vec2f, dtype: Any) -> Any:
+def texture_sample(tex: Texture2D, uv: vec2f, dtype: Any, lod: float32) -> Any:
     """Sample the 2D texture at the given UV coordinates.
 
     Args:
@@ -4680,6 +4680,7 @@ def texture_sample(tex: Texture2D, uv: vec2f, dtype: Any) -> Any:
         uv: UV coordinates as a :class:`warp.vec2f`. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, width] x [0, height] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
+        lod: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -4689,7 +4690,7 @@ def texture_sample(tex: Texture2D, uv: vec2f, dtype: Any) -> Any:
     ...
 
 @over
-def texture_sample(tex: Texture2D, u: float32, v: float32, dtype: Any) -> Any:
+def texture_sample(tex: Texture2D, u: float32, v: float32, dtype: Any, lod: float32) -> Any:
     """Sample the 2D texture at the given UV coordinates.
 
     Args:
@@ -4699,6 +4700,7 @@ def texture_sample(tex: Texture2D, u: float32, v: float32, dtype: Any) -> Any:
         v: V coordinate. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, height] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
+        lod: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -4708,7 +4710,7 @@ def texture_sample(tex: Texture2D, u: float32, v: float32, dtype: Any) -> Any:
     ...
 
 @over
-def texture_sample(tex: Texture3D, uvw: vec3f, dtype: Any) -> Any:
+def texture_sample(tex: Texture3D, uvw: vec3f, dtype: Any, lod: float32) -> Any:
     """Sample the 3D texture at the given UVW coordinates.
 
     Args:
@@ -4716,6 +4718,7 @@ def texture_sample(tex: Texture3D, uvw: vec3f, dtype: Any) -> Any:
         uvw: UVW coordinates as a :class:`warp.vec3f`. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, width] x [0, height] x [0, depth] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
+        lod: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -4725,7 +4728,7 @@ def texture_sample(tex: Texture3D, uvw: vec3f, dtype: Any) -> Any:
     ...
 
 @over
-def texture_sample(tex: Texture3D, u: float32, v: float32, w: float32, dtype: Any) -> Any:
+def texture_sample(tex: Texture3D, u: float32, v: float32, w: float32, dtype: Any, lod: float32) -> Any:
     """Sample the 3D texture at the given UVW coordinates.
 
     Args:
@@ -4737,6 +4740,7 @@ def texture_sample(tex: Texture3D, u: float32, v: float32, w: float32, dtype: An
         w: W coordinate. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, depth] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
+        lod: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -7617,7 +7617,8 @@ def texture_sample_2d_dispatch_func(input_types: Mapping[str, type], return_type
 # texture_sample for 2D textures with vec2 coordinates
 add_builtin(
     "texture_sample",
-    input_types={"tex": Texture2D, "uv": vec2f, "dtype": Any},
+    input_types={"tex": Texture2D, "uv": vec2f, "dtype": Any, "load": float},
+    defaults={"load": 0.0},
     value_func=texture_sample_2d_value_func,
     export_func=lambda input_types: {k: v for k, v in input_types.items() if k != "dtype"},
     dispatch_func=texture_sample_2d_dispatch_func,
@@ -7630,6 +7631,7 @@ add_builtin(
         uv: UV coordinates as a :class:`warp.vec2f`. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, width] x [0, height] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
+        load: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -7641,7 +7643,8 @@ add_builtin(
 # texture_sample for 2D textures with separate u, v coordinates
 add_builtin(
     "texture_sample",
-    input_types={"tex": Texture2D, "u": float, "v": float, "dtype": Any},
+    input_types={"tex": Texture2D, "u": float, "v": float, "dtype": Any, "load": float},
+    defaults={"load": 0.0},
     value_func=texture_sample_2d_value_func,
     export_func=lambda input_types: {k: v for k, v in input_types.items() if k != "dtype"},
     dispatch_func=texture_sample_2d_dispatch_func,
@@ -7656,6 +7659,7 @@ add_builtin(
         v: V coordinate. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, height] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
+        load: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -7686,7 +7690,8 @@ def texture_sample_3d_dispatch_func(input_types: Mapping[str, type], return_type
 # texture_sample for 3D textures with vec3 coordinates
 add_builtin(
     "texture_sample",
-    input_types={"tex": Texture3D, "uvw": vec3f, "dtype": Any},
+    input_types={"tex": Texture3D, "uvw": vec3f, "dtype": Any, "load": float},
+    defaults={"load": 0.0},
     value_func=texture_sample_3d_value_func,
     export_func=lambda input_types: {k: v for k, v in input_types.items() if k != "dtype"},
     dispatch_func=texture_sample_3d_dispatch_func,
@@ -7699,6 +7704,7 @@ add_builtin(
         uvw: UVW coordinates as a :class:`warp.vec3f`. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, width] x [0, height] x [0, depth] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
+        load: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -7710,7 +7716,8 @@ add_builtin(
 # texture_sample for 3D textures with separate u, v, w coordinates
 add_builtin(
     "texture_sample",
-    input_types={"tex": Texture3D, "u": float, "v": float, "w": float, "dtype": Any},
+    input_types={"tex": Texture3D, "u": float, "v": float, "w": float, "dtype": Any, "load": float},
+    defaults={"load": 0.0},
     value_func=texture_sample_3d_value_func,
     export_func=lambda input_types: {k: v for k, v in input_types.items() if k != "dtype"},
     dispatch_func=texture_sample_3d_dispatch_func,
@@ -7727,6 +7734,7 @@ add_builtin(
         w: W coordinate. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, depth] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
+        load: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -7617,8 +7617,8 @@ def texture_sample_2d_dispatch_func(input_types: Mapping[str, type], return_type
 # texture_sample for 2D textures with vec2 coordinates
 add_builtin(
     "texture_sample",
-    input_types={"tex": Texture2D, "uv": vec2f, "dtype": Any, "load": float},
-    defaults={"load": 0.0},
+    input_types={"tex": Texture2D, "uv": vec2f, "dtype": Any, "lod": float},
+    defaults={"lod": 0.0},
     value_func=texture_sample_2d_value_func,
     export_func=lambda input_types: {k: v for k, v in input_types.items() if k != "dtype"},
     dispatch_func=texture_sample_2d_dispatch_func,
@@ -7631,7 +7631,7 @@ add_builtin(
         uv: UV coordinates as a :class:`warp.vec2f`. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, width] x [0, height] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
-        load: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
+        lod: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -7643,8 +7643,8 @@ add_builtin(
 # texture_sample for 2D textures with separate u, v coordinates
 add_builtin(
     "texture_sample",
-    input_types={"tex": Texture2D, "u": float, "v": float, "dtype": Any, "load": float},
-    defaults={"load": 0.0},
+    input_types={"tex": Texture2D, "u": float, "v": float, "dtype": Any, "lod": float},
+    defaults={"lod": 0.0},
     value_func=texture_sample_2d_value_func,
     export_func=lambda input_types: {k: v for k, v in input_types.items() if k != "dtype"},
     dispatch_func=texture_sample_2d_dispatch_func,
@@ -7659,7 +7659,7 @@ add_builtin(
         v: V coordinate. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, height] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
-        load: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
+        lod: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -7690,8 +7690,8 @@ def texture_sample_3d_dispatch_func(input_types: Mapping[str, type], return_type
 # texture_sample for 3D textures with vec3 coordinates
 add_builtin(
     "texture_sample",
-    input_types={"tex": Texture3D, "uvw": vec3f, "dtype": Any, "load": float},
-    defaults={"load": 0.0},
+    input_types={"tex": Texture3D, "uvw": vec3f, "dtype": Any, "lod": float},
+    defaults={"lod": 0.0},
     value_func=texture_sample_3d_value_func,
     export_func=lambda input_types: {k: v for k, v in input_types.items() if k != "dtype"},
     dispatch_func=texture_sample_3d_dispatch_func,
@@ -7704,7 +7704,7 @@ add_builtin(
         uvw: UVW coordinates as a :class:`warp.vec3f`. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, width] x [0, height] x [0, depth] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
-        load: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
+        lod: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -7716,8 +7716,8 @@ add_builtin(
 # texture_sample for 3D textures with separate u, v, w coordinates
 add_builtin(
     "texture_sample",
-    input_types={"tex": Texture3D, "u": float, "v": float, "w": float, "dtype": Any, "load": float},
-    defaults={"load": 0.0},
+    input_types={"tex": Texture3D, "u": float, "v": float, "w": float, "dtype": Any, "lod": float},
+    defaults={"lod": 0.0},
     value_func=texture_sample_3d_value_func,
     export_func=lambda input_types: {k: v for k, v in input_types.items() if k != "dtype"},
     dispatch_func=texture_sample_3d_dispatch_func,
@@ -7734,7 +7734,7 @@ add_builtin(
         w: W coordinate. Range is [0, 1] if the texture was created with
             ``normalized_coords=True`` (default), or [0, depth] if ``normalized_coords=False``.
         dtype: The return type (``float``, :class:`warp.vec2f`, or :class:`warp.vec4f`).
-        load: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
+        lod: Level of detail for mipmapped textures. Default is 0.0 (no mipmaps).
 
     Returns:
         The sampled value of the specified ``dtype``.

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -4341,12 +4341,17 @@ class Runtime:
                 ctypes.c_int,  # num_channels
                 ctypes.c_int,  # dtype (0=uint8, 1=uint16, 2=float32)
                 ctypes.c_int,  # filter_mode
+                ctypes.c_int,  # mip_filter_mode
                 ctypes.c_int,  # address_mode_u
                 ctypes.c_int,  # address_mode_v
                 ctypes.c_bool,  # use_normalized_coords
+                ctypes.c_int,  # num_mip_levels
                 ctypes.c_void_p,  # data
+                ctypes.POINTER(ctypes.c_int32),  # mip_widths
+                ctypes.POINTER(ctypes.c_int32),  # mip_heights
                 ctypes.POINTER(ctypes.c_uint64),  # tex_handle_out
                 ctypes.POINTER(ctypes.c_uint64),  # array_handle_out
+                ctypes.POINTER(ctypes.c_uint64),  # mipmap_handle_out
             ]
             self.core.wp_texture2d_create_device.restype = ctypes.c_bool
 
@@ -4354,6 +4359,7 @@ class Runtime:
                 ctypes.c_void_p,  # context
                 ctypes.c_uint64,  # tex_handle
                 ctypes.c_uint64,  # array_handle
+                ctypes.c_uint64,  # mipmap_handle
             ]
             self.core.wp_texture2d_destroy_device.restype = None
 
@@ -4365,13 +4371,19 @@ class Runtime:
                 ctypes.c_int,  # num_channels
                 ctypes.c_int,  # dtype (0=uint8, 1=uint16, 2=float32)
                 ctypes.c_int,  # filter_mode
+                ctypes.c_int,  # mip_filter_mode
                 ctypes.c_int,  # address_mode_u
                 ctypes.c_int,  # address_mode_v
                 ctypes.c_int,  # address_mode_w
                 ctypes.c_bool,  # use_normalized_coords
+                ctypes.c_int,  # num_mip_levels
                 ctypes.c_void_p,  # data
+                ctypes.POINTER(ctypes.c_int32),  # mip_widths
+                ctypes.POINTER(ctypes.c_int32),  # mip_heights
+                ctypes.POINTER(ctypes.c_int32),  # mip_depths
                 ctypes.POINTER(ctypes.c_uint64),  # tex_handle_out
                 ctypes.POINTER(ctypes.c_uint64),  # array_handle_out
+                ctypes.POINTER(ctypes.c_uint64),  # mipmap_handle_out
             ]
             self.core.wp_texture3d_create_device.restype = ctypes.c_bool
 
@@ -4379,6 +4391,7 @@ class Runtime:
                 ctypes.c_void_p,  # context
                 ctypes.c_uint64,  # tex_handle
                 ctypes.c_uint64,  # array_handle
+                ctypes.c_uint64,  # mipmap_handle
             ]
             self.core.wp_texture3d_destroy_device.restype = None
 
@@ -4389,10 +4402,14 @@ class Runtime:
                 ctypes.c_int,  # num_channels
                 ctypes.c_int,  # dtype (0=uint8, 1=uint16, 2=float32)
                 ctypes.c_int,  # filter_mode
+                ctypes.c_int,  # mip_filter_mode
                 ctypes.c_int,  # address_mode_u
                 ctypes.c_int,  # address_mode_v
                 ctypes.c_bool,  # use_normalized_coords
+                ctypes.c_int,  # num_mip_levels
                 ctypes.c_void_p,  # data
+                ctypes.POINTER(ctypes.c_int32),  # mip_widths
+                ctypes.POINTER(ctypes.c_int32),  # mip_heights
                 ctypes.POINTER(ctypes.c_uint64),  # tex_handle_out
             ]
             self.core.wp_texture2d_create_host.restype = ctypes.c_bool
@@ -4409,11 +4426,16 @@ class Runtime:
                 ctypes.c_int,  # num_channels
                 ctypes.c_int,  # dtype (0=uint8, 1=uint16, 2=float32)
                 ctypes.c_int,  # filter_mode
+                ctypes.c_int,  # mip_filter_mode
                 ctypes.c_int,  # address_mode_u
                 ctypes.c_int,  # address_mode_v
                 ctypes.c_int,  # address_mode_w
                 ctypes.c_bool,  # use_normalized_coords
+                ctypes.c_int,  # num_mip_levels
                 ctypes.c_void_p,  # data
+                ctypes.POINTER(ctypes.c_int32),  # mip_widths
+                ctypes.POINTER(ctypes.c_int32),  # mip_heights
+                ctypes.POINTER(ctypes.c_int32),  # mip_depths
                 ctypes.POINTER(ctypes.c_uint64),  # tex_handle_out
             ]
             self.core.wp_texture3d_create_host.restype = ctypes.c_bool

--- a/warp/native/cuda_util.cpp
+++ b/warp/native/cuda_util.cpp
@@ -138,6 +138,9 @@ static PFN_cuMemcpy2D_v3020 pfn_cuMemcpy2D;
 static PFN_cuMemcpy3D_v3020 pfn_cuMemcpy3D;
 static PFN_cuTexObjectCreate_v5000 pfn_cuTexObjectCreate;
 static PFN_cuTexObjectDestroy_v5000 pfn_cuTexObjectDestroy;
+static PFN_cuMipmappedArrayCreate_v5000 pfn_cuMipmappedArrayCreate;
+static PFN_cuMipmappedArrayGetLevel_v5000 pfn_cuMipmappedArrayGetLevel;
+static PFN_cuMipmappedArrayDestroy_v5000 pfn_cuMipmappedArrayDestroy;
 
 static bool cuda_driver_initialized = false;
 
@@ -297,6 +300,9 @@ bool init_cuda_driver()
     get_driver_entry_point("cuMemcpy3D", 3020, &(void*&)pfn_cuMemcpy3D);
     get_driver_entry_point("cuTexObjectCreate", 5000, &(void*&)pfn_cuTexObjectCreate);
     get_driver_entry_point("cuTexObjectDestroy", 5000, &(void*&)pfn_cuTexObjectDestroy);
+    get_driver_entry_point("cuMipmappedArrayCreate", 5000, &(void*&)pfn_cuMipmappedArrayCreate);
+    get_driver_entry_point("cuMipmappedArrayGetLevel", 5000, &(void*&)pfn_cuMipmappedArrayGetLevel);
+    get_driver_entry_point("cuMipmappedArrayDestroy", 5000, &(void*&)pfn_cuMipmappedArrayDestroy);
 
     if (pfn_cuInit)
         cuda_driver_initialized = check_cu(pfn_cuInit(0));
@@ -794,6 +800,25 @@ CUresult cuTexObjectCreate_f(
 CUresult cuTexObjectDestroy_f(CUtexObject texObject)
 {
     return pfn_cuTexObjectDestroy ? pfn_cuTexObjectDestroy(texObject) : DRIVER_ENTRY_POINT_ERROR;
+}
+
+CUresult cuMipmappedArrayCreate_f(
+    CUmipmappedArray* pHandle, const CUDA_ARRAY3D_DESCRIPTOR* pMipmappedArrayDesc, unsigned int numMipmapLevels
+)
+{
+    return pfn_cuMipmappedArrayCreate ? pfn_cuMipmappedArrayCreate(pHandle, pMipmappedArrayDesc, numMipmapLevels)
+                                      : DRIVER_ENTRY_POINT_ERROR;
+}
+
+CUresult cuMipmappedArrayGetLevel_f(CUarray* pLevelArray, CUmipmappedArray hMipmappedArray, unsigned int level)
+{
+    return pfn_cuMipmappedArrayGetLevel ? pfn_cuMipmappedArrayGetLevel(pLevelArray, hMipmappedArray, level)
+                                        : DRIVER_ENTRY_POINT_ERROR;
+}
+
+CUresult cuMipmappedArrayDestroy_f(CUmipmappedArray hMipmappedArray)
+{
+    return pfn_cuMipmappedArrayDestroy ? pfn_cuMipmappedArrayDestroy(hMipmappedArray) : DRIVER_ENTRY_POINT_ERROR;
 }
 
 #endif  // WP_ENABLE_CUDA

--- a/warp/native/cuda_util.h
+++ b/warp/native/cuda_util.h
@@ -182,6 +182,11 @@ CUresult cuTexObjectCreate_f(
     const CUDA_RESOURCE_VIEW_DESC* pResViewDesc
 );
 CUresult cuTexObjectDestroy_f(CUtexObject texObject);
+CUresult cuMipmappedArrayCreate_f(
+    CUmipmappedArray* pHandle, const CUDA_ARRAY3D_DESCRIPTOR* pMipmappedArrayDesc, unsigned int numMipmapLevels
+);
+CUresult cuMipmappedArrayGetLevel_f(CUarray* pLevelArray, CUmipmappedArray hMipmappedArray, unsigned int level);
+CUresult cuMipmappedArrayDestroy_f(CUmipmappedArray hMipmappedArray);
 
 bool init_cuda_driver();
 bool is_cuda_driver_initialized();

--- a/warp/native/texture.cpp
+++ b/warp/native/texture.cpp
@@ -57,6 +57,11 @@ struct cpu_texture2d_data {
     int address_mode_u;  // WP_TEXTURE_ADDRESS_* for U axis
     int address_mode_v;  // WP_TEXTURE_ADDRESS_* for V axis
     bool use_normalized_coords;  // If true, coords in [0,1]; if false, in texel space
+    int num_mip_levels;  // 1 = no mipmaps
+    int mip_filter_mode;  // 0=closest, 1=linear
+    void** mip_data;
+    int* mip_widths;
+    int* mip_heights;
 };
 
 struct cpu_texture3d_data {
@@ -71,6 +76,12 @@ struct cpu_texture3d_data {
     int address_mode_v;  // WP_TEXTURE_ADDRESS_* for V axis
     int address_mode_w;  // WP_TEXTURE_ADDRESS_* for W axis
     bool use_normalized_coords;  // If true, coords in [0,1]; if false, in texel space
+    int num_mip_levels;  // 1 = no mipmaps
+    int mip_filter_mode;  // 0=closest, 1=linear
+    void** mip_data;
+    int* mip_widths;
+    int* mip_heights;
+    int* mip_depths;
 };
 
 // Helper function to get bytes per channel from dtype
@@ -97,10 +108,14 @@ bool wp_texture2d_create_host(
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
     uint64_t* tex_handle_out
 )
 {
@@ -124,18 +139,56 @@ bool wp_texture2d_create_host(
         return false;
     }
 
-    // Calculate data size and allocate storage
     int bytes_per_channel = get_bytes_per_channel(dtype);
-    size_t data_size = (size_t)width * height * num_channels * bytes_per_channel;
 
-    tex_data->data = malloc(data_size);
-    if (tex_data->data == nullptr) {
-        free(tex_data);
-        return false;
+    if (num_mip_levels > 1 && mip_widths != nullptr && mip_heights != nullptr) {
+        // Mipmapped path: compute total data size across all levels
+        size_t total_size = 0;
+        for (int i = 0; i < num_mip_levels; ++i) {
+            total_size += (size_t)mip_widths[i] * mip_heights[i] * num_channels * bytes_per_channel;
+        }
+
+        void* all_data = malloc(total_size);
+        if (all_data == nullptr) {
+            free(tex_data);
+            return false;
+        }
+        memcpy(all_data, data, total_size);
+
+        // Allocate mipmap arrays
+        tex_data->mip_data = (void**)malloc(sizeof(void*) * num_mip_levels);
+        tex_data->mip_widths = (int*)malloc(sizeof(int) * num_mip_levels);
+        tex_data->mip_heights = (int*)malloc(sizeof(int) * num_mip_levels);
+
+        // Set up per-level pointers into the contiguous buffer
+        char* ptr = (char*)all_data;
+        for (int i = 0; i < num_mip_levels; ++i) {
+            tex_data->mip_data[i] = ptr;
+            tex_data->mip_widths[i] = mip_widths[i];
+            tex_data->mip_heights[i] = mip_heights[i];
+            ptr += (size_t)mip_widths[i] * mip_heights[i] * num_channels * bytes_per_channel;
+        }
+
+        tex_data->data = all_data;
+        tex_data->num_mip_levels = num_mip_levels;
+        tex_data->mip_filter_mode = mip_filter_mode;
+    } else {
+        // Non-mipmapped path
+        size_t data_size = (size_t)width * height * num_channels * bytes_per_channel;
+
+        tex_data->data = malloc(data_size);
+        if (tex_data->data == nullptr) {
+            free(tex_data);
+            return false;
+        }
+        memcpy(tex_data->data, data, data_size);
+
+        tex_data->num_mip_levels = 1;
+        tex_data->mip_filter_mode = 0;
+        tex_data->mip_data = nullptr;
+        tex_data->mip_widths = nullptr;
+        tex_data->mip_heights = nullptr;
     }
-
-    // Copy the texture data
-    memcpy(tex_data->data, data, data_size);
 
     // Store metadata
     tex_data->width = width;
@@ -159,9 +212,14 @@ void wp_texture2d_destroy_host(uint64_t tex_handle)
         return;
 
     cpu_texture2d_data* tex_data = (cpu_texture2d_data*)tex_handle;
-    if (tex_data->data != nullptr) {
+    if (tex_data->data != nullptr)
         free(tex_data->data);
-    }
+    if (tex_data->mip_data != nullptr)
+        free(tex_data->mip_data);
+    if (tex_data->mip_widths != nullptr)
+        free(tex_data->mip_widths);
+    if (tex_data->mip_heights != nullptr)
+        free(tex_data->mip_heights);
     free(tex_data);
 }
 
@@ -172,11 +230,16 @@ bool wp_texture3d_create_host(
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     int address_mode_w,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
+    const int* mip_depths,
     uint64_t* tex_handle_out
 )
 {
@@ -200,18 +263,57 @@ bool wp_texture3d_create_host(
         return false;
     }
 
-    // Calculate data size and allocate storage
     int bytes_per_channel = get_bytes_per_channel(dtype);
-    size_t data_size = (size_t)width * height * depth * num_channels * bytes_per_channel;
 
-    tex_data->data = malloc(data_size);
-    if (tex_data->data == nullptr) {
-        free(tex_data);
-        return false;
+    if (num_mip_levels > 1 && mip_widths != nullptr && mip_heights != nullptr && mip_depths != nullptr) {
+        // Mipmapped path
+        size_t total_size = 0;
+        for (int i = 0; i < num_mip_levels; ++i) {
+            total_size += (size_t)mip_widths[i] * mip_heights[i] * mip_depths[i] * num_channels * bytes_per_channel;
+        }
+
+        void* all_data = malloc(total_size);
+        if (all_data == nullptr) {
+            free(tex_data);
+            return false;
+        }
+        memcpy(all_data, data, total_size);
+
+        tex_data->mip_data = (void**)malloc(sizeof(void*) * num_mip_levels);
+        tex_data->mip_widths = (int*)malloc(sizeof(int) * num_mip_levels);
+        tex_data->mip_heights = (int*)malloc(sizeof(int) * num_mip_levels);
+        tex_data->mip_depths = (int*)malloc(sizeof(int) * num_mip_levels);
+
+        char* ptr = (char*)all_data;
+        for (int i = 0; i < num_mip_levels; ++i) {
+            tex_data->mip_data[i] = ptr;
+            tex_data->mip_widths[i] = mip_widths[i];
+            tex_data->mip_heights[i] = mip_heights[i];
+            tex_data->mip_depths[i] = mip_depths[i];
+            ptr += (size_t)mip_widths[i] * mip_heights[i] * mip_depths[i] * num_channels * bytes_per_channel;
+        }
+
+        tex_data->data = all_data;
+        tex_data->num_mip_levels = num_mip_levels;
+        tex_data->mip_filter_mode = mip_filter_mode;
+    } else {
+        // Non-mipmapped path
+        size_t data_size = (size_t)width * height * depth * num_channels * bytes_per_channel;
+
+        tex_data->data = malloc(data_size);
+        if (tex_data->data == nullptr) {
+            free(tex_data);
+            return false;
+        }
+        memcpy(tex_data->data, data, data_size);
+
+        tex_data->num_mip_levels = 1;
+        tex_data->mip_filter_mode = 0;
+        tex_data->mip_data = nullptr;
+        tex_data->mip_widths = nullptr;
+        tex_data->mip_heights = nullptr;
+        tex_data->mip_depths = nullptr;
     }
-
-    // Copy the texture data
-    memcpy(tex_data->data, data, data_size);
 
     // Store metadata
     tex_data->width = width;
@@ -237,9 +339,16 @@ void wp_texture3d_destroy_host(uint64_t tex_handle)
         return;
 
     cpu_texture3d_data* tex_data = (cpu_texture3d_data*)tex_handle;
-    if (tex_data->data != nullptr) {
+    if (tex_data->data != nullptr)
         free(tex_data->data);
-    }
+    if (tex_data->mip_data != nullptr)
+        free(tex_data->mip_data);
+    if (tex_data->mip_widths != nullptr)
+        free(tex_data->mip_widths);
+    if (tex_data->mip_heights != nullptr)
+        free(tex_data->mip_heights);
+    if (tex_data->mip_depths != nullptr)
+        free(tex_data->mip_depths);
     free(tex_data);
 }
 
@@ -287,12 +396,17 @@ bool wp_texture2d_create_device(
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
     uint64_t* tex_handle_out,
-    uint64_t* array_handle_out
+    uint64_t* array_handle_out,
+    uint64_t* mipmap_handle_out
 )
 {
     if (width <= 0 || height <= 0 || data == nullptr) {
@@ -314,100 +428,145 @@ bool wp_texture2d_create_device(
     // Determine the CUDA array format
     CUarray_format format = get_cuda_format(dtype);
     int bytes_per_channel = get_bytes_per_channel(dtype);
-
-    // Create CUDA array descriptor
-    CUDA_ARRAY_DESCRIPTOR arr_desc = {};
-    arr_desc.Width = width;
-    arr_desc.Height = height;
-    arr_desc.Format = format;
-    arr_desc.NumChannels = num_channels;
-
-    // Create the array
-    CUarray cuda_array;
-    CUresult result = cuArrayCreate_f(&cuda_array, &arr_desc);
-    if (result != CUDA_SUCCESS) {
-        return false;
-    }
-
-    // Copy data to the array
     int bytes_per_texel = num_channels * bytes_per_channel;
-    CUDA_MEMCPY2D copy_params = {};
-    copy_params.srcXInBytes = 0;
-    copy_params.srcY = 0;
-    copy_params.srcMemoryType = CU_MEMORYTYPE_HOST;
-    copy_params.srcHost = data;
-    copy_params.srcPitch = width * bytes_per_texel;
 
-    copy_params.dstXInBytes = 0;
-    copy_params.dstY = 0;
-    copy_params.dstMemoryType = CU_MEMORYTYPE_ARRAY;
-    copy_params.dstArray = cuda_array;
+    bool use_mip = (num_mip_levels > 1 && mip_widths != nullptr && mip_heights != nullptr);
 
-    copy_params.WidthInBytes = width * bytes_per_texel;
-    copy_params.Height = height;
-
-    result = cuMemcpy2D_f(&copy_params);
-    if (result != CUDA_SUCCESS) {
-        cuArrayDestroy_f(cuda_array);
-        return false;
-    }
-
-    // Create resource descriptor
     CUDA_RESOURCE_DESC res_desc = {};
-    res_desc.resType = CU_RESOURCE_TYPE_ARRAY;
-    res_desc.res.array.hArray = cuda_array;
     res_desc.flags = 0;
+
+    CUarray cuda_array = nullptr;
+    CUmipmappedArray mip_array = nullptr;
+
+    if (use_mip) {
+        // Mipmapped path: create mipmapped array
+        CUDA_ARRAY3D_DESCRIPTOR arr_desc = {};
+        arr_desc.Width = width;
+        arr_desc.Height = height;
+        arr_desc.Depth = 0;  // 0 for 2D mipmapped arrays
+        arr_desc.Format = format;
+        arr_desc.NumChannels = num_channels;
+        arr_desc.Flags = 0;
+
+        CUresult result = cuMipmappedArrayCreate_f(&mip_array, &arr_desc, num_mip_levels);
+        if (result != CUDA_SUCCESS) {
+            return false;
+        }
+
+        // Copy data to each mip level
+        const char* src_ptr = (const char*)data;
+        for (int level = 0; level < num_mip_levels; ++level) {
+            CUarray level_array;
+            result = cuMipmappedArrayGetLevel_f(&level_array, mip_array, level);
+            if (result != CUDA_SUCCESS) {
+                cuMipmappedArrayDestroy_f(mip_array);
+                return false;
+            }
+
+            int lw = mip_widths[level];
+            int lh = mip_heights[level];
+
+            CUDA_MEMCPY2D copy_params = {};
+            copy_params.srcMemoryType = CU_MEMORYTYPE_HOST;
+            copy_params.srcHost = src_ptr;
+            copy_params.srcPitch = lw * bytes_per_texel;
+            copy_params.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+            copy_params.dstArray = level_array;
+            copy_params.WidthInBytes = lw * bytes_per_texel;
+            copy_params.Height = lh;
+
+            result = cuMemcpy2D_f(&copy_params);
+            if (result != CUDA_SUCCESS) {
+                cuMipmappedArrayDestroy_f(mip_array);
+                return false;
+            }
+
+            src_ptr += (size_t)lw * lh * bytes_per_texel;
+        }
+
+        res_desc.resType = CU_RESOURCE_TYPE_MIPMAPPED_ARRAY;
+        res_desc.res.mipmap.hMipmappedArray = mip_array;
+    } else {
+        // Non-mipmapped path: create regular CUDA array
+        CUDA_ARRAY_DESCRIPTOR arr_desc = {};
+        arr_desc.Width = width;
+        arr_desc.Height = height;
+        arr_desc.Format = format;
+        arr_desc.NumChannels = num_channels;
+
+        CUresult result = cuArrayCreate_f(&cuda_array, &arr_desc);
+        if (result != CUDA_SUCCESS) {
+            return false;
+        }
+
+        CUDA_MEMCPY2D copy_params = {};
+        copy_params.srcMemoryType = CU_MEMORYTYPE_HOST;
+        copy_params.srcHost = data;
+        copy_params.srcPitch = width * bytes_per_texel;
+        copy_params.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+        copy_params.dstArray = cuda_array;
+        copy_params.WidthInBytes = width * bytes_per_texel;
+        copy_params.Height = height;
+
+        result = cuMemcpy2D_f(&copy_params);
+        if (result != CUDA_SUCCESS) {
+            cuArrayDestroy_f(cuda_array);
+            return false;
+        }
+
+        res_desc.resType = CU_RESOURCE_TYPE_ARRAY;
+        res_desc.res.array.hArray = cuda_array;
+    }
 
     // Create texture descriptor
     CUDA_TEXTURE_DESC tex_desc = {};
-
-    // Per-axis address modes
     tex_desc.addressMode[0] = get_cuda_address_mode(address_mode_u);
     tex_desc.addressMode[1] = get_cuda_address_mode(address_mode_v);
-    tex_desc.addressMode[2] = CU_TR_ADDRESS_MODE_CLAMP;  // Not used for 2D, but set a default
-
-    // Filter mode: 0=nearest, 1=linear
+    tex_desc.addressMode[2] = CU_TR_ADDRESS_MODE_CLAMP;
     tex_desc.filterMode = (filter_mode == 0) ? CU_TR_FILTER_MODE_POINT : CU_TR_FILTER_MODE_LINEAR;
-
-    // Coordinate mode: normalized [0,1] or texel space [0,width/height]
-    // For uint8/uint16 textures, CUDA automatically normalizes values to [0,1] when sampled
-    // (since CU_TRSF_READ_AS_INTEGER is NOT set). Float32 textures return values as-is.
     tex_desc.flags = use_normalized_coords ? CU_TRSF_NORMALIZED_COORDINATES : 0;
-
     tex_desc.maxAnisotropy = 0;
-    tex_desc.mipmapFilterMode = CU_TR_FILTER_MODE_POINT;
+
+    if (use_mip) {
+        tex_desc.mipmapFilterMode = (mip_filter_mode == 0) ? CU_TR_FILTER_MODE_POINT : CU_TR_FILTER_MODE_LINEAR;
+        tex_desc.maxMipmapLevelClamp = (float)(num_mip_levels - 1);
+    } else {
+        tex_desc.mipmapFilterMode = CU_TR_FILTER_MODE_POINT;
+    }
     tex_desc.mipmapLevelBias = 0;
     tex_desc.minMipmapLevelClamp = 0;
-    tex_desc.maxMipmapLevelClamp = 0;
 
     // Create texture object
     CUtexObject tex_object;
-    result = cuTexObjectCreate_f(&tex_object, &res_desc, &tex_desc, nullptr);
+    CUresult result = cuTexObjectCreate_f(&tex_object, &res_desc, &tex_desc, nullptr);
     if (result != CUDA_SUCCESS) {
-        cuArrayDestroy_f(cuda_array);
+        if (use_mip)
+            cuMipmappedArrayDestroy_f(mip_array);
+        else
+            cuArrayDestroy_f(cuda_array);
         return false;
     }
 
     *tex_handle_out = (uint64_t)tex_object;
-    *array_handle_out = (uint64_t)cuda_array;
+    *array_handle_out = use_mip ? 0 : (uint64_t)cuda_array;
+    *mipmap_handle_out = use_mip ? (uint64_t)mip_array : 0;
 
     return true;
 }
 
-void wp_texture2d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle)
+void wp_texture2d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle, uint64_t mipmap_handle)
 {
-    if (tex_handle == 0 && array_handle == 0)
+    if (tex_handle == 0 && array_handle == 0 && mipmap_handle == 0)
         return;
 
     ContextGuard guard(context);
 
-    if (tex_handle != 0) {
+    if (tex_handle != 0)
         cuTexObjectDestroy_f((CUtexObject)tex_handle);
-    }
-
-    if (array_handle != 0) {
+    if (array_handle != 0)
         cuArrayDestroy_f((CUarray)array_handle);
-    }
+    if (mipmap_handle != 0)
+        cuMipmappedArrayDestroy_f((CUmipmappedArray)mipmap_handle);
 }
 
 bool wp_texture3d_create_device(
@@ -418,13 +577,19 @@ bool wp_texture3d_create_device(
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     int address_mode_w,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
+    const int* mip_depths,
     uint64_t* tex_handle_out,
-    uint64_t* array_handle_out
+    uint64_t* array_handle_out,
+    uint64_t* mipmap_handle_out
 )
 {
     if (width <= 0 || height <= 0 || depth <= 0 || data == nullptr) {
@@ -443,11 +608,18 @@ bool wp_texture3d_create_device(
 
     ContextGuard guard(context);
 
-    // Determine the CUDA array format
     CUarray_format format = get_cuda_format(dtype);
     int bytes_per_channel = get_bytes_per_channel(dtype);
+    int bytes_per_texel = num_channels * bytes_per_channel;
 
-    // Create CUDA 3D array descriptor
+    bool use_mip = (num_mip_levels > 1 && mip_widths != nullptr && mip_heights != nullptr && mip_depths != nullptr);
+
+    CUDA_RESOURCE_DESC res_desc = {};
+    res_desc.flags = 0;
+
+    CUarray cuda_array = nullptr;
+    CUmipmappedArray mip_array = nullptr;
+
     CUDA_ARRAY3D_DESCRIPTOR arr_desc = {};
     arr_desc.Width = width;
     arr_desc.Height = height;
@@ -456,96 +628,125 @@ bool wp_texture3d_create_device(
     arr_desc.NumChannels = num_channels;
     arr_desc.Flags = 0;
 
-    // Create the 3D array
-    CUarray cuda_array;
-    CUresult result = cuArray3DCreate_f(&cuda_array, &arr_desc);
-    if (result != CUDA_SUCCESS) {
-        return false;
+    if (use_mip) {
+        // Mipmapped path
+        CUresult result = cuMipmappedArrayCreate_f(&mip_array, &arr_desc, num_mip_levels);
+        if (result != CUDA_SUCCESS) {
+            return false;
+        }
+
+        const char* src_ptr = (const char*)data;
+        for (int level = 0; level < num_mip_levels; ++level) {
+            CUarray level_array;
+            result = cuMipmappedArrayGetLevel_f(&level_array, mip_array, level);
+            if (result != CUDA_SUCCESS) {
+                cuMipmappedArrayDestroy_f(mip_array);
+                return false;
+            }
+
+            int lw = mip_widths[level];
+            int lh = mip_heights[level];
+            int ld = mip_depths[level];
+
+            CUDA_MEMCPY3D copy_params = {};
+            copy_params.srcMemoryType = CU_MEMORYTYPE_HOST;
+            copy_params.srcHost = src_ptr;
+            copy_params.srcPitch = lw * bytes_per_texel;
+            copy_params.srcHeight = lh;
+            copy_params.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+            copy_params.dstArray = level_array;
+            copy_params.WidthInBytes = lw * bytes_per_texel;
+            copy_params.Height = lh;
+            copy_params.Depth = ld;
+
+            result = cuMemcpy3D_f(&copy_params);
+            if (result != CUDA_SUCCESS) {
+                cuMipmappedArrayDestroy_f(mip_array);
+                return false;
+            }
+
+            src_ptr += (size_t)lw * lh * ld * bytes_per_texel;
+        }
+
+        res_desc.resType = CU_RESOURCE_TYPE_MIPMAPPED_ARRAY;
+        res_desc.res.mipmap.hMipmappedArray = mip_array;
+    } else {
+        // Non-mipmapped path
+        CUresult result = cuArray3DCreate_f(&cuda_array, &arr_desc);
+        if (result != CUDA_SUCCESS) {
+            return false;
+        }
+
+        CUDA_MEMCPY3D copy_params = {};
+        copy_params.srcMemoryType = CU_MEMORYTYPE_HOST;
+        copy_params.srcHost = data;
+        copy_params.srcPitch = width * bytes_per_texel;
+        copy_params.srcHeight = height;
+        copy_params.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+        copy_params.dstArray = cuda_array;
+        copy_params.WidthInBytes = width * bytes_per_texel;
+        copy_params.Height = height;
+        copy_params.Depth = depth;
+
+        result = cuMemcpy3D_f(&copy_params);
+        if (result != CUDA_SUCCESS) {
+            cuArrayDestroy_f(cuda_array);
+            return false;
+        }
+
+        res_desc.resType = CU_RESOURCE_TYPE_ARRAY;
+        res_desc.res.array.hArray = cuda_array;
     }
-
-    // Copy data to the 3D array
-    int bytes_per_texel = num_channels * bytes_per_channel;
-    CUDA_MEMCPY3D copy_params = {};
-    copy_params.srcXInBytes = 0;
-    copy_params.srcY = 0;
-    copy_params.srcZ = 0;
-    copy_params.srcMemoryType = CU_MEMORYTYPE_HOST;
-    copy_params.srcHost = data;
-    copy_params.srcPitch = width * bytes_per_texel;
-    copy_params.srcHeight = height;
-
-    copy_params.dstXInBytes = 0;
-    copy_params.dstY = 0;
-    copy_params.dstZ = 0;
-    copy_params.dstMemoryType = CU_MEMORYTYPE_ARRAY;
-    copy_params.dstArray = cuda_array;
-
-    copy_params.WidthInBytes = width * bytes_per_texel;
-    copy_params.Height = height;
-    copy_params.Depth = depth;
-
-    result = cuMemcpy3D_f(&copy_params);
-    if (result != CUDA_SUCCESS) {
-        cuArrayDestroy_f(cuda_array);
-        return false;
-    }
-
-    // Create resource descriptor
-    CUDA_RESOURCE_DESC res_desc = {};
-    res_desc.resType = CU_RESOURCE_TYPE_ARRAY;
-    res_desc.res.array.hArray = cuda_array;
-    res_desc.flags = 0;
 
     // Create texture descriptor
     CUDA_TEXTURE_DESC tex_desc = {};
-
-    // Per-axis address modes
     tex_desc.addressMode[0] = get_cuda_address_mode(address_mode_u);
     tex_desc.addressMode[1] = get_cuda_address_mode(address_mode_v);
     tex_desc.addressMode[2] = get_cuda_address_mode(address_mode_w);
-
-    // Filter mode: 0=nearest, 1=linear
     tex_desc.filterMode = (filter_mode == 0) ? CU_TR_FILTER_MODE_POINT : CU_TR_FILTER_MODE_LINEAR;
-
-    // Coordinate mode: normalized [0,1] or texel space [0,width/height/depth]
-    // For uint8/uint16 textures, CUDA automatically normalizes values to [0,1] when sampled
-    // (since CU_TRSF_READ_AS_INTEGER is NOT set). Float32 textures return values as-is.
     tex_desc.flags = use_normalized_coords ? CU_TRSF_NORMALIZED_COORDINATES : 0;
-
     tex_desc.maxAnisotropy = 0;
-    tex_desc.mipmapFilterMode = CU_TR_FILTER_MODE_POINT;
+
+    if (use_mip) {
+        tex_desc.mipmapFilterMode = (mip_filter_mode == 0) ? CU_TR_FILTER_MODE_POINT : CU_TR_FILTER_MODE_LINEAR;
+        tex_desc.maxMipmapLevelClamp = (float)(num_mip_levels - 1);
+    } else {
+        tex_desc.mipmapFilterMode = CU_TR_FILTER_MODE_POINT;
+    }
     tex_desc.mipmapLevelBias = 0;
     tex_desc.minMipmapLevelClamp = 0;
-    tex_desc.maxMipmapLevelClamp = 0;
 
     // Create texture object
     CUtexObject tex_object;
-    result = cuTexObjectCreate_f(&tex_object, &res_desc, &tex_desc, nullptr);
+    CUresult result = cuTexObjectCreate_f(&tex_object, &res_desc, &tex_desc, nullptr);
     if (result != CUDA_SUCCESS) {
-        cuArrayDestroy_f(cuda_array);
+        if (use_mip)
+            cuMipmappedArrayDestroy_f(mip_array);
+        else
+            cuArrayDestroy_f(cuda_array);
         return false;
     }
 
     *tex_handle_out = (uint64_t)tex_object;
-    *array_handle_out = (uint64_t)cuda_array;
+    *array_handle_out = use_mip ? 0 : (uint64_t)cuda_array;
+    *mipmap_handle_out = use_mip ? (uint64_t)mip_array : 0;
 
     return true;
 }
 
-void wp_texture3d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle)
+void wp_texture3d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle, uint64_t mipmap_handle)
 {
-    if (tex_handle == 0 && array_handle == 0)
+    if (tex_handle == 0 && array_handle == 0 && mipmap_handle == 0)
         return;
 
     ContextGuard guard(context);
 
-    if (tex_handle != 0) {
+    if (tex_handle != 0)
         cuTexObjectDestroy_f((CUtexObject)tex_handle);
-    }
-
-    if (array_handle != 0) {
+    if (array_handle != 0)
         cuArrayDestroy_f((CUarray)array_handle);
-    }
+    if (mipmap_handle != 0)
+        cuMipmappedArrayDestroy_f((CUmipmappedArray)mipmap_handle);
 }
 
 #else  // WP_ENABLE_CUDA
@@ -558,18 +759,23 @@ bool wp_texture2d_create_device(
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
     uint64_t* tex_handle_out,
-    uint64_t* array_handle_out
+    uint64_t* array_handle_out,
+    uint64_t* mipmap_handle_out
 )
 {
     return false;
 }
 
-void wp_texture2d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle) { }
+void wp_texture2d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle, uint64_t mipmap_handle) { }
 
 bool wp_texture3d_create_device(
     void* context,
@@ -579,18 +785,24 @@ bool wp_texture3d_create_device(
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     int address_mode_w,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
+    const int* mip_depths,
     uint64_t* tex_handle_out,
-    uint64_t* array_handle_out
+    uint64_t* array_handle_out,
+    uint64_t* mipmap_handle_out
 )
 {
     return false;
 }
 
-void wp_texture3d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle) { }
+void wp_texture3d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle, uint64_t mipmap_handle) { }
 
 #endif  // WP_ENABLE_CUDA

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -191,8 +191,11 @@ WP_API const char* wp_volume_get_blind_data_info(
 // num_channels: 1, 2, or 4
 // dtype: 0=uint8, 1=uint16, 2=float32
 // filter_mode: 0=nearest, 1=linear
+// mip_filter_mode: 0=nearest, 1=linear
 // address_mode_u, address_mode_v: 0=wrap, 1=clamp, 2=mirror, 3=border (per-axis)
 // use_normalized_coords: if true, texture coordinates are in [0,1]; if false, in texel space [0,width/height]
+// num_mip_levels: number of mip levels to create
+// mip_widths, mip_heights: array of mip widths and heights (must be power of two)
 WP_API bool wp_texture2d_create_device(
     void* context,
     int width,
@@ -200,14 +203,20 @@ WP_API bool wp_texture2d_create_device(
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
     uint64_t* tex_handle_out,
-    uint64_t* array_handle_out
+    uint64_t* array_handle_out,
+    uint64_t* mipmap_handle_out
 );
-WP_API void wp_texture2d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle);
+WP_API void
+wp_texture2d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle, uint64_t mipmap_handle);
 
 // Texture2D functions (CPU host)
 // Creates a 2D texture from data on the host. Returns texture handle (pointer to internal data).
@@ -216,18 +225,25 @@ WP_API void wp_texture2d_destroy_device(void* context, uint64_t tex_handle, uint
 // num_channels: 1, 2, or 4
 // dtype: 0=uint8, 1=uint16, 2=float32
 // filter_mode: 0=nearest, 1=linear
+// mip_filter_mode: 0=nearest, 1=linear
 // address_mode_u, address_mode_v: 0=wrap, 1=clamp, 2=mirror, 3=border (per-axis)
 // use_normalized_coords: if true, texture coordinates are in [0,1]; if false, in texel space [0,width/height]
+// num_mip_levels: number of mip levels to create
+// mip_widths, mip_heights: array of mip widths and heights (must be power of two)
 WP_API bool wp_texture2d_create_host(
     int width,
     int height,
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
     uint64_t* tex_handle_out
 );
 WP_API void wp_texture2d_destroy_host(uint64_t tex_handle);
@@ -239,8 +255,11 @@ WP_API void wp_texture2d_destroy_host(uint64_t tex_handle);
 // num_channels: 1, 2, or 4
 // dtype: 0=uint8, 1=uint16, 2=float32
 // filter_mode: 0=nearest, 1=linear
+// mip_filter_mode: 0=nearest, 1=linear
 // address_mode_u, address_mode_v, address_mode_w: 0=wrap, 1=clamp, 2=mirror, 3=border (per-axis)
 // use_normalized_coords: if true, texture coordinates are in [0,1]; if false, in texel space [0,width/height/depth]
+// num_mip_levels: number of mip levels to create
+// mip_widths, mip_heights, mip_depths: array of mip widths, heights, and depths (must be power of two)
 WP_API bool wp_texture3d_create_device(
     void* context,
     int width,
@@ -249,15 +268,22 @@ WP_API bool wp_texture3d_create_device(
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     int address_mode_w,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
+    const int* mip_depths,
     uint64_t* tex_handle_out,
-    uint64_t* array_handle_out
+    uint64_t* array_handle_out,
+    uint64_t* mipmap_handle_out
 );
-WP_API void wp_texture3d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle);
+WP_API void
+wp_texture3d_destroy_device(void* context, uint64_t tex_handle, uint64_t array_handle, uint64_t mipmap_handle);
 
 // Texture3D functions (CPU host)
 // Creates a 3D texture from data on the host. Returns texture handle (pointer to internal data).
@@ -266,8 +292,11 @@ WP_API void wp_texture3d_destroy_device(void* context, uint64_t tex_handle, uint
 // num_channels: 1, 2, or 4
 // dtype: 0=uint8, 1=uint16, 2=float32
 // filter_mode: 0=nearest, 1=linear
+// mip_filter_mode: 0=nearest, 1=linear
 // address_mode_u, address_mode_v, address_mode_w: 0=wrap, 1=clamp, 2=mirror, 3=border (per-axis)
 // use_normalized_coords: if true, texture coordinates are in [0,1]; if false, in texel space [0,width/height/depth]
+// num_mip_levels: number of mip levels to create
+// mip_widths, mip_heights, mip_depths: array of mip widths, heights, and depths (must be power of two)
 WP_API bool wp_texture3d_create_host(
     int width,
     int height,
@@ -275,11 +304,16 @@ WP_API bool wp_texture3d_create_host(
     int num_channels,
     int dtype,
     int filter_mode,
+    int mip_filter_mode,
     int address_mode_u,
     int address_mode_v,
     int address_mode_w,
     bool use_normalized_coords,
+    int num_mip_levels,
     const void* data,
+    const int* mip_widths,
+    const int* mip_heights,
+    const int* mip_depths,
     uint64_t* tex_handle_out
 );
 WP_API void wp_texture3d_destroy_host(uint64_t tex_handle);

--- a/warp/tests/cuda/test_texture.py
+++ b/warp/tests/cuda/test_texture.py
@@ -2041,11 +2041,11 @@ def sample_texture2d_load_f(
     lods: wp.array(dtype=float),
     output: wp.array(dtype=float),
 ):
-    """Sample a 1-channel 2D texture at specified UV coordinates and LOAD."""
+    """Sample a 1-channel 2D texture at specified UV coordinates and LOD."""
     tid = wp.tid()
     uv = uvs[tid]
-    load = lods[tid]
-    output[tid] = wp.texture_sample(tex, uv, dtype=float, load=load)
+    lod = lods[tid]
+    output[tid] = wp.texture_sample(tex, uv, dtype=float, lod=lod)
 
 
 @wp.kernel
@@ -2055,11 +2055,11 @@ def sample_texture2d_load_v4(
     lods: wp.array(dtype=float),
     output: wp.array(dtype=wp.vec4f),
 ):
-    """Sample a 4-channel 2D texture at specified UV coordinates and LOAD."""
+    """Sample a 4-channel 2D texture at specified UV coordinates and LOD."""
     tid = wp.tid()
     uv = uvs[tid]
-    load = lods[tid]
-    output[tid] = wp.texture_sample(tex, uv, dtype=wp.vec4f, load=load)
+    lod = lods[tid]
+    output[tid] = wp.texture_sample(tex, uv, dtype=wp.vec4f, lod=lod)
 
 
 @wp.kernel
@@ -2069,11 +2069,11 @@ def sample_texture3d_load_f(
     lods: wp.array(dtype=float),
     output: wp.array(dtype=float),
 ):
-    """Sample a 1-channel 3D texture at specified UVW coordinates and LOAD."""
+    """Sample a 1-channel 3D texture at specified UVW coordinates and LOD."""
     tid = wp.tid()
     uvw = uvws[tid]
-    load = lods[tid]
-    output[tid] = wp.texture_sample(tex, uvw, dtype=float, load=load)
+    lod = lods[tid]
+    output[tid] = wp.texture_sample(tex, uvw, dtype=float, lod=lod)
 
 
 # ============================================================================
@@ -2110,7 +2110,7 @@ def test_mipmap2d_creation(test, device):
 
 
 def test_mipmap2d_load0_matches_base(test, device):
-    """Test that sampling at LOAD 0 gives the same result as texture_sample."""
+    """Test that sampling at LOD 0 gives the same result as texture_sample."""
     width, height = 16, 16
     data = generate_sin_pattern_2d(width, height, 1)
 


### PR DESCRIPTION
## Description

For downstream applications, adding mipmap support to the current texture API allows for better texture sampling for detailed textures at various distances. CUDA textures already support this but some modifications need to be done to correctly create and pass in the texture data.

This PR adds:
- Creating textures with mipmap support, with automatic downscaling of supplied texture data to create the texture maps between the current texture width x height all the way to 1x1
- Texture sampling using lod (level of detail).
- CPU logic to mimic the CUDA texture mipmap logic

Example without mip support for a plane with a checkerboard texture with border between squares:

<img width="256" height="256" alt="without_mip" src="https://github.com/user-attachments/assets/51f11fa9-db69-4c04-b9e7-b91c5c8257f6" />

After mip support passing lod (level of detail) into texture sample function:

<img width="256" height="256" alt="debug" src="https://github.com/user-attachments/assets/a236add7-11e4-40fb-a629-1f58c8dbcad4" />

Downstream the API usage changes from this:

```
# create texture ahead of time
wp.Texture2D(tex_data, filter_mode=wp.TextureFilterMode.LINEAR)

# sample
tex_color = wp.texture_sample(tex, wp.vec2(u, v), dtype=wp.vec4)
```

to this:

```
# create texture ahead of time
# specifying 0 means internally we calculate all the texture maps between current resolution and 1x1
wp.Texture2D(tex_data, filter_mode=wp.TextureFilterMode.LINEAR, num_mip_levels=0)

# new arguments lod, can be calculating from raycast data
tex_color = wp.texture_sample(tex, wp.vec2(u, v), dtype=wp.vec4, lod=lod)
```

TODO:
- Add documentation for this feature
- Build the docs once API is finalized

## Before your PR is "Ready for review"



- [ ] All commits are [signed-off](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) to indicate that your contribution adheres to the [Developer Certificate of Origin](https://developercertificate.org/) requirements
- [x] Necessary tests have been added
- [ ] Documentation is up-to-date
- [ ] Auto-generated files modified by compiling Warp and building the documentation have been updated (e.g. `__init__.pyi`, `docs/api_reference/`, `docs/language_reference/`)
- [x] Code passes formatting and linting checks with `pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mipmapping support for 2D and 3D textures with automatic mip-chain generation and configurable mip filter modes.
  * Texture constructors now accept num_mip_levels and mip_filter_mode; Texture exposes a public num_mip_levels property.
  * Texture sampling accepts an optional lod (mipmap level) parameter with a default of 0.0 (no mipmaps).

* **Tests**
  * Added comprehensive mipmapping tests covering 2D/3D, multiple channels and data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->