### PR TITLE
Fix struct field assignment unwrapping Warp scalar types

### DIFF
--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -462,8 +462,10 @@ def _make_struct_field_setter(cls, field: str, var_type: type):
         if value is None:
             # zero initialize
             setattr(inst._ctype, field, var_type._type_())
+            cls.__setattr__(inst, field, var_type())
         else:
-            if hasattr(value, "_type_"):
+            is_warp_scalar = hasattr(value, "_type_")
+            if is_warp_scalar:
                 # assigning warp type value (e.g.: wp.float32)
                 value = value.value
             # float16 needs conversion to uint16 bits
@@ -472,7 +474,10 @@ def _make_struct_field_setter(cls, field: str, var_type: type):
             else:
                 setattr(inst._ctype, field, value)
 
-        cls.__setattr__(inst, field, value)
+            # Re-wrap in the Warp scalar type so the Python attribute preserves
+            # the declared type (e.g. wp.uint8) instead of decaying to plain
+            # int/float, but only when the caller passed a Warp scalar.
+            cls.__setattr__(inst, field, var_type(value) if is_warp_scalar else value)
 
     def set_texture_value(inst, value):
         # Texture2D, Texture3D, etc.

--- a/warp/tests/test_struct.py
+++ b/warp/tests/test_struct.py
@@ -807,6 +807,54 @@ class TestStruct(unittest.TestCase):
 
         wp.launch(check_default_attributes_kernel, dim=1, inputs=[s])
 
+    def test_struct_field_type_preservation(self):
+        """Assigning a Warp scalar to a struct field should preserve the Warp type (GH-1288)."""
+
+        @wp.struct
+        class ScalarStruct:
+            u8: wp.uint8
+            i32: wp.int32
+            f16: wp.float16
+            f32: wp.float32
+            f64: wp.float64
+
+        s = ScalarStruct()
+
+        # Default-initialized fields should already have the correct Warp type.
+        self.assertIsInstance(s.u8, wp.uint8)
+        self.assertIsInstance(s.i32, wp.int32)
+        self.assertIsInstance(s.f16, wp.float16)
+        self.assertIsInstance(s.f32, wp.float32)
+        self.assertIsInstance(s.f64, wp.float64)
+
+        # After assignment of Warp scalars the type must be preserved,
+        # not decayed to int/float.
+        s.u8 = wp.uint8(1)
+        s.i32 = wp.int32(-7)
+        s.f16 = wp.float16(3.14)
+        s.f32 = wp.float32(3.14)
+        s.f64 = wp.float64(2.718)
+
+        self.assertIsInstance(s.u8, wp.uint8)
+        self.assertIsInstance(s.i32, wp.int32)
+        self.assertIsInstance(s.f16, wp.float16)
+        self.assertIsInstance(s.f32, wp.float32)
+        self.assertIsInstance(s.f64, wp.float64)
+
+        # Values should be correct too.
+        self.assertEqual(int(s.u8), 1)
+        self.assertEqual(int(s.i32), -7)
+        self.assertAlmostEqual(float(s.f16), 3.14, places=2)
+        self.assertAlmostEqual(float(s.f32), 3.14, places=6)
+        self.assertAlmostEqual(float(s.f64), 2.718, places=15)
+
+        # Assigning plain Python values should preserve the Python type,
+        # not wrap in Warp scalars (important for isinstance checks downstream).
+        s.i32 = 42
+        s.f64 = 1.5
+        self.assertIsInstance(s.i32, int)
+        self.assertIsInstance(s.f64, float)
+
     def test_nested_vec_assignment(self):
         v = VecStruct()
         v.value[0] = 1.0


### PR DESCRIPTION
## Description

Fix `wp.struct` field assignment silently unwrapping Warp scalar types (e.g. `wp.uint8`) to plain Python types. Closes #1288.

The struct field setter (`set_primitive_value` in `codegen.py`) extracted the raw Python value from Warp scalars for the ctypes backing store, but then stored that unwrapped value as the Python attribute. This caused the declared type to decay after assignment (e.g. `wp.uint8(1)` became `int(1)`), breaking downstream type comparisons.

The fix re-wraps the value in the declared Warp scalar type before storing it in the Python `__dict__`, consistent with how fields are initialized by default.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

```bash
uv run python -c "
import unittest
from warp.tests.test_struct import TestStruct
suite = unittest.TestLoader().loadTestsFromName('test_struct_field_type_preservation', TestStruct)
unittest.TextTestRunner(verbosity=2).run(suite)
"
```

## Bug fix

```python
import warp as wp

STATUS_ACTIVE = wp.uint8(1)

@wp.struct
class MyState:
    status: wp.uint8

s = MyState()
assert type(s.status) == wp.uint8  # OK

s.status = STATUS_ACTIVE
assert type(s.status) == wp.uint8  # AssertionError! Type is now int
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve Warp scalar type information for struct fields during assignment and default/None initialization so Python-side attributes keep declared Warp scalar types while values remain correct.

* **Tests**
  * Added tests verifying struct field type preservation across Warp scalar types, default initialization, scalar assignments, and numeric value correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->