### PR TITLE
Add dynamic CUDA linking support to build system

### DIFF
--- a/build_lib.py
+++ b/build_lib.py
@@ -321,6 +321,12 @@ def main(argv: list[str] | None = None) -> int:
         default=False,
         help="Fast build mode: compile for minimal GPU architectures (PTX-only for sm_75), disable CUDA forward compatibility",
     )
+    group_build.add_argument(
+        "--use-dynamic-cuda",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Link against shared CUDA libraries instead of embedding them statically; the corresponding shared libraries must be present at runtime",
+    )
 
     # Clang/LLVM options
     group_clang_llvm = parser.add_argument_group(

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -166,7 +166,19 @@ Upon success, the script will output platform-specific binary files in ``warp/bi
 The build script will look for the CUDA Toolkit in its default installation path.
 This path can be overridden by setting the ``CUDA_PATH`` environment variable. Alternatively,
 the path to the CUDA Toolkit can be passed to the build command as
-``--cuda-path="..."``. After building, the Warp package should be installed using:
+``--cuda-path="..."``.
+
+By default, CUDA libraries (cudart, NVRTC, nvJitLink, MathDx) are linked statically
+to produce self-contained binaries. To link against shared CUDA libraries instead,
+pass ``--use-dynamic-cuda``:
+
+.. code-block:: console
+
+    $ python build_lib.py --use-dynamic-cuda
+
+The corresponding shared libraries must be available at runtime when using this option.
+
+After building, the Warp package should be installed using:
 
 .. code-block:: console
 

--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -664,12 +664,22 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str
 
                     linkopts.append(quote(cu_out))
 
-                linkopts.append(
-                    f'cudart_static.lib nvrtc_static.lib nvrtc-builtins_static.lib nvptxcompiler_static.lib ws2_32.lib user32.lib /LIBPATH:"{cuda_home}/lib/x64"'
-                )
+                if args.use_dynamic_cuda:
+                    linkopts.append(
+                        f'cudart.lib nvrtc.lib nvptxcompiler_static.lib ws2_32.lib user32.lib /LIBPATH:"{cuda_home}/lib/x64"'
+                    )
+                else:
+                    linkopts.append(
+                        f'cudart_static.lib nvrtc_static.lib nvrtc-builtins_static.lib nvptxcompiler_static.lib ws2_32.lib user32.lib /LIBPATH:"{cuda_home}/lib/x64"'
+                    )
 
                 if args.libmathdx_path:
-                    linkopts.append(f'nvJitLink_static.lib /LIBPATH:"{args.libmathdx_path}/lib/x64" mathdx_static.lib')
+                    if args.use_dynamic_cuda:
+                        linkopts.append(f'nvJitLink.lib /LIBPATH:"{args.libmathdx_path}/lib/x64" mathdx.lib')
+                    else:
+                        linkopts.append(
+                            f'nvJitLink_static.lib /LIBPATH:"{args.libmathdx_path}/lib/x64" mathdx_static.lib'
+                        )
 
             if args.jobs <= 1:
                 with ScopedTimer("build_cuda", active=args.verbose):
@@ -779,12 +789,20 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str
 
                     ld_inputs.append(quote(cu_out))
 
-                ld_inputs.append(
-                    f'-L"{cuda_home}/lib64" -lcudart_static -lnvrtc_static -lnvrtc-builtins_static -lnvptxcompiler_static -lpthread -ldl -lrt'
-                )
+                if args.use_dynamic_cuda:
+                    ld_inputs.append(
+                        f'-L"{cuda_home}/lib64" -L"{cuda_home}/lib" -lcudart -lnvrtc -lnvptxcompiler_static -lpthread -ldl -lrt'
+                    )
+                else:
+                    ld_inputs.append(
+                        f'-L"{cuda_home}/lib64" -lcudart_static -lnvrtc_static -lnvrtc-builtins_static -lnvptxcompiler_static -lpthread -ldl -lrt'
+                    )
 
                 if args.libmathdx_path:
-                    ld_inputs.append(f"-lnvJitLink_static -L{args.libmathdx_path}/lib -lmathdx_static")
+                    if args.use_dynamic_cuda:
+                        ld_inputs.append(f"-lnvJitLink -L{args.libmathdx_path}/lib -lmathdx")
+                    else:
+                        ld_inputs.append(f"-lnvJitLink_static -L{args.libmathdx_path}/lib -lmathdx_static")
 
             if args.jobs <= 1:
                 with ScopedTimer("build_cuda", active=args.verbose):


### PR DESCRIPTION
## Description

Related to #1334, this PR adds an option that modifies the linker invocations so that builds can link against shared CUDA libraries instead of the statically embedded ones. Default behavior is unchanged.
 
This upstreams the patch currently carried by the conda-forge [warp-lang-feedstock](https://github.com/conda-forge/warp-lang-feedstock), allowing it to build Warp without out-of-tree patches.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Test plan

<!-- How did you verify these changes? Example commands, test names,
     or manual steps. -->

## New feature / enhancement

<!-- If this is a new feature or enhancement, provide a code example showing
     what this PR enables. Delete this section if not applicable. -->

```python
import warp as wp
# Code that demonstrates the new capability
```

FYI @traversaro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new build flag --use-dynamic-cuda to allow linking CUDA libraries dynamically at build time, providing runtime library flexibility.

* **Documentation**
  * Updated installation/build guide to document the new flag, show usage examples, and note that required CUDA shared libraries must be present at runtime when dynamic linking is chosen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->