### PR TITLE
feat: support anisotropic voxel sizes in Volume.load_from_numpy and Volume.allocate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@
 
 ### Changed
 
+- Allow `wp.Volume.load_from_numpy()` and `wp.Volume.allocate()` to accept a 3-element sequence for
+  ``voxel_size``, enabling volumes with anisotropic voxel spacing
+  ([GH-1193](https://github.com/NVIDIA/warp/issues/1193)).
 - **Breaking**: Return Warp scalar types (`wp.float16`, `wp.float64`, `wp.int8`, etc.) from built-in
   functions and vector/matrix indexing instead of Python native types for non-native scalar types.
   Native scalar types (`wp.int32`, `wp.float32`, `wp.bool`) continue to return Python `int`, `float`,

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -5975,7 +5975,12 @@ class Volume:
 
     @classmethod
     def load_from_numpy(
-        cls, ndarray: np.ndarray, min_world=(0.0, 0.0, 0.0), voxel_size=1.0, bg_value=0.0, device=None
+        cls,
+        ndarray: np.ndarray,
+        min_world=(0.0, 0.0, 0.0),
+        voxel_size: float | list[float] | tuple[float, float, float] = 1.0,
+        bg_value=0.0,
+        device=None,
     ) -> Volume:
         """Create a :class:`Volume` object from a dense 3D NumPy array.
 
@@ -5983,14 +5988,23 @@ class Volume:
 
         Args:
             min_world: The 3D coordinate of the lower corner of the volume.
-            voxel_size: The size of each voxel in spatial coordinates.
+            voxel_size (float or array-like): The size of each voxel in spatial
+                coordinates. Can be a scalar for isotropic voxels or a 3-element
+                sequence ``(sx, sy, sz)`` for anisotropic voxels.
             bg_value: Background value
-            device: The CUDA device to create the volume on, e.g.: "cuda" or "cuda:0".
+            device: The CUDA device to create the volume on, e.g.: ``"cuda"`` or ``"cuda:0"``.
 
         Returns:
 
             A ``warp.Volume`` object.
         """
+        if isinstance(voxel_size, (int, float)):
+            voxel_size = (float(voxel_size), float(voxel_size), float(voxel_size))
+        else:
+            voxel_size = tuple(float(v) for v in voxel_size)
+            if len(voxel_size) != 3:
+                raise ValueError(f"voxel_size must be a scalar or a 3-element sequence, got length {len(voxel_size)}")
+
         target_shape = (
             math.ceil(ndarray.shape[0] / 8) * 8,
             math.ceil(ndarray.shape[1] / 8) * 8,
@@ -6022,9 +6036,9 @@ class Volume:
         volume = warp.Volume.allocate(
             min_world,
             [
-                min_world[0] + (shape[0] - 1) * voxel_size,
-                min_world[1] + (shape[1] - 1) * voxel_size,
-                min_world[2] + (shape[2] - 1) * voxel_size,
+                min_world[0] + (shape[0] - 1) * voxel_size[0],
+                min_world[1] + (shape[1] - 1) * voxel_size[1],
+                min_world[2] + (shape[2] - 1) * voxel_size[2],
             ],
             voxel_size,
             bg_value=bg_value,
@@ -6063,7 +6077,7 @@ class Volume:
         cls,
         min: list[int],
         max: list[int],
-        voxel_size: float,
+        voxel_size: float | list[float] | tuple[float, float, float],
         bg_value=0.0,
         translation=(0.0, 0.0, 0.0),
         points_in_world_space=False,
@@ -6083,15 +6097,17 @@ class Volume:
         Args:
             min (array-like): Lower 3D coordinates of the bounding box in index space or world space, inclusive.
             max (array-like): Upper 3D coordinates of the bounding box in index space or world space, inclusive.
-            voxel_size: Voxel size of the new volume.
+            voxel_size (float or array-like): Voxel size(s) of the new volume. Can be a scalar for isotropic
+              voxels or a 3-element sequence ``(sx, sy, sz)`` for anisotropic voxels.
             bg_value (float or array-like): Value of unallocated voxels of the volume, also defines the volume's type,
               a :class:`warp.vec3` volume is created if this is `array-like`, otherwise a float volume is created
             translation (array-like): Translation between the index and world spaces.
             device: The CUDA device to create the volume on, e.g.: ``"cuda"`` or ``"cuda:0"``.
         """
         if points_in_world_space:
-            min = np.around((np.array(min, dtype=np.float32) - translation) / voxel_size)
-            max = np.around((np.array(max, dtype=np.float32) - translation) / voxel_size)
+            vs = np.asarray(voxel_size, dtype=np.float32)
+            min = np.around((np.array(min, dtype=np.float32) - translation) / vs)
+            max = np.around((np.array(max, dtype=np.float32) - translation) / vs)
 
         tile_min = np.array(min, dtype=np.int32) // 8
         tile_max = np.array(max, dtype=np.int32) // 8

--- a/warp/tests/geometry/test_volume.py
+++ b/warp/tests/geometry/test_volume.py
@@ -912,6 +912,72 @@ def test_volume_from_numpy_3d(test, device):
     test.assertIsNone(sphere_vdb_array.deleter)
 
 
+def test_volume_from_numpy_anisotropic(test, device):
+    # Verify load_from_numpy works with per-axis voxel sizes
+    mins = np.array([-2.0, -2.0, -2.0])
+    voxel_size = (0.2, 0.3, 0.4)
+    maxs = np.array([2.0, 2.0, 2.0])
+    nums = np.ceil((maxs - mins) / np.array(voxel_size)).astype(dtype=int)
+    center = np.array([0.0, 0.0, 0.0])
+    rad = 1.5
+    sphere_sdf_np = np.zeros(tuple(nums), dtype=np.float32)
+    for x in range(nums[0]):
+        for y in range(nums[1]):
+            for z in range(nums[2]):
+                pos = mins + np.array(voxel_size) * np.array([x, y, z])
+                dis = np.linalg.norm(pos - center)
+                sphere_sdf_np[x, y, z] = dis - rad
+
+    sphere_vdb = wp.Volume.load_from_numpy(sphere_sdf_np, mins, voxel_size, bg_value=0.0, device=device)
+    test.assertNotEqual(sphere_vdb.id, 0)
+
+    # Verify the grid transform has the expected diagonal voxel sizes
+    info = sphere_vdb.get_grid_info()
+    transform = np.array(info.transform_matrix).reshape(3, 3)
+    np.testing.assert_allclose(np.diag(transform), list(voxel_size), atol=1e-6)
+
+
+def test_volume_from_numpy_3d_anisotropic(test, device):
+    # Verify load_from_numpy with vec3 bg_value and anisotropic voxel_size
+    mins = np.array([-1.0, -1.0, -1.0])
+    voxel_size = (0.1, 0.2, 0.3)
+    maxs = np.array([1.0, 1.0, 1.0])
+    nums = np.ceil((maxs - mins) / np.array(voxel_size)).astype(dtype=int)
+    data = np.zeros((*tuple(nums), 3), dtype=np.float32)
+
+    volume = wp.Volume.load_from_numpy(data, mins, voxel_size, bg_value=(0.0, 0.0, 0.0), device=device)
+    test.assertNotEqual(volume.id, 0)
+
+    info = volume.get_grid_info()
+    transform = np.array(info.transform_matrix).reshape(3, 3)
+    np.testing.assert_allclose(np.diag(transform), list(voxel_size), atol=1e-6)
+
+
+def test_volume_from_numpy_bad_voxel_size(test, device):
+    # Verify ValueError for voxel_size with wrong number of elements
+    data = np.zeros((8, 8, 8), dtype=np.float32)
+    with test.assertRaises(ValueError):
+        wp.Volume.load_from_numpy(data, (0, 0, 0), voxel_size=(0.1, 0.2), device=device)
+
+
+def test_volume_allocate_anisotropic(test, device):
+    # Verify Volume.allocate works with anisotropic voxel_size
+    volume = wp.Volume.allocate(
+        min=[0, 0, 0],
+        max=[2.0, 3.0, 4.0],
+        voxel_size=(0.2, 0.3, 0.4),
+        bg_value=0.0,
+        translation=(0.0, 0.0, 0.0),
+        points_in_world_space=True,
+        device=device,
+    )
+    test.assertNotEqual(volume.id, 0)
+
+    info = volume.get_grid_info()
+    transform = np.array(info.transform_matrix).reshape(3, 3)
+    np.testing.assert_allclose(np.diag(transform), [0.2, 0.3, 0.4], atol=1e-6)
+
+
 def test_volume_aniso_transform(test, device):
     # XY-rotation + z scale
     transform = [
@@ -1008,6 +1074,30 @@ add_function_test(
 )
 add_function_test(
     TestVolume, "test_volume_from_numpy_3d", test_volume_from_numpy_3d, devices=get_selected_cuda_test_devices()
+)
+add_function_test(
+    TestVolume,
+    "test_volume_from_numpy_anisotropic",
+    test_volume_from_numpy_anisotropic,
+    devices=get_selected_cuda_test_devices(),
+)
+add_function_test(
+    TestVolume,
+    "test_volume_from_numpy_3d_anisotropic",
+    test_volume_from_numpy_3d_anisotropic,
+    devices=get_selected_cuda_test_devices(),
+)
+add_function_test(
+    TestVolume,
+    "test_volume_from_numpy_bad_voxel_size",
+    test_volume_from_numpy_bad_voxel_size,
+    devices=get_selected_cuda_test_devices(),
+)
+add_function_test(
+    TestVolume,
+    "test_volume_allocate_anisotropic",
+    test_volume_allocate_anisotropic,
+    devices=get_selected_cuda_test_devices(),
 )
 add_function_test(
     TestVolume, "test_volume_aniso_transform", test_volume_aniso_transform, devices=get_selected_cuda_test_devices()


### PR DESCRIPTION
## Description

Allow `wp.Volume.load_from_numpy()` and `wp.Volume.allocate()` to accept a 3-element sequence for `voxel_size` (e.g. `(0.2, 0.3, 0.4)`), enabling volumes with anisotropic voxel spacing.

The underlying `allocate_by_tiles()` and `allocate_by_voxels()` already support anisotropic transforms via `_fill_transform_buffers()`, but the higher-level `load_from_numpy` and `allocate` entry points assumed a scalar `voxel_size`, causing crashes when a tuple was passed.

Closes #1193

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- Added `test_volume_from_numpy_anisotropic` — anisotropic float SDF volume, verifies grid transform diagonal matches requested voxel sizes
- Added `test_volume_from_numpy_3d_anisotropic` — anisotropic vec3 volume
- Added `test_volume_from_numpy_bad_voxel_size` — verifies `ValueError` for wrong-length sequence
- Added `test_volume_allocate_anisotropic` — anisotropic `allocate()` with world-space coordinates

```bash
uv run --extra dev -m warp.tests -s autodetect -k TestVolume
```

## New feature / enhancement

```python
import warp as wp
import numpy as np

# Before: only scalar voxel_size worked
# wp.Volume.load_from_numpy(data, min_world, voxel_size=0.2)

# After: anisotropic voxel sizes are supported
data = np.zeros((20, 14, 10), dtype=np.float32)
volume = wp.Volume.load_from_numpy(
    data,
    min_world=(0.0, 0.0, 0.0),
    voxel_size=(0.2, 0.3, 0.4),  # different size per axis
    device="cuda:0",
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Volume creation methods now support anisotropic voxel spacing, allowing different voxel sizes across axes for non-uniform grid spacing.

* **Tests**
  * Added comprehensive test coverage for anisotropic voxel sizing scenarios and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->