### PR TITLE
Increase test-warp-gpu timeout and enable apt proxy cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,13 +166,15 @@ jobs:
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Display GPU information
         run: nvidia-smi
 
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
 
       - name: Install git and git-lfs
         run: |


### PR DESCRIPTION
## Summary
- Increase `test-warp-gpu` job timeout from 30 to 45 minutes to account for slow networking on self-hosted GitHub runners (~14 min in preparatory steps)
- Enable `enable-apt: true` on the `setup-proxy-cache` action to cache apt package downloads

## Test plan
- [ ] Verify the `test-warp-gpu` job completes successfully on GitHub Actions without timing out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GPU testing workflow with extended timeout and package caching to improve build reliability and speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->