### PR TITLE
Fix UB in float-to-unsigned scalar type conversions

### DIFF
--- a/repro_uint8_bug.py
+++ b/repro_uint8_bug.py
@@ -1,0 +1,40 @@
+"""Minimal reproduction of the uint8 type closure conversion bug."""
+
+import warp as wp
+
+wp.init()
+
+
+def create_type_closure_scalar(scalar_type):
+    @wp.kernel
+    def k(input: float, expected: float):
+        x = scalar_type(input)
+        wp.expect_eq(float(x), expected)
+
+    return k
+
+
+# These work fine (int, float closures)
+type_closure_kernel_int = create_type_closure_scalar(int)
+type_closure_kernel_float = create_type_closure_scalar(float)
+
+# This is the broken one
+type_closure_kernel_uint8 = create_type_closure_scalar(wp.uint8)
+
+print("Testing int closure...")
+wp.launch(type_closure_kernel_int, dim=1, inputs=[-1.5, -1.0], device="cpu")
+wp.synchronize()
+print("  PASSED")
+
+print("Testing float closure...")
+wp.launch(type_closure_kernel_float, dim=1, inputs=[-1.5, -1.5], device="cpu")
+wp.synchronize()
+print("  PASSED")
+
+print("Testing uint8 closure...")
+try:
+    wp.launch(type_closure_kernel_uint8, dim=1, inputs=[-1.5, 255.0], device="cpu")
+    wp.synchronize()
+    print("  PASSED")
+except Exception as e:
+    print(f"  FAILED with exception: {type(e).__name__}: {e}")

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -1007,8 +1007,17 @@ add_builtin(
 
 # scalar type constructors between all storage / compute types
 scalar_types_all = [*scalar_types, bool, int, float]
+
+unsigned_int_types = (uint8, uint16, uint32, uint64)
+float_src_types = {float16: "float16", float32: "float32", float64: "float64", float: "float32"}
+
 for t in scalar_types_all:
     for u in scalar_types_all:
+        # Use safe cast for float -> unsigned to avoid C++ UB
+        safe_native = None
+        if t in unsigned_int_types and u in float_src_types:
+            safe_native = f"{float_src_types[u]}_to_{t.__name__}"
+
         add_builtin(
             t.__name__,
             input_types={"a": u},
@@ -1017,7 +1026,8 @@ for t in scalar_types_all:
             hidden=True,
             group="Scalar Math",
             export=False,
-            namespace="wp::" if t is not bool else "",
+            namespace="wp::" if t is not bool and not safe_native else "",
+            native_func=safe_native if safe_native else t.__name__,
         )
 
 

--- a/warp/native/builtin.h
+++ b/warp/native/builtin.h
@@ -105,6 +105,46 @@ typedef uint64_t uint64;
 typedef const char* str;
 
 
+// Float-to-unsigned conversions: cast through int64 to avoid C++ UB
+// (C++ 7.3.11: float -> unsigned is UB when truncated value is negative)
+template <typename F> CUDA_CALLABLE inline int64 safe_float_to_int64(F x)
+{
+    if (!(x == x))
+        return 0;
+    constexpr F min_int64 = static_cast<F>(-9223372036854775808.0);  // -2^63
+    constexpr F max_overflow = static_cast<F>(9223372036854775808.0);  // 2^63
+    if (x < min_int64)
+        return -9223372036854775807LL - 1LL;
+    if (x >= max_overflow)
+        return 9223372036854775807LL;
+    return static_cast<int64>(x);
+}
+
+template <typename F> CUDA_CALLABLE inline uint64 safe_float_to_uint64(F x)
+{
+    if (!(x == x))
+        return 0;
+    if (x <= 0.0)
+        return static_cast<uint64>(safe_float_to_int64(x));
+    constexpr F pow2_63 = static_cast<F>(9223372036854775808.0);  // 2^63
+    constexpr F overflow_uint64 = static_cast<F>(18446744073709551616.0);  // 2^64
+    if (x >= overflow_uint64)
+        return 18446744073709551615ULL;
+    if (x >= pow2_63)
+        return static_cast<uint64>(safe_float_to_int64(x - pow2_63)) + 9223372036854775808ULL;
+    return static_cast<uint64>(safe_float_to_int64(x));
+}
+
+CUDA_CALLABLE inline uint8 float32_to_uint8(float32 x) { return static_cast<uint8>(safe_float_to_int64(x)); }
+CUDA_CALLABLE inline uint8 float64_to_uint8(float64 x) { return static_cast<uint8>(safe_float_to_int64(x)); }
+CUDA_CALLABLE inline uint16 float32_to_uint16(float32 x) { return static_cast<uint16>(safe_float_to_int64(x)); }
+CUDA_CALLABLE inline uint16 float64_to_uint16(float64 x) { return static_cast<uint16>(safe_float_to_int64(x)); }
+CUDA_CALLABLE inline uint32 float32_to_uint32(float32 x) { return static_cast<uint32>(safe_float_to_int64(x)); }
+CUDA_CALLABLE inline uint32 float64_to_uint32(float64 x) { return static_cast<uint32>(safe_float_to_int64(x)); }
+CUDA_CALLABLE inline uint64 float32_to_uint64(float32 x) { return safe_float_to_uint64(x); }
+CUDA_CALLABLE inline uint64 float64_to_uint64(float64 x) { return safe_float_to_uint64(x); }
+
+
 struct half;
 
 CUDA_CALLABLE half float_to_half(float x);
@@ -181,6 +221,12 @@ struct half {
 static_assert(sizeof(half) == 2, "Size of half / float16 type must be 2-bytes");
 
 typedef half float16;
+
+// Handle float16 source
+CUDA_CALLABLE inline uint8 float16_to_uint8(float16 x) { return float32_to_uint8(float32(x)); }
+CUDA_CALLABLE inline uint16 float16_to_uint16(float16 x) { return float32_to_uint16(float32(x)); }
+CUDA_CALLABLE inline uint32 float16_to_uint32(float16 x) { return float32_to_uint32(float32(x)); }
+CUDA_CALLABLE inline uint64 float16_to_uint64(float16 x) { return float32_to_uint64(float32(x)); }
 
 // Approximate division/reciprocal intrinsics
 #if defined(__CUDA_ARCH__)
@@ -337,6 +383,19 @@ template <typename T> CUDA_CALLABLE inline void adj_float16(T x, T& adj_x, float
 template <typename T> CUDA_CALLABLE inline void adj_float32(T x, T& adj_x, float32 adj_ret) { adj_x += T(adj_ret); }
 template <typename T> CUDA_CALLABLE inline void adj_float64(T x, T& adj_x, float64 adj_ret) { adj_x += T(adj_ret); }
 
+// Adjoint stubs for safe float-to-unsigned casts (no-op since they are cast functions)
+template <typename T> CUDA_CALLABLE inline void adj_float32_to_uint8(T, T&, uint8) { }
+template <typename T> CUDA_CALLABLE inline void adj_float64_to_uint8(T, T&, uint8) { }
+template <typename T> CUDA_CALLABLE inline void adj_float16_to_uint8(T, T&, uint8) { }
+template <typename T> CUDA_CALLABLE inline void adj_float32_to_uint16(T, T&, uint16) { }
+template <typename T> CUDA_CALLABLE inline void adj_float64_to_uint16(T, T&, uint16) { }
+template <typename T> CUDA_CALLABLE inline void adj_float16_to_uint16(T, T&, uint16) { }
+template <typename T> CUDA_CALLABLE inline void adj_float32_to_uint32(T, T&, uint32) { }
+template <typename T> CUDA_CALLABLE inline void adj_float64_to_uint32(T, T&, uint32) { }
+template <typename T> CUDA_CALLABLE inline void adj_float16_to_uint32(T, T&, uint32) { }
+template <typename T> CUDA_CALLABLE inline void adj_float32_to_uint64(T, T&, uint64) { }
+template <typename T> CUDA_CALLABLE inline void adj_float64_to_uint64(T, T&, uint64) { }
+template <typename T> CUDA_CALLABLE inline void adj_float16_to_uint64(T, T&, uint64) { }
 
 #define kEps 0.0f
 

--- a/warp/tests/test_codegen_instancing.py
+++ b/warp/tests/test_codegen_instancing.py
@@ -1091,13 +1091,31 @@ type_closure_kernel_float = create_type_closure_scalar(float)
 type_closure_kernel_uint8 = create_type_closure_scalar(wp.uint8)
 
 
+def create_type_closure_scalar_f64(scalar_type):
+    @wp.kernel
+    def k(input: wp.float64, expected: wp.float64):
+        x = scalar_type(input)
+        wp.expect_eq(wp.float64(x), expected)
+
+    return k
+
+
+type_closure_kernel_uint64_f64 = create_type_closure_scalar_f64(wp.uint64)
+
+
 def test_type_closure_scalar(test, device):
     with wp.ScopedDevice(device):
         wp.launch(type_closure_kernel_int, dim=1, inputs=[-1.5, -1.0])
         wp.launch(type_closure_kernel_float, dim=1, inputs=[-1.5, -1.5])
 
-        # FIXME: a problem with type conversions breaks this case
-        # wp.launch(type_closure_kernel_uint8, dim=1, inputs=[-1.5, 255.0])
+        wp.launch(type_closure_kernel_uint8, dim=1, inputs=[-1.5, 255.0])
+        wp.launch(type_closure_kernel_uint8, dim=1, inputs=[-0.1, 0.0])
+        wp.launch(type_closure_kernel_uint8, dim=1, inputs=[255.1, 255.0])
+        wp.launch(type_closure_kernel_uint8, dim=1, inputs=[128.0, 128.0])
+        wp.launch(type_closure_kernel_uint8, dim=1, inputs=[-100.0, 156.0])
+
+        # Test boundary cases for uint64 truncation safety with float64 precision
+        wp.launch(type_closure_kernel_uint64_f64, dim=1, inputs=[9223372036854774784.0, 9223372036854774784.0])
 
 
 # =======================================================================


### PR DESCRIPTION
## Description
This PR fixes a bug causing undefined behavior when casting negative float values to unsigned integer scalar types (like `wp.uint8`) inside Warp kernels.
When `wp.uint8(float_val)` is used, the codegen emitted a direct C-style functional cast `wp::uint8(float_val)`. Since [uint8](cci:2://file:///home/shivanshsingh/Desktop/warp/warp/warp/_src/types.py:311:0-315:27) maps directly to `uint8_t` (unsigned char), casting a float with a negative truncated value to this unsigned type triggers **undefined behavior** per the C++ standard (§7.3.11).
* **Fix:** For `float* -> uint*` pairs during codegen, the emitted C++ code now routes via custom safe-cast functional overloads in [builtin.h](cci:7://file:///home/shivanshsingh/Desktop/warp/warp/warp/native/builtin.h:0:0-0:0) (e.g., [float32_to_uint8](cci:1://file:///home/shivanshsingh/Desktop/warp/warp/warp/native/builtin.h:109:0-109:111)). These explicitly perform a two-step cast: `float -> int64 -> unsigned`, leveraging C++'s well-defined modular arithmetic rule for signed-to-unsigned conversion.
* **Test Enabled:** Re-enabled the [test_type_closure_scalar](cci:1://file:///home/shivanshsingh/Desktop/warp/warp/warp/tests/test_codegen_instancing.py:1093:0-1098:73) case for [uint8](cci:2://file:///home/shivanshsingh/Desktop/warp/warp/warp/_src/types.py:311:0-315:27) in `test_codegen_instancing.py:1099`.
Closes FIXME in `warp/tests/test_codegen_instancing.py:1099`.
## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
## Test plan
- Ensured that `python3 -m pytest warp/tests/test_codegen_instancing.py::TestCodeGenInstancing::test_type_closure_scalar_cpu -v` passes.
- Confirmed that explicit wrap-around bounds are handled correctly with arbitrary bounds:
  - `wp.uint8(-0.1)` yields `0`
  - `wp.uint8(255.1)` yields `255`
  - `wp.uint8(128.0)` yields `128`
  - `wp.uint8(-100.0)` yields `156` (expected modular wrap-around)
## Bug fix
```python
import warp as wp
wp.init()
@wp.kernel
def cast_negative_float():
    x = wp.float32(-1.5)
    
    # Without this PR, mapping a negative float directly to 
    # unsigned integer triggers undefined behavior in C++
    y = wp.uint8(x)
    wp.printf("y = %d\\n", int(y))
wp.launch(cast_negative_float, dim=1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safe, well-defined float→unsigned integer conversion routines (including float16 paths) with corresponding no-op adjoint support.

* **Tests**
  * Expanded scalar conversion tests: re-enabled and broadened uint8 cases and added uint64/float64 boundary coverage.

* **Notes**
  * Public APIs and documented behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->