### PR TITLE
Support launch_dims in jax_kernel with enable_backward=True (GH-1380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@
   array writes (e.g. matrix component assignments) may be slower due to the additional zeroing. See
   the [differentiability guide](https://nvidia.github.io/warp/user_guide/differentiability.html)
   for details ([GH-1062](https://github.com/NVIDIA/warp/issues/1062)).
+- Allow `launch_dims` to be specified when `enable_backward=True` in `jax_kernel()` ([GH-1380](https://github.com/NVIDIA/warp/issues/1380)).
 
 ### Fixed
 

--- a/docs/user_guide/interoperability_jax.rst
+++ b/docs/user_guide/interoperability_jax.rst
@@ -540,7 +540,59 @@ The autodiff functionality is considered experimental and is still a work in pro
 - Scalar inputs must be static arguments in JAX.
 - Gradients are returned for differentiable array inputs (static scalars are excluded from the gradient tuple).
 - Input-output arguments (``in_out_argnames``) are not supported when ``enable_backward=True``, because in-place modifications are not differentiable.
-- Custom launch and output dimensions (``launch_dims``, ``output_dims``) are not currently supported when ``enable_backward=True``, but the goal is to support them in the future. Launch dimensions are inferred from the shape of the first array argument, thus at least one input array is required.
+- ``output_dims`` is not currently supported when ``enable_backward=True`` (this requires separate output-buffer allocation logic; it is planned as a follow-up).
+- ``launch_dims`` **is** supported when ``enable_backward=True``. The captured value is used by both the forward and the adjoint launches. This is required for correct gradient values when the input array has more dimensions than the kernel's ``wp.tid()`` iteration space (for example, an LBM distribution ``(Q, nx, ny, nz)`` with a 3-D spatial ``tid`` or a batched volume ``(B, x, y, z)``). If ``launch_dims`` is omitted, the dimensions are inferred from the shape of the first array argument as before.
+
+Computing gradients with custom launch dimensions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When an input array has more dimensions than the kernel's ``wp.tid()``
+iteration space, ``launch_dims`` can be specified together with
+``enable_backward=True``. The same ``launch_dims`` is used for both the
+forward launch and the adjoint launch, so gradients computed via
+``jax.grad`` are scaled correctly.
+
+.. code-block:: python
+
+    import jax
+    import jax.numpy as jnp
+    import warp as wp
+    from warp.jax_experimental import jax_kernel
+
+    wp.init()
+
+
+    @wp.kernel
+    def scale(
+        a: wp.array4d(dtype=wp.float32),
+        b: wp.array4d(dtype=wp.float32),
+    ):
+        # tid is 3-D; the outer axis is iterated inside the kernel.
+        i, j, k = wp.tid()
+        for m in range(a.shape[0]):
+            b[m, i, j, k] = a[m, i, j, k] * 2.0
+
+
+    jax_func = jax_kernel(
+        scale,
+        num_outputs=1,
+        launch_dims=(16, 16, 16),   # spatial dimensions only
+        enable_backward=True,
+    )
+
+    a = jnp.ones((8, 16, 16, 16), dtype=jnp.float32)
+    grad = jax.grad(lambda x: jnp.sum(jax_func(x)[0]))(a)
+    # grad is 2.0 everywhere (analytical gradient)
+
+If ``launch_dims`` is omitted, Warp infers it from the shape of the first
+input array. For scalar-dtype arrays with ``array.ndim > kernel.tid_ndim``
+the inferred shape includes the outer axis. For kernels whose per-location
+write is idempotent (for example, ``b[i] = f(a[i])``), the forward kernel
+still produces the correct value; kernels using non-idempotent patterns
+(e.g. atomic accumulation into the output) may also see wrong forward
+values. In either case, the adjoint kernel over-accumulates gradients by
+a factor of the outer axis size via ``atomic_add``. Passing
+``launch_dims`` explicitly is the recommended way to avoid this.
 
 .. _jax-callable:
 

--- a/warp/_src/jax_experimental/ffi.py
+++ b/warp/_src/jax_experimental/ffi.py
@@ -1226,11 +1226,11 @@ def jax_kernel(
             "jax_kernel(): Input-output arguments (in_out_argnames) are not supported when enable_backward=True."
         )
 
-    # TODO: we should support passing these to the forward and backward callables
-    if launch_dims is not None or output_dims is not None:
-        raise NotImplementedError(
-            "jax_kernel(): Custom dimensions (launch_dims, output_dims) are not supported when enable_backward=True."
-        )
+    # TODO: support output_dims with enable_backward=True (requires separate
+    # output-buffer allocation logic). launch_dims is supported below: the
+    # captured value is applied to both the forward and the adjoint launches.
+    if output_dims is not None:
+        raise NotImplementedError("jax_kernel(): output_dims is not yet supported when enable_backward=True.")
 
     # Differentiable path: build a custom VJP wrapper inline.
     # Infer the original kernel signature (names and annotations)
@@ -1250,8 +1250,17 @@ def jax_kernel(
             else:
                 raise TypeError(f"Invalid type for argument '{p.name}', expected array or scalar, got {type}")
 
+    # Capture an explicit user-supplied launch_dims so the same value is used
+    # for both the forward launch and the adjoint launch (required for
+    # correct gradient values when array.ndim > kernel.tid_ndim).
+    # Reuse `hashable_launch_dims` (computed above for the cache key path)
+    # so 1-D integer and sequence forms are normalized identically.
+    _user_launch_dims = hashable_launch_dims if launch_dims is not None else None
+
     def _resolve_launch_dims(call_args):
-        # determine launch dimensions from the shape of the first input array
+        if _user_launch_dims is not None:
+            return _user_launch_dims
+        # Fallback: determine launch dimensions from the shape of the first input array
         for i, p in enumerate(parameters[:num_inputs]):
             param_type = p.annotation
             if matches_array_class(param_type, wp.array):
@@ -1306,8 +1315,12 @@ def jax_kernel(
                     warn(f"Failed to zero gradient array: {e}", stacklevel=2)
                     raise e
 
-        # NOTE: We cannot use a passed launch_dims here, the backward rule doesn't receive it (and it could be wrong under pmap/vmap).
-        # We need to infer from the inputs.
+        # The same _resolve_launch_dims() is used here so that the adjoint
+        # kernel launches with exactly the same iteration space as the forward
+        # kernel (captured from the enclosing scope via _user_launch_dims when
+        # the caller supplied an explicit value, otherwise inferred from the
+        # inputs). This matches the forward path and avoids N x
+        # over-accumulation in atomic_add when array.ndim > kernel.tid_ndim.
         wp.launch(
             kernel,
             dim=_resolve_launch_dims(inputs),
@@ -1441,6 +1454,11 @@ def jax_kernel(
         vmap_method,
         module_preload_mode,
         has_side_effect,
+        # Include the normalized launch_dims so that wrapping the same kernel
+        # with different launch_dims produces independent cache entries.
+        # Reusing _user_launch_dims ensures int and 1-tuple forms of the same
+        # value map to the same key.
+        _user_launch_dims,
     )
 
     if static_args:

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -1474,6 +1474,240 @@ def test_ffi_jax_kernel_autodiff_pmap_multi_output(test, device):
     assert_np_equal(np.asarray(db), ref_db)
 
 
+# --- launch_dims + enable_backward=True tests (GH-1380) --------------------
+
+
+@wp.kernel
+def scale_extra_axis_kernel(
+    a: wp.array4d(dtype=wp.float32),
+    b: wp.array4d(dtype=wp.float32),
+):
+    """3-D tid but 4-D array; outer axis iterated inside the kernel body."""
+    i, j, k = wp.tid()
+    for m in range(a.shape[0]):
+        b[m, i, j, k] = a[m, i, j, k] * 2.0
+
+
+@wp.kernel
+def scale_outer_2d_kernel(
+    a: wp.array3d(dtype=wp.float32),
+    b: wp.array3d(dtype=wp.float32),
+):
+    """2-D tid with an outer axis iterated inside; used for the vmap test."""
+    i, j = wp.tid()
+    for m in range(a.shape[0]):
+        b[m, i, j] = a[m, i, j] * 2.0
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
+def test_ffi_jax_kernel_launch_dims_autodiff_basic(test, device):
+    """launch_dims is accepted with enable_backward=True (GH-1380)."""
+    import jax
+    import jax.numpy as jnp
+
+    from warp.jax_experimental.ffi import jax_kernel
+
+    N = 8
+    with jax.default_device(wp.device_to_jax(device)):
+        jax_func = jax_kernel(
+            scale_extra_axis_kernel,
+            num_outputs=1,
+            launch_dims=(N, N, N),
+            enable_backward=True,
+        )
+
+        a = jnp.ones((4, N, N, N), dtype=jnp.float32)
+        out = jax_func(a)
+        if isinstance(out, (list, tuple)):
+            out = out[0]
+
+        expected = 2.0 * np.ones((4, N, N, N), dtype=np.float32)
+        assert_np_equal(np.asarray(out), expected)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
+def test_ffi_jax_kernel_launch_dims_autodiff_gradient(test, device):
+    """Gradient matches the analytical value when launch_dims is explicit (GH-1380).
+
+    Without this fix, auto-inference returns the full 4-D shape and the
+    adjoint kernel over-accumulates by a factor equal to the outer axis
+    size via atomic_add. Explicit launch_dims, shared between forward and
+    adjoint via the enclosing closure, prevents this.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    from warp.jax_experimental.ffi import jax_kernel
+
+    BATCH, N = 4, 8
+    with jax.default_device(wp.device_to_jax(device)):
+        jax_func = jax_kernel(
+            scale_extra_axis_kernel,
+            num_outputs=1,
+            launch_dims=(N, N, N),
+            enable_backward=True,
+        )
+
+        a = jnp.ones((BATCH, N, N, N), dtype=jnp.float32)
+
+        def loss(x):
+            """Sum of the kernel's output; analytical gradient is 2.0 everywhere."""
+            y = jax_func(x)
+            if isinstance(y, (list, tuple)):
+                y = y[0]
+            return jnp.sum(y)
+
+        grad = jax.grad(loss)(a)
+
+        expected = 2.0 * np.ones((BATCH, N, N, N), dtype=np.float32)
+        assert_np_equal(np.asarray(grad), expected)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
+def test_ffi_jax_kernel_launch_dims_autodiff_separate_cache(test, device):
+    """Wrapping the same kernel with different launch_dims must not share
+    wrappers (GH-1380).
+
+    Regression guard for the _FFI_DIFF_KERNEL_REGISTRY cache key: without
+    launch_dims in the key, the second wrapper silently reuses the first
+    wrapper's closure, so the launch_dims passed to the second call is
+    ignored at runtime.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    from warp.jax_experimental.ffi import jax_kernel
+
+    with jax.default_device(wp.device_to_jax(device)):
+        ffi_small = jax_kernel(
+            scale_extra_axis_kernel,
+            num_outputs=1,
+            launch_dims=(4, 4, 4),
+            enable_backward=True,
+        )
+        ffi_large = jax_kernel(
+            scale_extra_axis_kernel,
+            num_outputs=1,
+            launch_dims=(8, 8, 8),
+            enable_backward=True,
+        )
+
+        a_small = jnp.ones((2, 4, 4, 4), dtype=jnp.float32)
+        a_large = jnp.ones((2, 8, 8, 8), dtype=jnp.float32)
+
+        out_small = ffi_small(a_small)
+        out_large = ffi_large(a_large)
+        if isinstance(out_small, (list, tuple)):
+            out_small = out_small[0]
+        if isinstance(out_large, (list, tuple)):
+            out_large = out_large[0]
+
+        test.assertEqual(out_small.shape, (2, 4, 4, 4))
+        test.assertEqual(out_large.shape, (2, 8, 8, 8))
+        assert_np_equal(
+            np.asarray(out_small),
+            2.0 * np.ones((2, 4, 4, 4), dtype=np.float32),
+        )
+        assert_np_equal(
+            np.asarray(out_large),
+            2.0 * np.ones((2, 8, 8, 8), dtype=np.float32),
+        )
+
+        # Also exercise the adjoint path: if the cache key were missing
+        # launch_dims, the second wrapper would silently reuse the first
+        # wrapper's closure and the gradient would be computed with the
+        # wrong launch dimensions (atomic_add over-accumulation).
+        def loss_small(x):
+            """Sum; analytical gradient is 2.0 everywhere."""
+            y = ffi_small(x)
+            if isinstance(y, (list, tuple)):
+                y = y[0]
+            return jnp.sum(y)
+
+        grad_small = jax.grad(loss_small)(a_small)
+        assert_np_equal(
+            np.asarray(grad_small),
+            2.0 * np.ones((2, 4, 4, 4), dtype=np.float32),
+        )
+
+        def loss_large(x):
+            """Sum; analytical gradient is 2.0 everywhere."""
+            y = ffi_large(x)
+            if isinstance(y, (list, tuple)):
+                y = y[0]
+            return jnp.sum(y)
+
+        grad_large = jax.grad(loss_large)(a_large)
+        assert_np_equal(
+            np.asarray(grad_large),
+            2.0 * np.ones((2, 8, 8, 8), dtype=np.float32),
+        )
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
+def test_ffi_jax_kernel_output_dims_autodiff_still_blocked(test, device):
+    """output_dims with enable_backward=True remains a follow-up (still blocked)."""
+    from warp.jax_experimental.ffi import jax_kernel
+
+    @wp.kernel
+    def noop(a: wp.array1d(dtype=wp.float32), b: wp.array1d(dtype=wp.float32)):
+        """Identity copy; used only to trigger the output_dims guard path."""
+        i = wp.tid()
+        b[i] = a[i]
+
+    with test.assertRaises(NotImplementedError):
+        jax_kernel(
+            noop,
+            num_outputs=1,
+            output_dims={"b": (8,)},
+            enable_backward=True,
+        )
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
+def test_ffi_jax_kernel_launch_dims_autodiff_vmap(test, device):
+    """launch_dims + enable_backward=True composes with jax.vmap (GH-1380).
+
+    The user-supplied launch_dims fixes the inner (kernel tid) iteration
+    space, and jax.vmap prefixes an additional outer axis which the FFI
+    layer handles via collapse_batch_dims/compute_batch_size. The two
+    operate on disjoint axes, so forward values and gradients remain
+    correct under vmap.
+    """
+    import jax
+    import jax.numpy as jnp
+
+    from warp.jax_experimental.ffi import jax_kernel
+
+    OUTER, INNER, N = 3, 4, 8
+    with jax.default_device(wp.device_to_jax(device)):
+        jax_func = jax_kernel(
+            scale_outer_2d_kernel,
+            num_outputs=1,
+            launch_dims=(N, N),
+            enable_backward=True,
+        )
+        batched = jax.vmap(jax_func)
+
+        a = jnp.ones((OUTER, INNER, N, N), dtype=jnp.float32)
+        out = batched(a)
+        if isinstance(out, (list, tuple)):
+            out = out[0]
+
+        expected = 2.0 * np.ones((OUTER, INNER, N, N), dtype=np.float32)
+        assert_np_equal(np.asarray(out), expected)
+
+        def loss(x):
+            """Sum over all axes; analytical gradient is 2.0 everywhere."""
+            y = batched(x)
+            if isinstance(y, (list, tuple)):
+                y = y[0]
+            return jnp.sum(y)
+
+        grad = jax.grad(loss)(a)
+        assert_np_equal(np.asarray(grad), expected)
+
+
 @unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
 def test_ffi_vmap_add(test, device, vmap_method):
     """Test basic batching over different input and output axes."""
@@ -2058,6 +2292,38 @@ try:
             "test_ffi_jax_kernel_autodiff_pmap_multi_output",
             test_ffi_jax_kernel_autodiff_pmap_multi_output,
             devices=None,
+        )
+
+        # launch_dims + enable_backward=True tests (GH-1380)
+        add_function_test(
+            TestJax,
+            "test_ffi_jax_kernel_launch_dims_autodiff_basic",
+            test_ffi_jax_kernel_launch_dims_autodiff_basic,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_ffi_jax_kernel_launch_dims_autodiff_gradient",
+            test_ffi_jax_kernel_launch_dims_autodiff_gradient,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_ffi_jax_kernel_launch_dims_autodiff_separate_cache",
+            test_ffi_jax_kernel_launch_dims_autodiff_separate_cache,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_ffi_jax_kernel_output_dims_autodiff_still_blocked",
+            test_ffi_jax_kernel_output_dims_autodiff_still_blocked,
+            devices=jax_compatible_cuda_devices,
+        )
+        add_function_test(
+            TestJax,
+            "test_ffi_jax_kernel_launch_dims_autodiff_vmap",
+            test_ffi_jax_kernel_launch_dims_autodiff_vmap,
+            devices=jax_compatible_cuda_devices,
         )
 
         # vmap tests


### PR DESCRIPTION
## Description

Fixes #1380. Allows `launch_dims` to be passed to `jax_kernel()` when `enable_backward=True`, so that the adjoint kernel launches with the same iteration space as the forward kernel.

### Why this matters (correctness, not just performance)

When a scalar-dtype input has more dimensions than the kernel's `wp.tid()` iteration space — e.g. LBM distributions `(Q, nx, ny, nz)` with a 3-D spatial `tid`, or batched volumes `(B, x, y, z)` with 3-D `tid` — `_resolve_launch_dims` falls back to the full input array shape. The forward kernel uses assignment (`=`), which is idempotent, so extra-axis duplicate threads just waste GPU cycles and the output remains correct. The adjoint kernel, however, uses `wp.atomic_add` (required by the chain rule), so the same duplicate threads each accumulate the gradient, producing values that are `N×` the analytical gradient, where `N` is the product of the excess axes.

With `BATCH=16`, `jax.grad` silently returns `2.0 * 16 = 32.0` instead of `2.0`. Nothing raises; the forward result looks correct; the bug only surfaces at optimiser-convergence time, and is typically misattributed to learning-rate issues.

The obvious workaround — passing `launch_dims=(nx, ny, nz)` explicitly — was blocked by `NotImplementedError` (a pre-existing TODO at the top of the `enable_backward=True` branch).

### Why the minimal fix needs three pieces

1. **Relax the guard** (`ffi.py` ~line 1282): accept `launch_dims` while keeping `output_dims` blocked (output_dims still requires separate buffer-allocation logic, left as a follow-up).

2. **Capture `launch_dims` in a closure** (`ffi.py` ~line 1309): `_resolve_launch_dims` is called from both the forward and the adjoint wrapper. Capturing the user-supplied value in an enclosing variable makes both launches share the same dims automatically (addresses the original `# NOTE: We cannot use a passed launch_dims here, the backward rule doesn't receive it` comment).

3. **Include `launch_dims` in `_FFI_DIFF_KERNEL_REGISTRY`** (`ffi.py` ~line 1453): this registry caches the `jax.custom_vjp`-wrapped result per kernel. Without `launch_dims` in the cache key, wrapping the same Warp kernel with a different `launch_dims` returns the first wrapper silently — with its closure-captured value, not the new one — which defeats step 2 in realistic usage. Verified with instance-id tracing.

Auto-inference behaviour (when `launch_dims` is omitted) is deliberately unchanged in this PR, to avoid silently altering behaviour for users who may rely on the current full-shape launch. Safer auto-inference is a follow-up discussion; `output_dims` support is another.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `pytest warp/tests/interop/test_jax.py -v -k launch_dims_autodiff`
- `uvx pre-commit run --all-files`

Tests added:
- `launch_dims` accepted with `enable_backward=True` (previously raised `NotImplementedError`).
- Gradient equals the analytical value for a 4-D scalar-dtype array with 3-D tid.
- Two wrappers of the same kernel with different `launch_dims` tuples do not share wrappers (cache key regression guard).
- `output_dims` with `enable_backward=True` still rejected (intentional).

## Bug fix

```python
import jax, jax.numpy as jnp
import warp as wp
from warp.jax_experimental.ffi import jax_kernel

wp.init()
BATCH, N = 8, 16


@wp.kernel
def scale(
    a: wp.array4d(dtype=wp.float32),
    b: wp.array4d(dtype=wp.float32),
):
    # tid is 3-D; the outer axis is iterated inside the kernel.
    i, j, k = wp.tid()
    for m in range(a.shape[0]):
        b[m, i, j, k] = a[m, i, j, k] * 2.0


# Before this PR: NotImplementedError.
# After this PR: accepted; same launch_dims shared by forward and adjoint.
jax_func = jax_kernel(
    scale, num_outputs=1,
    launch_dims=(N, N, N),
    enable_backward=True,
)

ones = jnp.ones((BATCH, N, N, N), dtype=jnp.float32)
grad = jax.grad(lambda x: jnp.sum(jax_func(x)[0]))(ones)
# grad.mean() == 2.0          (was silently 2.0 * BATCH without this PR)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JAX kernel calls with autodiff now accept custom launch dimensions for forward and backward passes; kernels use the same iteration space and caching is separated per launch-dimension.

* **Documentation**
  * Clarified that output-dimension mode is still unsupported in backward mode, explained gradient scaling with extra outer dimensions, and added a how-to example.

* **Tests**
  * Added interop tests validating forward results, gradients, cache separation, output-dims restriction, and vmap composition.

* **Changelog**
  * Added unreleased entry describing these updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->