### PR TITLE
fix(jax): include in_out_argnames and stage argnames in FFI registry …

### DIFF
--- a/warp/_src/jax_experimental/ffi.py
+++ b/warp/_src/jax_experimental/ffi.py
@@ -1203,6 +1203,7 @@ def jax_kernel(
         hashable_launch_dims = launch_dims
 
     if not enable_backward:
+        hashable_in_out = tuple(in_out_argnames) if in_out_argnames is not None else None
         key = (
             kernel.func,
             kernel.sig,
@@ -1210,6 +1211,7 @@ def jax_kernel(
             vmap_method,
             hashable_launch_dims,
             hashable_output_dims,
+            hashable_in_out,
             module_preload_mode,
             has_side_effect,
         )
@@ -1548,12 +1550,18 @@ def jax_callable(
         hashable_output_dims = output_dims
 
     # Note: we don't include graph_cache_max in the key, it is applied below.
+    hashable_in_out = tuple(in_out_argnames) if in_out_argnames is not None else None
+    hashable_stage_in = tuple(stage_in_argnames) if stage_in_argnames is not None else None
+    hashable_stage_out = tuple(stage_out_argnames) if stage_out_argnames is not None else None
     key = (
         func,
         num_outputs,
         graph_mode,
         vmap_method,
         hashable_output_dims,
+        hashable_in_out,
+        hashable_stage_in,
+        hashable_stage_out,
         module_preload_mode,
         has_side_effect,
     )


### PR DESCRIPTION
Issue: 
Both 
jax_kernel()
 and 
jax_callable()
 use a registry dict to cache and deduplicate FFI wrappers. The key tuple used to look up the registry was missing parameters that affect the wrapper's behaviour — in_out_argnames in 
jax_kernel()
, and in_out_argnames, stage_in_argnames, stage_out_argnames in 
jax_callable()
. This meant calling either function with the same kernel but different argname configurations silently returned the first cached object with the wrong configuration.

Fix:
 Added the missing parameters to the key tuples in both functions in 
warp/_src/jax_experimental/ffi.py
. Since list is not hashable, they are converted to tuple before being added to the key. Two wrappers with different configurations now correctly produce different keys and are stored as separate objects in the registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FFI operation caching to correctly distinguish entries based on argument configurations, enhancing cache accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->