### PR TITLE
Hard-error on wp.launch() dim-rank mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,13 +109,14 @@
   ([GH-1297](https://github.com/NVIDIA/warp/issues/1297)).
 - Template `launch_bounds_t` on dimensionality (`launch_bounds_t<N>`) so that `launch_coord()` and `wp.tid()`
   use `if constexpr` instead of runtime dimension checks, eliminating dead branches and reducing register
-  pressure for lower-dimensional launches
-  ([GH-1270](https://github.com/NVIDIA/warp/issues/1270)).
-  **Breaking:** Kernels that use fewer ``wp.tid()`` return values than launch dimensions now flatten
-  excess dimensions instead of unraveling them. For example, a kernel using ``i = wp.tid()`` launched
-  with ``dim=(3, 3)`` now yields thread IDs ``0, 1, …, 8`` instead of the previous ``0, 0, 0, 1, 1, 1,
-  2, 2, 2``. To preserve the old behavior, unpack all dimensions and discard the ones you don't need
-  (e.g. ``i, _ = wp.tid()`` to recover the previous first-dimension indexing).
+  pressure for lower-dimensional launches.
+  **Breaking:** `wp.launch()`, `Launch.set_dim()`, `wp.launch_tiled()`, and the experimental JAX FFI paths
+  now raise `ValueError` when the rank of `dim` does not match the kernel's `wp.tid()` unpack arity
+  (e.g. `i = wp.tid()` launched with `dim=(3, 3)`); the error message lists concrete migration options.
+  To recover the previous first-dimension indexing, unpack all dimensions and discard extras
+  (e.g. `i, _ = wp.tid()`). Kernels that do not call `wp.tid()` still accept any `dim`, flattened to
+  total thread count. `launch_tiled`'s rank-mismatch error changed from `RuntimeError` to `ValueError`
+  for consistency ([GH-1270](https://github.com/NVIDIA/warp/issues/1270)).
 - Allow `wp.Volume.load_from_numpy()` and `wp.Volume.allocate()` to accept a 3-element sequence for `voxel_size`,
   enabling anisotropic voxel spacing ([GH-1193](https://github.com/NVIDIA/warp/issues/1193)).
 - Include the Warp version in kernel cache paths when a custom cache path is set,

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -17,6 +17,7 @@ import inspect
 import io
 import itertools
 import json
+import math
 import operator
 import os
 import platform
@@ -7884,6 +7885,7 @@ class Launch:
         max_blocks: int = 0,
         block_dim: int = 256,
         adjoint: bool = False,
+        tiled: bool = False,
     ):
         # retain the module executable so it doesn't get unloaded
         self.module_exec = kernel.module.load(device, block_dim)
@@ -7951,14 +7953,28 @@ class Launch:
         self.adjoint: bool = adjoint
         """Whether to run the adjoint kernel instead of the forward kernel."""
 
+        self.tiled: bool = tiled
+        """True if this launch was created via :func:`wp.launch_tiled`. Used by
+        :meth:`set_dim` to route replays through the tiled dim-validation path.
+        Not the same as ``bounds.tiled``; see ``_construct_tiled_bounds`` for
+        when each is set.
+        """
+
     def set_dim(self, dim: int | list[int] | tuple[int, ...]):
         """Set the launch dimensions.
+
+        For recorded tiled launches (``self.tiled == True``), reconstructs
+        bounds via the same tiled path used at record time so the user-rank
+        semantics (block axis implicit or unpacked) are preserved.
 
         Args:
             dim: The dimensions of the launch.
         """
-        normalized = _normalize_launch_dim(dim, self.kernel.adj.kernel_dim)
-        self.bounds = launch_bounds_t(normalized)
+        if self.tiled:
+            self.bounds = _construct_tiled_bounds(dim, self.block_dim, self.kernel)
+        else:
+            normalized = _prepare_launch_dim(dim, self.kernel)
+            self.bounds = launch_bounds_t(normalized)
 
         # launch bounds always at index 0
         self.params[0] = self.bounds
@@ -8108,60 +8124,157 @@ def _canonicalize_dim(dim: int | Sequence[int]) -> tuple[int, ...]:
     return tuple(dim)
 
 
-def _normalize_launch_dim(dim: int | Sequence[int], kernel_dim: int) -> tuple[int, ...]:
-    """Reshape *dim* to exactly *kernel_dim* dimensions for ABI compatibility.
+_TID_NAMES = ("i", "j", "k", "l")  # canonical Warp tid-unpack variable names
 
-    The compiled C++ kernel expects ``launch_bounds_t<kernel_dim>``, so the
-    Python-side ctypes struct must have exactly *kernel_dim* shape elements.
-    Excess dimensions are folded into the last slot; missing dimensions are
-    padded with ones.
+
+def _tid_unpack(n: int) -> str:
+    """Render the canonical ``wp.tid()`` unpack syntax for an n-dimensional kernel.
+
+    Returns a string like ``"i, j = wp.tid()"``. Falls back to a generic
+    placeholder for ``n`` outside ``[1, len(_TID_NAMES)]`` — used when the user's
+    requested arity exceeds the standard tid naming (e.g. over-rank launches
+    with ``ndim == 5`` surfaced through :func:`_build_rank_error`).
+    """
+    if n <= 0 or n > len(_TID_NAMES):
+        return f"... = wp.tid()  # {n} variables"
+    if n == 1:
+        return "i = wp.tid()"
+    return f"{', '.join(_TID_NAMES[:n])} = wp.tid()"
+
+
+def _build_rank_error(
+    dim: tuple[int, ...],
+    kernel_dim: int,
+    kernel,
+    tiled: bool,
+) -> str:
+    """Compose the ValueError message for a launch-dim rank mismatch.
+
+    Lists concrete migration options with pre-computed values for the specific
+    call that triggered the error so users don't have to do a doc round-trip.
+    """
+    ndim = len(dim)
+    flat = math.prod(dim) if dim else 0
+    key = kernel.key
+
+    header = (
+        f"Launch dim {dim} has rank {ndim} but kernel '{key}' unpacks "
+        f"wp.tid() into {kernel_dim} variable{'s' if kernel_dim != 1 else ''} "
+        f"(kernel_dim={kernel_dim})."
+    )
+
+    if ndim > kernel_dim:
+        options = []
+        # Launch-side fixes only make sense when the kernel is already scalar.
+        # For kernel_dim >= 2, these would require a second (kernel-side) edit
+        # to actually succeed, so presenting them as single-step fixes would
+        # mislead the user.
+        if kernel_dim == 1:
+            options.append(f"  - flat linear index over {flat} threads: launch with dim={flat}")
+            options.append(f"  - first-dim index (0..{dim[0] - 1}, no repetition): launch with dim={dim[0]}")
+        # Kernel-side fixes are always applicable.
+        repeat_unpack = "i, " + ", ".join(["_"] * (ndim - 1)) + " = wp.tid()"
+        options.append(f"  - first-dim index with repetition: unpack as `{repeat_unpack}`")
+        options.append(f"  - per-dim indexing: unpack as `{_tid_unpack(ndim)}`")
+    else:
+        # ndim < kernel_dim: under-rank
+        padded = dim + (1,) * (kernel_dim - ndim)
+        options = [f"  - keep {kernel_dim}-D kernel, launch with matching rank: dim={padded}"]
+        # Tiled launches also accept len(dim) == kernel_dim - 1 (block_dim axis is implicit);
+        # offer that as a concrete alternative when it differs from the rank-matching option.
+        if tiled and kernel_dim >= 2:
+            padded_tiled = dim + (1,) * (kernel_dim - 1 - ndim)
+            options.append(
+                f"  - keep {kernel_dim}-D kernel with implicit block_dim axis, launch with dim={padded_tiled}"
+            )
+        # Kernel-side unpack hint only makes sense for non-empty dim; dim=() would
+        # render as `... = wp.tid()  # 0 variables`, which isn't actionable.
+        if ndim >= 1:
+            options.append(
+                f"  - change kernel to unpack {ndim} variable{'s' if ndim != 1 else ''}: `{_tid_unpack(ndim)}`"
+            )
+
+    tiled_note = (
+        "\n(For launch_tiled, dim may also match kernel_dim - 1; the block_dim axis is supplied implicitly.)"
+        if tiled
+        else ""
+    )
+
+    return "\n".join([header, "Pick the intended behavior:", *options]) + tiled_note
+
+
+def _prepare_launch_dim(
+    dim,  # int | Sequence[int]
+    kernel,
+    *,
+    tiled: bool = False,
+) -> tuple[int, ...]:
+    """Canonicalize ``dim`` and check its rank against the kernel's ``wp.tid()`` arity.
+
+    For kernels that do not call ``wp.tid()`` (``max_tid_dimensionality == 0``),
+    any ``dim`` is accepted and flattened to a 1-tuple total thread count, since
+    the kernel is dim-agnostic.
+
+    For kernels that call ``wp.tid()``, the rank of ``dim`` must equal
+    ``kernel.adj.kernel_dim`` (or ``kernel_dim - 1`` when ``tiled=True``, since
+    ``launch_tiled`` supplies the block_dim axis implicitly).
+
+    Args:
+        dim: An integer or sequence of integers giving the launch shape.
+        kernel: The target kernel; its ``adj.kernel_dim`` and
+          ``adj.max_tid_dimensionality`` attributes drive validation.
+        tiled: If ``True``, also accept ``len(dim) == kernel_dim - 1`` (the
+          ``launch_tiled`` path, which supplies the block_dim axis implicitly).
+
+    Returns:
+        The canonicalized ``dim`` tuple, ready to pass to ``launch_bounds_t(...)``.
+
+    Raises:
+        ValueError: The rank of ``dim`` does not match the kernel's ``wp.tid()``
+          arity. The message lists the valid migration options.
     """
     dim = _canonicalize_dim(dim)
-    ndim = len(dim)
-    if ndim == kernel_dim:
+    if kernel.adj.max_tid_dimensionality == 0:
+        # Kernel is dim-agnostic — collapse to total thread count so it fits the
+        # default launch_bounds_t<1> ABI. Not validation; a bypass.
+        return (math.prod(dim),) if dim else (0,)
+    expected = kernel.adj.kernel_dim
+    if tiled and len(dim) == expected - 1:
+        # launch_tiled: kernel_dim may legitimately be ndim+1 because block_dim
+        # adds the trailing axis implicitly.
         return dim
-    elif ndim < kernel_dim:
-        return dim + (1,) * (kernel_dim - ndim)
-    else:
-        head = dim[: kernel_dim - 1]
-        tail_product = 1
-        for d in dim[kernel_dim - 1 :]:
-            tail_product *= d
-        return (*head, tail_product)
+    if len(dim) == expected:
+        return dim
+    raise ValueError(_build_rank_error(dim, expected, kernel, tiled))
 
 
 def _construct_tiled_bounds(dim, block_dim, kernel):
     """Construct launch bounds for a tiled launch.
 
-    After compilation, kernel_dim tells us how many dimensions wp.tid() uses.
-    If it matches len(dim), the user's wp.tid() covers only the user-facing
-    dims and we set tiled=True so launch_coord divides out block_dim().
-    If it's len(dim)+1, the user explicitly covers the block_dim dimension
-    in their wp.tid() call, so we append block_dim to the shape.
+    Delegates rank validation to ``_prepare_launch_dim(tiled=True)``, which
+    either returns a canonicalized dim tuple with ``len(dim)`` in
+    ``{kernel_dim, kernel_dim - 1}`` (or ``(prod(dim),)`` for zero-tid
+    kernels), or raises ``ValueError``. Given that postcondition:
+
+    - ``len(dim) == kernel_dim``: user's ``wp.tid()`` covers only user dims;
+      set ``tiled=True`` so ``launch_coord()`` divides out ``block_dim()``.
+    - ``len(dim) == kernel_dim - 1``: user's ``wp.tid()`` explicitly covers
+      the ``block_dim`` axis; append ``block_dim`` to the shape.
     """
-    dim = _canonicalize_dim(dim)
-    ndim = len(dim)
+    dim = _prepare_launch_dim(dim, kernel, tiled=True)
     kernel_dim = kernel.adj.kernel_dim
+    ndim = len(dim)
 
-    if kernel.adj.max_tid_dimensionality == 0:
-        # No wp.tid() calls — flatten to 1D, only total thread count matters.
-        dim = _normalize_launch_dim(dim, 1)
-        ndim = 1
-
-    if kernel_dim == ndim:
+    # _prepare_launch_dim with tiled=True accepts ndim in (kernel_dim, kernel_dim-1)
+    # or flattens zero-tid kernels to a 1-tuple. After that call:
+    if ndim == kernel_dim:
         # wp.tid() returns user dims only — block_dim threads share coordinates
         bounds = launch_bounds_t(dim)
         bounds.size *= block_dim
         bounds.tiled = True
-    elif kernel_dim == ndim + 1:
-        # wp.tid() explicitly covers the block_dim dimension
-        bounds = launch_bounds_t((*dim, block_dim))
     else:
-        raise RuntimeError(
-            f"Tiled launch dimension mismatch for kernel '{kernel.key}': "
-            f"wp.tid() uses {kernel_dim} dimensions but launch_tiled was given {ndim} user dimensions. "
-            f"Expected kernel_dim to be {ndim} or {ndim + 1}."
-        )
+        # ndim == kernel_dim - 1: wp.tid() explicitly covers the block_dim dimension
+        bounds = launch_bounds_t((*dim, block_dim))
 
     return bounds
 
@@ -8276,7 +8389,7 @@ def launch(
         if tiled:
             bounds = _construct_tiled_bounds(dim, block_dim, kernel)
         else:
-            normalized = _normalize_launch_dim(dim, kernel.adj.kernel_dim)
+            normalized = _prepare_launch_dim(dim, kernel)
             bounds = launch_bounds_t(normalized)
 
         # first param is the number of threads
@@ -8321,6 +8434,7 @@ def launch(
                     device=device,
                     block_dim=block_dim,
                     adjoint=adjoint,
+                    tiled=tiled,
                 )
                 return launch
 
@@ -8398,6 +8512,7 @@ def launch(
                         max_blocks=max_blocks,
                         block_dim=block_dim,
                         adjoint=adjoint,
+                        tiled=tiled,
                     )
                     return launch
                 else:
@@ -8435,6 +8550,7 @@ def launch(
                         device=device,
                         max_blocks=max_blocks,
                         block_dim=block_dim,
+                        tiled=tiled,
                     )
                     return launch
                 else:

--- a/warp/_src/jax_experimental/custom_call.py
+++ b/warp/_src/jax_experimental/custom_call.py
@@ -5,7 +5,7 @@ import ctypes
 from functools import reduce
 
 import warp as wp
-from warp._src.context import _normalize_launch_dim, type_str
+from warp._src.context import _prepare_launch_dim, type_str
 from warp._src.jax import get_jax_device
 from warp._src.types import array_t, launch_bounds_t, matches_array_class, strides_from_shape
 from warp._src.utils import warn
@@ -97,7 +97,7 @@ def _warp_custom_callback(stream, buffers, opaque, opaque_len):
 
     # Parse launch dimensions.
     dims = [int(d) for d in dim_str.split(",")]
-    normalized = _normalize_launch_dim(dims, kernel.adj.kernel_dim)
+    normalized = _prepare_launch_dim(dims, kernel)
     bounds = launch_bounds_t(normalized)
 
     # Parse arguments.

--- a/warp/_src/jax_experimental/ffi.py
+++ b/warp/_src/jax_experimental/ffi.py
@@ -15,7 +15,7 @@ import jax
 
 import warp as wp
 from warp._src.codegen import get_full_arg_spec, make_full_qualified_name
-from warp._src.context import CudaMemcpyKind, _canonicalize_dim, _normalize_launch_dim
+from warp._src.context import CudaMemcpyKind, _canonicalize_dim, _prepare_launch_dim
 from warp._src.jax import get_jax_device
 from warp._src.types import (
     array_t,
@@ -418,7 +418,7 @@ class FfiKernel:
                         # roll batch size into the first launch dimension
                         launch_dims = (batch_size * launch_dims[0], *launch_dims[1:])
 
-                normalized = _normalize_launch_dim(launch_dims, self.kernel.adj.kernel_dim)
+                normalized = _prepare_launch_dim(launch_dims, self.kernel)
                 launch_bounds = launch_bounds_t(normalized)
                 kernel_params[0] = ctypes.addressof(launch_bounds)
 

--- a/warp/tests/test_template_launch_bounds.py
+++ b/warp/tests/test_template_launch_bounds.py
@@ -11,15 +11,19 @@ coordinates across all supported launch configurations:
 - launch_tiled with wp.tid() explicitly covering all dimensions
 - Manual tiled launches (wp.launch with block_dim baked into dim)
 - Untiled launches that use tile functions
-- Dimension normalization: padding (dim < kernel_dim) and flattening (dim > kernel_dim)
+- Launch-dim rank validation: under-rank and over-rank both raise ValueError
 - Kernels that never call wp.tid()
 """
 
 import unittest
+from types import SimpleNamespace
 
 import numpy as np
 
 import warp as wp
+
+# Private helpers live under warp._src; tests import them directly.
+from warp._src.context import _build_rank_error, _prepare_launch_dim, _tid_unpack
 from warp.tests.unittest_utils import *
 
 BLOCK_DIM = 64
@@ -92,53 +96,51 @@ def test_regular_4d(test, device):
 
 
 # ============================================================================
-# Dimension normalization: padding (dim < kernel_dim)
+# Launch-dim rank validation: mismatch raises ValueError with migration options
 # ============================================================================
 
 
-def test_dim_padding_1d_to_2d(test, device):
-    """Launch a 2D kernel with a scalar dim — should pad to (N, 1)."""
-    N = 128
-    out = wp.zeros((N, 1), dtype=int, device=device)
-    wp.launch(regular_2d_kernel, dim=N, inputs=[out, N, 1], device=device)
-    result = out.numpy()
-    expected = np.arange(N).reshape(N, 1)
-    np.testing.assert_array_equal(result, expected)
+def test_launch_dim_over_rank_kernel_dim_1_error(test, device):
+    """dim rank > kernel_dim=1: error lists all 4 intent options."""
+    N = 3
+    out = wp.zeros(N * N, dtype=int, device=device)
+    with test.assertRaises(ValueError) as cm:
+        wp.launch(regular_1d_kernel, dim=(N, N), inputs=[out], device=device)
+    msg = str(cm.exception)
+    test.assertIn("kernel_dim=1", msg)
+    test.assertIn("flat linear index over 9 threads: launch with dim=9", msg)
+    test.assertIn("first-dim index (0..2, no repetition): launch with dim=3", msg)
+    test.assertIn("first-dim index with repetition: unpack as `i, _ = wp.tid()`", msg)
+    test.assertIn("per-dim indexing: unpack as `i, j = wp.tid()`", msg)
 
 
-def test_dim_padding_1d_to_3d(test, device):
-    """Launch a 3D kernel with a scalar dim — should pad to (N, 1, 1)."""
-    N = 64
-    out = wp.zeros((N, 1, 1), dtype=int, device=device)
-    wp.launch(regular_3d_kernel, dim=N, inputs=[out, N, 1, 1], device=device)
-    result = out.numpy()
-    expected = np.arange(N).reshape(N, 1, 1)
-    np.testing.assert_array_equal(result, expected)
-
-
-# ============================================================================
-# Dimension normalization: flattening (dim > kernel_dim)
-# ============================================================================
-
-
-def test_dim_flattening_2d_to_1d(test, device):
-    """Launch a 1D kernel with dim=[M, N] — should flatten to (M*N,)."""
-    M, N = 8, 16
-    total = M * N
-    out = wp.zeros(total, dtype=int, device=device)
-    wp.launch(regular_1d_kernel, dim=[M, N], inputs=[out], device=device)
-    result = out.numpy()
-    np.testing.assert_array_equal(result, np.arange(total))
-
-
-def test_dim_flattening_3d_to_2d(test, device):
-    """Launch a 2D kernel with dim=[M, N, K] — should flatten to (M, N*K)."""
-    M, N, K = 4, 8, 2
+def test_launch_dim_over_rank_kernel_dim_2_error(test, device):
+    """dim rank > kernel_dim=2: launch-only options omitted (they'd require kernel edit too)."""
+    M, N, K = 2, 3, 4
     out = wp.zeros((M, N * K), dtype=int, device=device)
-    wp.launch(regular_2d_kernel, dim=[M, N, K], inputs=[out, M, N * K], device=device)
-    result = out.numpy()
-    expected = np.arange(M * N * K).reshape(M, N * K)
-    np.testing.assert_array_equal(result, expected)
+    with test.assertRaises(ValueError) as cm:
+        wp.launch(regular_2d_kernel, dim=(M, N, K), inputs=[out, M, N * K], device=device)
+    msg = str(cm.exception)
+    test.assertIn("kernel_dim=2", msg)
+    # Guard: misleading launch-only fixes must NOT appear when kernel_dim >= 2.
+    test.assertNotIn("flat linear", msg)
+    test.assertNotIn(f"launch with dim={M * N * K}", msg)
+    test.assertNotIn("no repetition", msg)
+    # Kernel-side fixes still appear.
+    test.assertIn("first-dim index with repetition: unpack as `i, _, _ = wp.tid()`", msg)
+    test.assertIn("per-dim indexing: unpack as `i, j, k = wp.tid()`", msg)
+
+
+def test_launch_dim_under_rank_error(test, device):
+    """dim rank < kernel_dim: error lists the two fix options."""
+    N = 10
+    out = wp.zeros((N, 1), dtype=int, device=device)
+    with test.assertRaises(ValueError) as cm:
+        wp.launch(regular_2d_kernel, dim=N, inputs=[out, N, 1], device=device)
+    msg = str(cm.exception)
+    test.assertIn("kernel_dim=2", msg)
+    test.assertIn("keep 2-D kernel, launch with matching rank: dim=(10, 1)", msg)
+    test.assertIn("change kernel to unpack 1 variable: `i = wp.tid()`", msg)
 
 
 # ============================================================================
@@ -257,14 +259,14 @@ def test_manual_tiled(test, device):
 
 
 def test_tiled_dim_mismatch_error(test, device):
-    """launch_tiled should raise when kernel_dim is incompatible with dim."""
+    """launch_tiled should raise ValueError with migration hint when kernel_dim is incompatible with dim."""
 
     @wp.kernel
     def _tiled_4d_kernel(out: wp.array(dtype=float)):
         _i, _j, _k, _l = wp.tid()
         pass
 
-    with test.assertRaises(RuntimeError):
+    with test.assertRaises(ValueError) as cm:
         wp.launch_tiled(
             _tiled_4d_kernel,
             dim=[2, 3],
@@ -272,25 +274,241 @@ def test_tiled_dim_mismatch_error(test, device):
             block_dim=BLOCK_DIM,
             device=device,
         )
+    msg = str(cm.exception)
+    test.assertIn("kernel_dim=4", msg)
+    # tiled hint should appear because this is a tiled launch
+    test.assertIn("For launch_tiled, dim may also match kernel_dim - 1", msg)
 
 
 # ============================================================================
-# Launch.set_dim normalizes correctly
+# Launch.set_dim rank validation
 # ============================================================================
 
 
-def test_launch_set_dim(test, device):
-    """Launch.set_dim() should normalize dim to kernel_dim dimensions."""
+def test_set_dim_matching_rank(test, device):
+    """Launch.set_dim() with rank matching kernel_dim should succeed."""
     N = 64
     out = wp.zeros(N, dtype=int, device=device)
     launch = wp.launch(regular_1d_kernel, dim=N, inputs=[out], device=device, record_cmd=True)
 
-    # Re-set with a 2D dim — should flatten to 1D to match kernel_dim=1
-    launch.set_dim([8, 8])
+    # Re-set with a new 1D dim — matches kernel_dim=1, should succeed
+    launch.set_dim(32)
     launch.launch()
 
     result = out.numpy()
-    np.testing.assert_array_equal(result, np.arange(N))
+    # only the first 32 entries were written; rest remain 0
+    np.testing.assert_array_equal(result[:32], np.arange(32))
+    np.testing.assert_array_equal(result[32:], np.zeros(N - 32))
+
+
+def test_set_dim_rank_mismatch_error(test, device):
+    """Launch.set_dim() with rank != kernel_dim should raise ValueError."""
+    N = 64
+    out = wp.zeros(N, dtype=int, device=device)
+    launch = wp.launch(regular_1d_kernel, dim=N, inputs=[out], device=device, record_cmd=True)
+
+    with test.assertRaises(ValueError) as cm:
+        launch.set_dim([8, 8])
+    msg = str(cm.exception)
+    test.assertIn("kernel_dim=1", msg)
+    test.assertIn("flat linear index over 64 threads", msg)
+
+
+def test_set_dim_preserves_tiled_flag(test, device):
+    """Launch.set_dim() on a recorded tiled launch should preserve tiled semantics."""
+    N = TILE_N * 5
+    A = wp.full(N, 42.0, dtype=float, device=device)
+    B = wp.zeros(N, dtype=float, device=device)
+    launch = wp.launch_tiled(
+        tiled_1d_kernel,
+        dim=[int(N / TILE_N)],
+        inputs=[A, B],
+        block_dim=BLOCK_DIM,
+        device=device,
+        record_cmd=True,
+    )
+    # set_dim should accept user-rank dim (len == kernel_dim for this kernel)
+    launch.set_dim([int(N / TILE_N)])
+    test.assertTrue(launch.bounds.tiled, "tiled flag should be preserved after set_dim")
+    launch.launch()
+    np.testing.assert_array_equal(B.numpy(), A.numpy())
+
+
+def test_set_dim_tiled_explicit_block_axis(test, device):
+    """Replaying a recorded launch_tiled whose kernel unpacks the block axis.
+
+    When ``wp.tid()`` covers the block_dim axis (kernel_dim == len(dim) + 1),
+    ``_construct_tiled_bounds`` appends block_dim to the shape and leaves the
+    C-struct ``bounds.tiled`` flag False. ``set_dim`` must still recognize the
+    launch as tiled (via ``self.tiled``) and route through
+    ``_construct_tiled_bounds`` — otherwise the non-tiled path would raise
+    ``ValueError`` because ``len(dim) == kernel_dim - 1``.
+    """
+
+    @wp.kernel
+    def _tiled_block_axis_kernel(out: wp.array(dtype=int)):
+        _i, _t = wp.tid()
+
+    N = 4
+    out = wp.zeros(N * BLOCK_DIM, dtype=int, device=device)
+    launch = wp.launch_tiled(
+        _tiled_block_axis_kernel,
+        dim=[N],
+        inputs=[out],
+        block_dim=BLOCK_DIM,
+        device=device,
+        record_cmd=True,
+    )
+    # This path leaves bounds.tiled False — block axis is baked into the shape.
+    test.assertFalse(launch.bounds.tiled)
+    test.assertTrue(launch.tiled)
+    # Regression: previously set_dim consulted bounds.tiled and raised on this
+    # shape. It must now accept the same user-rank dim the record call used.
+    launch.set_dim([N])
+    launch.launch()
+
+
+# ============================================================================
+# Unit tests for launch-dim preparation helpers
+# ============================================================================
+
+
+def _stub_kernel(key: str = "foo", *, kernel_dim: int = 1, max_tid_dim: int | None = None):
+    """Produce a minimal object matching the attributes _prepare_launch_dim reads.
+
+    ``max_tid_dim`` defaults to ``kernel_dim`` (the common case where the kernel
+    has at least one wp.tid() call). Pass ``max_tid_dim=0`` to simulate a kernel
+    with no wp.tid() calls at all.
+    """
+    if max_tid_dim is None:
+        max_tid_dim = kernel_dim
+    adj = SimpleNamespace(kernel_dim=kernel_dim, max_tid_dimensionality=max_tid_dim)
+    return SimpleNamespace(key=key, adj=adj)
+
+
+class TestTidUnpack(unittest.TestCase):
+    def test_scalar(self):
+        self.assertEqual(_tid_unpack(1), "i = wp.tid()")
+
+    def test_two(self):
+        self.assertEqual(_tid_unpack(2), "i, j = wp.tid()")
+
+    def test_three(self):
+        self.assertEqual(_tid_unpack(3), "i, j, k = wp.tid()")
+
+    def test_four(self):
+        self.assertEqual(_tid_unpack(4), "i, j, k, l = wp.tid()")
+
+    def test_beyond_supported(self):
+        # degrades gracefully when n > len(_TID_NAMES)
+        self.assertEqual(_tid_unpack(5), "... = wp.tid()  # 5 variables")
+
+    def test_zero(self):
+        # guards against pathological input; real callers always pass n >= 1
+        self.assertEqual(_tid_unpack(0), "... = wp.tid()  # 0 variables")
+
+
+class TestBuildRankError(unittest.TestCase):
+    def test_over_rank_kernel_dim_1_lists_all_four_options(self):
+        msg = _build_rank_error((3, 3), kernel_dim=1, kernel=_stub_kernel("foo"), tiled=False)
+        self.assertIn("Launch dim (3, 3) has rank 2", msg)
+        self.assertIn("kernel 'foo'", msg)
+        self.assertIn("kernel_dim=1", msg)
+        self.assertIn("flat linear index over 9 threads: launch with dim=9", msg)
+        self.assertIn("first-dim index (0..2, no repetition): launch with dim=3", msg)
+        self.assertIn("first-dim index with repetition: unpack as `i, _ = wp.tid()`", msg)
+        self.assertIn("per-dim indexing: unpack as `i, j = wp.tid()`", msg)
+
+    def test_over_rank_kernel_dim_2_omits_launch_only_options(self):
+        # With kernel_dim >= 2 the launch-only options would require a second
+        # kernel edit to land — don't offer them.
+        msg = _build_rank_error((2, 3, 4), kernel_dim=2, kernel=_stub_kernel("baz"), tiled=False)
+        self.assertIn("kernel_dim=2", msg)
+        self.assertNotIn("flat linear", msg)
+        self.assertNotIn("launch with dim=24", msg)
+        self.assertNotIn("no repetition", msg)
+        self.assertIn("first-dim index with repetition: unpack as `i, _, _ = wp.tid()`", msg)
+        self.assertIn("per-dim indexing: unpack as `i, j, k = wp.tid()`", msg)
+
+    def test_under_rank_lists_two_options(self):
+        msg = _build_rank_error((10,), kernel_dim=2, kernel=_stub_kernel("bar"), tiled=False)
+        self.assertIn("Launch dim (10,) has rank 1", msg)
+        self.assertIn("kernel_dim=2", msg)
+        self.assertIn("keep 2-D kernel, launch with matching rank: dim=(10, 1)", msg)
+        self.assertIn("change kernel to unpack 1 variable: `i = wp.tid()`", msg)
+
+    def test_under_rank_tiled_lists_kernel_dim_minus_one_option(self):
+        # For tiled launches, dim rank may also match kernel_dim - 1; offer a
+        # concrete option alongside the rank-matching one.
+        msg = _build_rank_error((2, 3), kernel_dim=4, kernel=_stub_kernel("baz"), tiled=True)
+        self.assertIn("kernel_dim=4", msg)
+        # rank-kernel_dim option
+        self.assertIn("keep 4-D kernel, launch with matching rank: dim=(2, 3, 1, 1)", msg)
+        # rank-(kernel_dim - 1) option — the new one
+        self.assertIn("keep 4-D kernel with implicit block_dim axis, launch with dim=(2, 3, 1)", msg)
+
+    def test_under_rank_non_tiled_omits_kernel_dim_minus_one_option(self):
+        # Non-tiled launches have no kernel_dim - 1 escape hatch.
+        msg = _build_rank_error((2, 3), kernel_dim=4, kernel=_stub_kernel("baz"), tiled=False)
+        self.assertNotIn("implicit block_dim axis", msg)
+
+    def test_tiled_flag_appends_hint(self):
+        msg = _build_rank_error((3, 3), kernel_dim=1, kernel=_stub_kernel("foo"), tiled=True)
+        self.assertIn("For launch_tiled, dim may also match kernel_dim - 1", msg)
+
+    def test_non_tiled_omits_hint(self):
+        msg = _build_rank_error((3, 3), kernel_dim=1, kernel=_stub_kernel("foo"), tiled=False)
+        self.assertNotIn("launch_tiled", msg)
+
+
+class TestPrepareLaunchDim(unittest.TestCase):
+    def test_matching_rank_returns_canonicalized(self):
+        kernel = _stub_kernel(kernel_dim=2)
+        self.assertEqual(_prepare_launch_dim((3, 4), kernel), (3, 4))
+
+    def test_scalar_int_canonicalized_for_1d(self):
+        kernel = _stub_kernel(kernel_dim=1)
+        self.assertEqual(_prepare_launch_dim(10, kernel), (10,))
+
+    def test_list_canonicalized(self):
+        kernel = _stub_kernel(kernel_dim=2)
+        self.assertEqual(_prepare_launch_dim([3, 4], kernel), (3, 4))
+
+    def test_zero_tid_kernel_flattens_multidim(self):
+        # max_tid_dimensionality=0 → any dim is accepted, flattened to total count
+        kernel = _stub_kernel(kernel_dim=1, max_tid_dim=0)
+        self.assertEqual(_prepare_launch_dim((3, 4, 5), kernel), (60,))
+
+    def test_zero_tid_kernel_preserves_1d(self):
+        kernel = _stub_kernel(kernel_dim=1, max_tid_dim=0)
+        self.assertEqual(_prepare_launch_dim(100, kernel), (100,))
+
+    def test_over_rank_raises_value_error(self):
+        kernel = _stub_kernel(kernel_dim=1)
+        with self.assertRaises(ValueError) as cm:
+            _prepare_launch_dim((3, 3), kernel)
+        self.assertIn("kernel_dim=1", str(cm.exception))
+
+    def test_under_rank_raises_value_error(self):
+        kernel = _stub_kernel(kernel_dim=2)
+        with self.assertRaises(ValueError) as cm:
+            _prepare_launch_dim(10, kernel)
+        self.assertIn("kernel_dim=2", str(cm.exception))
+
+    def test_tiled_accepts_rank_minus_one(self):
+        # tiled=True allows len(dim) == kernel_dim - 1 (block_dim axis is implicit)
+        kernel = _stub_kernel(kernel_dim=2)
+        self.assertEqual(_prepare_launch_dim((5,), kernel, tiled=True), (5,))
+
+    def test_tiled_still_rejects_greater_mismatch(self):
+        kernel = _stub_kernel(kernel_dim=2)
+        with self.assertRaises(ValueError):
+            _prepare_launch_dim((3, 3, 3), kernel, tiled=True)
+
+    def test_non_tiled_rejects_rank_minus_one(self):
+        kernel = _stub_kernel(kernel_dim=2)
+        with self.assertRaises(ValueError):
+            _prepare_launch_dim((5,), kernel, tiled=False)
 
 
 # ============================================================================
@@ -308,13 +526,23 @@ add_function_test(TestTemplateLaunchBounds, "test_regular_1d", test_regular_1d, 
 add_function_test(TestTemplateLaunchBounds, "test_regular_2d", test_regular_2d, devices=devices)
 add_function_test(TestTemplateLaunchBounds, "test_regular_3d", test_regular_3d, devices=devices)
 add_function_test(TestTemplateLaunchBounds, "test_regular_4d", test_regular_4d, devices=devices)
-add_function_test(TestTemplateLaunchBounds, "test_dim_padding_1d_to_2d", test_dim_padding_1d_to_2d, devices=devices)
-add_function_test(TestTemplateLaunchBounds, "test_dim_padding_1d_to_3d", test_dim_padding_1d_to_3d, devices=devices)
 add_function_test(
-    TestTemplateLaunchBounds, "test_dim_flattening_2d_to_1d", test_dim_flattening_2d_to_1d, devices=devices
+    TestTemplateLaunchBounds,
+    "test_launch_dim_over_rank_kernel_dim_1_error",
+    test_launch_dim_over_rank_kernel_dim_1_error,
+    devices=devices,
 )
 add_function_test(
-    TestTemplateLaunchBounds, "test_dim_flattening_3d_to_2d", test_dim_flattening_3d_to_2d, devices=devices
+    TestTemplateLaunchBounds,
+    "test_launch_dim_over_rank_kernel_dim_2_error",
+    test_launch_dim_over_rank_kernel_dim_2_error,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_launch_dim_under_rank_error",
+    test_launch_dim_under_rank_error,
+    devices=devices,
 )
 add_function_test(TestTemplateLaunchBounds, "test_no_tid_kernel_multidim", test_no_tid_kernel_multidim, devices=devices)
 add_function_test(TestTemplateLaunchBounds, "test_tiled_1d", test_tiled_1d, devices=devices)
@@ -324,7 +552,25 @@ add_function_test(TestTemplateLaunchBounds, "test_manual_tiled", test_manual_til
 add_function_test(
     TestTemplateLaunchBounds, "test_tiled_dim_mismatch_error", test_tiled_dim_mismatch_error, devices=devices
 )
-add_function_test(TestTemplateLaunchBounds, "test_launch_set_dim", test_launch_set_dim, devices=devices)
+add_function_test(TestTemplateLaunchBounds, "test_set_dim_matching_rank", test_set_dim_matching_rank, devices=devices)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_set_dim_rank_mismatch_error",
+    test_set_dim_rank_mismatch_error,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_set_dim_preserves_tiled_flag",
+    test_set_dim_preserves_tiled_flag,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_set_dim_tiled_explicit_block_axis",
+    test_set_dim_tiled_explicit_block_axis,
+    devices=devices,
+)
 
 
 if __name__ == "__main__":

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -203,7 +203,12 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.test_struct import TestStruct
     from warp.tests.test_subscript_types import TestSubscriptTypes
     from warp.tests.test_tape import TestTape
-    from warp.tests.test_template_launch_bounds import TestTemplateLaunchBounds
+    from warp.tests.test_template_launch_bounds import (
+        TestBuildRankError,
+        TestPrepareLaunchDim,
+        TestTemplateLaunchBounds,
+        TestTidUnpack,
+    )
     from warp.tests.test_transient_module import TestTransientModule
     from warp.tests.test_triangle_closest_point import TestTriangleClosestPoint
     from warp.tests.test_types import TestTypes
@@ -349,7 +354,10 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestStruct,
         TestSubscriptTypes,
         TestTape,
+        TestBuildRankError,
+        TestPrepareLaunchDim,
         TestTemplateLaunchBounds,
+        TestTidUnpack,
         TestTexture,
         TestTile,
         TestTileAtomicBitwise,


### PR DESCRIPTION
## Description

Replace the silent fold/pad in `_normalize_launch_dim` with a hard `ValueError` on rank mismatch.

Introduce `_prepare_launch_dim(dim, kernel, *, tiled=False)` which canonicalizes `dim`, bypasses validation for kernels with no `wp.tid()` call (flattening any shape to total thread count via `math.prod`), and raises `ValueError` with a concrete migration hint listing 2–4 valid fix options computed from the specific call.

Wire into `wp.launch()`, `Launch.set_dim()`, `wp.launch_tiled()` via `_construct_tiled_bounds`, and the experimental JAX FFI paths (`custom_call.py`, `ffi.py`). Remove `_normalize_launch_dim` entirely. `Launch.set_dim()` preserves tiled semantics on recorded tiled launches.

The `launch_tiled` rank-mismatch error type changes from `RuntimeError` to `ValueError` for consistency with the regular launch path; kernels that do not call `wp.tid()` continue to accept any `dim`.

Motivation: the silent fold introduced by the `launch_bounds_t<N>` templating (GH-1270, unreleased) caused out-of-bounds indexing and heap corruption in downstream kernels — the trigger took a few hours of debugging to isolate in Newton ([newton-physics/newton#2546](https://github.com/newton-physics/newton/pull/2546)) because the overflow accumulates until an allocator validator notices. Since GH-1270 has not shipped in a release, the hard-error replaces the silent fold as the shipping behavior for 1.13 — the CHANGELOG entry is consolidated under GH-1270.

closes #1389

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `uv run --extra dev -m warp.tests -k test_template_launch_bounds` — 37 tests pass (includes 20 unit tests for new helpers + 6 integration tests for the three call sites + 11 prior launch-bounds tests).
- `uv run --extra dev -m warp.tests -k test_launch` — 19 tests pass (regression guard on existing launch functionality).
- Representative error output for ``tid = wp.tid()`` launched with ``dim=(3, 3)``:

```
ValueError: Launch dim (3, 3) has rank 2 but kernel 'foo' unpacks wp.tid() into 1 variable (kernel_dim=1).
Pick the intended behavior:
  - flat linear index over 9 threads: launch with dim=9
  - first-dim index (0..2, no repetition): launch with dim=3
  - first-dim index with repetition: unpack as \`i, _ = wp.tid()\`
  - per-dim indexing: unpack as \`i, j = wp.tid()\`
```

## Bug fix

Kernel code that worked under the pre-1.13 unravel semantics:

\`\`\`python
@wp.kernel
def repeat_first_dim(arr: wp.array3d(dtype=float)):
    # Pre-1.13: launched with dim=arr.shape (3-tuple), tid got first-dim
    # index 0,0,0,1,1,1,... — idempotent writes, coincidentally correct.
    tid = wp.tid()
    arr[tid, 0, 0] = float(tid)

wp.launch(repeat_first_dim, dim=arr.shape, inputs=[arr])
\`\`\`

Under unreleased GH-1270 this silently folds to a flat linear `tid`, which then indexes past `arr.shape[0]` and corrupts the heap. This PR raises `ValueError` at launch time with the migration options inline; the user picks \`tid = wp.tid()\` + \`dim=arr.shape[0]\` or \`i, _, _ = wp.tid()\` + \`dim=arr.shape\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Launch-dimension rank is now strictly validated; mismatches raise ValueError (including tiled launches). Kernels that read thread indices must use a matching rank; kernels that never read thread indices accept any shape by flattening to a total-thread count. launch_tiled rank-mismatch now raises ValueError.

* **Documentation**
  * Changelog updated with migration guidance and clarified validation messages.

* **Tests**
  * Expanded coverage for rank validation, error text, migration hints, and tiled vs non-tiled behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->