### PR TITLE
Fix array annotation repr to use eval-able subscript form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@
 
 ### Fixed
 
+- Fix ``_ArrayAnnotationBase.__repr__()`` emitting raw class paths for ``dtype``
+  (e.g., ``wp.array(dtype=<class 'warp._src.types.uint32'>, ndim=4)``). The repr now
+  produces the eval-able subscript form that matches user-written annotations
+  (e.g., ``wp.array4d[wp.uint32]``)
+  ([GH-1341](https://github.com/NVIDIA/warp/issues/1341)).
 - Fix compilation failures or crashes when multiple processes compile CUDA kernels concurrently with a shared kernel
   cache, caused by NVRTC precompiled header files racing in the shared `--pch-dir` directory; affects builds with
   CUDA Toolkit 12.8–12.9 ([GH-1284](https://github.com/NVIDIA/warp/issues/1284)).

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -4645,9 +4645,22 @@ class _ArrayAnnotationBase:
         self.ndim = ndim
 
     def __repr__(self):
-        dtype_str = "Any" if self.dtype is Any else self.dtype
-        ndim_str = "Any" if self.ndim is Any else self.ndim
-        return f"wp.{self._concrete_cls.__name__}(dtype={dtype_str}, ndim={ndim_str})"
+        if self.dtype is Any:
+            dtype_str = "Any"
+        else:
+            dtype_str = f"wp.{getattr(self.dtype, '__name__', None) or type_repr(self.dtype)}"
+        cls_name = self._concrete_cls.__name__
+        ndim = self.ndim
+        # Use the eval-able subscript form (e.g. wp.array4d[wp.float32])
+        if cls_name == "array" and ndim is not Any:
+            if ndim >= 2:
+                return f"wp.array{ndim}d[{dtype_str}]"
+            return f"wp.array[{dtype_str}]"
+        if ndim is not Any and ndim == 1:
+            return f"wp.{cls_name}[{dtype_str}]"
+        if ndim is not Any:
+            return f"wp.{cls_name}[{dtype_str}, Literal[{ndim}]]"
+        return f"wp.{cls_name}(dtype={dtype_str}, ndim=Any)"
 
     def __eq__(self, other):
         if isinstance(other, _ArrayAnnotationBase):

--- a/warp/tests/test_subscript_types.py
+++ b/warp/tests/test_subscript_types.py
@@ -502,6 +502,38 @@ class TestSubscriptTypes(unittest.TestCase):
         ia = wp.indexedarray[float]
         self.assertNotEqual(a1, ia)
 
+    def test_annotation_repr(self):
+        """repr() produces eval-able subscript forms (e.g. wp.array4d[wp.uint32])."""
+        # Regular array annotations use arrayNd shorthand
+        self.assertEqual(repr(wp.array[wp.float32]), "wp.array[wp.float32]")
+        self.assertEqual(repr(wp.array4d[wp.uint32]), "wp.array4d[wp.uint32]")
+        self.assertEqual(repr(wp.array3d[wp.vec3f]), "wp.array3d[wp.vec3f]")
+        self.assertEqual(repr(wp.array2d[wp.float32]), "wp.array2d[wp.float32]")
+        self.assertEqual(repr(wp.array[wp.transformf]), "wp.array[wp.transformf]")
+
+        # indexedarray uses its own class name with subscript syntax
+        self.assertEqual(repr(wp.indexedarray[wp.float32]), "wp.indexedarray[wp.float32]")
+        self.assertEqual(
+            repr(wp.indexedarray[wp.float32, Literal[3]]),
+            "wp.indexedarray[wp.float32, Literal[3]]",
+        )
+
+        # Any dtype/ndim falls back to non-subscript form
+        ann = _ArrayAnnotation(dtype=Any, ndim=2)
+        self.assertEqual(repr(ann), "wp.array2d[Any]")
+        ann = _ArrayAnnotation(dtype=wp.float32, ndim=Any)
+        self.assertEqual(repr(ann), "wp.array(dtype=wp.float32, ndim=Any)")
+
+        # Roundtrip: eval(repr(x)) == x
+        for annotation in [
+            wp.array[wp.float32],
+            wp.array4d[wp.uint32],
+            wp.array3d[wp.vec3f],
+            wp.indexedarray[wp.float32],
+            wp.indexedarray[wp.float32, Literal[3]],
+        ]:
+            self.assertEqual(eval(repr(annotation)), annotation)
+
     def test_typevar_delegation(self):
         """Verify that TypeVar parameters delegate to Generic (preserves static typing)."""
         T = TypeVar("T")  # dtype


### PR DESCRIPTION
Fixes #1341

## Summary

Fix `_ArrayAnnotationBase.__repr__()` to produce eval-able subscript forms that match user-written annotations, instead of leaking raw class paths for `dtype`.

### Before

```python
>>> wp.array4d[wp.uint32]
wp.array(dtype=<class 'warp._src.types.uint32'>, ndim=4)
>>> wp.indexedarray[wp.float32, Literal[3]]
wp.indexedarray(dtype=<class 'warp._src.types.float32'>, ndim=3)
```

### After

```python
>>> wp.array4d[wp.uint32]
wp.array4d[wp.uint32]
>>> wp.indexedarray[wp.float32, Literal[3]]
wp.indexedarray[wp.float32, Literal[3]]
```

## Root cause

The old code interpolated the raw dtype class object into an f-string:

```python
dtype_str = "Any" if self.dtype is Any else self.dtype  # str(class) → <class '...'>
```

## Changes

- **`warp/_src/types.py`**: Rewrite `_ArrayAnnotationBase.__repr__()` to:
  - Use `dtype.__name__` (with `type_repr()` fallback) for clean dtype names
  - Emit `wp.arrayNd[wp.dtype]` for plain `array` annotations with concrete `ndim` ≥ 2
  - Emit `wp.array[wp.dtype]` for `ndim == 1`
  - Emit `wp.{cls}[wp.dtype]` / `wp.{cls}[wp.dtype, Literal[ndim]]` for `indexedarray`, `fabricarray`, etc.
  - Fall back to `wp.{cls}(dtype=..., ndim=Any)` only when `ndim` is `Any`
- **`warp/tests/test_subscript_types.py`**: Add `test_annotation_repr` covering all array types, `Any` edge cases, and `eval(repr(x)) == x` roundtrip verification
- **`CHANGELOG.md`**: Add entry under `### Fixed`

## Output examples

| Expression | `repr()` |
|---|---|
| `wp.array[wp.float32]` | `wp.array[wp.float32]` |
| `wp.array4d[wp.uint32]` | `wp.array4d[wp.uint32]` |
| `wp.array3d[wp.vec3f]` | `wp.array3d[wp.vec3f]` |
| `wp.indexedarray[wp.float32]` | `wp.indexedarray[wp.float32]` |
| `wp.indexedarray[wp.float32, Literal[3]]` | `wp.indexedarray[wp.float32, Literal[3]]` |
| `_ArrayAnnotation(dtype=Any, ndim=4)` | `wp.array4d[Any]` |
| `_ArrayAnnotation(dtype=wp.float32, ndim=Any)` | `wp.array(dtype=wp.float32, ndim=Any)` |

All concrete-`ndim` reprs roundtrip: `eval(repr(x)) == x`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array annotation representation: `repr()` now outputs clean, eval-able type annotations (e.g., `wp.array4d[wp.uint32]`) instead of raw Python class paths, making type information more readable and consistent with user-written annotations.

* **Tests**
  * Added comprehensive validation tests for array annotation string representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->