### PR TITLE
Skip scheduled workflow runs on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ permissions:
 
 jobs:
   build-warp:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -103,6 +104,7 @@ jobs:
             warp/native/version.h
 
   test-warp:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ${{ matrix.os }}
     needs: build-warp
     strategy:
@@ -148,6 +150,7 @@ jobs:
         if: always()
 
   test-warp-debug:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ubuntu-24.04
     needs: build-warp
     timeout-minutes: 30
@@ -237,6 +240,7 @@ jobs:
         if: always()
 
   build-docs:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ubuntu-latest
     needs: build-warp
     outputs:
@@ -269,6 +273,7 @@ jobs:
             docs/language_reference
 
   check-build-docs-output:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ubuntu-latest
     needs: build-docs
     steps:
@@ -293,6 +298,7 @@ jobs:
           (echo "Please run build_docs.py (or download from $ARTIFACT_URL) and add warp/__init__.pyi to your pull request." && false)
 
   check-generated-files:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ubuntu-latest
     needs: build-warp
     steps:
@@ -321,6 +327,7 @@ jobs:
           (echo "Please run build_lib.py and add warp/native/version.h to your pull request." && false)
 
   check-unnamespaced-symbols:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ubuntu-latest
     needs: build-warp
     steps:
@@ -360,6 +367,7 @@ jobs:
 
   # Validate that the type stub file (warp/__init__.pyi) passes static type checking.
   type-check-stubs:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   analyze:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 360


### PR DESCRIPTION
## Description

Forks of the Warp repo inherit the `schedule` triggers in GitHub Actions
workflows, causing daily cron runs that burn the fork owner's Actions minutes
for no benefit. This adds a guard condition to all jobs in `ci.yml` and
`codeql.yml` so that scheduled runs only execute on `NVIDIA/warp`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

Verified by inspection that the `if` condition logic is correct:
- Non-schedule events (push, PR, workflow_call, workflow_dispatch) always pass
- Schedule events only pass when `github.repository == 'NVIDIA/warp'`
- The `needs:` dependency chain is safe since all jobs share the same skip condition
- `test-warp-gpu` was left unchanged since its existing condition already includes `github.repository == 'NVIDIA/warp'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to optimize job execution in forked repositories, preventing unnecessary scheduled builds and code analysis runs outside the primary repository while maintaining full functionality for standard development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->