### PR TITLE
fix: respect user warning filters in warp.utils.warn()

### DIFF
--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -56,18 +56,23 @@ def warp_showwarning(message, category, filename, lineno, file=None, line=None):
     sys.stdout.write(s)
 
 
+# Register Warp's custom warning handler globally at import time.
+# This preserves Warp-branded formatting while respecting user-configured
+# warning filters (unlike setting it inside catch_warnings() on each call).
+warnings.showwarning = warp_showwarning
+
+
 def warn(message, category=None, stacklevel=1, once=False):
     if (category, message) in warnings_seen:
         return
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("default")  # Change the filter in this process
-        warnings.showwarning = warp_showwarning
-        warnings.warn(
-            message,
-            category,
-            stacklevel=stacklevel + 1,  # Increment stacklevel by 1 since we are in a wrapper
-        )
+    # Call warnings.warn() directly, respecting user-configured filters.
+    # Increment stacklevel by 1 since we are in a wrapper.
+    warnings.warn(
+        message,
+        category,
+        stacklevel=stacklevel + 1,
+    )
 
     if category is DeprecationWarning or once:
         warnings_seen.add((category, message))

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -56,25 +56,55 @@ def warp_showwarning(message, category, filename, lineno, file=None, line=None):
     sys.stdout.write(s)
 
 
-# Register Warp's custom warning handler globally at import time.
-# This preserves Warp-branded formatting while respecting user-configured
-# warning filters (unlike setting it inside catch_warnings() on each call).
-warnings.showwarning = warp_showwarning
+# Save the original showwarning handler so non-warp warnings are unaffected.
+_original_showwarning = warnings.showwarning
+
+# Thread-safe flag to indicate we're inside warp's warn().
+_warp_warn_active = threading.local()
+
+
+def _warp_showwarning_dispatch(message, category, filename, lineno, file=None, line=None):
+    """Route to warp_showwarning for warp-originated warnings, else fall through to original."""
+    if getattr(_warp_warn_active, "inside", False):
+        warp_showwarning(message, category, filename, lineno, file, line)
+    elif _original_showwarning is not None:
+        _original_showwarning(message, category, filename, lineno, file, line)
+    else:
+        sys.stderr.write(f"{category.__name__}: {message}\n")
+
+
+warnings.showwarning = _warp_showwarning_dispatch
 
 
 def warn(message, category=None, stacklevel=1, once=False):
     if (category, message) in warnings_seen:
         return
 
-    # Call warnings.warn() directly, respecting user-configured filters.
-    # Increment stacklevel by 1 since we are in a wrapper.
-    warnings.warn(
-        message,
-        category,
-        stacklevel=stacklevel + 1,
-    )
+    if category is None:
+        category = UserWarning
 
-    if category is DeprecationWarning or once:
+    # Capture whether the warning was actually shown (not filtered out)
+    original_showwarning = warnings.showwarning
+    shown = [False]
+
+    def _tracking_showwarning(m, cat, fn, ln, file=None, line=None):
+        shown[0] = True
+        warp_showwarning(m, cat, fn, ln, file, line)
+
+    _warp_warn_active.inside = True
+    warnings.showwarning = _tracking_showwarning
+    try:
+        warnings.warn(
+            message,
+            category,
+            stacklevel=stacklevel + 1,
+        )
+    finally:
+        warnings.showwarning = original_showwarning
+        _warp_warn_active.inside = False
+
+    # Only mark as "seen" if the warning was actually shown (not filtered out)
+    if shown[0] and (category is DeprecationWarning or once):
         warnings_seen.add((category, message))
 
 

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -56,15 +56,15 @@ def warp_showwarning(message, category, filename, lineno, file=None, line=None):
     sys.stdout.write(s)
 
 
-# Save the original showwarning handler so non-warp warnings are unaffected.
+# Save the original showwarning handler so non-Warp warnings are unaffected.
 _original_showwarning = warnings.showwarning
 
-# Thread-safe flag to indicate we're inside warp's warn().
+# Thread-safe flag to indicate we're inside Warp's warn().
 _warp_warn_active = threading.local()
 
 
 def _warp_showwarning_dispatch(message, category, filename, lineno, file=None, line=None):
-    """Route to warp_showwarning for warp-originated warnings, else fall through to original."""
+    """Route to ``warp_showwarning`` for Warp-originated warnings, else fall through to original."""
     if getattr(_warp_warn_active, "inside", False):
         warp_showwarning(message, category, filename, lineno, file, line)
     elif _original_showwarning is not None:
@@ -77,34 +77,38 @@ warnings.showwarning = _warp_showwarning_dispatch
 
 
 def warn(message, category=None, stacklevel=1, once=False):
-    if (category, message) in warnings_seen:
-        return
-
     if category is None:
         category = UserWarning
 
-    # Capture whether the warning was actually shown (not filtered out)
-    original_showwarning = warnings.showwarning
-    shown = [False]
+    if (category, message) in warnings_seen:
+        return
 
-    def _tracking_showwarning(m, cat, fn, ln, file=None, line=None):
-        shown[0] = True
-        warp_showwarning(m, cat, fn, ln, file, line)
+    shown = False
 
-    _warp_warn_active.inside = True
-    warnings.showwarning = _tracking_showwarning
-    try:
+    with warnings.catch_warnings(record=True) as caught:
         warnings.warn(
             message,
             category,
             stacklevel=stacklevel + 1,
         )
+
+    _warp_warn_active.inside = True
+    try:
+        for warning in caught:
+            shown = True
+            warp_showwarning(
+                warning.message,
+                warning.category,
+                warning.filename,
+                warning.lineno,
+                warning.file,
+                warning.line,
+            )
     finally:
-        warnings.showwarning = original_showwarning
         _warp_warn_active.inside = False
 
     # Only mark as "seen" if the warning was actually shown (not filtered out)
-    if shown[0] and (category is DeprecationWarning or once):
+    if shown and (category is DeprecationWarning or once):
         warnings_seen.add((category, message))
 
 

--- a/warp/tests/test_utils.py
+++ b/warp/tests/test_utils.py
@@ -395,6 +395,9 @@ class TestUtils(unittest.TestCase):
     def test_warn_respects_user_filters(self):
         # Verify that user-configured warning filters are not overridden by warp.warn().
         saved_filters = warnings.filters[:] if hasattr(warnings, 'filters') else []
+        saved_showwarning = warnings.showwarning
+        saved_seen = wp._src.utils.warnings_seen.copy()
+        wp._src.utils.warnings_seen.clear()
         try:
             # Suppress all DeprecationWarnings via the standard Python API.
             warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -410,10 +413,21 @@ class TestUtils(unittest.TestCase):
 
             self.assertEqual(f.getvalue(), "Warp UserWarning: should appear\n")
 
+            # Verify that warnings_seen did NOT record the suppressed warning.
+            # This ensures removing the filter later would re-enable the warning.
+            self.assertNotIn(
+                (DeprecationWarning, "should be suppressed"),
+                wp._src.utils.warnings_seen,
+                "Suppressed warnings should not be marked as seen",
+            )
+
         finally:
-            # Restore original filters.
+            # Restore original filters, showwarning handler, and seen set.
             if hasattr(warnings, 'filters'):
                 warnings.filters[:] = saved_filters
+            warnings.showwarning = saved_showwarning
+            wp._src.utils.warnings_seen.clear()
+            wp._src.utils.warnings_seen.update(saved_seen)
 
     def test_transform_expand(self):
         t = (1.0, 2.0, 3.0, 4.0, 3.0, 2.0, 1.0)

--- a/warp/tests/test_utils.py
+++ b/warp/tests/test_utils.py
@@ -5,6 +5,7 @@ import contextlib
 import inspect
 import io
 import unittest
+import warnings
 
 from warp.tests.unittest_utils import *
 
@@ -390,6 +391,29 @@ class TestUtils(unittest.TestCase):
         expected = "Warp DeprecationWarning: foo\nWarp DeprecationWarning: bar\n"
 
         self.assertEqual(f.getvalue(), expected)
+
+    def test_warn_respects_user_filters(self):
+        # Verify that user-configured warning filters are not overridden by warp.warn().
+        saved_filters = warnings.filters[:] if hasattr(warnings, 'filters') else []
+        try:
+            # Suppress all DeprecationWarnings via the standard Python API.
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+            with contextlib.redirect_stdout(io.StringIO()) as f:
+                wp._src.utils.warn("should be suppressed", category=DeprecationWarning)
+
+            self.assertEqual(f.getvalue(), "", "User-suppressed DeprecationWarning should produce no output")
+
+            # Verify non-suppressed warnings still appear.
+            with contextlib.redirect_stdout(io.StringIO()) as f:
+                wp._src.utils.warn("should appear", category=UserWarning)
+
+            self.assertEqual(f.getvalue(), "Warp UserWarning: should appear\n")
+
+        finally:
+            # Restore original filters.
+            if hasattr(warnings, 'filters'):
+                warnings.filters[:] = saved_filters
 
     def test_transform_expand(self):
         t = (1.0, 2.0, 3.0, 4.0, 3.0, 2.0, 1.0)

--- a/warp/tests/test_utils.py
+++ b/warp/tests/test_utils.py
@@ -394,24 +394,27 @@ class TestUtils(unittest.TestCase):
 
     def test_warn_respects_user_filters(self):
         # Verify that user-configured warning filters are not overridden by warp.warn().
-        saved_filters = warnings.filters[:] if hasattr(warnings, 'filters') else []
         saved_showwarning = warnings.showwarning
         saved_seen = wp._src.utils.warnings_seen.copy()
         wp._src.utils.warnings_seen.clear()
         try:
             # Suppress all DeprecationWarnings via the standard Python API.
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=DeprecationWarning)
 
-            with contextlib.redirect_stdout(io.StringIO()) as f:
-                wp._src.utils.warn("should be suppressed", category=DeprecationWarning)
+                with contextlib.redirect_stdout(io.StringIO()) as f:
+                    wp._src.utils.warn("should be suppressed", category=DeprecationWarning)
 
-            self.assertEqual(f.getvalue(), "", "User-suppressed DeprecationWarning should produce no output")
+                self.assertEqual(f.getvalue(), "", "User-suppressed DeprecationWarning should produce no output")
 
             # Verify non-suppressed warnings still appear.
-            with contextlib.redirect_stdout(io.StringIO()) as f:
-                wp._src.utils.warn("should appear", category=UserWarning)
+            with warnings.catch_warnings():
+                warnings.simplefilter("default")
 
-            self.assertEqual(f.getvalue(), "Warp UserWarning: should appear\n")
+                with contextlib.redirect_stdout(io.StringIO()) as f:
+                    wp._src.utils.warn("should appear", category=UserWarning)
+
+                self.assertEqual(f.getvalue(), "Warp UserWarning: should appear\n")
 
             # Verify that warnings_seen did NOT record the suppressed warning.
             # This ensures removing the filter later would re-enable the warning.
@@ -422,9 +425,7 @@ class TestUtils(unittest.TestCase):
             )
 
         finally:
-            # Restore original filters, showwarning handler, and seen set.
-            if hasattr(warnings, 'filters'):
-                warnings.filters[:] = saved_filters
+            # Restore original showwarning handler and seen set.
             warnings.showwarning = saved_showwarning
             wp._src.utils.warnings_seen.clear()
             wp._src.utils.warnings_seen.update(saved_seen)


### PR DESCRIPTION
## Problem

warp.utils.warn() wraps warnings.warn() in a catch_warnings() context that calls simplefilter('default'), silently overriding any user-configured warning filters.

This means the standard Python mechanism for suppressing warnings has no effect on Warp warnings:

```python
import warnings
warnings.filterwarnings('ignore', category=DeprecationWarning)
# This still prints because simplefilter('default') resets filters
wp.utils.warn('deprecation msg', category=DeprecationWarning)
```

## Impact

In distributed training (torchrun, srun), every rank emits identical deprecation warnings. A 256-GPU job produces 256 copies of each warning that users cannot suppress.

## Fix

- Remove catch_warnings() / simplefilter('default') wrapper
- Register warp_showwarning once at module import time instead of inside each warn() call
- Warp-branded output format is preserved
- User warning filters are now respected

Closes #1315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Warning behavior updated so user-configured warning filters are respected; unspecified categories now default to UserWarning, duplicate warnings are de-duplicated, and only warnings actually shown are recorded.

* **Tests**
  * Added tests verifying suppressed warnings produce no output, active warnings are shown, and warning state is preserved and restored between runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1372)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->