### PR TITLE
Add adjoints for `texture_sample` for all address modes

### DIFF
--- a/PUBLICATIONS.md
+++ b/PUBLICATIONS.md
@@ -8,8 +8,6 @@ pull request on GitHub or email a link to your arXiv preprint (preferred) or DOI
 ## 2026
 
 - **Discovering neural cohesive zone laws from displacement fields**. *G. Barkoulis Gavris, W. Sun*. April 2026. [DOI:10.1016/j.cma.2026.118733](https://doi.org/10.1016/j.cma.2026.118733)
-- **Kamino: GPU-based Massively Parallel Simulation of Multi-Body Systems with Challenging Topologies**. *V. Tsounis, G. Maloisel, C. Schumacher, R. Grandia, A. Serifi, D. Müller, C. Amevor, T. Widmer, M. Bächer*. March 2026. [arXiv:2603.16536](https://arxiv.org/abs/2603.16536)
-- **ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control**. *C. Borse, Z. Xie, W. Huang, W. Jin*. March 2026. [arXiv:2603.12185](https://arxiv.org/abs/2603.12185)
 - **cuRoboV2: Dynamics-Aware Motion Generation with Depth-Fused Distance Fields for High-DoF Robots**. *B. Sundaralingam, A. Murali, S. Birchfield*. March 2026. [arXiv:2603.05493](https://arxiv.org/abs/2603.05493)
 - **GaussTwin: Unified Simulation and Correction with Gaussian Splatting for Robotic Digital Twins**. *Y. Cai, P. Jansonnie, C. de Farias, O. Arenz, J. Peters*. March 2026. [arXiv:2603.05108](https://arxiv.org/abs/2603.05108)
 - **X-Loco: Towards Generalist Humanoid Locomotion Control via Synergetic Policy Distillation**. *D. Wang, X. Wang, C. Zhang, J. Shi, Y. Zhao, C. Bai, X. Li*. March 2026. [arXiv:2603.03733](https://arxiv.org/abs/2603.03733)

--- a/PUBLICATIONS.md
+++ b/PUBLICATIONS.md
@@ -8,6 +8,8 @@ pull request on GitHub or email a link to your arXiv preprint (preferred) or DOI
 ## 2026
 
 - **Discovering neural cohesive zone laws from displacement fields**. *G. Barkoulis Gavris, W. Sun*. April 2026. [DOI:10.1016/j.cma.2026.118733](https://doi.org/10.1016/j.cma.2026.118733)
+- **Kamino: GPU-based Massively Parallel Simulation of Multi-Body Systems with Challenging Topologies**. *V. Tsounis, G. Maloisel, C. Schumacher, R. Grandia, A. Serifi, D. Müller, C. Amevor, T. Widmer, M. Bächer*. March 2026. [arXiv:2603.16536](https://arxiv.org/abs/2603.16536)
+- **ComFree-Sim: A GPU-Parallelized Analytical Contact Physics Engine for Scalable Contact-Rich Robotics Simulation and Control**. *C. Borse, Z. Xie, W. Huang, W. Jin*. March 2026. [arXiv:2603.12185](https://arxiv.org/abs/2603.12185)
 - **cuRoboV2: Dynamics-Aware Motion Generation with Depth-Fused Distance Fields for High-DoF Robots**. *B. Sundaralingam, A. Murali, S. Birchfield*. March 2026. [arXiv:2603.05493](https://arxiv.org/abs/2603.05493)
 - **GaussTwin: Unified Simulation and Correction with Gaussian Splatting for Robotic Digital Twins**. *Y. Cai, P. Jansonnie, C. de Farias, O. Arenz, J. Peters*. March 2026. [arXiv:2603.05108](https://arxiv.org/abs/2603.05108)
 - **X-Loco: Towards Generalist Humanoid Locomotion Control via Synergetic Policy Distillation**. *D. Wang, X. Wang, C. Zhang, J. Shi, Y. Zhao, C. Bai, X. Li*. March 2026. [arXiv:2603.03733](https://arxiv.org/abs/2603.03733)

--- a/changelog/1301.added.md
+++ b/changelog/1301.added.md
@@ -1,0 +1,3 @@
+Add adjoints for `wp.texture_sample()` so gradients propagate to the sampling
+coordinates and `lod` argument under every address mode, on both the CPU and
+CUDA backends. Gradients are not propagated to the texture data itself.

--- a/docs/user_guide/runtime.rst
+++ b/docs/user_guide/runtime.rst
@@ -2759,6 +2759,12 @@ Supported data types include ``wp.uint8``, ``wp.uint16``, ``wp.uint32``, ``wp.in
 normalized to the [0, 1] range when sampled; signed integer textures are normalized to [-1, 1];
 float types are returned as-is.
 
+Texture sampling is differentiable with respect to the sampling coordinates and the ``lod``
+argument under every address mode, so sampling positions can be optimized with
+:class:`wp.Tape <warp.Tape>`. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+value is piecewise constant in the coordinates, so their gradients are zero. Gradients are not
+propagated to the texture data itself.
+
 .. seealso:: `Reference <../language_reference/builtins.html#textures>`__ for the texture sampling functions available in kernels.
 
 

--- a/docs/user_guide/runtime.rst
+++ b/docs/user_guide/runtime.rst
@@ -2759,11 +2759,12 @@ Supported data types include ``wp.uint8``, ``wp.uint16``, ``wp.uint32``, ``wp.in
 normalized to the [0, 1] range when sampled; signed integer textures are normalized to [-1, 1];
 float types are returned as-is.
 
-Texture sampling is differentiable with respect to the sampling coordinates and the ``lod``
-argument under every address mode, so sampling positions can be optimized with
-:class:`wp.Tape <warp.Tape>`. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-value is piecewise constant in the coordinates, so their gradients are zero. Gradients are not
-propagated to the texture data itself.
+Texture sampling is differentiable with respect to sampling coordinates wherever the sample is
+locally linear, and with respect to ``lod`` for linear mip-level blending, so sampling positions
+can be optimized with :class:`wp.Tape <warp.Tape>`. Gradients at interpolation/address-mode
+boundaries and integer LOD kinks follow Warp's branch convention. With closest spatial or mip
+filtering the corresponding coordinate or ``lod`` gradients are zero. Texture data gradients are
+not propagated.
 
 .. seealso:: `Reference <../language_reference/builtins.html#textures>`__ for the texture sampling functions available in kernels.
 

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -6814,6 +6814,11 @@ def texture_sample(tex: Texture1D, u: float32, dtype: Any, lod: float32) -> Any:
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself.
+
     Example:
 
         .. testcode::
@@ -6882,7 +6887,12 @@ def texture_sample(tex: Texture2D, uv: vec2f, dtype: Any, lod: float32) -> Any:
     The filtering mode (:class:`warp.TextureFilterMode`) and the addressing of out-of-range
     coordinates (:class:`warp.TextureAddressMode`) are those set when the texture was created; see
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
-    ``normalized_coords=False`` (the CPU sampler honors them)."""
+    ``normalized_coords=False`` (the CPU sampler honors them).
+
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself."""
     ...
 
 @over
@@ -6927,7 +6937,12 @@ def texture_sample(tex: Texture2D, u: float32, v: float32, dtype: Any, lod: floa
     The filtering mode (:class:`warp.TextureFilterMode`) and the addressing of out-of-range
     coordinates (:class:`warp.TextureAddressMode`) are those set when the texture was created; see
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
-    ``normalized_coords=False`` (the CPU sampler honors them)."""
+    ``normalized_coords=False`` (the CPU sampler honors them).
+
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself."""
     ...
 
 @over
@@ -6970,7 +6985,12 @@ def texture_sample(tex: Texture3D, uvw: vec3f, dtype: Any, lod: float32) -> Any:
     The filtering mode (:class:`warp.TextureFilterMode`) and the addressing of out-of-range
     coordinates (:class:`warp.TextureAddressMode`) are those set when the texture was created; see
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
-    ``normalized_coords=False`` (the CPU sampler honors them)."""
+    ``normalized_coords=False`` (the CPU sampler honors them).
+
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself."""
     ...
 
 @over
@@ -7020,7 +7040,12 @@ def texture_sample(tex: Texture3D, u: float32, v: float32, w: float32, dtype: An
     The filtering mode (:class:`warp.TextureFilterMode`) and the addressing of out-of-range
     coordinates (:class:`warp.TextureAddressMode`) are those set when the texture was created; see
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
-    ``normalized_coords=False`` (the CPU sampler honors them)."""
+    ``normalized_coords=False`` (the CPU sampler honors them).
+
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself."""
     ...
 
 @over

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -6805,6 +6805,9 @@ def texture_sample(tex: Texture1D, u: float32, dtype: Any, lod: float32) -> Any:
             values blend between neighbouring mip levels when ``mip_filter_mode`` is
             :attr:`warp.TextureFilterMode.LINEAR`; the coordinate is evaluated independently at
             each level used in the blend. Ignored for textures created with a single mip level.
+            The ``lod`` adjoint is nonzero only for mipmapped textures with
+            ``mip_filter_mode=TextureFilterMode.LINEAR`` and an unclamped, nonnegative LOD;
+            integer LODs are mip-blend kinks where Warp uses the forward branch convention.
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -6814,10 +6817,12 @@ def texture_sample(tex: Texture1D, u: float32, dtype: Any, lod: float32) -> Any:
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself.
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself.
 
     Example:
 
@@ -6889,10 +6894,12 @@ def texture_sample(tex: Texture2D, uv: vec2f, dtype: Any, lod: float32) -> Any:
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself."""
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself."""
     ...
 
 @over
@@ -6939,10 +6946,12 @@ def texture_sample(tex: Texture2D, u: float32, v: float32, dtype: Any, lod: floa
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself."""
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself."""
     ...
 
 @over
@@ -6987,10 +6996,12 @@ def texture_sample(tex: Texture3D, uvw: vec3f, dtype: Any, lod: float32) -> Any:
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself."""
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself."""
     ...
 
 @over
@@ -7042,10 +7053,12 @@ def texture_sample(tex: Texture3D, u: float32, v: float32, w: float32, dtype: An
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself."""
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself."""
     ...
 
 @over

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -9828,6 +9828,17 @@ add_builtin(
     group="Utility",
 )
 
+# Bool vector assign_inplace (bool is not part of Scalar)
+add_builtin(
+    "assign_inplace",
+    input_types={"a": vector(length=Any, dtype=bool), "i": Any, "value": Any},
+    value_type=None,
+    dispatch_func=vector_assign_dispatch_func,
+    hidden=True,
+    export=False,
+    group="Utility",
+)
+
 # implements quaternion[index] = value
 add_builtin(
     "assign_inplace",
@@ -9859,6 +9870,17 @@ def vector_assign_copy_value_func(arg_types: Mapping[str, type], arg_values: Map
 add_builtin(
     "assign_copy",
     input_types={"a": vector(length=Any, dtype=Scalar), "i": Any, "value": Any},
+    value_func=vector_assign_copy_value_func,
+    dispatch_func=vector_assign_dispatch_func,
+    hidden=True,
+    export=False,
+    group="Utility",
+)
+
+# Bool vector assign_copy (bool is not part of Scalar)
+add_builtin(
+    "assign_copy",
+    input_types={"a": vector(length=Any, dtype=bool), "i": Any, "value": Any},
     value_func=vector_assign_copy_value_func,
     dispatch_func=vector_assign_dispatch_func,
     hidden=True,

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -7809,7 +7809,7 @@ add_builtin(
         The sampled value of the specified ``dtype``.
 
     Filtering mode is :attr:`warp.TextureFilterMode.CLOSEST` or :attr:`warp.TextureFilterMode.LINEAR`.""",
-    is_differentiable=False,
+    is_differentiable=True,
 )
 
 
@@ -7856,7 +7856,7 @@ add_builtin(
         The sampled value of the specified ``dtype``.
 
     Filtering mode is :attr:`warp.TextureFilterMode.CLOSEST` or :attr:`warp.TextureFilterMode.LINEAR`.""",
-    is_differentiable=False,
+    is_differentiable=True,
 )
 
 # texture_sample for 2D textures with separate u, v coordinates
@@ -7886,7 +7886,7 @@ add_builtin(
         The sampled value of the specified ``dtype``.
 
     Filtering mode is :attr:`warp.TextureFilterMode.CLOSEST` or :attr:`warp.TextureFilterMode.LINEAR`.""",
-    is_differentiable=False,
+    is_differentiable=True,
 )
 
 
@@ -7933,7 +7933,7 @@ add_builtin(
         The sampled value of the specified ``dtype``.
 
     Filtering mode is :attr:`warp.TextureFilterMode.CLOSEST` or :attr:`warp.TextureFilterMode.LINEAR`.""",
-    is_differentiable=False,
+    is_differentiable=True,
 )
 
 # texture_sample for 3D textures with separate u, v, w coordinates
@@ -7965,7 +7965,7 @@ add_builtin(
         The sampled value of the specified ``dtype``.
 
     Filtering mode is :attr:`warp.TextureFilterMode.CLOSEST` or :attr:`warp.TextureFilterMode.LINEAR`.""",
-    is_differentiable=False,
+    is_differentiable=True,
 )
 
 
@@ -9828,17 +9828,6 @@ add_builtin(
     group="Utility",
 )
 
-# Bool vector assign_inplace (bool is not part of Scalar)
-add_builtin(
-    "assign_inplace",
-    input_types={"a": vector(length=Any, dtype=bool), "i": Any, "value": Any},
-    value_type=None,
-    dispatch_func=vector_assign_dispatch_func,
-    hidden=True,
-    export=False,
-    group="Utility",
-)
-
 # implements quaternion[index] = value
 add_builtin(
     "assign_inplace",
@@ -9870,17 +9859,6 @@ def vector_assign_copy_value_func(arg_types: Mapping[str, type], arg_values: Map
 add_builtin(
     "assign_copy",
     input_types={"a": vector(length=Any, dtype=Scalar), "i": Any, "value": Any},
-    value_func=vector_assign_copy_value_func,
-    dispatch_func=vector_assign_dispatch_func,
-    hidden=True,
-    export=False,
-    group="Utility",
-)
-
-# Bool vector assign_copy (bool is not part of Scalar)
-add_builtin(
-    "assign_copy",
-    input_types={"a": vector(length=Any, dtype=bool), "i": Any, "value": Any},
     value_func=vector_assign_copy_value_func,
     dispatch_func=vector_assign_dispatch_func,
     hidden=True,

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -10997,6 +10997,11 @@ add_builtin(
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself.
+
     Example:
 
         .. testcode::
@@ -11024,7 +11029,7 @@ add_builtin(
         .. testoutput::
 
             5.0 1.0 1.0""",
-    is_differentiable=False,
+    is_differentiable=True,
 )
 
 
@@ -11093,8 +11098,13 @@ add_builtin(
     The filtering mode (:class:`warp.TextureFilterMode`) and the addressing of out-of-range
     coordinates (:class:`warp.TextureAddressMode`) are those set when the texture was created; see
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
-    ``normalized_coords=False`` (the CPU sampler honors them).""",
-    is_differentiable=False,
+    ``normalized_coords=False`` (the CPU sampler honors them).
+
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself.""",
+    is_differentiable=True,
 )
 
 # texture_sample for 2D textures with separate u, v coordinates
@@ -11147,8 +11157,13 @@ add_builtin(
     The filtering mode (:class:`warp.TextureFilterMode`) and the addressing of out-of-range
     coordinates (:class:`warp.TextureAddressMode`) are those set when the texture was created; see
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
-    ``normalized_coords=False`` (the CPU sampler honors them).""",
-    is_differentiable=False,
+    ``normalized_coords=False`` (the CPU sampler honors them).
+
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself.""",
+    is_differentiable=True,
 )
 
 
@@ -11218,8 +11233,13 @@ add_builtin(
     The filtering mode (:class:`warp.TextureFilterMode`) and the addressing of out-of-range
     coordinates (:class:`warp.TextureAddressMode`) are those set when the texture was created; see
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
-    ``normalized_coords=False`` (the CPU sampler honors them).""",
-    is_differentiable=False,
+    ``normalized_coords=False`` (the CPU sampler honors them).
+
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself.""",
+    is_differentiable=True,
 )
 
 # texture_sample for 3D textures with separate u, v, w coordinates
@@ -11277,8 +11297,13 @@ add_builtin(
     The filtering mode (:class:`warp.TextureFilterMode`) and the addressing of out-of-range
     coordinates (:class:`warp.TextureAddressMode`) are those set when the texture was created; see
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
-    ``normalized_coords=False`` (the CPU sampler honors them).""",
-    is_differentiable=False,
+    ``normalized_coords=False`` (the CPU sampler honors them).
+
+    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
+    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
+    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
+    are not propagated to the texture data itself.""",
+    is_differentiable=True,
 )
 
 

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -10988,6 +10988,9 @@ add_builtin(
             values blend between neighbouring mip levels when ``mip_filter_mode`` is
             :attr:`warp.TextureFilterMode.LINEAR`; the coordinate is evaluated independently at
             each level used in the blend. Ignored for textures created with a single mip level.
+            The ``lod`` adjoint is nonzero only for mipmapped textures with
+            ``mip_filter_mode=TextureFilterMode.LINEAR`` and an unclamped, nonnegative LOD;
+            integer LODs are mip-blend kinks where Warp uses the forward branch convention.
 
     Returns:
         The sampled value of the specified ``dtype``.
@@ -10997,10 +11000,12 @@ add_builtin(
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself.
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself.
 
     Example:
 
@@ -11100,10 +11105,12 @@ add_builtin(
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself.""",
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself.""",
     is_differentiable=True,
 )
 
@@ -11159,10 +11166,12 @@ add_builtin(
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself.""",
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself.""",
     is_differentiable=True,
 )
 
@@ -11235,10 +11244,12 @@ add_builtin(
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself.""",
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself.""",
     is_differentiable=True,
 )
 
@@ -11299,10 +11310,12 @@ add_builtin(
     :class:`warp.Texture`. On CUDA, ``WRAP`` and ``MIRROR`` are treated as ``CLAMP`` when
     ``normalized_coords=False`` (the CPU sampler honors them).
 
-    The backward pass propagates gradients to the sampling coordinates and ``lod`` under
-    every address mode. With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled
-    value is piecewise constant in the coordinates, so their gradients are zero. Gradients
-    are not propagated to the texture data itself.""",
+    The backward pass propagates gradients to the sampling coordinates wherever the sample
+    is locally linear. At interpolation-cell and address-mode boundaries the mathematical
+    derivative is not unique, so Warp follows the branch selected by the forward sampler.
+    With :attr:`warp.TextureFilterMode.CLOSEST` filtering the sampled value is piecewise
+    constant in the coordinates, so coordinate gradients are zero. Gradients are not
+    propagated to the texture data itself.""",
     is_differentiable=True,
 )
 

--- a/warp/_src/texture.py
+++ b/warp/_src/texture.py
@@ -80,12 +80,16 @@ class texture1d_t(ctypes.Structure):
         ("tex", ctypes.c_uint64),
         ("width", ctypes.c_int32),
         ("num_channels", ctypes.c_int32),
+        ("filter_mode", ctypes.c_int32),
+        ("use_normalized_coords", ctypes.c_int32),
     )
 
-    def __init__(self, tex=0, width=0, num_channels=0):
+    def __init__(self, tex=0, width=0, num_channels=0, filter_mode=0, use_normalized_coords=1):
         self.tex = tex
         self.width = width
         self.num_channels = num_channels
+        self.filter_mode = filter_mode
+        self.use_normalized_coords = use_normalized_coords
 
 
 class texture2d_t(ctypes.Structure):
@@ -99,13 +103,17 @@ class texture2d_t(ctypes.Structure):
         ("width", ctypes.c_int32),
         ("height", ctypes.c_int32),
         ("num_channels", ctypes.c_int32),
+        ("filter_mode", ctypes.c_int32),
+        ("use_normalized_coords", ctypes.c_int32),
     )
 
-    def __init__(self, tex=0, width=0, height=0, num_channels=0):
+    def __init__(self, tex=0, width=0, height=0, num_channels=0, filter_mode=0, use_normalized_coords=1):
         self.tex = tex
         self.width = width
         self.height = height
         self.num_channels = num_channels
+        self.filter_mode = filter_mode
+        self.use_normalized_coords = use_normalized_coords
 
 
 class texture3d_t(ctypes.Structure):
@@ -120,14 +128,18 @@ class texture3d_t(ctypes.Structure):
         ("height", ctypes.c_int32),
         ("depth", ctypes.c_int32),
         ("num_channels", ctypes.c_int32),
+        ("filter_mode", ctypes.c_int32),
+        ("use_normalized_coords", ctypes.c_int32),
     )
 
-    def __init__(self, tex=0, width=0, height=0, depth=0, num_channels=0):
+    def __init__(self, tex=0, width=0, height=0, depth=0, num_channels=0, filter_mode=0, use_normalized_coords=1):
         self.tex = tex
         self.width = width
         self.height = height
         self.depth = depth
         self.num_channels = num_channels
+        self.filter_mode = filter_mode
+        self.use_normalized_coords = use_normalized_coords
 
 
 class cuda_array_desc_t(ctypes.Structure):
@@ -956,7 +968,13 @@ class Texture1D(Texture):
         """Return the ctypes structure for passing to kernels."""
         if self._tex_handle == 0:
             raise RuntimeError("Texture was created with data=None but never initialized.")
-        return texture1d_t(self._tex_handle, self._width, self._num_channels)
+        return texture1d_t(
+            self._tex_handle,
+            self._width,
+            self._num_channels,
+            int(self._filter_mode),
+            int(self._normalized_coords),
+        )
 
 
 class Texture2D(Texture):
@@ -1033,7 +1051,14 @@ class Texture2D(Texture):
         """Return the ctypes structure for passing to kernels."""
         if self._tex_handle == 0:
             raise RuntimeError("Texture was created with data=None but never initialized.")
-        return texture2d_t(self._tex_handle, self._width, self._height, self._num_channels)
+        return texture2d_t(
+            self._tex_handle,
+            self._width,
+            self._height,
+            self._num_channels,
+            int(self._filter_mode),
+            int(self._normalized_coords),
+        )
 
 
 class Texture3D(Texture):
@@ -1114,7 +1139,15 @@ class Texture3D(Texture):
         """Return the ctypes structure for passing to kernels."""
         if self._tex_handle == 0:
             raise RuntimeError("Texture was created with data=None but never initialized.")
-        return texture3d_t(self._tex_handle, self._width, self._height, self._depth, self._num_channels)
+        return texture3d_t(
+            self._tex_handle,
+            self._width,
+            self._height,
+            self._depth,
+            self._num_channels,
+            int(self._filter_mode),
+            int(self._normalized_coords),
+        )
 
 
 class TextureResourceFlags(enum.IntEnum):

--- a/warp/_src/texture.py
+++ b/warp/_src/texture.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import ctypes
 import enum
+import warnings
 from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
@@ -176,6 +177,13 @@ class Texture:
     ``wp.float16``, and ``wp.float32`` data types. Unsigned integer textures are read as normalized
     floats in [0, 1]; signed integer textures are normalized to [-1, 1]; float types are returned as-is.
 
+    .. warning::
+        **Automatic differentiation is only correct when all texture address modes are set to BORDER.**
+        Using ``wp.texture_sample()`` with ``requires_grad=True`` on textures with WRAP, CLAMP, or
+        MIRROR address modes will produce silent gradient errors. The gradient computation zeros out
+        when sampling positions straddle texture boundaries, which is correct for BORDER mode but
+        incorrect for other modes where the forward pass returns valid interpolated data.
+
     This class should not be instantiated directly. A specific subclass should be used instead
     (:class:`Texture1D`, :class:`Texture2D`, or :class:`Texture3D`).
 
@@ -274,6 +282,25 @@ class Texture:
         address_mode_w = (
             self._resolve_address_mode(address_mode, address_mode_w, 2) if ndim > 2 else TextureAddressMode.CLAMP
         )
+
+        # Warn if using non-BORDER address modes (differentiation only supports BORDER)
+        non_border_modes = []
+        if address_mode_u != TextureAddressMode.BORDER:
+            non_border_modes.append(f"U={TextureAddressMode(address_mode_u).name}")
+        if ndim > 1 and address_mode_v != TextureAddressMode.BORDER:
+            non_border_modes.append(f"V={TextureAddressMode(address_mode_v).name}")
+        if ndim > 2 and address_mode_w != TextureAddressMode.BORDER:
+            non_border_modes.append(f"W={TextureAddressMode(address_mode_w).name}")
+
+        if non_border_modes:
+            warnings.warn(
+                f"Texture created with non-BORDER address mode(s): {', '.join(non_border_modes)}. "
+                f"Automatic differentiation (wp.texture_sample with requires_grad=True) only produces "
+                f"correct gradients when all address modes are BORDER. Non-BORDER modes will silently "
+                f"return incorrect gradients at texture boundaries.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         # if an external CUDA array was given, infer texture shape and dtype from it
         if cuda_array:

--- a/warp/_src/texture.py
+++ b/warp/_src/texture.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import ctypes
 import enum
-import warnings
 from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
@@ -83,14 +82,16 @@ class texture1d_t(ctypes.Structure):
         ("num_channels", ctypes.c_int32),
         ("filter_mode", ctypes.c_int32),
         ("use_normalized_coords", ctypes.c_int32),
+        ("address_mode_u", ctypes.c_int32),
     )
 
-    def __init__(self, tex=0, width=0, num_channels=0, filter_mode=0, use_normalized_coords=1):
+    def __init__(self, tex=0, width=0, num_channels=0, filter_mode=0, use_normalized_coords=1, address_mode_u=0):
         self.tex = tex
         self.width = width
         self.num_channels = num_channels
         self.filter_mode = filter_mode
         self.use_normalized_coords = use_normalized_coords
+        self.address_mode_u = address_mode_u
 
 
 class texture2d_t(ctypes.Structure):
@@ -106,15 +107,29 @@ class texture2d_t(ctypes.Structure):
         ("num_channels", ctypes.c_int32),
         ("filter_mode", ctypes.c_int32),
         ("use_normalized_coords", ctypes.c_int32),
+        ("address_mode_u", ctypes.c_int32),
+        ("address_mode_v", ctypes.c_int32),
     )
 
-    def __init__(self, tex=0, width=0, height=0, num_channels=0, filter_mode=0, use_normalized_coords=1):
+    def __init__(
+        self,
+        tex=0,
+        width=0,
+        height=0,
+        num_channels=0,
+        filter_mode=0,
+        use_normalized_coords=1,
+        address_mode_u=0,
+        address_mode_v=0,
+    ):
         self.tex = tex
         self.width = width
         self.height = height
         self.num_channels = num_channels
         self.filter_mode = filter_mode
         self.use_normalized_coords = use_normalized_coords
+        self.address_mode_u = address_mode_u
+        self.address_mode_v = address_mode_v
 
 
 class texture3d_t(ctypes.Structure):
@@ -131,9 +146,24 @@ class texture3d_t(ctypes.Structure):
         ("num_channels", ctypes.c_int32),
         ("filter_mode", ctypes.c_int32),
         ("use_normalized_coords", ctypes.c_int32),
+        ("address_mode_u", ctypes.c_int32),
+        ("address_mode_v", ctypes.c_int32),
+        ("address_mode_w", ctypes.c_int32),
     )
 
-    def __init__(self, tex=0, width=0, height=0, depth=0, num_channels=0, filter_mode=0, use_normalized_coords=1):
+    def __init__(
+        self,
+        tex=0,
+        width=0,
+        height=0,
+        depth=0,
+        num_channels=0,
+        filter_mode=0,
+        use_normalized_coords=1,
+        address_mode_u=0,
+        address_mode_v=0,
+        address_mode_w=0,
+    ):
         self.tex = tex
         self.width = width
         self.height = height
@@ -141,6 +171,9 @@ class texture3d_t(ctypes.Structure):
         self.num_channels = num_channels
         self.filter_mode = filter_mode
         self.use_normalized_coords = use_normalized_coords
+        self.address_mode_u = address_mode_u
+        self.address_mode_v = address_mode_v
+        self.address_mode_w = address_mode_w
 
 
 class cuda_array_desc_t(ctypes.Structure):
@@ -178,11 +211,18 @@ class Texture:
     floats in [0, 1]; signed integer textures are normalized to [-1, 1]; float types are returned as-is.
 
     .. warning::
-        **Automatic differentiation is only correct when all texture address modes are set to BORDER.**
-        Using ``wp.texture_sample()`` with ``requires_grad=True`` on textures with WRAP, CLAMP, or
-        MIRROR address modes will produce silent gradient errors. The gradient computation zeros out
-        when sampling positions straddle texture boundaries, which is correct for BORDER mode but
-        incorrect for other modes where the forward pass returns valid interpolated data.
+        **Automatic differentiation with LINEAR filtering is only correct when all texture
+        address modes are set to BORDER.**
+
+        Using ``wp.texture_sample()`` with ``requires_grad=True``, ``filter_mode=LINEAR``,
+        and address modes other than BORDER (WRAP/CLAMP/MIRROR) will produce silent gradient
+        errors at texture boundaries. The gradient computation assumes BORDER behavior
+        (returns zero outside bounds).
+
+        If you need automatic differentiation with LINEAR filtering, create textures with
+        ``address_mode=wp.TextureAddressMode.BORDER``. CLOSEST filtering does not have this
+        limitation (gradients are always zero).
+
 
     This class should not be instantiated directly. A specific subclass should be used instead
     (:class:`Texture1D`, :class:`Texture2D`, or :class:`Texture3D`).
@@ -282,25 +322,6 @@ class Texture:
         address_mode_w = (
             self._resolve_address_mode(address_mode, address_mode_w, 2) if ndim > 2 else TextureAddressMode.CLAMP
         )
-
-        # Warn if using non-BORDER address modes (differentiation only supports BORDER)
-        non_border_modes = []
-        if address_mode_u != TextureAddressMode.BORDER:
-            non_border_modes.append(f"U={TextureAddressMode(address_mode_u).name}")
-        if ndim > 1 and address_mode_v != TextureAddressMode.BORDER:
-            non_border_modes.append(f"V={TextureAddressMode(address_mode_v).name}")
-        if ndim > 2 and address_mode_w != TextureAddressMode.BORDER:
-            non_border_modes.append(f"W={TextureAddressMode(address_mode_w).name}")
-
-        if non_border_modes:
-            warnings.warn(
-                f"Texture created with non-BORDER address mode(s): {', '.join(non_border_modes)}. "
-                f"Automatic differentiation (wp.texture_sample with requires_grad=True) only produces "
-                f"correct gradients when all address modes are BORDER. Non-BORDER modes will silently "
-                f"return incorrect gradients at texture boundaries.",
-                UserWarning,
-                stacklevel=2,
-            )
 
         # if an external CUDA array was given, infer texture shape and dtype from it
         if cuda_array:
@@ -1001,6 +1022,7 @@ class Texture1D(Texture):
             self._num_channels,
             int(self._filter_mode),
             int(self._normalized_coords),
+            int(self._address_mode_u),
         )
 
 
@@ -1085,6 +1107,8 @@ class Texture2D(Texture):
             self._num_channels,
             int(self._filter_mode),
             int(self._normalized_coords),
+            int(self._address_mode_u),
+            int(self._address_mode_v),
         )
 
 
@@ -1174,6 +1198,9 @@ class Texture3D(Texture):
             self._num_channels,
             int(self._filter_mode),
             int(self._normalized_coords),
+            int(self._address_mode_u),
+            int(self._address_mode_v),
+            int(self._address_mode_w),
         )
 
 

--- a/warp/_src/texture.py
+++ b/warp/_src/texture.py
@@ -84,12 +84,29 @@ class texture1d_t(ctypes.Structure):
         ("tex", ctypes.c_uint64),
         ("width", ctypes.c_int32),
         ("num_channels", ctypes.c_int32),
+        ("filter_mode", ctypes.c_int32),
+        ("mip_filter_mode", ctypes.c_int32),
+        ("num_mip_levels", ctypes.c_int32),
+        ("use_normalized_coords", ctypes.c_int32),
     )
 
-    def __init__(self, tex=0, width=0, num_channels=0):
+    def __init__(
+        self,
+        tex=0,
+        width=0,
+        num_channels=0,
+        filter_mode=0,
+        mip_filter_mode=0,
+        num_mip_levels=1,
+        use_normalized_coords=1,
+    ):
         self.tex = tex
         self.width = width
         self.num_channels = num_channels
+        self.filter_mode = filter_mode
+        self.mip_filter_mode = mip_filter_mode
+        self.num_mip_levels = num_mip_levels
+        self.use_normalized_coords = use_normalized_coords
 
 
 class texture2d_t(ctypes.Structure):
@@ -103,13 +120,31 @@ class texture2d_t(ctypes.Structure):
         ("width", ctypes.c_int32),
         ("height", ctypes.c_int32),
         ("num_channels", ctypes.c_int32),
+        ("filter_mode", ctypes.c_int32),
+        ("mip_filter_mode", ctypes.c_int32),
+        ("num_mip_levels", ctypes.c_int32),
+        ("use_normalized_coords", ctypes.c_int32),
     )
 
-    def __init__(self, tex=0, width=0, height=0, num_channels=0):
+    def __init__(
+        self,
+        tex=0,
+        width=0,
+        height=0,
+        num_channels=0,
+        filter_mode=0,
+        mip_filter_mode=0,
+        num_mip_levels=1,
+        use_normalized_coords=1,
+    ):
         self.tex = tex
         self.width = width
         self.height = height
         self.num_channels = num_channels
+        self.filter_mode = filter_mode
+        self.mip_filter_mode = mip_filter_mode
+        self.num_mip_levels = num_mip_levels
+        self.use_normalized_coords = use_normalized_coords
 
 
 class texture3d_t(ctypes.Structure):
@@ -124,14 +159,33 @@ class texture3d_t(ctypes.Structure):
         ("height", ctypes.c_int32),
         ("depth", ctypes.c_int32),
         ("num_channels", ctypes.c_int32),
+        ("filter_mode", ctypes.c_int32),
+        ("mip_filter_mode", ctypes.c_int32),
+        ("num_mip_levels", ctypes.c_int32),
+        ("use_normalized_coords", ctypes.c_int32),
     )
 
-    def __init__(self, tex=0, width=0, height=0, depth=0, num_channels=0):
+    def __init__(
+        self,
+        tex=0,
+        width=0,
+        height=0,
+        depth=0,
+        num_channels=0,
+        filter_mode=0,
+        mip_filter_mode=0,
+        num_mip_levels=1,
+        use_normalized_coords=1,
+    ):
         self.tex = tex
         self.width = width
         self.height = height
         self.depth = depth
         self.num_channels = num_channels
+        self.filter_mode = filter_mode
+        self.mip_filter_mode = mip_filter_mode
+        self.num_mip_levels = num_mip_levels
+        self.use_normalized_coords = use_normalized_coords
 
 
 class cuda_array_desc_t(ctypes.Structure):
@@ -1190,7 +1244,15 @@ class Texture1D(Texture):
         """Return the ctypes structure for passing to kernels."""
         if self._tex_handle == 0:
             raise RuntimeError("Texture was created with data=None but never initialized.")
-        return texture1d_t(self._tex_handle, self._width, self._num_channels)
+        return texture1d_t(
+            self._tex_handle,
+            self._width,
+            self._num_channels,
+            int(self._filter_mode),
+            int(self._mip_filter_mode),
+            self._num_mip_levels,
+            int(self._normalized_coords),
+        )
 
 
 class Texture2D(Texture):
@@ -1271,7 +1333,16 @@ class Texture2D(Texture):
         """Return the ctypes structure for passing to kernels."""
         if self._tex_handle == 0:
             raise RuntimeError("Texture was created with data=None but never initialized.")
-        return texture2d_t(self._tex_handle, self._width, self._height, self._num_channels)
+        return texture2d_t(
+            self._tex_handle,
+            self._width,
+            self._height,
+            self._num_channels,
+            int(self._filter_mode),
+            int(self._mip_filter_mode),
+            self._num_mip_levels,
+            int(self._normalized_coords),
+        )
 
 
 class Texture3D(Texture):
@@ -1356,7 +1427,17 @@ class Texture3D(Texture):
         """Return the ctypes structure for passing to kernels."""
         if self._tex_handle == 0:
             raise RuntimeError("Texture was created with data=None but never initialized.")
-        return texture3d_t(self._tex_handle, self._width, self._height, self._depth, self._num_channels)
+        return texture3d_t(
+            self._tex_handle,
+            self._width,
+            self._height,
+            self._depth,
+            self._num_channels,
+            int(self._filter_mode),
+            int(self._mip_filter_mode),
+            self._num_mip_levels,
+            int(self._normalized_coords),
+        )
 
 
 class TextureResourceFlags(enum.IntEnum):

--- a/warp/native/texture.h
+++ b/warp/native/texture.h
@@ -155,18 +155,26 @@ struct texture1d_t {
     uint64 tex;  // CUtexObject handle (GPU) or Texture* (CPU)
     int32 width;
     int32 num_channels;
+    int32 filter_mode;
+    int32 use_normalized_coords;
 
     CUDA_CALLABLE inline texture1d_t()
         : tex(0)
         , width(0)
         , num_channels(0)
+        , filter_mode(0)
+        , use_normalized_coords(1)
     {
     }
 
-    CUDA_CALLABLE inline texture1d_t(uint64 tex, int32 width, int32 num_channels)
+    CUDA_CALLABLE inline texture1d_t(
+        uint64 tex, int32 width, int32 num_channels, int32 filter_mode, int32 use_normalized_coords
+    )
         : tex(tex)
         , width(width)
         , num_channels(num_channels)
+        , filter_mode(filter_mode)
+        , use_normalized_coords(use_normalized_coords)
     {
     }
 };
@@ -176,20 +184,28 @@ struct texture2d_t {
     int32 width;
     int32 height;
     int32 num_channels;
+    int32 filter_mode;
+    int32 use_normalized_coords;
 
     CUDA_CALLABLE inline texture2d_t()
         : tex(0)
         , width(0)
         , height(0)
         , num_channels(0)
+        , filter_mode(0)
+        , use_normalized_coords(1)
     {
     }
 
-    CUDA_CALLABLE inline texture2d_t(uint64 tex, int32 width, int32 height, int32 num_channels)
+    CUDA_CALLABLE inline texture2d_t(
+        uint64 tex, int32 width, int32 height, int32 num_channels, int32 filter_mode, int32 use_normalized_coords
+    )
         : tex(tex)
         , width(width)
         , height(height)
         , num_channels(num_channels)
+        , filter_mode(filter_mode)
+        , use_normalized_coords(use_normalized_coords)
     {
     }
 };
@@ -200,6 +216,8 @@ struct texture3d_t {
     int32 height;
     int32 depth;
     int32 num_channels;
+    int32 filter_mode;
+    int32 use_normalized_coords;
 
     CUDA_CALLABLE inline texture3d_t()
         : tex(0)
@@ -207,15 +225,27 @@ struct texture3d_t {
         , height(0)
         , depth(0)
         , num_channels(0)
+        , filter_mode(0)
+        , use_normalized_coords(1)
     {
     }
 
-    CUDA_CALLABLE inline texture3d_t(uint64 tex, int32 width, int32 height, int32 depth, int32 num_channels)
+    CUDA_CALLABLE inline texture3d_t(
+        uint64 tex,
+        int32 width,
+        int32 height,
+        int32 depth,
+        int32 num_channels,
+        int32 filter_mode,
+        int32 use_normalized_coords
+    )
         : tex(tex)
         , width(width)
         , height(height)
         , depth(depth)
         , num_channels(num_channels)
+        , filter_mode(filter_mode)
+        , use_normalized_coords(use_normalized_coords)
     {
     }
 };
@@ -658,6 +688,12 @@ template <> struct texture_sample_helper<float> {
     }
 
     static CUDA_CALLABLE float zero() { return 0.0f; }
+
+#if defined(__CUDA_ARCH__)
+    static CUDA_CALLABLE float fetch_1d(uint64 t, float u, int c) { return tex1D<float>(t, u); }
+    static CUDA_CALLABLE float fetch_2d(uint64 t, float u, float v, int c) { return tex2D<float>(t, u, v); }
+    static CUDA_CALLABLE float fetch_3d(uint64 t, float u, float v, float w, int c) { return tex3D<float>(t, u, v, w); }
+#endif
 };
 
 template <> struct texture_sample_helper<vec2f> {
@@ -701,6 +737,24 @@ template <> struct texture_sample_helper<vec2f> {
     }
 
     static CUDA_CALLABLE vec2f zero() { return vec2f(0.0f, 0.0f); }
+
+#if defined(__CUDA_ARCH__)
+    static CUDA_CALLABLE float fetch_1d(uint64 t, float u, int c)
+    {
+        float2 v = tex1D<float2>(t, u);
+        return c == 0 ? v.x : v.y;
+    }
+    static CUDA_CALLABLE float fetch_2d(uint64 t, float u, float v_, int c)
+    {
+        float2 v = tex2D<float2>(t, u, v_);
+        return c == 0 ? v.x : v.y;
+    }
+    static CUDA_CALLABLE float fetch_3d(uint64 t, float u, float v_, float w, int c)
+    {
+        float2 v = tex3D<float2>(t, u, v_, w);
+        return c == 0 ? v.x : v.y;
+    }
+#endif
 };
 
 template <> struct texture_sample_helper<vec4f> {
@@ -753,6 +807,24 @@ template <> struct texture_sample_helper<vec4f> {
     }
 
     static CUDA_CALLABLE vec4f zero() { return vec4f(0.0f, 0.0f, 0.0f, 0.0f); }
+
+#if defined(__CUDA_ARCH__)
+    static CUDA_CALLABLE float fetch_1d(uint64 t, float u, int c)
+    {
+        float4 v = tex1D<float4>(t, u);
+        return c == 0 ? v.x : c == 1 ? v.y : c == 2 ? v.z : v.w;
+    }
+    static CUDA_CALLABLE float fetch_2d(uint64 t, float u, float v_, int c)
+    {
+        float4 v = tex2D<float4>(t, u, v_);
+        return c == 0 ? v.x : c == 1 ? v.y : c == 2 ? v.z : v.w;
+    }
+    static CUDA_CALLABLE float fetch_3d(uint64 t, float u, float v_, float w, int c)
+    {
+        float4 v = tex3D<float4>(t, u, v_, w);
+        return c == 0 ? v.x : c == 1 ? v.y : c == 2 ? v.z : v.w;
+    }
+#endif
 };
 
 // 1D texture sampling with scalar coordinate
@@ -785,19 +857,66 @@ template <typename T> CUDA_CALLABLE T texture_sample(const texture3d_t& tex, flo
     return texture_sample_helper<T>::sample_3d(tex, u, v, w);
 }
 
-// Adjoint stubs for texture sampling (non-differentiable for now)
+// Adjoints for texture sampling w.r.t. sampling coordinates.
+// Gradients w.r.t. texture data are not supported; adj_tex is a no-op.
+// On GPU, requires filter_mode and use_normalized_coords in the descriptor.
+// Boundary behavior matches PyTorch grid_sample with padding_mode="border":
+// gradient is zero when the sampling position straddles a volume boundary.
 template <typename T>
 CUDA_CALLABLE void
 adj_texture_sample(const texture1d_t& tex, float u, texture1d_t& adj_tex, float& adj_u, const T& adj_ret)
 {
-    // Texture sampling is not differentiable in this implementation
+    if (tex.filter_mode == WP_TEXTURE_FILTER_CLOSEST)
+        return;
+
+    float gtx_mult = tex.use_normalized_coords ? (float)tex.width : 1.0f;
+
+#if defined(__CUDA_ARCH__)
+    float raw_tx = tex.use_normalized_coords ? u * (float)tex.width - 0.5f : u - 0.5f;
+    int x0 = (int)floor(raw_tx);
+    int x1 = x0 + 1;
+
+    if (x0 >= 0 && x1 < tex.width) {
+        float u0 = tex.use_normalized_coords ? ((float)x0 + 0.5f) / (float)tex.width : (float)x0 + 0.5f;
+        float u1 = tex.use_normalized_coords ? ((float)x1 + 0.5f) / (float)tex.width : (float)x1 + 0.5f;
+        float gtx = 0.0f;
+        for (int c = 0; c < tex.num_channels; c++)
+            gtx += (texture_sample_helper<T>::fetch_1d(tex.tex, u1, c)
+                    - texture_sample_helper<T>::fetch_1d(tex.tex, u0, c))
+                * ((const float*)&adj_ret)[c];
+        adj_u += gtx_mult * gtx;
+    }
+#else
+    if (tex.tex == 0)
+        return;
+    const Texture* cpu_tex = (const Texture*)tex.tex;
+
+    float coord_u = cpu_tex->use_normalized_coords ? u : (u / (float)cpu_tex->width);
+    float raw_tx = coord_u * (float)cpu_tex->width - 0.5f;
+    float tx = cpu_apply_address_mode_1d(coord_u, cpu_tex->width, cpu_tex->address_mode_u);
+
+    int x0_raw = (int)floor(raw_tx);
+    int x1_raw = x0_raw + 1;
+    int x0 = (int)floor(tx);
+    int x1 = x0 + 1;
+
+    if (cpu_in_bounds_1d(x0_raw, cpu_tex->width) && cpu_in_bounds_1d(x1_raw, cpu_tex->width)) {
+        int x0w = cpu_apply_address_mode_index(x0, cpu_tex->width, cpu_tex->address_mode_u);
+        int x1w = cpu_apply_address_mode_index(x1, cpu_tex->width, cpu_tex->address_mode_u);
+        float gtx = 0.0f;
+        for (int c = 0; c < cpu_tex->num_channels; c++)
+            gtx += (cpu_fetch_texel_1d(cpu_tex, x1w, c) - cpu_fetch_texel_1d(cpu_tex, x0w, c))
+                * ((const float*)&adj_ret)[c];
+        adj_u += gtx_mult * gtx;
+    }
+#endif
 }
 
 template <typename T>
 CUDA_CALLABLE void
 adj_texture_sample(const texture2d_t& tex, const vec2f& uv, texture2d_t& adj_tex, vec2f& adj_uv, const T& adj_ret)
 {
-    // Texture sampling is not differentiable in this implementation
+    adj_texture_sample(tex, uv[0], uv[1], adj_tex, adj_uv[0], adj_uv[1], adj_ret);
 }
 
 template <typename T>
@@ -805,14 +924,98 @@ CUDA_CALLABLE void adj_texture_sample(
     const texture2d_t& tex, float u, float v, texture2d_t& adj_tex, float& adj_u, float& adj_v, const T& adj_ret
 )
 {
-    // Texture sampling is not differentiable in this implementation
+    if (tex.filter_mode == WP_TEXTURE_FILTER_CLOSEST)
+        return;
+
+    float gtx_mult = tex.use_normalized_coords ? (float)tex.width : 1.0f;
+    float gty_mult = tex.use_normalized_coords ? (float)tex.height : 1.0f;
+
+#if defined(__CUDA_ARCH__)
+    float raw_tx = tex.use_normalized_coords ? u * (float)tex.width - 0.5f : u - 0.5f;
+    float raw_ty = tex.use_normalized_coords ? v * (float)tex.height - 0.5f : v - 0.5f;
+    int x0 = (int)floor(raw_tx);
+    int x1 = x0 + 1;
+    int y0 = (int)floor(raw_ty);
+    int y1 = y0 + 1;
+    float fx = raw_tx - (float)x0;
+    float fy = raw_ty - (float)y0;
+
+    bool x_ok = (x0 >= 0 && x1 < tex.width);
+    bool y_ok = (y0 >= 0 && y1 < tex.height);
+
+    auto fetch = [&](int x, int y, int c) -> float {
+        float uf = tex.use_normalized_coords ? ((float)x + 0.5f) / (float)tex.width : (float)x + 0.5f;
+        float vf = tex.use_normalized_coords ? ((float)y + 0.5f) / (float)tex.height : (float)y + 0.5f;
+        return texture_sample_helper<T>::fetch_2d(tex.tex, uf, vf, c);
+    };
+
+    float gtx = 0.0f, gty = 0.0f;
+    for (int c = 0; c < tex.num_channels; c++) {
+        float gOut = ((const float*)&adj_ret)[c];
+        float v00 = fetch(x0, y0, c);
+        float v10 = fetch(x1, y0, c);
+        float v01 = fetch(x0, y1, c);
+        float v11 = fetch(x1, y1, c);
+        if (x_ok)
+            gtx += ((v10 - v00) * (1.0f - fy) + (v11 - v01) * fy) * gOut;
+        if (y_ok)
+            gty += ((v01 - v00) * (1.0f - fx) + (v11 - v10) * fx) * gOut;
+    }
+    adj_u += gtx_mult * gtx;
+    adj_v += gty_mult * gty;
+#else
+    if (tex.tex == 0)
+        return;
+    const Texture* cpu_tex = (const Texture*)tex.tex;
+
+    float coord_u = cpu_tex->use_normalized_coords ? u : (u / (float)cpu_tex->width);
+    float coord_v = cpu_tex->use_normalized_coords ? v : (v / (float)cpu_tex->height);
+    float raw_tx = coord_u * (float)cpu_tex->width - 0.5f;
+    float raw_ty = coord_v * (float)cpu_tex->height - 0.5f;
+    float tx = cpu_apply_address_mode_1d(coord_u, cpu_tex->width, cpu_tex->address_mode_u);
+    float ty = cpu_apply_address_mode_1d(coord_v, cpu_tex->height, cpu_tex->address_mode_v);
+
+    int x0_raw = (int)floor(raw_tx);
+    int x1_raw = x0_raw + 1;
+    int y0_raw = (int)floor(raw_ty);
+    int y1_raw = y0_raw + 1;
+    int x0 = (int)floor(tx);
+    int x1 = x0 + 1;
+    int y0 = (int)floor(ty);
+    int y1 = y0 + 1;
+    float fx = tx - (float)x0;
+    float fy = ty - (float)y0;
+
+    bool x_ok = (cpu_in_bounds_1d(x0_raw, cpu_tex->width) && cpu_in_bounds_1d(x1_raw, cpu_tex->width));
+    bool y_ok = (cpu_in_bounds_1d(y0_raw, cpu_tex->height) && cpu_in_bounds_1d(y1_raw, cpu_tex->height));
+
+    int x0w = cpu_apply_address_mode_index(x0, cpu_tex->width, cpu_tex->address_mode_u);
+    int x1w = cpu_apply_address_mode_index(x1, cpu_tex->width, cpu_tex->address_mode_u);
+    int y0w = cpu_apply_address_mode_index(y0, cpu_tex->height, cpu_tex->address_mode_v);
+    int y1w = cpu_apply_address_mode_index(y1, cpu_tex->height, cpu_tex->address_mode_v);
+
+    float gtx = 0.0f, gty = 0.0f;
+    for (int c = 0; c < cpu_tex->num_channels; c++) {
+        float gOut = ((const float*)&adj_ret)[c];
+        float v00 = cpu_fetch_texel_2d(cpu_tex, x0w, y0w, c);
+        float v10 = cpu_fetch_texel_2d(cpu_tex, x1w, y0w, c);
+        float v01 = cpu_fetch_texel_2d(cpu_tex, x0w, y1w, c);
+        float v11 = cpu_fetch_texel_2d(cpu_tex, x1w, y1w, c);
+        if (x_ok)
+            gtx += ((v10 - v00) * (1.0f - fy) + (v11 - v01) * fy) * gOut;
+        if (y_ok)
+            gty += ((v01 - v00) * (1.0f - fx) + (v11 - v10) * fx) * gOut;
+    }
+    adj_u += gtx_mult * gtx;
+    adj_v += gty_mult * gty;
+#endif
 }
 
 template <typename T>
 CUDA_CALLABLE void
 adj_texture_sample(const texture3d_t& tex, const vec3f& uvw, texture3d_t& adj_tex, vec3f& adj_uvw, const T& adj_ret)
 {
-    // Texture sampling is not differentiable in this implementation
+    adj_texture_sample(tex, uvw[0], uvw[1], uvw[2], adj_tex, adj_uvw[0], adj_uvw[1], adj_uvw[2], adj_ret);
 }
 
 template <typename T>
@@ -828,7 +1031,135 @@ CUDA_CALLABLE void adj_texture_sample(
     const T& adj_ret
 )
 {
-    // Texture sampling is not differentiable in this implementation
+    if (tex.filter_mode == WP_TEXTURE_FILTER_CLOSEST)
+        return;
+
+    float gtx_mult = tex.use_normalized_coords ? (float)tex.width : 1.0f;
+    float gty_mult = tex.use_normalized_coords ? (float)tex.height : 1.0f;
+    float gtz_mult = tex.use_normalized_coords ? (float)tex.depth : 1.0f;
+
+#if defined(__CUDA_ARCH__)
+    float raw_tx = tex.use_normalized_coords ? u * (float)tex.width - 0.5f : u - 0.5f;
+    float raw_ty = tex.use_normalized_coords ? v * (float)tex.height - 0.5f : v - 0.5f;
+    float raw_tz = tex.use_normalized_coords ? w * (float)tex.depth - 0.5f : w - 0.5f;
+    int x0 = (int)floor(raw_tx);
+    int x1 = x0 + 1;
+    int y0 = (int)floor(raw_ty);
+    int y1 = y0 + 1;
+    int z0 = (int)floor(raw_tz);
+    int z1 = z0 + 1;
+    float fx = raw_tx - (float)x0;
+    float fy = raw_ty - (float)y0;
+    float fz = raw_tz - (float)z0;
+
+    bool x_ok = (x0 >= 0 && x1 < tex.width);
+    bool y_ok = (y0 >= 0 && y1 < tex.height);
+    bool z_ok = (z0 >= 0 && z1 < tex.depth);
+
+    auto fetch = [&](int x, int y, int z, int c) -> float {
+        float uf = tex.use_normalized_coords ? ((float)x + 0.5f) / (float)tex.width : (float)x + 0.5f;
+        float vf = tex.use_normalized_coords ? ((float)y + 0.5f) / (float)tex.height : (float)y + 0.5f;
+        float wf = tex.use_normalized_coords ? ((float)z + 0.5f) / (float)tex.depth : (float)z + 0.5f;
+        return texture_sample_helper<T>::fetch_3d(tex.tex, uf, vf, wf, c);
+    };
+
+    float gtx = 0.0f, gty = 0.0f, gtz = 0.0f;
+    for (int c = 0; c < tex.num_channels; c++) {
+        float gOut = ((const float*)&adj_ret)[c];
+        float v000 = fetch(x0, y0, z0, c);
+        float v100 = fetch(x1, y0, z0, c);
+        float v010 = fetch(x0, y1, z0, c);
+        float v110 = fetch(x1, y1, z0, c);
+        float v001 = fetch(x0, y0, z1, c);
+        float v101 = fetch(x1, y0, z1, c);
+        float v011 = fetch(x0, y1, z1, c);
+        float v111 = fetch(x1, y1, z1, c);
+        if (x_ok)
+            gtx += (((v100 - v000) * (1.0f - fy) + (v110 - v010) * fy) * (1.0f - fz)
+                    + ((v101 - v001) * (1.0f - fy) + (v111 - v011) * fy) * fz)
+                * gOut;
+        if (y_ok)
+            gty += (((v010 - v000) * (1.0f - fx) + (v110 - v100) * fx) * (1.0f - fz)
+                    + ((v011 - v001) * (1.0f - fx) + (v111 - v101) * fx) * fz)
+                * gOut;
+        if (z_ok)
+            gtz += (((v001 - v000) * (1.0f - fx) + (v101 - v100) * fx) * (1.0f - fy)
+                    + ((v011 - v010) * (1.0f - fx) + (v111 - v110) * fx) * fy)
+                * gOut;
+    }
+    adj_u += gtx_mult * gtx;
+    adj_v += gty_mult * gty;
+    adj_w += gtz_mult * gtz;
+#else
+    if (tex.tex == 0)
+        return;
+    const Texture* cpu_tex = (const Texture*)tex.tex;
+
+    float coord_u = cpu_tex->use_normalized_coords ? u : (u / (float)cpu_tex->width);
+    float coord_v = cpu_tex->use_normalized_coords ? v : (v / (float)cpu_tex->height);
+    float coord_w = cpu_tex->use_normalized_coords ? w : (w / (float)cpu_tex->depth);
+    float raw_tx = coord_u * (float)cpu_tex->width - 0.5f;
+    float raw_ty = coord_v * (float)cpu_tex->height - 0.5f;
+    float raw_tz = coord_w * (float)cpu_tex->depth - 0.5f;
+    float tx = cpu_apply_address_mode_1d(coord_u, cpu_tex->width, cpu_tex->address_mode_u);
+    float ty = cpu_apply_address_mode_1d(coord_v, cpu_tex->height, cpu_tex->address_mode_v);
+    float tz = cpu_apply_address_mode_1d(coord_w, cpu_tex->depth, cpu_tex->address_mode_w);
+
+    int x0_raw = (int)floor(raw_tx);
+    int x1_raw = x0_raw + 1;
+    int y0_raw = (int)floor(raw_ty);
+    int y1_raw = y0_raw + 1;
+    int z0_raw = (int)floor(raw_tz);
+    int z1_raw = z0_raw + 1;
+    int x0 = (int)floor(tx);
+    int x1 = x0 + 1;
+    int y0 = (int)floor(ty);
+    int y1 = y0 + 1;
+    int z0 = (int)floor(tz);
+    int z1 = z0 + 1;
+    float fx = tx - (float)x0;
+    float fy = ty - (float)y0;
+    float fz = tz - (float)z0;
+
+    bool x_ok = (cpu_in_bounds_1d(x0_raw, cpu_tex->width) && cpu_in_bounds_1d(x1_raw, cpu_tex->width));
+    bool y_ok = (cpu_in_bounds_1d(y0_raw, cpu_tex->height) && cpu_in_bounds_1d(y1_raw, cpu_tex->height));
+    bool z_ok = (cpu_in_bounds_1d(z0_raw, cpu_tex->depth) && cpu_in_bounds_1d(z1_raw, cpu_tex->depth));
+
+    int x0w = cpu_apply_address_mode_index(x0, cpu_tex->width, cpu_tex->address_mode_u);
+    int x1w = cpu_apply_address_mode_index(x1, cpu_tex->width, cpu_tex->address_mode_u);
+    int y0w = cpu_apply_address_mode_index(y0, cpu_tex->height, cpu_tex->address_mode_v);
+    int y1w = cpu_apply_address_mode_index(y1, cpu_tex->height, cpu_tex->address_mode_v);
+    int z0w = cpu_apply_address_mode_index(z0, cpu_tex->depth, cpu_tex->address_mode_w);
+    int z1w = cpu_apply_address_mode_index(z1, cpu_tex->depth, cpu_tex->address_mode_w);
+
+    float gtx = 0.0f, gty = 0.0f, gtz = 0.0f;
+    for (int c = 0; c < cpu_tex->num_channels; c++) {
+        float gOut = ((const float*)&adj_ret)[c];
+        float v000 = cpu_fetch_texel_3d(cpu_tex, x0w, y0w, z0w, c);
+        float v100 = cpu_fetch_texel_3d(cpu_tex, x1w, y0w, z0w, c);
+        float v010 = cpu_fetch_texel_3d(cpu_tex, x0w, y1w, z0w, c);
+        float v110 = cpu_fetch_texel_3d(cpu_tex, x1w, y1w, z0w, c);
+        float v001 = cpu_fetch_texel_3d(cpu_tex, x0w, y0w, z1w, c);
+        float v101 = cpu_fetch_texel_3d(cpu_tex, x1w, y0w, z1w, c);
+        float v011 = cpu_fetch_texel_3d(cpu_tex, x0w, y1w, z1w, c);
+        float v111 = cpu_fetch_texel_3d(cpu_tex, x1w, y1w, z1w, c);
+        if (x_ok)
+            gtx += (((v100 - v000) * (1.0f - fy) + (v110 - v010) * fy) * (1.0f - fz)
+                    + ((v101 - v001) * (1.0f - fy) + (v111 - v011) * fy) * fz)
+                * gOut;
+        if (y_ok)
+            gty += (((v010 - v000) * (1.0f - fx) + (v110 - v100) * fx) * (1.0f - fz)
+                    + ((v011 - v001) * (1.0f - fx) + (v111 - v101) * fx) * fz)
+                * gOut;
+        if (z_ok)
+            gtz += (((v001 - v000) * (1.0f - fx) + (v101 - v100) * fx) * (1.0f - fy)
+                    + ((v011 - v010) * (1.0f - fx) + (v111 - v110) * fx) * fy)
+                * gOut;
+    }
+    adj_u += gtx_mult * gtx;
+    adj_v += gty_mult * gty;
+    adj_w += gtz_mult * gtz;
+#endif
 }
 
 // Type aliases for code generation

--- a/warp/native/texture.h
+++ b/warp/native/texture.h
@@ -157,6 +157,7 @@ struct texture1d_t {
     int32 num_channels;
     int32 filter_mode;
     int32 use_normalized_coords;
+    int32 address_mode_u;
 
     CUDA_CALLABLE inline texture1d_t()
         : tex(0)
@@ -164,17 +165,24 @@ struct texture1d_t {
         , num_channels(0)
         , filter_mode(0)
         , use_normalized_coords(1)
+        , address_mode_u(0)
     {
     }
 
     CUDA_CALLABLE inline texture1d_t(
-        uint64 tex, int32 width, int32 num_channels, int32 filter_mode, int32 use_normalized_coords
+        uint64 tex,
+        int32 width,
+        int32 num_channels,
+        int32 filter_mode,
+        int32 use_normalized_coords,
+        int32 address_mode_u
     )
         : tex(tex)
         , width(width)
         , num_channels(num_channels)
         , filter_mode(filter_mode)
         , use_normalized_coords(use_normalized_coords)
+        , address_mode_u(address_mode_u)
     {
     }
 };
@@ -186,6 +194,8 @@ struct texture2d_t {
     int32 num_channels;
     int32 filter_mode;
     int32 use_normalized_coords;
+    int32 address_mode_u;
+    int32 address_mode_v;
 
     CUDA_CALLABLE inline texture2d_t()
         : tex(0)
@@ -194,11 +204,20 @@ struct texture2d_t {
         , num_channels(0)
         , filter_mode(0)
         , use_normalized_coords(1)
+        , address_mode_u(0)
+        , address_mode_v(0)
     {
     }
 
     CUDA_CALLABLE inline texture2d_t(
-        uint64 tex, int32 width, int32 height, int32 num_channels, int32 filter_mode, int32 use_normalized_coords
+        uint64 tex,
+        int32 width,
+        int32 height,
+        int32 num_channels,
+        int32 filter_mode,
+        int32 use_normalized_coords,
+        int32 address_mode_u,
+        int32 address_mode_v
     )
         : tex(tex)
         , width(width)
@@ -206,6 +225,8 @@ struct texture2d_t {
         , num_channels(num_channels)
         , filter_mode(filter_mode)
         , use_normalized_coords(use_normalized_coords)
+        , address_mode_u(address_mode_u)
+        , address_mode_v(address_mode_v)
     {
     }
 };
@@ -218,6 +239,9 @@ struct texture3d_t {
     int32 num_channels;
     int32 filter_mode;
     int32 use_normalized_coords;
+    int32 address_mode_u;
+    int32 address_mode_v;
+    int32 address_mode_w;
 
     CUDA_CALLABLE inline texture3d_t()
         : tex(0)
@@ -227,6 +251,9 @@ struct texture3d_t {
         , num_channels(0)
         , filter_mode(0)
         , use_normalized_coords(1)
+        , address_mode_u(0)
+        , address_mode_v(0)
+        , address_mode_w(0)
     {
     }
 
@@ -237,7 +264,10 @@ struct texture3d_t {
         int32 depth,
         int32 num_channels,
         int32 filter_mode,
-        int32 use_normalized_coords
+        int32 use_normalized_coords,
+        int32 address_mode_u,
+        int32 address_mode_v,
+        int32 address_mode_w
     )
         : tex(tex)
         , width(width)
@@ -246,6 +276,9 @@ struct texture3d_t {
         , num_channels(num_channels)
         , filter_mode(filter_mode)
         , use_normalized_coords(use_normalized_coords)
+        , address_mode_u(address_mode_u)
+        , address_mode_v(address_mode_v)
+        , address_mode_w(address_mode_w)
     {
     }
 };
@@ -882,22 +915,23 @@ adj_texture_sample(const texture1d_t& tex, float u, texture1d_t& adj_tex, float&
     if (tex.filter_mode == WP_TEXTURE_FILTER_CLOSEST)
         return;
 
-#ifndef NDEBUG
-// Warning: This check is only active in debug builds
-// Differentiation is only correct for BORDER address mode
-#if !defined(__CUDA_ARCH__)
-    if (tex.tex != 0) {
-        const Texture* cpu_tex = (const Texture*)tex.tex;
-        if (cpu_tex->address_mode_u != WP_TEXTURE_ADDRESS_BORDER) {
-            printf(
-                "WARNING: texture_sample adjoint may produce incorrect gradients. "
-                "Address mode is %d but differentiation only supports BORDER mode (3).\n",
-                cpu_tex->address_mode_u
-            );
-        }
+    // Check address mode compatibility with differentiation
+    if (tex.address_mode_u != WP_TEXTURE_ADDRESS_BORDER) {
+#if defined(__CUDA_ARCH__)
+        printf(
+            "ERROR: texture_sample gradient computation requires BORDER address mode. "
+            "Texture has address_mode_u=%d. Gradients will be incorrect.\n",
+            tex.address_mode_u
+        );
+#else
+        printf(
+            "ERROR: texture_sample gradient computation requires BORDER address mode. "
+            "Texture has address_mode_u=%d. Gradients will be incorrect.\n",
+            tex.address_mode_u
+        );
+#endif
+        return;  // Return zero gradient
     }
-#endif
-#endif
 
     float gtx_mult = tex.use_normalized_coords ? (float)tex.width : 1.0f;
 
@@ -957,21 +991,22 @@ CUDA_CALLABLE void adj_texture_sample(
     if (tex.filter_mode == WP_TEXTURE_FILTER_CLOSEST)
         return;
 
-#ifndef NDEBUG
-#if !defined(__CUDA_ARCH__)
-    if (tex.tex != 0) {
-        const Texture* cpu_tex = (const Texture*)tex.tex;
-        if (cpu_tex->address_mode_u != WP_TEXTURE_ADDRESS_BORDER
-            || cpu_tex->address_mode_v != WP_TEXTURE_ADDRESS_BORDER) {
-            printf(
-                "WARNING: texture_sample adjoint may produce incorrect gradients. "
-                "Address modes are (%d, %d) but differentiation only supports BORDER mode (3).\n",
-                cpu_tex->address_mode_u, cpu_tex->address_mode_v
-            );
-        }
+    if (tex.address_mode_u != WP_TEXTURE_ADDRESS_BORDER || tex.address_mode_v != WP_TEXTURE_ADDRESS_BORDER) {
+#if defined(__CUDA_ARCH__)
+        printf(
+            "ERROR: texture_sample gradient computation requires BORDER address mode. "
+            "Texture has address modes (%d, %d). Gradients will be incorrect.\n",
+            tex.address_mode_u, tex.address_mode_v
+        );
+#else
+        printf(
+            "ERROR: texture_sample gradient computation requires BORDER address mode. "
+            "Texture has address modes (%d, %d). Gradients will be incorrect.\n",
+            tex.address_mode_u, tex.address_mode_v
+        );
+#endif
+        return;
     }
-#endif
-#endif
 
     float gtx_mult = tex.use_normalized_coords ? (float)tex.width : 1.0f;
     float gty_mult = tex.use_normalized_coords ? (float)tex.height : 1.0f;
@@ -1080,21 +1115,23 @@ CUDA_CALLABLE void adj_texture_sample(
     if (tex.filter_mode == WP_TEXTURE_FILTER_CLOSEST)
         return;
 
-#ifndef NDEBUG
-#if !defined(__CUDA_ARCH__)
-    if (tex.tex != 0) {
-        const Texture* cpu_tex = (const Texture*)tex.tex;
-        if (cpu_tex->address_mode_u != WP_TEXTURE_ADDRESS_BORDER || cpu_tex->address_mode_v != WP_TEXTURE_ADDRESS_BORDER
-            || cpu_tex->address_mode_w != WP_TEXTURE_ADDRESS_BORDER) {
-            printf(
-                "WARNING: texture_sample adjoint may produce incorrect gradients. "
-                "Address modes are (%d, %d, %d) but differentiation only supports BORDER mode (3).\n",
-                cpu_tex->address_mode_u, cpu_tex->address_mode_v, cpu_tex->address_mode_w
-            );
-        }
+    if (tex.address_mode_u != WP_TEXTURE_ADDRESS_BORDER || tex.address_mode_v != WP_TEXTURE_ADDRESS_BORDER
+        || tex.address_mode_w != WP_TEXTURE_ADDRESS_BORDER) {
+#if defined(__CUDA_ARCH__)
+        printf(
+            "ERROR: texture_sample gradient computation requires BORDER address mode. "
+            "Texture has address modes (%d, %d, %d). Gradients will be incorrect.\n",
+            tex.address_mode_u, tex.address_mode_v, tex.address_mode_w
+        );
+#else
+        printf(
+            "ERROR: texture_sample gradient computation requires BORDER address mode. "
+            "Texture has address modes (%d, %d, %d). Gradients will be incorrect.\n",
+            tex.address_mode_u, tex.address_mode_v, tex.address_mode_w
+        );
+#endif
+        return;
     }
-#endif
-#endif
 
     float gtx_mult = tex.use_normalized_coords ? (float)tex.width : 1.0f;
     float gty_mult = tex.use_normalized_coords ? (float)tex.height : 1.0f;

--- a/warp/native/texture.h
+++ b/warp/native/texture.h
@@ -857,17 +857,47 @@ template <typename T> CUDA_CALLABLE T texture_sample(const texture3d_t& tex, flo
     return texture_sample_helper<T>::sample_3d(tex, u, v, w);
 }
 
-// Adjoints for texture sampling w.r.t. sampling coordinates.
-// Gradients w.r.t. texture data are not supported; adj_tex is a no-op.
-// On GPU, requires filter_mode and use_normalized_coords in the descriptor.
-// Boundary behavior matches PyTorch grid_sample with padding_mode="border":
-// gradient is zero when the sampling position straddles a volume boundary.
+// ============================================================================
+// Texture Sampling Adjoints
+// ============================================================================
+//
+// IMPORTANT: Differentiation is only correct when all texture address modes
+// are set to BORDER (WP_TEXTURE_ADDRESS_BORDER = 3).
+//
+// The gradient computation zeros out when sampling positions straddle texture
+// boundaries, which is correct for BORDER mode (returns 0 outside bounds) but
+// incorrect for WRAP/MIRROR/CLAMP modes where the forward pass returns valid
+// interpolated data across boundaries.
+//
+// Using differentiation with WRAP (mode 0), CLAMP (mode 1), or MIRROR (mode 2)
+// will silently produce incorrect gradients without error or warning.
+//
+// Future work: Implement proper gradient computation for all address modes.
+// ============================================================================
+
 template <typename T>
 CUDA_CALLABLE void
 adj_texture_sample(const texture1d_t& tex, float u, texture1d_t& adj_tex, float& adj_u, const T& adj_ret)
 {
     if (tex.filter_mode == WP_TEXTURE_FILTER_CLOSEST)
         return;
+
+#ifndef NDEBUG
+// Warning: This check is only active in debug builds
+// Differentiation is only correct for BORDER address mode
+#if !defined(__CUDA_ARCH__)
+    if (tex.tex != 0) {
+        const Texture* cpu_tex = (const Texture*)tex.tex;
+        if (cpu_tex->address_mode_u != WP_TEXTURE_ADDRESS_BORDER) {
+            printf(
+                "WARNING: texture_sample adjoint may produce incorrect gradients. "
+                "Address mode is %d but differentiation only supports BORDER mode (3).\n",
+                cpu_tex->address_mode_u
+            );
+        }
+    }
+#endif
+#endif
 
     float gtx_mult = tex.use_normalized_coords ? (float)tex.width : 1.0f;
 
@@ -926,6 +956,22 @@ CUDA_CALLABLE void adj_texture_sample(
 {
     if (tex.filter_mode == WP_TEXTURE_FILTER_CLOSEST)
         return;
+
+#ifndef NDEBUG
+#if !defined(__CUDA_ARCH__)
+    if (tex.tex != 0) {
+        const Texture* cpu_tex = (const Texture*)tex.tex;
+        if (cpu_tex->address_mode_u != WP_TEXTURE_ADDRESS_BORDER
+            || cpu_tex->address_mode_v != WP_TEXTURE_ADDRESS_BORDER) {
+            printf(
+                "WARNING: texture_sample adjoint may produce incorrect gradients. "
+                "Address modes are (%d, %d) but differentiation only supports BORDER mode (3).\n",
+                cpu_tex->address_mode_u, cpu_tex->address_mode_v
+            );
+        }
+    }
+#endif
+#endif
 
     float gtx_mult = tex.use_normalized_coords ? (float)tex.width : 1.0f;
     float gty_mult = tex.use_normalized_coords ? (float)tex.height : 1.0f;
@@ -1033,6 +1079,22 @@ CUDA_CALLABLE void adj_texture_sample(
 {
     if (tex.filter_mode == WP_TEXTURE_FILTER_CLOSEST)
         return;
+
+#ifndef NDEBUG
+#if !defined(__CUDA_ARCH__)
+    if (tex.tex != 0) {
+        const Texture* cpu_tex = (const Texture*)tex.tex;
+        if (cpu_tex->address_mode_u != WP_TEXTURE_ADDRESS_BORDER || cpu_tex->address_mode_v != WP_TEXTURE_ADDRESS_BORDER
+            || cpu_tex->address_mode_w != WP_TEXTURE_ADDRESS_BORDER) {
+            printf(
+                "WARNING: texture_sample adjoint may produce incorrect gradients. "
+                "Address modes are (%d, %d, %d) but differentiation only supports BORDER mode (3).\n",
+                cpu_tex->address_mode_u, cpu_tex->address_mode_v, cpu_tex->address_mode_w
+            );
+        }
+    }
+#endif
+#endif
 
     float gtx_mult = tex.use_normalized_coords ? (float)tex.width : 1.0f;
     float gty_mult = tex.use_normalized_coords ? (float)tex.height : 1.0f;

--- a/warp/native/texture.h
+++ b/warp/native/texture.h
@@ -157,18 +157,40 @@ struct texture1d_t {
     uint64 tex;  // CUtexObject handle (GPU) or Texture* (CPU)
     int32 width;
     int32 num_channels;
+    // Sampling configuration mirrored from the owning texture so that
+    // adj_texture_sample can differentiate without host-side lookups.
+    int32 filter_mode;
+    int32 mip_filter_mode;
+    int32 num_mip_levels;
+    int32 use_normalized_coords;
 
     CUDA_CALLABLE inline texture1d_t()
         : tex(0)
         , width(0)
         , num_channels(0)
+        , filter_mode(0)
+        , mip_filter_mode(0)
+        , num_mip_levels(1)
+        , use_normalized_coords(1)
     {
     }
 
-    CUDA_CALLABLE inline texture1d_t(uint64 tex, int32 width, int32 num_channels)
+    CUDA_CALLABLE inline texture1d_t(
+        uint64 tex,
+        int32 width,
+        int32 num_channels,
+        int32 filter_mode,
+        int32 mip_filter_mode,
+        int32 num_mip_levels,
+        int32 use_normalized_coords
+    )
         : tex(tex)
         , width(width)
         , num_channels(num_channels)
+        , filter_mode(filter_mode)
+        , mip_filter_mode(mip_filter_mode)
+        , num_mip_levels(num_mip_levels)
+        , use_normalized_coords(use_normalized_coords)
     {
     }
 };
@@ -178,20 +200,43 @@ struct texture2d_t {
     int32 width;
     int32 height;
     int32 num_channels;
+    // Sampling configuration mirrored from the owning texture so that
+    // adj_texture_sample can differentiate without host-side lookups.
+    int32 filter_mode;
+    int32 mip_filter_mode;
+    int32 num_mip_levels;
+    int32 use_normalized_coords;
 
     CUDA_CALLABLE inline texture2d_t()
         : tex(0)
         , width(0)
         , height(0)
         , num_channels(0)
+        , filter_mode(0)
+        , mip_filter_mode(0)
+        , num_mip_levels(1)
+        , use_normalized_coords(1)
     {
     }
 
-    CUDA_CALLABLE inline texture2d_t(uint64 tex, int32 width, int32 height, int32 num_channels)
+    CUDA_CALLABLE inline texture2d_t(
+        uint64 tex,
+        int32 width,
+        int32 height,
+        int32 num_channels,
+        int32 filter_mode,
+        int32 mip_filter_mode,
+        int32 num_mip_levels,
+        int32 use_normalized_coords
+    )
         : tex(tex)
         , width(width)
         , height(height)
         , num_channels(num_channels)
+        , filter_mode(filter_mode)
+        , mip_filter_mode(mip_filter_mode)
+        , num_mip_levels(num_mip_levels)
+        , use_normalized_coords(use_normalized_coords)
     {
     }
 };
@@ -202,6 +247,12 @@ struct texture3d_t {
     int32 height;
     int32 depth;
     int32 num_channels;
+    // Sampling configuration mirrored from the owning texture so that
+    // adj_texture_sample can differentiate without host-side lookups.
+    int32 filter_mode;
+    int32 mip_filter_mode;
+    int32 num_mip_levels;
+    int32 use_normalized_coords;
 
     CUDA_CALLABLE inline texture3d_t()
         : tex(0)
@@ -209,15 +260,33 @@ struct texture3d_t {
         , height(0)
         , depth(0)
         , num_channels(0)
+        , filter_mode(0)
+        , mip_filter_mode(0)
+        , num_mip_levels(1)
+        , use_normalized_coords(1)
     {
     }
 
-    CUDA_CALLABLE inline texture3d_t(uint64 tex, int32 width, int32 height, int32 depth, int32 num_channels)
+    CUDA_CALLABLE inline texture3d_t(
+        uint64 tex,
+        int32 width,
+        int32 height,
+        int32 depth,
+        int32 num_channels,
+        int32 filter_mode,
+        int32 mip_filter_mode,
+        int32 num_mip_levels,
+        int32 use_normalized_coords
+    )
         : tex(tex)
         , width(width)
         , height(height)
         , depth(depth)
         , num_channels(num_channels)
+        , filter_mode(filter_mode)
+        , mip_filter_mode(mip_filter_mode)
+        , num_mip_levels(num_mip_levels)
+        , use_normalized_coords(use_normalized_coords)
     {
     }
 };
@@ -891,31 +960,230 @@ template <typename T> CUDA_CALLABLE T texture_sample(const texture3d_t& tex, flo
     return texture_sample_helper<T>::sample_3d(tex, u, v, w, lod);
 }
 
-// Adjoint stubs for texture sampling
+// ============================================================================
+// Texture Sampling Adjoints
+// ============================================================================
+//
+// Gradients with respect to the sampling coordinates (and LOD) are computed by
+// re-sampling the texture through the same forward sampler at two interior
+// points of the current interpolation cell. With linear filtering the forward
+// function restricted to one cell is exactly a lerp of the cell's corner
+// values, and every address-mode coordinate mapping (wrap, clamp, mirror,
+// border) is piecewise affine with slope in {0, +/-1}, folding only at cell
+// boundaries in raw texel space. A scaled difference of two in-cell samples is
+// therefore the exact derivative of the actual forward function, with each
+// mode's boundary behavior (clamp's zero slope, mirror's sign flip, wrap's
+// periodicity, border's zero padding) inherited from the sampler itself, on
+// both the CPU and CUDA backends.
+//
+// The samples are taken at the cell's quarter points (fractions 0.25 and
+// 0.75) rather than at the texel centers on the cell boundary: quarter points
+// sit a safe distance from any fold or floor rounding, and both fractions are
+// exact in the CUDA hardware's 9-bit fixed-point interpolator, so the
+// difference recovers the lerp slope exactly.
+//
+// Gradients with respect to the texel data (``adj_tex``) are not implemented.
+
+// dot(adjoint, delta) for the supported sample value types
+CUDA_CALLABLE inline float texture_grad_dot(float a, float b) { return a * b; }
+
+CUDA_CALLABLE inline float texture_grad_dot(const vec2f& a, const vec2f& b) { return a[0] * b[0] + a[1] * b[1]; }
+
+CUDA_CALLABLE inline float texture_grad_dot(const vec4f& a, const vec4f& b)
+{
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2] + a[3] * b[3];
+}
+
+// Dimension of a mip level (mip chains always use floor-halving)
+CUDA_CALLABLE inline int texture_mip_dim(int base_dim, int level)
+{
+    int d = base_dim >> level;
+    return d < 1 ? 1 : d;
+}
+
+// Derivative of the raw texel-space coordinate with respect to the sampling
+// coordinate: texel = coord * scale - 0.5. Unnormalized coordinates address
+// mip levels in base-level texel space, hence the level/base ratio.
+CUDA_CALLABLE inline float texture_coord_scale(int use_normalized_coords, int level_dim, int base_dim)
+{
+    return use_normalized_coords ? (float)level_dim : ((float)level_dim / (float)base_dim);
+}
+
+// Quarter points of the interpolation cell containing texel-space coordinate
+// t, mapped back to coordinate space (coord = (t + 0.5) / scale).
+CUDA_CALLABLE inline void texture_grad_cell_points(float coord, float scale, float& coord_a, float& coord_b)
+{
+    float n = floor(coord * scale - 0.5f);
+    coord_a = (n + 0.75f) / scale;
+    coord_b = (n + 1.25f) / scale;
+}
+
+// Per-level coordinate gradients accumulated via quarter-point differences.
+// ``sample_lod`` is the LOD passed to the sampler (an integer level for
+// mipmapped textures so that exactly one level is read, or the original
+// ``lod`` argument when the texture has a single level).
+template <typename T>
+CUDA_CALLABLE inline void texture_grad_coords_1d(
+    const texture1d_t& tex, float u, float sample_lod, int level, float weight, const T& adj_ret, float& adj_u
+)
+{
+    const int level_w = texture_mip_dim(tex.width, level);
+    const float su = texture_coord_scale(tex.use_normalized_coords, level_w, tex.width);
+
+    float ua, ub;
+    texture_grad_cell_points(u, su, ua, ub);
+    const T va = texture_sample_helper<T>::sample_1d(tex, ua, sample_lod);
+    const T vb = texture_sample_helper<T>::sample_1d(tex, ub, sample_lod);
+    adj_u += weight * 2.0f * su * texture_grad_dot(adj_ret, vb - va);
+}
+
+template <typename T>
+CUDA_CALLABLE inline void texture_grad_coords_2d(
+    const texture2d_t& tex,
+    float u,
+    float v,
+    float sample_lod,
+    int level,
+    float weight,
+    const T& adj_ret,
+    float& adj_u,
+    float& adj_v
+)
+{
+    const int level_w = texture_mip_dim(tex.width, level);
+    const int level_h = texture_mip_dim(tex.height, level);
+    const float su = texture_coord_scale(tex.use_normalized_coords, level_w, tex.width);
+    const float sv = texture_coord_scale(tex.use_normalized_coords, level_h, tex.height);
+
+    float a, b;
+
+    texture_grad_cell_points(u, su, a, b);
+    const T vua = texture_sample_helper<T>::sample_2d(tex, a, v, sample_lod);
+    const T vub = texture_sample_helper<T>::sample_2d(tex, b, v, sample_lod);
+    adj_u += weight * 2.0f * su * texture_grad_dot(adj_ret, vub - vua);
+
+    texture_grad_cell_points(v, sv, a, b);
+    const T vva = texture_sample_helper<T>::sample_2d(tex, u, a, sample_lod);
+    const T vvb = texture_sample_helper<T>::sample_2d(tex, u, b, sample_lod);
+    adj_v += weight * 2.0f * sv * texture_grad_dot(adj_ret, vvb - vva);
+}
+
+template <typename T>
+CUDA_CALLABLE inline void texture_grad_coords_3d(
+    const texture3d_t& tex,
+    float u,
+    float v,
+    float w,
+    float sample_lod,
+    int level,
+    float weight,
+    const T& adj_ret,
+    float& adj_u,
+    float& adj_v,
+    float& adj_w
+)
+{
+    const int level_w = texture_mip_dim(tex.width, level);
+    const int level_h = texture_mip_dim(tex.height, level);
+    const int level_d = texture_mip_dim(tex.depth, level);
+    const float su = texture_coord_scale(tex.use_normalized_coords, level_w, tex.width);
+    const float sv = texture_coord_scale(tex.use_normalized_coords, level_h, tex.height);
+    const float sw = texture_coord_scale(tex.use_normalized_coords, level_d, tex.depth);
+
+    float a, b;
+
+    texture_grad_cell_points(u, su, a, b);
+    const T vua = texture_sample_helper<T>::sample_3d(tex, a, v, w, sample_lod);
+    const T vub = texture_sample_helper<T>::sample_3d(tex, b, v, w, sample_lod);
+    adj_u += weight * 2.0f * su * texture_grad_dot(adj_ret, vub - vua);
+
+    texture_grad_cell_points(v, sv, a, b);
+    const T vva = texture_sample_helper<T>::sample_3d(tex, u, a, w, sample_lod);
+    const T vvb = texture_sample_helper<T>::sample_3d(tex, u, b, w, sample_lod);
+    adj_v += weight * 2.0f * sv * texture_grad_dot(adj_ret, vvb - vva);
+
+    texture_grad_cell_points(w, sw, a, b);
+    const T vwa = texture_sample_helper<T>::sample_3d(tex, u, v, a, sample_lod);
+    const T vwb = texture_sample_helper<T>::sample_3d(tex, u, v, b, sample_lod);
+    adj_w += weight * 2.0f * sw * texture_grad_dot(adj_ret, vwb - vwa);
+}
+
+// Resolve the mip levels and blend weights the forward pass reads for a given
+// LOD, mirroring cpu_clamp_lod and the mip filter selection. Returns the
+// number of levels contributing spatial gradients (1 or 2).
+CUDA_CALLABLE inline int
+texture_grad_mip_levels(int num_mip_levels, int mip_filter_mode, float lod, int* levels, float* weights)
+{
+    const float max_lod = (float)(num_mip_levels - 1);
+    float clamped = lod < 0.0f ? 0.0f : (lod > max_lod ? max_lod : lod);
+
+    if (mip_filter_mode == WP_TEXTURE_FILTER_CLOSEST) {
+        int nearest = (int)floor(clamped + 0.5f);
+        if (nearest >= num_mip_levels)
+            nearest = num_mip_levels - 1;
+        levels[0] = nearest;
+        weights[0] = 1.0f;
+        return 1;
+    }
+
+    const int level0 = (int)floor(clamped);
+    int level1 = level0 + 1;
+    if (level1 >= num_mip_levels)
+        level1 = num_mip_levels - 1;
+    const float fl = clamped - (float)level0;
+
+    levels[0] = level0;
+    weights[0] = 1.0f - fl;
+    if (level1 == level0 || fl == 0.0f)
+        return 1;
+    levels[1] = level1;
+    weights[1] = fl;
+    return 2;
+}
+
+// LOD gradient: the mip-linear blend is piecewise linear in the clamped LOD,
+// with derivative sample(level1) - sample(level0) between levels and zero in
+// the clamped ranges or with a CLOSEST mip filter.
+CUDA_CALLABLE inline bool
+texture_grad_lod_levels(int num_mip_levels, int mip_filter_mode, float lod, int& level0, int& level1)
+{
+    if (num_mip_levels <= 1 || mip_filter_mode != WP_TEXTURE_FILTER_LINEAR)
+        return false;
+    if (lod < 0.0f || lod >= (float)(num_mip_levels - 1))
+        return false;
+    level0 = (int)floor(lod);
+    level1 = level0 + 1;
+    return true;
+}
+
 template <typename T>
 CUDA_CALLABLE void adj_texture_sample(
     const texture1d_t& tex, float u, float lod, texture1d_t& adj_tex, float& adj_u, float& adj_lod, const T& adj_ret
 )
 {
-    // MISSINGADJOINT: differentiable for linear interpolation;
-    // route adj_ret to neighboring texels and mip levels (weighted by interpolation factors)
-    // and to adj_u/adj_lod (via the interpolation derivatives along U and LOD).
-}
+    if (tex.tex == 0)
+        return;
 
-template <typename T>
-CUDA_CALLABLE void adj_texture_sample(
-    const texture2d_t& tex,
-    const vec2f& uv,
-    float lod,
-    texture2d_t& adj_tex,
-    vec2f& adj_uv,
-    float& adj_lod,
-    const T& adj_ret
-)
-{
-    // MISSINGADJOINT: differentiable for linear interpolation;
-    // route adj_ret to the four neighboring texels and mip levels (weighted by interpolation factors)
-    // and to adj_uv/adj_lod (via the interpolation derivatives along U, V, and LOD).
+    const bool mipmapped = tex.num_mip_levels > 1 && lod >= 0.0f;
+
+    if (tex.filter_mode == WP_TEXTURE_FILTER_LINEAR) {
+        if (!mipmapped) {
+            texture_grad_coords_1d(tex, u, lod, 0, 1.0f, adj_ret, adj_u);
+        } else {
+            int levels[2];
+            float weights[2];
+            const int n = texture_grad_mip_levels(tex.num_mip_levels, tex.mip_filter_mode, lod, levels, weights);
+            for (int i = 0; i < n; ++i)
+                texture_grad_coords_1d(tex, u, (float)levels[i], levels[i], weights[i], adj_ret, adj_u);
+        }
+    }
+
+    int level0, level1;
+    if (mipmapped && texture_grad_lod_levels(tex.num_mip_levels, tex.mip_filter_mode, lod, level0, level1)) {
+        const T v0 = texture_sample_helper<T>::sample_1d(tex, u, (float)level0);
+        const T v1 = texture_sample_helper<T>::sample_1d(tex, u, (float)level1);
+        adj_lod += texture_grad_dot(adj_ret, v1 - v0);
+    }
 }
 
 template <typename T>
@@ -931,25 +1199,43 @@ CUDA_CALLABLE void adj_texture_sample(
     const T& adj_ret
 )
 {
-    // MISSINGADJOINT: differentiable for linear interpolation;
-    // route adj_ret to the four neighboring texels and mip levels (weighted by interpolation factors)
-    // and to adj_u/adj_v/adj_lod (via the interpolation derivatives along each axis and LOD).
+    if (tex.tex == 0)
+        return;
+
+    const bool mipmapped = tex.num_mip_levels > 1 && lod >= 0.0f;
+
+    if (tex.filter_mode == WP_TEXTURE_FILTER_LINEAR) {
+        if (!mipmapped) {
+            texture_grad_coords_2d(tex, u, v, lod, 0, 1.0f, adj_ret, adj_u, adj_v);
+        } else {
+            int levels[2];
+            float weights[2];
+            const int n = texture_grad_mip_levels(tex.num_mip_levels, tex.mip_filter_mode, lod, levels, weights);
+            for (int i = 0; i < n; ++i)
+                texture_grad_coords_2d(tex, u, v, (float)levels[i], levels[i], weights[i], adj_ret, adj_u, adj_v);
+        }
+    }
+
+    int level0, level1;
+    if (mipmapped && texture_grad_lod_levels(tex.num_mip_levels, tex.mip_filter_mode, lod, level0, level1)) {
+        const T v0 = texture_sample_helper<T>::sample_2d(tex, u, v, (float)level0);
+        const T v1 = texture_sample_helper<T>::sample_2d(tex, u, v, (float)level1);
+        adj_lod += texture_grad_dot(adj_ret, v1 - v0);
+    }
 }
 
 template <typename T>
 CUDA_CALLABLE void adj_texture_sample(
-    const texture3d_t& tex,
-    const vec3f& uvw,
+    const texture2d_t& tex,
+    const vec2f& uv,
     float lod,
-    texture3d_t& adj_tex,
-    vec3f& adj_uvw,
+    texture2d_t& adj_tex,
+    vec2f& adj_uv,
     float& adj_lod,
     const T& adj_ret
 )
 {
-    // MISSINGADJOINT: differentiable for linear interpolation;
-    // route adj_ret to the eight neighboring texels and mip levels (weighted by interpolation factors)
-    // and to adj_uvw/adj_lod (via the interpolation derivatives along U, V, W, and LOD).
+    adj_texture_sample(tex, uv[0], uv[1], lod, adj_tex, adj_uv[0], adj_uv[1], adj_lod, adj_ret);
 }
 
 template <typename T>
@@ -967,9 +1253,45 @@ CUDA_CALLABLE void adj_texture_sample(
     const T& adj_ret
 )
 {
-    // MISSINGADJOINT: differentiable for linear interpolation;
-    // route adj_ret to the eight neighboring texels and mip levels (weighted by interpolation factors)
-    // and to adj_u/adj_v/adj_w/adj_lod (via the interpolation derivatives along each axis and LOD).
+    if (tex.tex == 0)
+        return;
+
+    const bool mipmapped = tex.num_mip_levels > 1 && lod >= 0.0f;
+
+    if (tex.filter_mode == WP_TEXTURE_FILTER_LINEAR) {
+        if (!mipmapped) {
+            texture_grad_coords_3d(tex, u, v, w, lod, 0, 1.0f, adj_ret, adj_u, adj_v, adj_w);
+        } else {
+            int levels[2];
+            float weights[2];
+            const int n = texture_grad_mip_levels(tex.num_mip_levels, tex.mip_filter_mode, lod, levels, weights);
+            for (int i = 0; i < n; ++i)
+                texture_grad_coords_3d(
+                    tex, u, v, w, (float)levels[i], levels[i], weights[i], adj_ret, adj_u, adj_v, adj_w
+                );
+        }
+    }
+
+    int level0, level1;
+    if (mipmapped && texture_grad_lod_levels(tex.num_mip_levels, tex.mip_filter_mode, lod, level0, level1)) {
+        const T v0 = texture_sample_helper<T>::sample_3d(tex, u, v, w, (float)level0);
+        const T v1 = texture_sample_helper<T>::sample_3d(tex, u, v, w, (float)level1);
+        adj_lod += texture_grad_dot(adj_ret, v1 - v0);
+    }
+}
+
+template <typename T>
+CUDA_CALLABLE void adj_texture_sample(
+    const texture3d_t& tex,
+    const vec3f& uvw,
+    float lod,
+    texture3d_t& adj_tex,
+    vec3f& adj_uvw,
+    float& adj_lod,
+    const T& adj_ret
+)
+{
+    adj_texture_sample(tex, uvw[0], uvw[1], uvw[2], lod, adj_tex, adj_uvw[0], adj_uvw[1], adj_uvw[2], adj_lod, adj_ret);
 }
 
 // Type aliases for code generation

--- a/warp/tests/cuda/test_texture.py
+++ b/warp/tests/cuda/test_texture.py
@@ -2836,12 +2836,16 @@ def test_texture2d_adj_vec2f_linear_x(test, device):
     H, W = 6, 10
     data = np.zeros((H, W, 2), dtype=np.float32)
     for x in range(W):
-        data[:, x, 0] = x / W          # channel 0: linear in x
+        data[:, x, 0] = x / W  # channel 0: linear in x
         data[:, x, 1] = (W - 1 - x) / W  # channel 1: linear in x, reversed
 
-    tex = wp.Texture2D(data, normalized_coords=False,
-                       filter_mode=wp.TextureFilterMode.LINEAR,
-                       address_mode=wp.TextureAddressMode.BORDER, device=device)
+    tex = wp.Texture2D(
+        data,
+        normalized_coords=False,
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
 
     @wp.kernel
     def sample_2d_vec2(tex: wp.Texture2D, pos: wp.array(dtype=wp.vec2f), out: wp.array(dtype=wp.vec2f)):
@@ -2868,12 +2872,16 @@ def test_texture2d_adj_vec2f_channels_independent(test, device):
     H, W = 6, 10
     data = np.zeros((H, W, 2), dtype=np.float32)
     for x in range(W):
-        data[:, x, 0] = x / W   # channel 0: linear in x
-        data[:, x, 1] = 0.0     # channel 1: constant
+        data[:, x, 0] = x / W  # channel 0: linear in x
+        data[:, x, 1] = 0.0  # channel 1: constant
 
-    tex = wp.Texture2D(data, normalized_coords=False,
-                       filter_mode=wp.TextureFilterMode.LINEAR,
-                       address_mode=wp.TextureAddressMode.BORDER, device=device)
+    tex = wp.Texture2D(
+        data,
+        normalized_coords=False,
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
 
     @wp.kernel
     def sample_2d_vec2(tex: wp.Texture2D, pos: wp.array(dtype=wp.vec2f), out: wp.array(dtype=wp.vec2f)):
@@ -2899,12 +2907,16 @@ def test_texture3d_adj_vec2f_linear_z(test, device):
     D, H, W = 8, 6, 10
     data = np.zeros((D, H, W, 2), dtype=np.float32)
     for z in range(D):
-        data[z, :, :, 0] = z / D   # channel 0: linear in z
-        data[z, :, :, 1] = 0.0     # channel 1: constant
+        data[z, :, :, 0] = z / D  # channel 0: linear in z
+        data[z, :, :, 1] = 0.0  # channel 1: constant
 
-    tex = wp.Texture3D(data, normalized_coords=False,
-                       filter_mode=wp.TextureFilterMode.LINEAR,
-                       address_mode=wp.TextureAddressMode.BORDER, device=device)
+    tex = wp.Texture3D(
+        data,
+        normalized_coords=False,
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
 
     @wp.kernel
     def sample_3d_vec2(tex: wp.Texture3D, pos: wp.array(dtype=wp.vec3f), out: wp.array(dtype=wp.vec2f)):
@@ -2923,6 +2935,7 @@ def test_texture3d_adj_vec2f_linear_z(test, device):
     np.testing.assert_allclose(g[0], 0.0, atol=1e-5)
     np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
     np.testing.assert_allclose(g[2], 1.0 / D, atol=1e-5)
+
 
 # ============================================================================
 # Test Class
@@ -3212,9 +3225,18 @@ add_function_test(TestTexture, "test_texture3d_adj_uniform_zero", test_texture3d
 add_function_test(TestTexture, "test_texture3d_adj_linear_x", test_texture3d_adj_linear_x, devices=all_devices)
 add_function_test(TestTexture, "test_texture3d_adj_linear_y", test_texture3d_adj_linear_y, devices=all_devices)
 add_function_test(TestTexture, "test_texture3d_adj_linear_z", test_texture3d_adj_linear_z, devices=all_devices)
-add_function_test(TestTexture, "test_texture2d_adj_vec2f_linear_x", test_texture2d_adj_vec2f_linear_x, devices=all_devices)
-add_function_test(TestTexture, "test_texture2d_adj_vec2f_channels_independent", test_texture2d_adj_vec2f_channels_independent, devices=all_devices)
-add_function_test(TestTexture, "test_texture3d_adj_vec2f_linear_z", test_texture3d_adj_vec2f_linear_z, devices=all_devices)
+add_function_test(
+    TestTexture, "test_texture2d_adj_vec2f_linear_x", test_texture2d_adj_vec2f_linear_x, devices=all_devices
+)
+add_function_test(
+    TestTexture,
+    "test_texture2d_adj_vec2f_channels_independent",
+    test_texture2d_adj_vec2f_channels_independent,
+    devices=all_devices,
+)
+add_function_test(
+    TestTexture, "test_texture3d_adj_vec2f_linear_z", test_texture3d_adj_vec2f_linear_z, devices=all_devices
+)
 
 
 if __name__ == "__main__":

--- a/warp/tests/cuda/test_texture.py
+++ b/warp/tests/cuda/test_texture.py
@@ -2601,6 +2601,330 @@ def test_texture3d_array(test, device):
 
 
 # ============================================================================
+# Adjoint tests
+# ============================================================================
+
+
+@wp.kernel
+def sample_1d(tex: wp.Texture1D, pos: wp.array(dtype=float), out: wp.array(dtype=float)):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos[tid], dtype=float)
+
+
+@wp.kernel
+def sample_2d(tex: wp.Texture2D, pos: wp.array(dtype=wp.vec2f), out: wp.array(dtype=float)):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos[tid], dtype=float)
+
+
+@wp.kernel
+def sample_3d(tex: wp.Texture3D, pos: wp.array(dtype=wp.vec3f), out: wp.array(dtype=float)):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos[tid], dtype=float)
+
+
+def _grad_1d(data, u, device):
+    tex = wp.Texture1D(
+        data,
+        normalized_coords=False,
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
+    pos = wp.array([u], dtype=float, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_1d, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    out.grad = wp.ones(1, dtype=float, device=device)
+    tape.backward()
+    return pos.grad.numpy()[0]
+
+
+def _grad_2d(data, coord, device):
+    tex = wp.Texture2D(
+        data,
+        normalized_coords=False,
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
+    pos = wp.array([wp.vec2f(*coord)], dtype=wp.vec2f, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_2d, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    out.grad = wp.ones(1, dtype=float, device=device)
+    tape.backward()
+    return pos.grad.numpy()[0]
+
+
+def _grad_3d(data, coord, device):
+    tex = wp.Texture3D(
+        data,
+        normalized_coords=False,
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
+    pos = wp.array([wp.vec3f(*coord)], dtype=wp.vec3f, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_3d, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    out.grad = wp.ones(1, dtype=float, device=device)
+    tape.backward()
+    return pos.grad.numpy()[0]
+
+
+def test_texture1d_adj_boundary_zero(test, device):
+    """Gradient is zero when sampling position straddles the near boundary."""
+    data = np.random.default_rng(0).standard_normal(16).astype(np.float32)
+    np.testing.assert_allclose(_grad_1d(data, 0.1, device), 0.0, atol=1e-6)
+
+
+def test_texture1d_adj_far_boundary_zero(test, device):
+    """Gradient is zero when sampling position straddles the far boundary."""
+    data = np.random.default_rng(1).standard_normal(16).astype(np.float32)
+    np.testing.assert_allclose(_grad_1d(data, 15.9, device), 0.0, atol=1e-6)
+
+
+def test_texture1d_adj_closest_zero(test, device):
+    """Gradient is zero for CLOSEST filter mode."""
+    data = np.random.default_rng(2).standard_normal(16).astype(np.float32)
+    tex = wp.Texture1D(
+        data,
+        normalized_coords=False,
+        filter_mode=wp.TextureFilterMode.CLOSEST,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
+    pos = wp.array([7.3], dtype=float, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_1d, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    out.grad = wp.ones(1, dtype=float, device=device)
+    tape.backward()
+    np.testing.assert_allclose(pos.grad.numpy()[0], 0.0, atol=1e-6)
+
+
+def test_texture1d_adj_linear_signal(test, device):
+    """Gradient of a linear signal is constant and analytically known."""
+    W = 16
+    # value = x / W, so d(value)/d(u) = 1/W
+    data = np.arange(W, dtype=np.float32) / W
+    g = _grad_1d(data, 7.3, device)
+    np.testing.assert_allclose(g, 1.0 / W, atol=1e-5)
+
+
+def test_texture2d_adj_near_boundary_zero(test, device):
+    """2D gradient is zero when straddling the near boundary in both axes."""
+    data = np.random.default_rng(3).standard_normal((8, 10)).astype(np.float32)
+    g = _grad_2d(data, (0.1, 0.1), device)
+    np.testing.assert_allclose(g, [0.0, 0.0], atol=1e-6)
+
+
+def test_texture2d_adj_far_boundary_zero(test, device):
+    """2D gradient is zero when straddling the far boundary."""
+    data = np.random.default_rng(4).standard_normal((8, 10)).astype(np.float32)
+    H, W = data.shape
+    g = _grad_2d(data, (W - 0.1, H - 0.1), device)
+    np.testing.assert_allclose(g, [0.0, 0.0], atol=1e-6)
+
+
+def test_texture2d_adj_partial_boundary(test, device):
+    """2D gradient: x interior but y straddling boundary — only y grad is zero."""
+    data = np.random.default_rng(5).standard_normal((8, 10)).astype(np.float32)
+    g = _grad_2d(data, (3.7, 0.1), device)
+    # x is interior so gradient should be nonzero; y straddles boundary so zero
+    test.assertNotEqual(g[0], 0.0)
+    np.testing.assert_allclose(g[1], 0.0, atol=1e-6)
+
+
+def test_texture2d_adj_linear_x(test, device):
+    """2D gradient of signal linear in x: x-grad is 1/W, y-grad is zero."""
+    H, W = 6, 10
+    data = np.zeros((H, W), dtype=np.float32)
+    for x in range(W):
+        data[:, x] = x / W
+    g = _grad_2d(data, (4.5, 3.0), device)
+    np.testing.assert_allclose(g[0], 1.0 / W, atol=1e-5)
+    np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
+
+
+def test_texture2d_adj_linear_y(test, device):
+    """2D gradient of signal linear in y: y-grad is 1/H, x-grad is zero."""
+    H, W = 6, 10
+    data = np.zeros((H, W), dtype=np.float32)
+    for y in range(H):
+        data[y, :] = y / H
+    g = _grad_2d(data, (4.5, 3.0), device)
+    np.testing.assert_allclose(g[0], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[1], 1.0 / H, atol=1e-5)
+
+
+def test_texture3d_adj_near_boundary_zero(test, device):
+    """3D gradient is zero when straddling the near boundary in all axes."""
+    data = np.random.default_rng(6).standard_normal((8, 6, 10)).astype(np.float32)
+    g = _grad_3d(data, (0.1, 0.1, 0.1), device)
+    np.testing.assert_allclose(g, [0.0, 0.0, 0.0], atol=1e-6)
+
+
+def test_texture3d_adj_far_boundary_zero(test, device):
+    """3D gradient is zero when straddling the far boundary."""
+    data = np.random.default_rng(7).standard_normal((8, 6, 10)).astype(np.float32)
+    D, H, W = data.shape
+    g = _grad_3d(data, (W - 0.1, H - 0.1, D - 0.1), device)
+    np.testing.assert_allclose(g, [0.0, 0.0, 0.0], atol=1e-6)
+
+
+def test_texture3d_adj_partial_boundary(test, device):
+    """3D gradient: x and y interior, z straddling boundary — only z grad is zero."""
+    data = np.random.default_rng(8).standard_normal((8, 6, 10)).astype(np.float32)
+    g = _grad_3d(data, (2.3, 3.7, 0.1), device)
+    test.assertNotEqual(g[0], 0.0)
+    test.assertNotEqual(g[1], 0.0)
+    np.testing.assert_allclose(g[2], 0.0, atol=1e-6)
+
+
+def test_texture3d_adj_uniform_zero(test, device):
+    """Gradient of a uniform volume is zero (no spatial variation to differentiate)."""
+    data = np.ones((8, 6, 10), dtype=np.float32)
+    g = _grad_3d(data, (2.3, 3.7, 1.1), device)
+    np.testing.assert_allclose(g, [0.0, 0.0, 0.0], atol=1e-6)
+
+
+def test_texture3d_adj_linear_x(test, device):
+    """3D gradient of signal linear in x: x-grad is 1/W, y and z grads are zero."""
+    D, H, W = 8, 6, 10
+    data = np.zeros((D, H, W), dtype=np.float32)
+    for x in range(W):
+        data[:, :, x] = x / W
+    g = _grad_3d(data, (4.5, 3.0, 3.0), device)
+    np.testing.assert_allclose(g[0], 1.0 / W, atol=1e-5)
+    np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[2], 0.0, atol=1e-5)
+
+
+def test_texture3d_adj_linear_y(test, device):
+    """3D gradient of signal linear in y: y-grad is 1/H, x and z grads are zero."""
+    D, H, W = 8, 6, 10
+    data = np.zeros((D, H, W), dtype=np.float32)
+    for y in range(H):
+        data[:, y, :] = y / H
+    g = _grad_3d(data, (4.5, 3.0, 3.0), device)
+    np.testing.assert_allclose(g[0], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[1], 1.0 / H, atol=1e-5)
+    np.testing.assert_allclose(g[2], 0.0, atol=1e-5)
+
+
+def test_texture3d_adj_linear_z(test, device):
+    """3D gradient of signal linear in z: z-grad is 1/D, x and y grads are zero."""
+    D, H, W = 8, 6, 10
+    data = np.zeros((D, H, W), dtype=np.float32)
+    for z in range(D):
+        data[z, :, :] = z / D
+    g = _grad_3d(data, (4.5, 3.0, 3.0), device)
+    np.testing.assert_allclose(g[0], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[2], 1.0 / D, atol=1e-5)
+
+
+def test_texture2d_adj_vec2f_linear_x(test, device):
+    """2D vec2f texture: x-grad matches scalar case for each channel independently."""
+    H, W = 6, 10
+    data = np.zeros((H, W, 2), dtype=np.float32)
+    for x in range(W):
+        data[:, x, 0] = x / W          # channel 0: linear in x
+        data[:, x, 1] = (W - 1 - x) / W  # channel 1: linear in x, reversed
+
+    tex = wp.Texture2D(data, normalized_coords=False,
+                       filter_mode=wp.TextureFilterMode.LINEAR,
+                       address_mode=wp.TextureAddressMode.BORDER, device=device)
+
+    @wp.kernel
+    def sample_2d_vec2(tex: wp.Texture2D, pos: wp.array(dtype=wp.vec2f), out: wp.array(dtype=wp.vec2f)):
+        tid = wp.tid()
+        out[tid] = wp.texture_sample(tex, pos[tid], dtype=wp.vec2f)
+
+    pos = wp.array([wp.vec2f(4.5, 3.0)], dtype=wp.vec2f, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=wp.vec2f, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_2d_vec2, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    # seed gradient: both channels contribute equally
+    out.grad = wp.array([wp.vec2f(1.0, 1.0)], dtype=wp.vec2f, device=device)
+    tape.backward()
+
+    g = pos.grad.numpy()[0]
+    # d(ch0)/dx = 1/W, d(ch1)/dx = -1/W, sum = 0
+    np.testing.assert_allclose(g[0], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
+
+
+def test_texture2d_adj_vec2f_channels_independent(test, device):
+    """2D vec2f texture: seeding only channel 0 gives channel-0-only gradient."""
+    H, W = 6, 10
+    data = np.zeros((H, W, 2), dtype=np.float32)
+    for x in range(W):
+        data[:, x, 0] = x / W   # channel 0: linear in x
+        data[:, x, 1] = 0.0     # channel 1: constant
+
+    tex = wp.Texture2D(data, normalized_coords=False,
+                       filter_mode=wp.TextureFilterMode.LINEAR,
+                       address_mode=wp.TextureAddressMode.BORDER, device=device)
+
+    @wp.kernel
+    def sample_2d_vec2(tex: wp.Texture2D, pos: wp.array(dtype=wp.vec2f), out: wp.array(dtype=wp.vec2f)):
+        tid = wp.tid()
+        out[tid] = wp.texture_sample(tex, pos[tid], dtype=wp.vec2f)
+
+    pos = wp.array([wp.vec2f(4.5, 3.0)], dtype=wp.vec2f, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=wp.vec2f, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_2d_vec2, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    # seed only channel 0
+    out.grad = wp.array([wp.vec2f(1.0, 0.0)], dtype=wp.vec2f, device=device)
+    tape.backward()
+
+    g = pos.grad.numpy()[0]
+    np.testing.assert_allclose(g[0], 1.0 / W, atol=1e-5)
+    np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
+
+
+def test_texture3d_adj_vec2f_linear_z(test, device):
+    """3D vec2f texture: z-grad is 1/D when only channel 0 is linear in z."""
+    D, H, W = 8, 6, 10
+    data = np.zeros((D, H, W, 2), dtype=np.float32)
+    for z in range(D):
+        data[z, :, :, 0] = z / D   # channel 0: linear in z
+        data[z, :, :, 1] = 0.0     # channel 1: constant
+
+    tex = wp.Texture3D(data, normalized_coords=False,
+                       filter_mode=wp.TextureFilterMode.LINEAR,
+                       address_mode=wp.TextureAddressMode.BORDER, device=device)
+
+    @wp.kernel
+    def sample_3d_vec2(tex: wp.Texture3D, pos: wp.array(dtype=wp.vec3f), out: wp.array(dtype=wp.vec2f)):
+        tid = wp.tid()
+        out[tid] = wp.texture_sample(tex, pos[tid], dtype=wp.vec2f)
+
+    pos = wp.array([wp.vec3f(4.5, 3.0, 3.0)], dtype=wp.vec3f, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=wp.vec2f, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_3d_vec2, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    out.grad = wp.array([wp.vec2f(1.0, 0.0)], dtype=wp.vec2f, device=device)
+    tape.backward()
+
+    g = pos.grad.numpy()[0]
+    np.testing.assert_allclose(g[0], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[2], 1.0 / D, atol=1e-5)
+
+# ============================================================================
 # Test Class
 # ============================================================================
 
@@ -2852,6 +3176,45 @@ add_function_test(TestTexture, "test_texture3d_struct_member", test_texture3d_st
 add_function_test(
     TestTexture, "test_texture_struct_both_members", test_texture_struct_both_members, devices=all_devices
 )
+
+# Adjoint
+add_function_test(
+    TestTexture, "test_texture1d_adj_boundary_zero", test_texture1d_adj_boundary_zero, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture1d_adj_far_boundary_zero", test_texture1d_adj_far_boundary_zero, devices=all_devices
+)
+add_function_test(TestTexture, "test_texture1d_adj_closest_zero", test_texture1d_adj_closest_zero, devices=all_devices)
+add_function_test(
+    TestTexture, "test_texture1d_adj_linear_signal", test_texture1d_adj_linear_signal, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture2d_adj_near_boundary_zero", test_texture2d_adj_near_boundary_zero, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture2d_adj_far_boundary_zero", test_texture2d_adj_far_boundary_zero, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture2d_adj_partial_boundary", test_texture2d_adj_partial_boundary, devices=all_devices
+)
+add_function_test(TestTexture, "test_texture2d_adj_linear_x", test_texture2d_adj_linear_x, devices=all_devices)
+add_function_test(TestTexture, "test_texture2d_adj_linear_y", test_texture2d_adj_linear_y, devices=all_devices)
+add_function_test(
+    TestTexture, "test_texture3d_adj_near_boundary_zero", test_texture3d_adj_near_boundary_zero, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture3d_adj_far_boundary_zero", test_texture3d_adj_far_boundary_zero, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture3d_adj_partial_boundary", test_texture3d_adj_partial_boundary, devices=all_devices
+)
+add_function_test(TestTexture, "test_texture3d_adj_uniform_zero", test_texture3d_adj_uniform_zero, devices=all_devices)
+add_function_test(TestTexture, "test_texture3d_adj_linear_x", test_texture3d_adj_linear_x, devices=all_devices)
+add_function_test(TestTexture, "test_texture3d_adj_linear_y", test_texture3d_adj_linear_y, devices=all_devices)
+add_function_test(TestTexture, "test_texture3d_adj_linear_z", test_texture3d_adj_linear_z, devices=all_devices)
+add_function_test(TestTexture, "test_texture2d_adj_vec2f_linear_x", test_texture2d_adj_vec2f_linear_x, devices=all_devices)
+add_function_test(TestTexture, "test_texture2d_adj_vec2f_channels_independent", test_texture2d_adj_vec2f_channels_independent, devices=all_devices)
+add_function_test(TestTexture, "test_texture3d_adj_vec2f_linear_z", test_texture3d_adj_vec2f_linear_z, devices=all_devices)
 
 
 if __name__ == "__main__":

--- a/warp/tests/cuda/test_texture.py
+++ b/warp/tests/cuda/test_texture.py
@@ -2677,6 +2677,63 @@ def _grad_3d(data, coord, device):
     return pos.grad.numpy()[0]
 
 
+def _grad_1d_normalized(data, u_normalized, device):
+    """Helper for 1D gradient with normalized coordinates."""
+    tex = wp.Texture1D(
+        data,
+        normalized_coords=True,  # Use default normalized coordinates
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
+    pos = wp.array([u_normalized], dtype=float, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_1d, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    out.grad = wp.ones(1, dtype=float, device=device)
+    tape.backward()
+    return pos.grad.numpy()[0]
+
+
+def _grad_2d_normalized(data, coord_normalized, device):
+    """Helper for 2D gradient with normalized coordinates."""
+    tex = wp.Texture2D(
+        data,
+        normalized_coords=True,  # Use default normalized coordinates
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
+    pos = wp.array([wp.vec2f(*coord_normalized)], dtype=wp.vec2f, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_2d, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    out.grad = wp.ones(1, dtype=float, device=device)
+    tape.backward()
+    return pos.grad.numpy()[0]
+
+
+def _grad_3d_normalized(data, coord_normalized, device):
+    """Helper for 3D gradient with normalized coordinates."""
+    tex = wp.Texture3D(
+        data,
+        normalized_coords=True,  # Use default normalized coordinates
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
+    pos = wp.array([wp.vec3f(*coord_normalized)], dtype=wp.vec3f, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_3d, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+    out.grad = wp.ones(1, dtype=float, device=device)
+    tape.backward()
+    return pos.grad.numpy()[0]
+
+
 def test_texture1d_adj_boundary_zero(test, device):
     """Gradient is zero when sampling position straddles the near boundary."""
     data = np.random.default_rng(0).standard_normal(16).astype(np.float32)
@@ -2935,6 +2992,68 @@ def test_texture3d_adj_vec2f_linear_z(test, device):
     np.testing.assert_allclose(g[0], 0.0, atol=1e-5)
     np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
     np.testing.assert_allclose(g[2], 1.0 / D, atol=1e-5)
+
+
+def test_texture1d_adj_normalized_boundary(test, device):
+    """1D normalized coords: gradient is zero at boundary (u ≈ 0.0 or u ≈ 1.0)."""
+    data = np.random.default_rng(10).standard_normal(16).astype(np.float32)
+    g_near = _grad_1d_normalized(data, 0.01, device)
+    g_far = _grad_1d_normalized(data, 0.99, device)
+    np.testing.assert_allclose(g_near, 0.0, atol=1e-6)
+    np.testing.assert_allclose(g_far, 0.0, atol=1e-6)
+
+
+def test_texture1d_adj_normalized_linear(test, device):
+    """1D normalized coords: gradient of linear signal."""
+    W = 16
+    data = np.arange(W, dtype=np.float32) / W
+    # With normalized coords, d(value)/d(u_norm) = d(value)/d(u_texel) * d(u_texel)/d(u_norm)
+    # = (1/W) * W = 1.0
+    g = _grad_1d_normalized(data, 0.5, device)
+    np.testing.assert_allclose(g, 1.0, atol=1e-4)
+
+
+def test_texture2d_adj_normalized_boundary(test, device):
+    """2D normalized coords: gradient is zero at boundaries."""
+    data = np.random.default_rng(11).standard_normal((8, 10)).astype(np.float32)
+    g_near = _grad_2d_normalized(data, (0.01, 0.01), device)
+    g_far = _grad_2d_normalized(data, (0.99, 0.99), device)
+    np.testing.assert_allclose(g_near, [0.0, 0.0], atol=1e-6)
+    np.testing.assert_allclose(g_far, [0.0, 0.0], atol=1e-6)
+
+
+def test_texture2d_adj_normalized_linear_x(test, device):
+    """2D normalized coords: x-gradient of signal linear in x."""
+    H, W = 6, 10
+    data = np.zeros((H, W), dtype=np.float32)
+    for x in range(W):
+        data[:, x] = x / W
+    g = _grad_2d_normalized(data, (0.5, 0.5), device)
+    # With normalized coords: d(value)/d(u_norm) = 1.0
+    np.testing.assert_allclose(g[0], 1.0, atol=1e-4)
+    np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
+
+
+def test_texture3d_adj_normalized_boundary(test, device):
+    """3D normalized coords: gradient is zero at boundaries."""
+    data = np.random.default_rng(12).standard_normal((8, 6, 10)).astype(np.float32)
+    g_near = _grad_3d_normalized(data, (0.01, 0.01, 0.01), device)
+    g_far = _grad_3d_normalized(data, (0.99, 0.99, 0.99), device)
+    np.testing.assert_allclose(g_near, [0.0, 0.0, 0.0], atol=1e-6)
+    np.testing.assert_allclose(g_far, [0.0, 0.0, 0.0], atol=1e-6)
+
+
+def test_texture3d_adj_normalized_linear_z(test, device):
+    """3D normalized coords: z-gradient of signal linear in z."""
+    D, H, W = 8, 6, 10
+    data = np.zeros((D, H, W), dtype=np.float32)
+    for z in range(D):
+        data[z, :, :] = z / D
+    g = _grad_3d_normalized(data, (0.5, 0.5, 0.5), device)
+    # With normalized coords: d(value)/d(w_norm) = 1.0
+    np.testing.assert_allclose(g[0], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[1], 0.0, atol=1e-5)
+    np.testing.assert_allclose(g[2], 1.0, atol=1e-4)
 
 
 # ============================================================================
@@ -3236,6 +3355,24 @@ add_function_test(
 )
 add_function_test(
     TestTexture, "test_texture3d_adj_vec2f_linear_z", test_texture3d_adj_vec2f_linear_z, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture1d_adj_normalized_boundary", test_texture1d_adj_normalized_boundary, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture1d_adj_normalized_linear", test_texture1d_adj_normalized_linear, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture2d_adj_normalized_boundary", test_texture2d_adj_normalized_boundary, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture2d_adj_normalized_linear_x", test_texture2d_adj_normalized_linear_x, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture3d_adj_normalized_boundary", test_texture3d_adj_normalized_boundary, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture3d_adj_normalized_linear_z", test_texture3d_adj_normalized_linear_z, devices=all_devices
 )
 
 

--- a/warp/tests/cuda/test_texture.py
+++ b/warp/tests/cuda/test_texture.py
@@ -3147,7 +3147,7 @@ def test_texture_sample_grad_3d(test, device):
             device=device,
         )
         for point_texel in points:
-            coords = tuple(c * s for c, s in zip(point_texel, scales))
+            coords = tuple(c * s for c, s in zip(point_texel, scales, strict=True))
             u, v, w = coords
             fd = []
             for axis in range(3):

--- a/warp/tests/cuda/test_texture.py
+++ b/warp/tests/cuda/test_texture.py
@@ -2847,8 +2847,16 @@ _GRAD_ADDRESS_MODES = (
 # Tolerance for adjoint vs. finite differences of the forward pass. The
 # adjoint reconstructs the exact lerp slope, but the CUDA forward interpolates
 # with 9-bit fixed-point fractions, so the finite difference itself carries
-# O(1/256 / h) noise.
+# O(1/256 / h) noise. In the 2D/3D tests the sample points are quarter-aligned
+# (texel fractions that are multiples of 0.25) so that every interpolation
+# weight, including the off-axis ones, is exact in the hardware fixed-point
+# format; a misaligned off-axis weight couples through the cell's mixed
+# derivative and the half-texel stencil amplifies it to percent-level noise.
 _GRAD_FD_TOL = 2e-2
+
+# Mipmapped sampling stacks two levels of interpolation, so the finite
+# difference carries more quantization noise than the single-level case.
+_GRAD_MIP_FD_TOL = 3e-2
 
 
 @wp.kernel
@@ -3075,25 +3083,37 @@ def test_texture_sample_grad_2d(test, device):
     rng = np.random.default_rng(2)
     data = rng.standard_normal((height, width)).astype(np.float32)
 
-    points = ((3.25, 2.8), (0.2, 0.25), (7.75, 5.8), (-0.25, 4.2))
+    points = ((3.25, 2.75), (0.25, 0.25), (7.75, 5.75), (-0.25, 4.25))
 
-    for address_mode in (wp.TextureAddressMode.CLAMP, wp.TextureAddressMode.BORDER):
+    for address_mode in _GRAD_ADDRESS_MODES:
+        # WRAP and MIRROR run with normalized coordinates because CUDA treats
+        # them as CLAMP otherwise.
+        normalized = address_mode in (wp.TextureAddressMode.WRAP, wp.TextureAddressMode.MIRROR)
+        su = 1.0 / width if normalized else 1.0
+        sv = 1.0 / height if normalized else 1.0
         tex = wp.Texture2D(
             data,
-            normalized_coords=False,
+            normalized_coords=normalized,
             filter_mode=wp.TextureFilterMode.LINEAR,
             address_mode=address_mode,
             device=device,
         )
-        for u, v in points:
-            h = 0.25
-            fu = _forward_values(sample_grad_2d_scalar_f, tex, [[u - h, u + h], [v, v]], float, device)
-            fv = _forward_values(sample_grad_2d_scalar_f, tex, [[u, u], [v - h, v + h]], float, device)
-            fd = ((fu[1] - fu[0]) / (2.0 * h), (fv[1] - fv[0]) / (2.0 * h))
+        for u_texel, v_texel in points:
+            u, v = u_texel * su, v_texel * sv
+            hu, hv = 0.25 * su, 0.25 * sv
+            fu = _forward_values(sample_grad_2d_scalar_f, tex, [[u - hu, u + hu], [v, v]], float, device)
+            fv = _forward_values(sample_grad_2d_scalar_f, tex, [[u, u], [v - hv, v + hv]], float, device)
+            fd = ((fu[1] - fu[0]) / (2.0 * hu), (fv[1] - fv[0]) / (2.0 * hv))
 
             # scalar-coordinate overload
             gu, gv = _tape_gradients(sample_grad_2d_scalar_f, tex, [[u], [v]], float, device)
-            np.testing.assert_allclose((gu[0], gv[0]), fd, rtol=_GRAD_FD_TOL, atol=_GRAD_FD_TOL)
+            np.testing.assert_allclose(
+                (gu[0], gv[0]),
+                fd,
+                rtol=_GRAD_FD_TOL,
+                atol=_GRAD_FD_TOL,
+                err_msg=f"mode={address_mode.name} u_texel={u_texel} v_texel={v_texel}",
+            )
 
             # vec2 overload
             pos = wp.array([wp.vec2f(u, v)], dtype=wp.vec2f, requires_grad=True, device=device)
@@ -3112,21 +3132,26 @@ def test_texture_sample_grad_3d(test, device):
     rng = np.random.default_rng(3)
     data = rng.standard_normal((depth, height, width)).astype(np.float32)
 
-    points = ((3.25, 2.8, 1.2), (0.2, 0.25, 3.75), (7.75, 5.8, 0.75))
+    points = ((3.25, 2.75, 1.25), (0.25, 0.25, 3.75), (7.75, 5.75, 0.75))
 
-    for address_mode in (wp.TextureAddressMode.CLAMP, wp.TextureAddressMode.BORDER):
+    for address_mode in _GRAD_ADDRESS_MODES:
+        # WRAP and MIRROR run with normalized coordinates because CUDA treats
+        # them as CLAMP otherwise.
+        normalized = address_mode in (wp.TextureAddressMode.WRAP, wp.TextureAddressMode.MIRROR)
+        scales = (1.0 / width, 1.0 / height, 1.0 / depth) if normalized else (1.0, 1.0, 1.0)
         tex = wp.Texture3D(
             data,
-            normalized_coords=False,
+            normalized_coords=normalized,
             filter_mode=wp.TextureFilterMode.LINEAR,
             address_mode=address_mode,
             device=device,
         )
-        for u, v, w in points:
-            h = 0.25
-            coords = (u, v, w)
+        for point_texel in points:
+            coords = tuple(c * s for c, s in zip(point_texel, scales))
+            u, v, w = coords
             fd = []
             for axis in range(3):
+                h = 0.25 * scales[axis]
                 lo = list(coords)
                 hi = list(coords)
                 lo[axis] -= h
@@ -3141,7 +3166,13 @@ def test_texture_sample_grad_3d(test, device):
                 fd.append((f[1] - f[0]) / (2.0 * h))
 
             gu, gv, gw = _tape_gradients(sample_grad_3d_scalar_f, tex, [[u], [v], [w]], float, device)
-            np.testing.assert_allclose((gu[0], gv[0], gw[0]), fd, rtol=_GRAD_FD_TOL, atol=_GRAD_FD_TOL)
+            np.testing.assert_allclose(
+                (gu[0], gv[0], gw[0]),
+                fd,
+                rtol=_GRAD_FD_TOL,
+                atol=_GRAD_FD_TOL,
+                err_msg=f"mode={address_mode.name} point_texel={point_texel}",
+            )
 
             pos = wp.array([wp.vec3f(u, v, w)], dtype=wp.vec3f, requires_grad=True, device=device)
             out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
@@ -3187,12 +3218,15 @@ def test_texture_sample_grad_lod(test, device):
                 np.testing.assert_allclose(
                     gu[0],
                     fd_u,
-                    rtol=3e-2,
-                    atol=3e-2,
+                    rtol=_GRAD_MIP_FD_TOL,
+                    atol=_GRAD_MIP_FD_TOL,
                     err_msg=f"mip={mip_filter_mode.name} lod={lod} u_texel={u_texel}",
                 )
 
                 if mip_filter_mode == wp.TextureFilterMode.LINEAR:
+                    # At an integer LOD the mip blend has a kink, so the adjoint
+                    # returns the right-hand derivative; a central difference
+                    # there is not a valid reference.
                     if lod % 1.0 != 0.0:
                         hl = 0.125
                         f = _forward_values(sample_grad_1d_lod_f, tex, [[u, u], [lod - hl, lod + hl]], float, device)
@@ -3200,8 +3234,8 @@ def test_texture_sample_grad_lod(test, device):
                         np.testing.assert_allclose(
                             glod[0],
                             fd_lod,
-                            rtol=3e-2,
-                            atol=3e-2,
+                            rtol=_GRAD_MIP_FD_TOL,
+                            atol=_GRAD_MIP_FD_TOL,
                             err_msg=f"lod gradient at lod={lod} u_texel={u_texel}",
                         )
                 else:

--- a/warp/tests/cuda/test_texture.py
+++ b/warp/tests/cuda/test_texture.py
@@ -2826,6 +2826,429 @@ def test_texture_mipmap_invalid_levels(test, device):
 
 
 # ============================================================================
+# Adjoint (Gradient) Tests
+# ============================================================================
+#
+# texture_sample gradients are checked against central finite differences of
+# Warp's own forward sampler. The forward is piecewise multilinear, so a
+# finite difference whose stencil stays inside one interpolation cell is the
+# exact derivative; all sample points below are chosen accordingly (cells span
+# [n, n+1) in texel space t = u_texel - 0.5). Checks run under every address
+# mode so that boundary behavior (CLAMP's zero slope, WRAP's periodicity,
+# MIRROR's sign flip, BORDER's zero padding) is exercised on both backends.
+
+_GRAD_ADDRESS_MODES = (
+    wp.TextureAddressMode.WRAP,
+    wp.TextureAddressMode.CLAMP,
+    wp.TextureAddressMode.MIRROR,
+    wp.TextureAddressMode.BORDER,
+)
+
+# Tolerance for adjoint vs. finite differences of the forward pass. The
+# adjoint reconstructs the exact lerp slope, but the CUDA forward interpolates
+# with 9-bit fixed-point fractions, so the finite difference itself carries
+# O(1/256 / h) noise.
+_GRAD_FD_TOL = 2e-2
+
+
+@wp.kernel
+def sample_grad_1d_f(tex: wp.Texture1D, pos: wp.array[float], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos[tid], dtype=float)
+
+
+@wp.kernel
+def sample_grad_1d_v2(tex: wp.Texture1D, pos: wp.array[float], out: wp.array[wp.vec2f]):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos[tid], dtype=wp.vec2f)
+
+
+@wp.kernel
+def sample_grad_1d_v4(tex: wp.Texture1D, pos: wp.array[float], out: wp.array[wp.vec4f]):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos[tid], dtype=wp.vec4f)
+
+
+@wp.kernel
+def sample_grad_1d_lod_f(tex: wp.Texture1D, pos: wp.array[float], lod: wp.array[float], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos[tid], dtype=float, lod=lod[tid])
+
+
+@wp.kernel
+def sample_grad_2d_f(tex: wp.Texture2D, pos: wp.array[wp.vec2f], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos[tid], dtype=float)
+
+
+@wp.kernel
+def sample_grad_2d_scalar_f(tex: wp.Texture2D, pos_u: wp.array[float], pos_v: wp.array[float], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos_u[tid], pos_v[tid], dtype=float)
+
+
+@wp.kernel
+def sample_grad_3d_f(tex: wp.Texture3D, pos: wp.array[wp.vec3f], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos[tid], dtype=float)
+
+
+@wp.kernel
+def sample_grad_3d_scalar_f(
+    tex: wp.Texture3D,
+    pos_u: wp.array[float],
+    pos_v: wp.array[float],
+    pos_w: wp.array[float],
+    out: wp.array[float],
+):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(tex, pos_u[tid], pos_v[tid], pos_w[tid], dtype=float)
+
+
+@wp.struct
+class TextureGradSubject:
+    tex: wp.Texture3D
+
+
+@wp.kernel
+def sample_grad_struct_3d_f(subject: TextureGradSubject, pos: wp.array[wp.vec3f], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = wp.texture_sample(subject.tex, pos[tid], dtype=float)
+
+
+def _forward_values(kernel, tex, coord_arrays, out_dtype, device):
+    """Run a sampling kernel and return the outputs as a NumPy array."""
+    n = len(coord_arrays[0])
+    inputs = [tex] + [wp.array(np.asarray(c, dtype=np.float32), dtype=float, device=device) for c in coord_arrays]
+    out = wp.zeros(n, dtype=out_dtype, device=device)
+    wp.launch(kernel, dim=n, inputs=inputs, outputs=[out], device=device)
+    return out.numpy()
+
+
+def _tape_gradients(kernel, tex, coord_arrays, out_dtype, device):
+    """Backpropagate ones through a sampling kernel; return per-input gradients."""
+    n = len(coord_arrays[0])
+    pos = [
+        wp.array(np.asarray(c, dtype=np.float32), dtype=float, requires_grad=True, device=device) for c in coord_arrays
+    ]
+    out = wp.zeros(n, dtype=out_dtype, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(kernel, dim=n, inputs=[tex, *pos], outputs=[out], device=device)
+    if out_dtype is float:
+        out.grad = wp.full(n, 1.0, dtype=float, device=device)
+    else:
+        out.grad = wp.array(np.ones((n, out_dtype._length_), dtype=np.float32), dtype=out_dtype, device=device)
+    tape.backward()
+    return [p.grad.numpy() for p in pos]
+
+
+def _check_grad_1d(test, tex, u, device, h=0.25, tol=_GRAD_FD_TOL):
+    f = _forward_values(sample_grad_1d_f, tex, [[u - h, u + h]], float, device)
+    fd = (f[1] - f[0]) / (2.0 * h)
+    (g,) = _tape_gradients(sample_grad_1d_f, tex, [[u]], float, device)
+    np.testing.assert_allclose(g[0], fd, rtol=tol, atol=tol, err_msg=f"1D gradient mismatch at u={u}")
+
+
+def test_texture_sample_grad_1d_address_modes(test, device):
+    """Adjoint matches finite differences under every address mode, both coordinate conventions."""
+    width = 8
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal(width).astype(np.float32)
+
+    # Texel-space points: interior, both half-texel boundary bands, and cells
+    # beyond the texture (wraparound / mirrored / clamped / border regions).
+    points_texel = (0.2, 3.25, 4.8, 7.75, 8.2, -0.25)
+
+    for address_mode in _GRAD_ADDRESS_MODES:
+        for normalized in (False, True):
+            tex = wp.Texture1D(
+                data,
+                normalized_coords=normalized,
+                filter_mode=wp.TextureFilterMode.LINEAR,
+                address_mode=address_mode,
+                device=device,
+            )
+            for u_texel in points_texel:
+                scale = 1.0 / width if normalized else 1.0
+                _check_grad_1d(test, tex, u_texel * scale, device, h=0.25 * scale)
+
+
+def test_texture_sample_grad_1d_analytic(test, device):
+    """Hand-computed boundary gradients for each address mode.
+
+    Data is ``v[i] = i + 1`` so interior cells have slope 1 (in texel units).
+    Expectations match PyTorch ``grid_sample``: ``padding_mode="zeros"`` for
+    BORDER and ``padding_mode="border"`` for CLAMP. WRAP/MIRROR run with
+    normalized coordinates because CUDA treats them as CLAMP otherwise.
+    """
+    width = 8
+    data = np.arange(1, width + 1, dtype=np.float32)
+
+    def grad_at(tex, u):
+        (g,) = _tape_gradients(sample_grad_1d_f, tex, [[u]], float, device)
+        return g[0]
+
+    def make_tex(address_mode, normalized):
+        return wp.Texture1D(
+            data,
+            normalized_coords=normalized,
+            filter_mode=wp.TextureFilterMode.LINEAR,
+            address_mode=address_mode,
+            device=device,
+        )
+
+    # (address_mode, normalized, u_texel, expected gradient in texel units)
+    cases = (
+        # interior cell [2, 3]: slope v[3] - v[2] = 1
+        (wp.TextureAddressMode.BORDER, False, 3.25, 1.0),
+        (wp.TextureAddressMode.CLAMP, False, 3.25, 1.0),
+        (wp.TextureAddressMode.WRAP, True, 3.25, 1.0),
+        (wp.TextureAddressMode.MIRROR, True, 3.25, 1.0),
+        # left boundary band, cell [-1, 0]: BORDER blends with zero padding
+        (wp.TextureAddressMode.BORDER, False, 0.25, data[0]),
+        (wp.TextureAddressMode.CLAMP, False, 0.25, 0.0),
+        # right boundary band, cell [7, 8]
+        (wp.TextureAddressMode.BORDER, False, 7.75, -data[width - 1]),
+        (wp.TextureAddressMode.CLAMP, False, 7.75, 0.0),
+        (wp.TextureAddressMode.WRAP, True, 7.75, data[0] - data[width - 1]),
+        (wp.TextureAddressMode.MIRROR, True, 7.75, 0.0),  # x1 = 8 mirrors back to 7: flat cell
+        # fully outside, cell [-2, -1]: BORDER is identically zero
+        (wp.TextureAddressMode.BORDER, False, -0.75, 0.0),
+        # mirrored descending segment, cell [8, 9]: v[map(9)] - v[map(8)] = v[6] - v[7]
+        (wp.TextureAddressMode.MIRROR, True, 8.75, data[6] - data[7]),
+        # wrapped cell [8, 9] repeats cell [0, 1]
+        (wp.TextureAddressMode.WRAP, True, 8.75, data[1] - data[0]),
+    )
+
+    for address_mode, normalized, u_texel, expected_texel in cases:
+        tex = make_tex(address_mode, normalized)
+        scale = 1.0 / width if normalized else 1.0
+        g = grad_at(tex, u_texel * scale)
+        np.testing.assert_allclose(
+            g * scale,
+            expected_texel,
+            atol=1e-4,
+            err_msg=f"mode={address_mode.name} normalized={normalized} u_texel={u_texel}",
+        )
+
+
+def test_texture_sample_grad_closest_zero(test, device):
+    """CLOSEST filtering is piecewise constant: coordinate gradients are zero."""
+    data = np.arange(1, 9, dtype=np.float32)
+    for address_mode in _GRAD_ADDRESS_MODES:
+        tex = wp.Texture1D(
+            data,
+            normalized_coords=False,
+            filter_mode=wp.TextureFilterMode.CLOSEST,
+            address_mode=address_mode,
+            device=device,
+        )
+        (g,) = _tape_gradients(sample_grad_1d_f, tex, [[3.3]], float, device)
+        test.assertEqual(g[0], 0.0)
+
+
+def test_texture_sample_grad_1d_multichannel(test, device):
+    """vec2f/vec4f samples: the coordinate gradient sums per-channel slopes."""
+    width = 8
+    rng = np.random.default_rng(1)
+    for num_channels, out_dtype, kernel in ((2, wp.vec2f, sample_grad_1d_v2), (4, wp.vec4f, sample_grad_1d_v4)):
+        data = rng.standard_normal((width, num_channels)).astype(np.float32)
+        tex = wp.Texture1D(
+            data,
+            normalized_coords=False,
+            filter_mode=wp.TextureFilterMode.LINEAR,
+            address_mode=wp.TextureAddressMode.CLAMP,
+            device=device,
+        )
+        for u in (0.2, 3.25, 6.8):
+            h = 0.25
+            f = _forward_values(kernel, tex, [[u - h, u + h]], out_dtype, device)
+            fd = (f[1] - f[0]) / (2.0 * h)  # per-channel slopes
+            (g,) = _tape_gradients(kernel, tex, [[u]], out_dtype, device)
+            np.testing.assert_allclose(g[0], fd.sum(), rtol=_GRAD_FD_TOL, atol=_GRAD_FD_TOL)
+
+
+def test_texture_sample_grad_2d(test, device):
+    """2D vec2 and scalar-coordinate overloads match finite differences per axis."""
+    height, width = 6, 8
+    rng = np.random.default_rng(2)
+    data = rng.standard_normal((height, width)).astype(np.float32)
+
+    points = ((3.25, 2.8), (0.2, 0.25), (7.75, 5.8), (-0.25, 4.2))
+
+    for address_mode in (wp.TextureAddressMode.CLAMP, wp.TextureAddressMode.BORDER):
+        tex = wp.Texture2D(
+            data,
+            normalized_coords=False,
+            filter_mode=wp.TextureFilterMode.LINEAR,
+            address_mode=address_mode,
+            device=device,
+        )
+        for u, v in points:
+            h = 0.25
+            fu = _forward_values(sample_grad_2d_scalar_f, tex, [[u - h, u + h], [v, v]], float, device)
+            fv = _forward_values(sample_grad_2d_scalar_f, tex, [[u, u], [v - h, v + h]], float, device)
+            fd = ((fu[1] - fu[0]) / (2.0 * h), (fv[1] - fv[0]) / (2.0 * h))
+
+            # scalar-coordinate overload
+            gu, gv = _tape_gradients(sample_grad_2d_scalar_f, tex, [[u], [v]], float, device)
+            np.testing.assert_allclose((gu[0], gv[0]), fd, rtol=_GRAD_FD_TOL, atol=_GRAD_FD_TOL)
+
+            # vec2 overload
+            pos = wp.array([wp.vec2f(u, v)], dtype=wp.vec2f, requires_grad=True, device=device)
+            out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+            tape = wp.Tape()
+            with tape:
+                wp.launch(sample_grad_2d_f, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+            out.grad = wp.ones(1, dtype=float, device=device)
+            tape.backward()
+            np.testing.assert_allclose(pos.grad.numpy()[0], fd, rtol=_GRAD_FD_TOL, atol=_GRAD_FD_TOL)
+
+
+def test_texture_sample_grad_3d(test, device):
+    """3D vec3 and scalar-coordinate overloads match finite differences per axis."""
+    depth, height, width = 4, 6, 8
+    rng = np.random.default_rng(3)
+    data = rng.standard_normal((depth, height, width)).astype(np.float32)
+
+    points = ((3.25, 2.8, 1.2), (0.2, 0.25, 3.75), (7.75, 5.8, 0.75))
+
+    for address_mode in (wp.TextureAddressMode.CLAMP, wp.TextureAddressMode.BORDER):
+        tex = wp.Texture3D(
+            data,
+            normalized_coords=False,
+            filter_mode=wp.TextureFilterMode.LINEAR,
+            address_mode=address_mode,
+            device=device,
+        )
+        for u, v, w in points:
+            h = 0.25
+            coords = (u, v, w)
+            fd = []
+            for axis in range(3):
+                lo = list(coords)
+                hi = list(coords)
+                lo[axis] -= h
+                hi[axis] += h
+                f = _forward_values(
+                    sample_grad_3d_scalar_f,
+                    tex,
+                    [[lo[0], hi[0]], [lo[1], hi[1]], [lo[2], hi[2]]],
+                    float,
+                    device,
+                )
+                fd.append((f[1] - f[0]) / (2.0 * h))
+
+            gu, gv, gw = _tape_gradients(sample_grad_3d_scalar_f, tex, [[u], [v], [w]], float, device)
+            np.testing.assert_allclose((gu[0], gv[0], gw[0]), fd, rtol=_GRAD_FD_TOL, atol=_GRAD_FD_TOL)
+
+            pos = wp.array([wp.vec3f(u, v, w)], dtype=wp.vec3f, requires_grad=True, device=device)
+            out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+            tape = wp.Tape()
+            with tape:
+                wp.launch(sample_grad_3d_f, dim=1, inputs=[tex, pos], outputs=[out], device=device)
+            out.grad = wp.ones(1, dtype=float, device=device)
+            tape.backward()
+            np.testing.assert_allclose(pos.grad.numpy()[0], fd, rtol=_GRAD_FD_TOL, atol=_GRAD_FD_TOL)
+
+
+def test_texture_sample_grad_lod(test, device):
+    """Mipmapped gradients: per-level coordinate slopes and the LOD gradient.
+
+    Sample points are chosen so the finite-difference stencil (h = 0.125 base
+    texels) stays inside one interpolation cell at every mip level.
+    """
+    width = 16
+    rng = np.random.default_rng(4)
+    data = rng.standard_normal(width).astype(np.float32)
+
+    points_texel = (3.3, 5.2, 10.2)
+    lods = (0.0, 1.0, 2.0, 0.5, 1.25, 1.75)
+
+    for mip_filter_mode in (wp.TextureFilterMode.LINEAR, wp.TextureFilterMode.CLOSEST):
+        tex = wp.Texture1D(
+            data,
+            normalized_coords=True,
+            filter_mode=wp.TextureFilterMode.LINEAR,
+            mip_filter_mode=mip_filter_mode,
+            address_mode=wp.TextureAddressMode.CLAMP,
+            num_mip_levels=3,  # widths 16, 8, 4
+            device=device,
+        )
+        for lod in lods:
+            for u_texel in points_texel:
+                u = u_texel / width
+                h = 0.125 / width
+
+                f = _forward_values(sample_grad_1d_lod_f, tex, [[u - h, u + h], [lod, lod]], float, device)
+                fd_u = (f[1] - f[0]) / (2.0 * h)
+                gu, glod = _tape_gradients(sample_grad_1d_lod_f, tex, [[u], [lod]], float, device)
+                np.testing.assert_allclose(
+                    gu[0],
+                    fd_u,
+                    rtol=3e-2,
+                    atol=3e-2,
+                    err_msg=f"mip={mip_filter_mode.name} lod={lod} u_texel={u_texel}",
+                )
+
+                if mip_filter_mode == wp.TextureFilterMode.LINEAR:
+                    if lod % 1.0 != 0.0:
+                        hl = 0.125
+                        f = _forward_values(sample_grad_1d_lod_f, tex, [[u, u], [lod - hl, lod + hl]], float, device)
+                        fd_lod = (f[1] - f[0]) / (2.0 * hl)
+                        np.testing.assert_allclose(
+                            glod[0],
+                            fd_lod,
+                            rtol=3e-2,
+                            atol=3e-2,
+                            err_msg=f"lod gradient at lod={lod} u_texel={u_texel}",
+                        )
+                else:
+                    # CLOSEST mip filter: piecewise constant in lod
+                    test.assertEqual(glod[0], 0.0, f"lod gradient should be zero at lod={lod}")
+
+
+def test_texture_sample_grad_struct_member(test, device):
+    """Gradients flow through a texture held inside a wp.struct (interop pattern)."""
+    depth, height, width = 4, 4, 4
+    rng = np.random.default_rng(5)
+    data = rng.standard_normal((depth, height, width)).astype(np.float32)
+
+    subject = TextureGradSubject()
+    subject.tex = wp.Texture3D(
+        data,
+        normalized_coords=False,
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.BORDER,
+        device=device,
+    )
+
+    u, v, w = 1.25, 2.2, 0.8
+    h = 0.25
+    fd = []
+    for axis in range(3):
+        lo = [u, v, w]
+        hi = [u, v, w]
+        lo[axis] -= h
+        hi[axis] += h
+        pos = wp.array([wp.vec3f(*lo), wp.vec3f(*hi)], dtype=wp.vec3f, device=device)
+        out = wp.zeros(2, dtype=float, device=device)
+        wp.launch(sample_grad_struct_3d_f, dim=2, inputs=[subject, pos], outputs=[out], device=device)
+        f = out.numpy()
+        fd.append((f[1] - f[0]) / (2.0 * h))
+
+    pos = wp.array([wp.vec3f(u, v, w)], dtype=wp.vec3f, requires_grad=True, device=device)
+    out = wp.zeros(1, dtype=float, requires_grad=True, device=device)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(sample_grad_struct_3d_f, dim=1, inputs=[subject, pos], outputs=[out], device=device)
+    out.grad = wp.ones(1, dtype=float, device=device)
+    tape.backward()
+    np.testing.assert_allclose(pos.grad.numpy()[0], fd, rtol=_GRAD_FD_TOL, atol=_GRAD_FD_TOL)
+
+
+# ============================================================================
 # Test Class
 # ============================================================================
 
@@ -3128,6 +3551,35 @@ add_function_test(
     TestTexture,
     "test_texture_mipmap_invalid_levels",
     test_texture_mipmap_invalid_levels,
+    devices=all_devices,
+)
+
+# Adjoint (gradient) tests - run on all devices
+add_function_test(
+    TestTexture,
+    "test_texture_sample_grad_1d_address_modes",
+    test_texture_sample_grad_1d_address_modes,
+    devices=all_devices,
+)
+add_function_test(
+    TestTexture, "test_texture_sample_grad_1d_analytic", test_texture_sample_grad_1d_analytic, devices=all_devices
+)
+add_function_test(
+    TestTexture, "test_texture_sample_grad_closest_zero", test_texture_sample_grad_closest_zero, devices=all_devices
+)
+add_function_test(
+    TestTexture,
+    "test_texture_sample_grad_1d_multichannel",
+    test_texture_sample_grad_1d_multichannel,
+    devices=all_devices,
+)
+add_function_test(TestTexture, "test_texture_sample_grad_2d", test_texture_sample_grad_2d, devices=all_devices)
+add_function_test(TestTexture, "test_texture_sample_grad_3d", test_texture_sample_grad_3d, devices=all_devices)
+add_function_test(TestTexture, "test_texture_sample_grad_lod", test_texture_sample_grad_lod, devices=all_devices)
+add_function_test(
+    TestTexture,
+    "test_texture_sample_grad_struct_member",
+    test_texture_sample_grad_struct_member,
     devices=all_devices,
 )
 


### PR DESCRIPTION
## Description

Implements adjoints for `wp.texture_sample()` so gradients propagate to the sampling coordinates and the `lod` argument, on both the CPU and CUDA backends, under **all four address modes** (WRAP, CLAMP, MIRROR, BORDER). Closes #1301.

**Driving workload:** [nanodrr](https://github.com/eigenvivek/nanodrr), a differentiable X-ray renderer for 2D/3D medical-image registration, ray-marches a `wp.Texture3D` (held in a `wp.struct`) and backpropagates to camera poses via `wp.Tape` inside a `torch.library.custom_op`. On upstream Warp its pose gradients are silently zero; I have confirmed this branch addresses that need end-to-end — pose gradients track finite differences and a pose-registration loop recovers a ground-truth camera offset (details in the validation summary below).

This supersedes the earlier BORDER-only implementation in this PR and addresses all outstanding review feedback:

- **All address modes are supported** (previously P1: silent wrong gradients for WRAP/MIRROR/CLAMP, which is the default). Instead of porting PyTorch's per-mode multiplier functions (`clip_coordinates_set_grad` / `reflect_coordinates_set_grad`), the adjoint re-samples the texture through the same forward sampler at the quarter points of the current interpolation cell. Every address-mode coordinate mapping is piecewise affine with folds only at cell boundaries, so the scaled difference of two in-cell samples is the exact derivative of the actual forward function — each mode's boundary behavior (CLAMP's zero slope, MIRROR's sign flip, WRAP's periodicity, BORDER's zero padding) is inherited from the sampler with no mode-specific code.
- **No kernel-side `printf` validation** (review: register waste) — there is no unsupported configuration left to warn about, so the guard is gone entirely, as is the Python-side warning.
- **Boundary bands use zeros-padding gradients** for BORDER ("Option A" from the review thread), matching PyTorch `grid_sample(padding_mode="zeros")`; verified by hand-computed cases in the tests.
- **Rebased onto the current texture API**: the adjoints handle the mipmap/LOD signatures, including per-level coordinate gradients for fractional LODs and the LOD gradient itself.
- Test kernels moved to module scope; `normalized_coords=True` (the default) is covered; the unrelated PUBLICATIONS.md changes are dropped; the changelog entry is a Towncrier fragment (`changelog/1301.added.md`).

Quarter points are used instead of texel centers because they sit a safe distance from floor/fold boundaries and the fractions 0.25/0.75 are exact in the CUDA hardware's 9-bit fixed-point interpolator, so the gradient of the ideal lerp is recovered exactly.

Gradients are **not** propagated to the texture data itself (documented); that needs a scatter-add companion buffer and is left as a separate feature. `CLOSEST` filtering yields zero coordinate gradients (matches `grid_sample(mode="nearest")`).

## Changes

- `warp/native/texture.h`: real `adj_texture_sample` implementations for all five overloads via shared per-axis quarter-point helpers; descriptor structs (`texture{1,2,3}d_t`) gain `filter_mode`, `mip_filter_mode`, `num_mip_levels`, `use_normalized_coords`.
- `warp/_src/texture.py`: ctypes mirrors of the new descriptor fields, populated in `__ctype__` (covers kernel params, texture arrays, and `wp.struct` members).
- `warp/_src/builtins.py`: `texture_sample` overloads flagged `is_differentiable=True`; docstrings document the gradient semantics.
- `warp/tests/cuda/test_texture.py`: adjoint tests (all address modes incl. boundary bands, normalized/unnormalized, multi-channel, 2D/3D scalar and vector overloads, mip integer/fractional LOD for both mip filters, LOD gradients, texture-in-struct).
- `docs/user_guide/runtime.rst`, changelog fragment, regenerated stubs.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

- The new `test_texture_sample_grad_*` tests check the adjoint against central finite differences of Warp's own forward sampler with stencils confined to one interpolation cell (where the forward is exactly linear), across every address mode, both coordinate conventions, 1D/2D/3D, all overloads, multi-channel dtypes, and mipmapped LODs — on CPU and CUDA. `test_texture_sample_grad_1d_analytic` additionally pins hand-computed boundary gradients (cross-checked against PyTorch `grid_sample` semantics: `padding_mode="zeros"` for BORDER, `"border"` for CLAMP).
- On `main` without this change, the issue's repro prints `pos.grad = [0.]`; on this branch it prints `[1.]` on both devices, and the new tests fail on `main` by construction (zero gradients).
- Full `warp/tests/cuda/test_texture.py` passes (151 tests), plus the `TestTape`/`TestGrad`/`TestStruct` suites.
- Docs build clean with `--warnings-as-errors`; doctests pass.
- End-to-end: validated with [nanodrr](https://github.com/eigenvivek/nanodrr) (differentiable X-ray renderer that ray-marches a `wp.Texture3D` held in a `wp.struct` inside a `torch.library.custom_op`): camera-pose gradients through the renderer track finite differences, and a pose-registration loop recovers a ground-truth camera offset (loss reduced ~700x).

## New feature / enhancement

```python
import numpy as np
import warp as wp

wp.init()


@wp.kernel
def sample(tex: wp.Texture1D, pos: wp.array(dtype=float), out: wp.array(dtype=float)):
    tid = wp.tid()
    out[tid] = wp.texture_sample(tex, pos[tid], dtype=float)


data = np.arange(16, dtype=np.float32)
tex = wp.Texture1D(data, normalized_coords=False)
pos = wp.array([4.0], dtype=float, requires_grad=True)
out = wp.zeros(1, dtype=float, requires_grad=True)

tape = wp.Tape()
with tape:
    wp.launch(sample, dim=1, inputs=[tex, pos], outputs=[out])
out.grad = wp.ones(1, dtype=float)
tape.backward()

print("out:", out.numpy())            # [3.5]
print("pos.grad:", pos.grad.numpy())  # [1.]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic gradients for texture sampling coordinates and mipmap LOD values across 1D, 2D, and 3D textures.
  * Supports normalized and texel coordinates, address modes, linear filtering, multichannel textures, and mipmap blending.
  * Closest filtering produces zero coordinate gradients; texture data does not receive gradients.

* **Documentation**
  * Updated texture sampling documentation and changelog with gradient behavior and limitations.

* **Tests**
  * Added comprehensive gradient validation for texture sampling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
