### PR TITLE
Add support for assigning values to boolean vectors in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
 - Fix struct field assignment unwrapping Warp scalar types (e.g., ``wp.float32``, ``wp.int32``) to their
   underlying Python types, causing subsequent reads to return plain ``float`` or ``int`` instead of the
   original Warp type ([GH-1288](https://github.com/NVIDIA/warp/issues/1288)).
+- Fix element assignment for boolean vectors failing with a missing function overload
+  ([GH-1302](https://github.com/NVIDIA/warp/issues/1302)).
 
 ### Documentation
 

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -9828,6 +9828,17 @@ add_builtin(
     group="Utility",
 )
 
+# Bool vector assign_inplace (bool is not part of Scalar)
+add_builtin(
+    "assign_inplace",
+    input_types={"a": vector(length=Any, dtype=bool), "i": Any, "value": Any},
+    value_type=None,
+    dispatch_func=vector_assign_dispatch_func,
+    hidden=True,
+    export=False,
+    group="Utility",
+)
+
 # implements quaternion[index] = value
 add_builtin(
     "assign_inplace",
@@ -9859,6 +9870,17 @@ def vector_assign_copy_value_func(arg_types: Mapping[str, type], arg_values: Map
 add_builtin(
     "assign_copy",
     input_types={"a": vector(length=Any, dtype=Scalar), "i": Any, "value": Any},
+    value_func=vector_assign_copy_value_func,
+    dispatch_func=vector_assign_dispatch_func,
+    hidden=True,
+    export=False,
+    group="Utility",
+)
+
+# Bool vector assign_copy (bool is not part of Scalar)
+add_builtin(
+    "assign_copy",
+    input_types={"a": vector(length=Any, dtype=bool), "i": Any, "value": Any},
     value_func=vector_assign_copy_value_func,
     dispatch_func=vector_assign_dispatch_func,
     hidden=True,

--- a/warp/tests/test_bool.py
+++ b/warp/tests/test_bool.py
@@ -188,6 +188,36 @@ def test_bool_mat_typing(test, device):
     wp.launch(test_bool_mat_anonymous_typing, (1,), inputs=[], device=device)
 
 
+@wp.func
+def bool_vec_assign():
+    v = vec3bool_type(True, False, True)
+
+    v[0] = False
+    v[2] = False
+
+    wp.expect_eq(v[0], False)
+    wp.expect_eq(v[1], False)
+    wp.expect_eq(v[2], False)
+
+    v[-1] = True
+    v[-3] = True
+
+    wp.expect_eq(v[-1], True)
+    wp.expect_eq(v[-2], False)
+    wp.expect_eq(v[-3], True)
+
+
+@wp.kernel
+def run_bool_vec_assign():
+    bool_vec_assign()
+
+
+def test_bool_vec_assign(test, device):
+    wp.launch(run_bool_vec_assign, 1, device=device)
+    wp.synchronize_device(device)
+    bool_vec_assign()
+
+
 devices = get_test_devices()
 
 
@@ -201,6 +231,7 @@ add_function_test(TestBool, "test_bool_constant_vec", test_bool_constant_vec, de
 add_function_test(TestBool, "test_bool_constant_mat", test_bool_constant_mat, devices=devices)
 add_function_test(TestBool, "test_bool_vec_typing", test_bool_vec_typing, devices=devices)
 add_function_test(TestBool, "test_bool_mat_typing", test_bool_mat_typing, devices=devices)
+add_function_test(TestBool, "test_bool_vec_assign", test_bool_vec_assign, devices=devices)
 
 
 if __name__ == "__main__":

--- a/warp/tests/test_vec_assign_copy.py
+++ b/warp/tests/test_vec_assign_copy.py
@@ -112,6 +112,30 @@ def test_vec_slicing_assign_backward(test, device):
     assert_np_equal(x.grad.numpy(), np.array(((1.0, 1.0),), dtype=float))
 
 
+vec3bool = wp.types.vector(length=3, dtype=bool)
+
+
+def test_bool_vec_assign_copy(test, device):
+    @wp.kernel(module="unique")
+    def bool_vec_assign_copy_kernel():
+        a = vec3bool(True, True, True)
+        b = a
+        b[1] = False
+
+        # a should be unchanged (copy semantics)
+        wp.expect_eq(a[0], True)
+        wp.expect_eq(a[1], True)
+        wp.expect_eq(a[2], True)
+
+        # b should reflect the mutation
+        wp.expect_eq(b[0], True)
+        wp.expect_eq(b[1], False)
+        wp.expect_eq(b[2], True)
+
+    wp.launch(bool_vec_assign_copy_kernel, 1, device=device)
+    wp.synchronize_device(device)
+
+
 devices = get_test_devices()
 
 
@@ -121,6 +145,7 @@ class TestVecAssignCopy(unittest.TestCase):
 
 add_function_test(TestVecAssignCopy, "test_vec_assign", test_vec_assign, devices=devices)
 add_function_test(TestVecAssignCopy, "test_vec_assign_copy", test_vec_assign_copy, devices=devices)
+add_function_test(TestVecAssignCopy, "test_bool_vec_assign_copy", test_bool_vec_assign_copy, devices=devices)
 add_function_test(
     TestVecAssignCopy, "test_vec_slicing_assign_backward", test_vec_slicing_assign_backward, devices=devices
 )


### PR DESCRIPTION
## Description

Currently, attempting to write to a field of a boolean vector within a kernel will lead to the error:

```
warp._src.codegen.WarpCodegenError: Error while parsing function "assign_bool_vector"
```

This PR adds support for assigning values to boolean vectors.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Test plan

I've added a test to the repo. The test is passing with the changes.

## Bug fix

To reproduce this in the current main:

```python
import warp as wp

@wp.kernel
def assign_int_vector():
    v = wp.vector(length=2, dtype=wp.int32)
    v[0] = 1

@wp.kernel
def assign_bool_vector():
    v = wp.vector(length=2, dtype=wp.bool)
    v[0] = True

wp.launch(assign_int_vector, dim=1)
wp.synchronize()

# Raises:
# warp._src.codegen.WarpCodegenError: Error while parsing function "assign_bool_vector"
wp.launch(assign_bool_vector, dim=1)
wp.synchronize()
```

The compilation of the kernel with the int vector (`assign_int_vector`) works, but the one with the boolean vector (`assign_bool_vector`) fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for boolean vector element assignment and mutation, including negative indexing.

* **Tests**
  * New test verifying boolean vector assignment and negative-index behavior across device launches.

* **Chores**
  * Changelog updated to note the fix for boolean vector element assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->