### PR TITLE
Use os.replace() instead of os.rename() for cache file moves on Windows

### DIFF
--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2901,8 +2901,8 @@ class Module:
                 # this is necessary in case different processes
                 # have different GPU architectures / devices
                 try:
-                    os.rename(output_path, binary_path)
-                except (OSError, FileExistsError):
+                    os.replace(output_path, binary_path)
+                except OSError:
                     # another process likely updated the module dir first
                     pass
 
@@ -2911,16 +2911,16 @@ class Module:
                 # this is necessary in case different processes
                 # have different GPU architectures / devices
                 try:
-                    os.rename(output_meta_path, meta_path)
-                except (OSError, FileExistsError):
+                    os.replace(output_meta_path, meta_path)
+                except OSError:
                     # another process likely updated the module dir first
                     pass
 
             try:
                 final_source_path = os.path.join(output_dir, os.path.basename(source_code_path))
                 if not os.path.exists(final_source_path) or self.options["strip_hash"]:
-                    os.rename(source_code_path, final_source_path)
-            except (OSError, FileExistsError):
+                    os.replace(source_code_path, final_source_path)
+            except OSError:
                 # another process likely updated the module dir first
                 pass
             except Exception as e:


### PR DESCRIPTION
## Summary

- Fix `_compile()` file-by-file fallback to use `os.replace()` instead of `os.rename()`, which raises `FileExistsError` on Windows when the destination exists
- This caused stale binaries to remain when `strip_hash=True` triggered an intentional overwrite, breaking the `test_aot_cache_skip` test on Windows GitHub runners

## Test plan

- [x] `test_aot_cache_skip` passes locally (CPU + CUDA)
- [ ] Verify `test_aot_cache_skip` passes on Windows GitHub runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overall reliability of file operations to ensure safer and more consistent handling, particularly in scenarios where target files already exist or operations span across different filesystems
  * Enhanced error handling mechanisms for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->