### PR TITLE
Use CUDA occupancy API as default block_dim for wp.launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@
   ([GH-418](https://github.com/NVIDIA/warp/issues/418)).
 - Reduce Python-side dispatch overhead for half-float conversion using `METH_FASTCALL`
   ([GH-1339](https://github.com/NVIDIA/warp/issues/1339)).
+- Change the default `block_dim` of `wp.launch()` from a fixed 256 to `None`,
+  which selects a value automatically using the CUDA occupancy API.
+  The heuristic uses the suggested block size when the launch is large enough to
+  fill all SMs, and reduces it (in warp-size multiples) for smaller launches.
+  Pass `block_dim=256` explicitly to restore the previous behavior.
 
 ### Fixed
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -7421,6 +7421,42 @@ class Launch:
                 )
 
 
+_WARP_SIZE = 32
+_DEFAULT_BLOCK_DIM = 256
+
+
+def _select_block_dim(kernel, total_threads: int, device, max_blocks: int = 0) -> int:
+    """Choose block_dim using the CUDA occupancy API.
+
+    Uses the default of 256 when it already produces enough blocks to fill
+    every SM.  For smaller launches, reduces block_dim (in warp-size
+    multiples) so that blocks are distributed across SMs.
+
+    The occupancy query result is cached on the kernel object (``_occupancy``)
+    so repeated launches only pay the cost of a ``getattr`` + arithmetic.
+    """
+    # Fast path: occupancy data already cached on this kernel.
+    occ = getattr(kernel, "_occupancy", None)
+    if occ is not None and occ[0] == device.ordinal:
+        suggested, min_blocks = occ[1], occ[2]
+    else:
+        suggested, min_blocks = get_suggested_block_size(kernel, device)
+        kernel._occupancy = (device.ordinal, suggested, min_blocks)
+
+    num_blocks = (total_threads + _DEFAULT_BLOCK_DIM - 1) // _DEFAULT_BLOCK_DIM
+    if max_blocks > 0:
+        num_blocks = min(num_blocks, max_blocks)
+
+    # Default already fills the GPU, or grid capped by max_blocks.
+    if num_blocks >= min_blocks or (max_blocks > 0 and max_blocks < min_blocks):
+        return _DEFAULT_BLOCK_DIM
+
+    # Reduce block_dim so there are enough blocks to fill the GPU.
+    # Round down to a warp-size multiple.
+    ideal = total_threads // min_blocks
+    return max(_WARP_SIZE, ideal // _WARP_SIZE * _WARP_SIZE)
+
+
 def launch(
     kernel,
     dim: int | Sequence[int],
@@ -7434,7 +7470,7 @@ def launch(
     record_tape: bool = True,
     record_cmd: bool = False,
     max_blocks: int = 0,
-    block_dim: int = 256,
+    block_dim: int | None = None,
 ):
     """Launch a Warp kernel on the target device
 
@@ -7459,7 +7495,9 @@ def launch(
         max_blocks: The maximum number of CUDA thread blocks to use.
           Only has an effect for CUDA kernel launches.
           If negative or zero, the maximum hardware value will be used.
-        block_dim: The number of threads per block (always 1 for "cpu" devices).
+        block_dim: The number of threads per block.  When ``None`` (the
+          default), a value is chosen automatically using the CUDA occupancy
+          API to maximize GPU utilization.  Always 1 for ``"cpu"`` devices.
     """
 
     init()
@@ -7514,6 +7552,11 @@ def launch(
         if kernel.is_generic:
             fwd_types = kernel.infer_argument_types(fwd_args)
             kernel = kernel.add_overload(fwd_types)
+
+        # Select block_dim after overload resolution so generic kernels
+        # have their concrete types (needed for the occupancy query).
+        if block_dim is None:
+            block_dim = _select_block_dim(kernel, bounds.size, device, max_blocks)
 
         # For unique module kernels, reset skip_build to allow compilation attempts on different devices.
         # Even though a Module compiles separately for each device (stored in Module.execs),

--- a/warp/tests/test_block_dim_dispatch.py
+++ b/warp/tests/test_block_dim_dispatch.py
@@ -48,7 +48,7 @@ def test_block_dim_cpu_then_cuda(test, device):
 
     # Now launch on CUDA (should load separate module with block_dim=256)
     result_cuda = wp.zeros(2, dtype=wp.int32, device=device)
-    wp.launch(simple_conditional, dim=1, inputs=[1.0, result_cuda], device=device)
+    wp.launch(simple_conditional, dim=1, inputs=[1.0, result_cuda], device=device, block_dim=256)
 
     # Verify CUDA module exec was loaded with block_dim=256
     cuda_exec_key = (device.context, 256)

--- a/warp/tests/test_launch.py
+++ b/warp/tests/test_launch.py
@@ -436,6 +436,101 @@ def test_launch_bounds_single_tuple(test, device):
     assert_np_equal(x.numpy(), np.full(n, 2.0, dtype=np.float32))
 
 
+# ==================================================================================
+# Auto block_dim tests
+# ==================================================================================
+
+
+@wp.kernel
+def saxpy(alpha: float, x: wp.array(dtype=float), y: wp.array(dtype=float)):
+    i = wp.tid()
+    y[i] = alpha * x[i] + y[i]
+
+
+def test_auto_block_dim_correctness(test, device):
+    """Auto block_dim produces correct results for various launch sizes."""
+    for n in [1, 31, 32, 33, 100, 1000, 100_000]:
+        x = wp.ones(n, dtype=float, device=device)
+        y = wp.zeros(n, dtype=float, device=device)
+        wp.launch(saxpy, dim=n, inputs=[2.0, x, y], device=device)
+        wp.synchronize_device(device)
+        np.testing.assert_allclose(y.numpy(), np.full(n, 2.0))
+
+
+def test_explicit_block_dim_passthrough(test, device):
+    """Explicit block_dim is respected and not overridden."""
+    n = 1000
+    x = wp.ones(n, dtype=float, device=device)
+    y = wp.zeros(n, dtype=float, device=device)
+    wp.launch(saxpy, dim=n, inputs=[2.0, x, y], block_dim=64, device=device)
+    wp.synchronize_device(device)
+    np.testing.assert_allclose(y.numpy(), np.full(n, 2.0))
+
+
+def test_auto_block_dim_values(test, device):
+    """Auto block_dim is a warp-size multiple and within bounds."""
+    if device == "cpu":
+        return
+
+    from warp._src.context import _select_block_dim  # noqa: PLC0415
+
+    _suggested, min_blocks = wp.get_suggested_block_size(saxpy, device)
+    dev = wp.get_device(device)
+
+    for total in [1, 32, 1000, 100_000, 10_000_000]:
+        bd = _select_block_dim(saxpy, total, dev)
+        test.assertGreaterEqual(bd, 32, f"block_dim should be >= warp size for total={total}")
+        test.assertEqual(bd % 32, 0, f"block_dim should be a warp-size multiple for total={total}")
+        test.assertLessEqual(bd, 1024, f"block_dim should be <= 1024 for total={total}")
+
+        default_blocks = (total + 256 - 1) // 256
+        if default_blocks >= min_blocks:
+            # Large launch — default fills the GPU, keep it.
+            test.assertEqual(bd, 256, f"should use default for total={total}")
+        else:
+            # Small launch — should reduce below the default.
+            test.assertLess(bd, 256, f"should reduce block_dim for total={total}")
+
+
+def test_auto_block_dim_max_blocks(test, device):
+    """When max_blocks caps the grid, block_dim should use the default."""
+    if device == "cpu":
+        return
+
+    from warp._src.context import _select_block_dim  # noqa: PLC0415
+
+    dev = wp.get_device(device)
+
+    # Small total with max_blocks=4: grid is capped, should use default
+    bd = _select_block_dim(saxpy, 100, dev, max_blocks=4)
+    test.assertEqual(bd, 256, "should use default when max_blocks caps the grid")
+
+    # Correctness check with max_blocks
+    n = 1000
+    x = wp.ones(n, dtype=float, device=device)
+    y = wp.zeros(n, dtype=float, device=device)
+    wp.launch(saxpy, dim=n, inputs=[2.0, x, y], max_blocks=4, device=device)
+    wp.synchronize_device(device)
+    np.testing.assert_allclose(y.numpy(), np.full(n, 2.0))
+
+
+def test_auto_block_dim_graph_capture(test, device):
+    """Auto block_dim works correctly under CUDA graph capture."""
+    if device == "cpu":
+        return
+
+    n = 10_000
+    x = wp.ones(n, dtype=float, device=device)
+    y = wp.zeros(n, dtype=float, device=device)
+
+    with wp.ScopedCapture(device=device) as capture:
+        wp.launch(saxpy, dim=n, inputs=[2.0, x, y], device=device)
+
+    wp.capture_launch(capture.graph)
+    wp.synchronize_device(device)
+    np.testing.assert_allclose(y.numpy(), np.full(n, 2.0))
+
+
 devices = get_test_devices()
 
 
@@ -462,6 +557,14 @@ add_function_test(TestLaunch, "test_launch_bounds_none", test_launch_bounds_none
 add_function_test(TestLaunch, "test_launch_bounds_single", test_launch_bounds_single, devices=devices)
 add_function_test(TestLaunch, "test_launch_bounds_tuple", test_launch_bounds_tuple, devices=devices)
 add_function_test(TestLaunch, "test_launch_bounds_single_tuple", test_launch_bounds_single_tuple, devices=devices)
+
+add_function_test(TestLaunch, "test_auto_block_dim_correctness", test_auto_block_dim_correctness, devices=devices)
+add_function_test(
+    TestLaunch, "test_explicit_block_dim_passthrough", test_explicit_block_dim_passthrough, devices=devices
+)
+add_function_test(TestLaunch, "test_auto_block_dim_values", test_auto_block_dim_values, devices=devices)
+add_function_test(TestLaunch, "test_auto_block_dim_max_blocks", test_auto_block_dim_max_blocks, devices=devices)
+add_function_test(TestLaunch, "test_auto_block_dim_graph_capture", test_auto_block_dim_graph_capture, devices=devices)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Change the default `block_dim` of `wp.launch()` from a fixed 256 to `None`, which queries the CUDA occupancy API (`cuOccupancyMaxPotentialBlockSize` via `wp.get_suggested_block_size()`) to determine the minimum number of blocks needed to fill all SMs on the device. When the default of 256 already produces enough blocks, it is kept. For smaller launches, `block_dim` is reduced (in warp-size multiples) so that blocks are distributed across SMs.

This improves GPU utilization for workloads with small-to-medium launch dimensions where the fixed 256 leaves many SMs idle.

Related to GH-1270.

### Benchmarks

**MuJoCo Warp** (humanoid, CUDA graph capture, RTX PRO 6000 Blackwell 188 SMs):

| nworld | baseline (steps/s) | occupancy (steps/s) | speedup |
|--------|-------------------:|--------------------:|--------:|
| 32     | 90,977             | 95,831              | 1.05x   |
| 256    | 586,402            | 650,580             | 1.11x   |
| 1024   | 2,078,053          | 2,265,941           | 1.09x   |
| 4096   | 5,338,400          | 5,508,975           | 1.03x   |
| 8192   | 6,584,653          | 6,604,272           | 1.00x   |
| 16384  | 6,718,417          | 6,716,243           | 1.00x   |

**Newton/Kamino** (graph capture, 200 steps):

| nworld | baseline (fps) | occupancy (fps) | speedup |
|--------|---------------:|----------------:|--------:|
| 64     | 5.51           | 5.57            | 1.01x   |
| 128    | 3.74           | 3.78            | 1.01x   |
| 256    | 2.26           | 2.28            | 1.01x   |
| 512    | 1.28           | 1.28            | 1.00x   |

No regressions on either codebase. Per-launch overhead is ~577ns (cache hit).

## Changes

- **warp/_src/context.py**: Add `_select_block_dim()` heuristic; change `block_dim` default from `256` to `None` in `launch()`; select after generic overload resolution to handle `dtype=Any` kernels
- **warp/tests/test_launch.py**: Add 5 tests (correctness, explicit passthrough, value properties, max_blocks, graph capture)
- **warp/tests/test_block_dim_dispatch.py**: Pin `block_dim=256` in existing test that checks CPU/CUDA exec separation
- **CHANGELOG.md**: Document the behavior change

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Test plan

```bash
uv run warp/tests/test_launch.py
uv run warp/tests/test_block_dim_dispatch.py
```

## New feature / enhancement

`wp.launch()` now auto-selects `block_dim` for better GPU utilization on small launches:

```python
import warp as wp

@wp.kernel
def saxpy(alpha: float, x: wp.array(dtype=float), y: wp.array(dtype=float)):
    i = wp.tid()
    y[i] = alpha * x[i] + y[i]

n = 1000
x = wp.ones(n, dtype=float)
y = wp.zeros(n, dtype=float)

# Auto block_dim (new default) — selects a smaller block_dim to fill SMs
wp.launch(saxpy, dim=n, inputs=[2.0, x, y])

# Explicit block_dim — still works, unchanged behavior
wp.launch(saxpy, dim=n, inputs=[2.0, x, y], block_dim=256)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `wp.launch()` now automatically selects optimal block dimensions for CUDA kernels using occupancy-based heuristics. Users can override by explicitly specifying `block_dim` value.

* **Tests**
  * Added comprehensive test coverage for automatic block dimension selection behavior across various kernel sizes and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->