### PR TITLE
 Fix vswhere.exe discovery for non-default Visual Studio installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@
 - Fix `BsrMatrix.notify_nnz_changed` sometimes failing to read the latest non-zero count from the `offsets` array.
 - `warp.fem`: Fix temporaries not being released promptly ([GH-1075](https://github.com/NVIDIA/warp/pull/1075)).
 - `warp.fem`: Fix uninitialized memory accesses in point-based function spaces with variable nodes per element.
+- Fix `vswhere.exe` discovery for non-default Visual Studio installations and standalone installs via
+  package managers (Chocolatey, Scoop, winget) ([GH-1235](https://github.com/NVIDIA/warp/issues/1235)).
 
 ### Documentation
 

--- a/build_lib.py
+++ b/build_lib.py
@@ -502,7 +502,12 @@ def main(argv: list[str] | None = None) -> int:
             # attempt to find MSVC in environment (will set vcvars)
             args.host_compiler = build_dll.find_host_compiler()
             if not args.host_compiler:
-                print("Warp build error: Could not find MSVC compiler")
+                print(
+                    "Warp build error: Could not find MSVC compiler.\n"
+                    "  Ensure Visual Studio 2019+ is installed with the 'Desktop development with C++' workload,\n"
+                    "  or use --msvc-path and --sdk-path to specify custom toolchain locations.\n"
+                    "  If Visual Studio is installed in a non-default location, adding vswhere.exe to PATH may help."
+                )
                 return 1
     else:
         args.host_compiler = build_dll.find_host_compiler()


### PR DESCRIPTION
# Description

This PR fixes an issue where `vswhere.exe` discovery would silently fail for non-default Visual Studio installations or when `vswhere` was installed via a standalone package manager (e.g., Chocolatey, Scoop, winget).

**Changes:**
- Added a `_find_vswhere()` helper in `warp/_src/build_dll.py` with multi-strategy path discovery. It now searches `PATH` before falling back to the standard VS Installer paths under `%ProgramFiles(x86)%` and `%ProgramFiles%`.
- Replaced the hardcoded path lookup in `find_host_compiler()` with a call to the new helper.
- Improved the error message in `build_lib.py` when MSVC cannot be found. The message now mentions actionable workarounds, such as using the `--msvc-path` and `--sdk-path` flags or ensuring `vswhere.exe` is in the `PATH`.
- Added an entry to `CHANGELOG.md` under the `Fixed` section.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable Visual Studio/MSVC discovery for non-default and package-manager installations.

* **Improvements**
  * Clearer, multi-line diagnostics when MSVC is not found, with actionable troubleshooting and custom toolchain options.
  * More robust handling and decoding of discovery outputs with additional verbose diagnostics for failure scenarios.

* **Documentation**
  * Added changelog entry noting the discovery and messaging updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->