### PR TITLE
Expose cudaStreamCaptureMode via ScopedCapture / capture_begin

### DIFF
--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -346,6 +346,7 @@ from warp._src.rmm_allocator import RmmAllocator as RmmAllocator
 
 # category: CUDA Graph Management
 
+from warp._src.context import CaptureMode as CaptureMode
 from warp._src.utils import ScopedCapture as ScopedCapture
 
 from warp._src.context import is_conditional_graph_supported as is_conditional_graph_supported

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -175,6 +175,7 @@ from warp._src.context import set_cuda_allocator as set_cuda_allocator
 from warp._src.context import set_device_allocator as set_device_allocator
 from warp._src.utils import ScopedAllocator as ScopedAllocator
 from warp._src.rmm_allocator import RmmAllocator as RmmAllocator
+from warp._src.context import CaptureMode as CaptureMode
 from warp._src.utils import ScopedCapture as ScopedCapture
 from warp._src.context import is_conditional_graph_supported as is_conditional_graph_supported
 from warp._src.context import capture_begin as capture_begin

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -9243,8 +9243,10 @@ def capture_begin(
           capture. ``CaptureMode.Relaxed`` is typically required when
           composing with libraries that transparently call capture-unsafe
           runtime APIs during the capture (e.g. lazy context
-          initialization). When ``external=True`` the caller already
-          opened the capture, so this value is not passed to
+          initialization). The value is ignored on CPU devices (which
+          record into an APIC byte stream rather than a CUDA stream
+          capture). When ``external=True`` the caller already opened the
+          capture, so this value is not passed to
           ``cudaStreamBeginCapture``; it is still recorded and used by
           ``capture_if`` / ``capture_while`` pause-resume cycles to
           re-open the capture in the same mode.

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -9238,13 +9238,16 @@ def capture_begin(
           CUDA this also enables APIC byte-stream recording during the capture;
           on CPU, recording happens regardless because it is the only
           replay mechanism.
-        capture_mode: The :class:`CaptureMode` (i.e. ``cudaStreamCaptureMode``)
-          used when Warp opens the capture. ``CaptureMode.Relaxed`` is
-          typically required when composing with libraries that
-          transparently call capture-unsafe runtime APIs during the
-          capture (e.g. lazy context initialization). Ignored when
-          ``external=True`` because the caller opened the capture and
-          therefore picked its mode.
+        capture_mode: The :class:`~warp.CaptureMode`
+          (i.e. ``cudaStreamCaptureMode``) used when Warp opens the
+          capture. ``CaptureMode.Relaxed`` is typically required when
+          composing with libraries that transparently call capture-unsafe
+          runtime APIs during the capture (e.g. lazy context
+          initialization). When ``external=True`` the caller already
+          opened the capture, so this value is not passed to
+          ``cudaStreamBeginCapture``; it is still recorded and used by
+          ``capture_if`` / ``capture_while`` pause-resume cycles to
+          re-open the capture in the same mode.
 
     """
     from warp._src.apic.capture import APICapture  # noqa: PLC0415

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -80,6 +80,20 @@ class CudaMemcpyKind(enum.IntEnum):
     Default = 4
 
 
+class CaptureMode(enum.IntEnum):
+    """CUDA stream capture mode; mirrors ``cudaStreamCaptureMode``.
+
+    Controls how strictly CUDA rejects capture-unsafe runtime APIs while a
+    capture is active. ``Relaxed`` is typically required when composing with
+    libraries that perform lazy / capture-unsafe runtime calls (e.g. context
+    initialization) during the capture.
+    """
+
+    Global = 0
+    ThreadLocal = 1
+    Relaxed = 2
+
+
 # represents either a built-in or user-defined function
 
 
@@ -5360,7 +5374,12 @@ class Runtime:
             self.core.wp_cuda_event_elapsed_time.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
             self.core.wp_cuda_event_elapsed_time.restype = ctypes.c_float
 
-            self.core.wp_cuda_graph_begin_capture.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
+            self.core.wp_cuda_graph_begin_capture.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.c_int,
+                ctypes.c_int,
+            ]
             self.core.wp_cuda_graph_begin_capture.restype = ctypes.c_bool
             self.core.wp_cuda_graph_end_capture.argtypes = [
                 ctypes.c_void_p,
@@ -9191,6 +9210,7 @@ def capture_begin(
     force_module_load: bool | None = None,
     external: bool = False,
     apic: bool = False,
+    capture_mode: CaptureMode = CaptureMode.ThreadLocal,
 ):
     """Begin capture of a graph.
 
@@ -9218,6 +9238,13 @@ def capture_begin(
           CUDA this also enables APIC byte-stream recording during the capture;
           on CPU, recording happens regardless because it is the only
           replay mechanism.
+        capture_mode: The :class:`CaptureMode` (i.e. ``cudaStreamCaptureMode``)
+          used when Warp opens the capture. ``CaptureMode.Relaxed`` is
+          typically required when composing with libraries that
+          transparently call capture-unsafe runtime APIs during the
+          capture (e.g. lazy context initialization). Ignored when
+          ``external=True`` because the caller opened the capture and
+          therefore picked its mode.
 
     """
     from warp._src.apic.capture import APICapture  # noqa: PLC0415
@@ -9288,7 +9315,9 @@ def capture_begin(
             if force_module_load:
                 force_load(device)
 
-        if not runtime.core.wp_cuda_graph_begin_capture(device.context, stream.cuda_stream, int(external)):
+        if not runtime.core.wp_cuda_graph_begin_capture(
+            device.context, stream.cuda_stream, int(external), int(CaptureMode(capture_mode))
+        ):
             raise RuntimeError(runtime.get_error_string())
     except Exception:
         if apic_capture is not None:

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -1639,10 +1639,12 @@ class ScopedCapture:
             (i.e. ``cudaStreamCaptureMode``) used when Warp opens the
             capture. ``CaptureMode.Relaxed`` lets libraries that still
             perform lazy / capture-unsafe CUDA runtime calls compose inside
-            a Warp capture without invalidating it. When ``external=True``
-            the caller already opened the capture, so this value is not
-            passed to ``cudaStreamBeginCapture``; it is still recorded and
-            used by pause-resume cycles in conditional / while graph nodes.
+            a Warp capture without invalidating it. The value is ignored
+            on CPU devices (which record into an APIC byte stream rather
+            than a CUDA stream capture). When ``external=True`` the caller
+            already opened the capture, so this value is not passed to
+            ``cudaStreamBeginCapture``; it is still recorded and used by
+            pause-resume cycles in conditional / while graph nodes.
 
     Attributes:
         graph: The captured graph, available after context exit.

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -1639,8 +1639,10 @@ class ScopedCapture:
             (i.e. ``cudaStreamCaptureMode``) used when Warp opens the
             capture. ``CaptureMode.Relaxed`` lets libraries that still
             perform lazy / capture-unsafe CUDA runtime calls compose inside
-            a Warp capture without invalidating it. Ignored when
-            ``external=True``.
+            a Warp capture without invalidating it. When ``external=True``
+            the caller already opened the capture, so this value is not
+            passed to ``cudaStreamBeginCapture``; it is still recorded and
+            used by pause-resume cycles in conditional / while graph nodes.
 
     Attributes:
         graph: The captured graph, available after context exit.

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -21,7 +21,7 @@ import numpy as np
 import warp as wp
 import warp._src.context
 import warp._src.types
-from warp._src.context import Allocator, DeviceLike, _validate_allocator
+from warp._src.context import Allocator, CaptureMode, DeviceLike, _validate_allocator
 from warp._src.types import Array, DType, type_repr, types_equal
 
 _wp_module_name_ = "warp.utils"
@@ -1635,6 +1635,12 @@ class ScopedCapture:
         apic: If ``True``, enable APIC recording for serialization via
             :func:`capture_save`. On CPU, recording always occurs regardless
             of this flag (needed for CPU graph replay). Default is ``False``.
+        capture_mode: The :class:`~warp.CaptureMode`
+            (i.e. ``cudaStreamCaptureMode``) used when Warp opens the
+            capture. ``CaptureMode.Relaxed`` lets libraries that still
+            perform lazy / capture-unsafe CUDA runtime calls compose inside
+            a Warp capture without invalidating it. Ignored when
+            ``external=True``.
 
     Attributes:
         graph: The captured graph, available after context exit.
@@ -1654,13 +1660,20 @@ class ScopedCapture:
     """
 
     def __init__(
-        self, device: DeviceLike = None, stream=None, force_module_load=None, external=False, apic: bool = False
+        self,
+        device: DeviceLike = None,
+        stream=None,
+        force_module_load=None,
+        external=False,
+        apic: bool = False,
+        capture_mode: CaptureMode = CaptureMode.ThreadLocal,
     ):
         self.device = device
         self.stream = stream
         self.force_module_load = force_module_load
         self.external = external
         self.apic = apic
+        self.capture_mode = capture_mode
         self.active = False
         self.graph = None
 
@@ -1672,6 +1685,7 @@ class ScopedCapture:
                 force_module_load=self.force_module_load,
                 external=self.external,
                 apic=self.apic,
+                capture_mode=self.capture_mode,
             )
             self.active = True
             return self

--- a/warp/native/warp.cpp
+++ b/warp/native/warp.cpp
@@ -1066,7 +1066,7 @@ WP_API void wp_cuda_event_record(void* event, void* stream, bool external) { }
 WP_API void wp_cuda_event_synchronize(void* event) { }
 WP_API float wp_cuda_event_elapsed_time(void* start_event, void* end_event) { return 0.0f; }
 
-WP_API bool wp_cuda_graph_begin_capture(void* context, void* stream, int external) { return false; }
+WP_API bool wp_cuda_graph_begin_capture(void* context, void* stream, int external, int mode) { return false; }
 WP_API bool wp_cuda_graph_end_capture(void* context, void* stream, void** graph_ret) { return false; }
 WP_API bool wp_cuda_graph_create_exec(void* context, void* stream, void* graph, void** graph_exec_ret) { return false; }
 WP_API bool wp_cuda_graph_launch(void* graph, void* stream) { return false; }

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -2757,7 +2757,7 @@ float wp_cuda_event_elapsed_time(void* start_event, void* end_event)
     return elapsed;
 }
 
-bool wp_cuda_graph_begin_capture(void* context, void* stream, int external)
+bool wp_cuda_graph_begin_capture(void* context, void* stream, int external, int mode)
 {
     ContextGuard guard(context);
 
@@ -2778,8 +2778,16 @@ bool wp_cuda_graph_begin_capture(void* context, void* stream, int external)
             return false;
         }
     } else {
-        // start the capture
-        if (!check_cuda(cudaStreamBeginCapture(cuda_stream, cudaStreamCaptureModeThreadLocal)))
+        cudaStreamCaptureMode capture_mode;
+        switch (mode) {
+        case 0: capture_mode = cudaStreamCaptureModeGlobal; break;
+        case 1: capture_mode = cudaStreamCaptureModeThreadLocal; break;
+        case 2: capture_mode = cudaStreamCaptureModeRelaxed; break;
+        default:
+            wp::set_error_string("Warp error: invalid capture mode (expected 0=Global, 1=ThreadLocal, 2=Relaxed)");
+            return false;
+        }
+        if (!check_cuda(cudaStreamBeginCapture(cuda_stream, capture_mode)))
             return false;
     }
 

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -175,6 +175,7 @@ struct CaptureInfo {
     CUstream stream = NULL;  // the main stream where capture begins and ends
     uint64_t id = 0;  // unique capture id from CUDA
     bool external = false;  // whether this is an external capture
+    cudaStreamCaptureMode mode = cudaStreamCaptureModeThreadLocal;  // mode used to open the capture (for pause/resume)
     std::vector<FreeInfo> tmp_allocs;  // temporary allocations owned by the graph (e.g., staged array fill values)
 };
 
@@ -2768,6 +2769,16 @@ bool wp_cuda_graph_begin_capture(void* context, void* stream, int external, int 
         return false;
     }
 
+    cudaStreamCaptureMode capture_mode;
+    switch (mode) {
+    case WP_CUDA_GRAPH_CAPTURE_MODE_GLOBAL:       capture_mode = cudaStreamCaptureModeGlobal;      break;
+    case WP_CUDA_GRAPH_CAPTURE_MODE_THREAD_LOCAL: capture_mode = cudaStreamCaptureModeThreadLocal; break;
+    case WP_CUDA_GRAPH_CAPTURE_MODE_RELAXED:      capture_mode = cudaStreamCaptureModeRelaxed;     break;
+    default:
+        wp::set_error_string("Warp error: invalid capture mode");
+        return false;
+    }
+
     if (external) {
         // if it's an external capture, make sure it's already active so we can get the capture id
         cudaStreamCaptureStatus status = cudaStreamCaptureStatusNone;
@@ -2778,15 +2789,6 @@ bool wp_cuda_graph_begin_capture(void* context, void* stream, int external, int 
             return false;
         }
     } else {
-        cudaStreamCaptureMode capture_mode;
-        switch (mode) {
-        case 0: capture_mode = cudaStreamCaptureModeGlobal; break;
-        case 1: capture_mode = cudaStreamCaptureModeThreadLocal; break;
-        case 2: capture_mode = cudaStreamCaptureModeRelaxed; break;
-        default:
-            wp::set_error_string("Warp error: invalid capture mode (expected 0=Global, 1=ThreadLocal, 2=Relaxed)");
-            return false;
-        }
         if (!check_cuda(cudaStreamBeginCapture(cuda_stream, capture_mode)))
             return false;
     }
@@ -2797,6 +2799,7 @@ bool wp_cuda_graph_begin_capture(void* context, void* stream, int external, int 
     capture->stream = cuda_stream;
     capture->id = capture_id;
     capture->external = bool(external);
+    capture->mode = capture_mode;
 
     // update stream info
     stream_info->capture = capture;
@@ -3262,8 +3265,17 @@ bool wp_cuda_graph_resume_capture(void* context, void* stream, void* graph)
     if (!get_graph_leaf_nodes(cuda_graph, leaf_nodes))
         return false;
 
+    // Resume with the same capture mode the user picked at begin time so a
+    // pause/resume cycle (driven by conditional/while graph nodes) does not
+    // silently downgrade Global/Relaxed captures to ThreadLocal.
+    cudaStreamCaptureMode resume_mode = cudaStreamCaptureModeThreadLocal;
+    if (StreamInfo* stream_info = get_stream_info(cuda_stream)) {
+        if (CaptureInfo* capture = stream_info->capture)
+            resume_mode = capture->mode;
+    }
+
     if (!check_cuda(cudaStreamBeginCaptureToGraph(
-            cuda_stream, cuda_graph, leaf_nodes.data(), nullptr, leaf_nodes.size(), cudaStreamCaptureModeThreadLocal
+            cuda_stream, cuda_graph, leaf_nodes.data(), nullptr, leaf_nodes.size(), resume_mode
         )))
         return false;
 

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -3273,12 +3273,24 @@ bool wp_cuda_graph_resume_capture(void* context, void* stream, void* graph)
 
     // Resume with the same capture mode the user picked at begin time so a
     // pause/resume cycle (driven by conditional/while graph nodes) does not
-    // silently downgrade Global/Relaxed captures to ThreadLocal.
-    cudaStreamCaptureMode resume_mode = cudaStreamCaptureModeThreadLocal;
-    if (StreamInfo* stream_info = get_stream_info(cuda_stream)) {
-        if (CaptureInfo* capture = stream_info->capture)
-            resume_mode = capture->mode;
+    // silently downgrade Global/Relaxed captures to ThreadLocal. The stream
+    // must already be known to Warp with an active CaptureInfo at this
+    // point because the resume path is only reached after a matching pause
+    // on a Warp-managed capture; if either is missing something is badly
+    // out of sync, fail fast rather than guess a mode.
+    StreamInfo* stream_info = get_stream_info(cuda_stream);
+    if (!stream_info) {
+        fprintf(stderr, "Warp error: resume_capture called on unknown stream %p\n", (void*)cuda_stream);
+        wp::set_error_string("Warp error: resume_capture called on unknown stream");
+        return false;
     }
+    CaptureInfo* capture = stream_info->capture;
+    if (!capture) {
+        fprintf(stderr, "Warp error: resume_capture called on stream %p with no active capture\n", (void*)cuda_stream);
+        wp::set_error_string("Warp error: resume_capture called on stream with no active capture");
+        return false;
+    }
+    cudaStreamCaptureMode resume_mode = capture->mode;
 
     if (!check_cuda(cudaStreamBeginCaptureToGraph(
             cuda_stream, cuda_graph, leaf_nodes.data(), nullptr, leaf_nodes.size(), resume_mode

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -2771,9 +2771,15 @@ bool wp_cuda_graph_begin_capture(void* context, void* stream, int external, int 
 
     cudaStreamCaptureMode capture_mode;
     switch (mode) {
-    case WP_CUDA_GRAPH_CAPTURE_MODE_GLOBAL:       capture_mode = cudaStreamCaptureModeGlobal;      break;
-    case WP_CUDA_GRAPH_CAPTURE_MODE_THREAD_LOCAL: capture_mode = cudaStreamCaptureModeThreadLocal; break;
-    case WP_CUDA_GRAPH_CAPTURE_MODE_RELAXED:      capture_mode = cudaStreamCaptureModeRelaxed;     break;
+    case WP_CUDA_GRAPH_CAPTURE_MODE_GLOBAL:
+        capture_mode = cudaStreamCaptureModeGlobal;
+        break;
+    case WP_CUDA_GRAPH_CAPTURE_MODE_THREAD_LOCAL:
+        capture_mode = cudaStreamCaptureModeThreadLocal;
+        break;
+    case WP_CUDA_GRAPH_CAPTURE_MODE_RELAXED:
+        capture_mode = cudaStreamCaptureModeRelaxed;
+        break;
     default:
         wp::set_error_string("Warp error: invalid capture mode");
         return false;

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -828,15 +828,28 @@ void wp_free_device_async(void* context, void* ptr)
         // check if the capture is still active
         auto capture_iter = g_captures.find(capture_id);
         if (capture_iter != g_captures.end()) {
-            // Add a mem free node.  Use all current leaf nodes as dependencies to ensure that all prior
-            // work completes before deallocating.  This works with both Warp-initiated and external captures
-            // and avoids the need to explicitly track all streams used during the capture.
+            // Add a mem free node depending on the current capture frontier of the
+            // capturing stream (rather than the leaves of the whole cudaGraph_t).
+            //
+            // Using cudaGraphGetNodes-derived leaves was correct as long as a graph
+            // held one capture at a time: "graph leaves" == "capture frontier".  With
+            // cudaStreamBeginCaptureToGraph (CUDA 12.3+), several independent captures
+            // can target the same cudaGraph_t (e.g. CUDASTF stackable contexts run two
+            // sibling tasks into one ctx_graph for parallel execution).  In that
+            // setting "graph leaves" includes leaves from sibling captures, and we end
+            // up wiring them as predecessors of this MEM_FREE -- a spurious cross-task
+            // edge that transitively serializes sibling captures behind each other.
+            //
+            // get_capture_dependencies() wraps cuStreamGetCaptureInfo and returns only
+            // the current capturing stream's frontier, so it ignores sibling captures
+            // sharing the same graph while still respecting any forked streams that
+            // have already been joined back into this capture.
             CaptureInfo* capture = capture_iter->second;
             cudaGraph_t graph = get_capture_graph(capture->stream);
-            std::vector<cudaGraphNode_t> leaf_nodes;
-            if (graph && get_graph_leaf_nodes(graph, leaf_nodes)) {
+            std::vector<cudaGraphNode_t> capture_deps;
+            if (graph && get_capture_dependencies(capture->stream, capture_deps)) {
                 cudaGraphNode_t free_node;
-                if (check_cuda(cudaGraphAddMemFreeNode(&free_node, graph, leaf_nodes.data(), leaf_nodes.size(), ptr))) {
+                if (check_cuda(cudaGraphAddMemFreeNode(&free_node, graph, capture_deps.data(), capture_deps.size(), ptr))) {
                     check_cu(cuStreamUpdateCaptureDependencies_f(
                         capture->stream, &free_node, 1, cudaStreamSetCaptureDependencies
                     ));

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -12,6 +12,12 @@
 
 #define WP_CURRENT_STREAM ((void*)0xffffffffffffffff)
 
+// Capture modes accepted by wp_cuda_graph_begin_capture. Values match
+// cudaStreamCaptureMode so the int can be passed straight through.
+#define WP_CUDA_GRAPH_CAPTURE_MODE_GLOBAL       0
+#define WP_CUDA_GRAPH_CAPTURE_MODE_THREAD_LOCAL 1
+#define WP_CUDA_GRAPH_CAPTURE_MODE_RELAXED      2
+
 struct timing_result_t;
 
 // this is the core runtime API exposed on the DLL level

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -475,7 +475,7 @@ WP_API void wp_cuda_event_record(void* event, void* stream, bool external = fals
 WP_API void wp_cuda_event_synchronize(void* event);
 WP_API float wp_cuda_event_elapsed_time(void* start_event, void* end_event);
 
-WP_API bool wp_cuda_graph_begin_capture(void* context, void* stream, int external);
+WP_API bool wp_cuda_graph_begin_capture(void* context, void* stream, int external, int mode);
 WP_API bool wp_cuda_graph_end_capture(void* context, void* stream, void** graph_ret);
 WP_API bool wp_cuda_graph_create_exec(void* context, void* stream, void* graph, void** graph_exec_ret);
 WP_API bool wp_cuda_graph_launch(void* graph, void* stream);

--- a/warp/tests/cuda/test_capture_mode.py
+++ b/warp/tests/cuda/test_capture_mode.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``capture_mode`` parameter of :class:`wp.ScopedCapture`.
+
+The CUDA driver rejects most runtime APIs while a stream is being captured
+under ``cudaStreamCaptureModeGlobal`` / ``cudaStreamCaptureModeThreadLocal``
+and invalidates the capture on the first such call.
+``cudaStreamCaptureModeRelaxed`` tolerates those calls, which lets Warp
+compose with libraries that still perform lazy / capture-unsafe CUDA
+runtime calls (e.g. ``cudaFree(0)`` during lazy context / allocator init)
+inside a Warp graph capture.
+
+The tests below exercise both directions using ``cudaFree(0)`` as a minimal
+"capture-unsafe" runtime call:
+
+* ``test_relaxed_allows_capture_unsafe_runtime_call``:
+  ``cudaFree(0)`` succeeds under ``CaptureMode.Relaxed`` and the capture
+  ends cleanly with a non-null graph.
+* ``test_thread_local_rejects_capture_unsafe_runtime_call``:
+  ``cudaFree(0)`` is rejected under ``CaptureMode.ThreadLocal`` and
+  ``wp.capture_end`` raises because the capture was invalidated.
+"""
+
+import ctypes
+import ctypes.util
+import unittest
+
+import warp as wp
+from warp.tests.unittest_utils import *
+
+
+def _load_cudart():
+    """Load the CUDA runtime library and bind ``cudaFree``.
+
+    Returns ``None`` if the library cannot be located, in which case the
+    tests below will skip (see :func:`unittest.TestCase.skipTest`).
+    """
+    name = ctypes.util.find_library("cudart")
+    if name is None:
+        return None
+    try:
+        lib = ctypes.CDLL(name)
+    except OSError:
+        return None
+    lib.cudaFree.argtypes = [ctypes.c_void_p]
+    lib.cudaFree.restype = ctypes.c_int
+    return lib
+
+
+CUDART = _load_cudart()
+
+
+class TestCaptureMode(unittest.TestCase):
+    pass
+
+
+def test_relaxed_allows_capture_unsafe_runtime_call(test, device):
+    """``CaptureMode.Relaxed`` tolerates ``cudaFree(0)`` during capture."""
+    if CUDART is None:
+        test.skipTest("libcudart not available")
+
+    with wp.ScopedDevice(device):
+        # Make sure the CUDA context is fully initialized before the capture
+        # opens, so cudaFree(0) exercises the runtime path under capture
+        # rather than lazy context init.
+        wp.synchronize_device()
+
+        with wp.ScopedCapture(capture_mode=wp.CaptureMode.Relaxed) as capture:
+            err = CUDART.cudaFree(0)
+            test.assertEqual(err, 0, f"cudaFree(0) failed with CUDA error {err} under Relaxed capture")
+
+        test.assertIsNotNone(capture.graph)
+
+
+def test_thread_local_rejects_capture_unsafe_runtime_call(test, device):
+    """``CaptureMode.ThreadLocal`` rejects ``cudaFree(0)`` during capture.
+
+    The rejection invalidates the capture, so ``wp.capture_end`` (called
+    from ``ScopedCapture.__exit__``) raises a ``RuntimeError``. We catch it
+    to confirm that the stricter mode is indeed doing its job.
+    """
+    if CUDART is None:
+        test.skipTest("libcudart not available")
+
+    with wp.ScopedDevice(device):
+        wp.synchronize_device()
+
+        with test.assertRaisesRegex(RuntimeError, "CUDA graph capture failed"):
+            with wp.ScopedCapture(capture_mode=wp.CaptureMode.ThreadLocal):
+                err = CUDART.cudaFree(0)
+                # cudaFree during a strict capture returns a non-zero CUDA
+                # error (typically cudaErrorStreamCaptureUnsupported = 900).
+                test.assertNotEqual(err, 0, "cudaFree(0) unexpectedly succeeded under ThreadLocal capture")
+
+
+devices = get_selected_cuda_test_devices()
+
+# check_output is disabled on the ThreadLocal test because the CUDA runtime
+# may emit a diagnostic line when it rejects cudaFree(0) during capture.
+add_function_test(
+    TestCaptureMode,
+    "test_relaxed_allows_capture_unsafe_runtime_call",
+    test_relaxed_allows_capture_unsafe_runtime_call,
+    devices=devices,
+)
+add_function_test(
+    TestCaptureMode,
+    "test_thread_local_rejects_capture_unsafe_runtime_call",
+    test_thread_local_rejects_capture_unsafe_runtime_call,
+    devices=devices,
+    check_output=False,
+)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds a new ``wp.CaptureMode`` IntEnum (``Global`` / ``ThreadLocal`` / ``Relaxed``) mirroring ``cudaStreamCaptureMode``, and a ``capture_mode`` kwarg on ``wp.capture_begin`` and ``wp.ScopedCapture`` so callers can pick a less-strict capture mode than the hard-coded ``ThreadLocal``. Default behavior is unchanged.

``Relaxed`` is required to compose cleanly with libraries that still perform lazy / capture-unsafe CUDA runtime calls during the capture (e.g. a one-shot ``cudaFree(0)`` or device/peer-access enumeration in a dependency's singleton init). Under the previous ``ThreadLocal`` default, those calls are rejected by the driver and poison the capture; ``Relaxed`` tolerates them, matching the flexibility PyTorch exposes via ``torch.cuda.graph(capture_error_mode=...)``.

Plumbed through to the native ABI by adding a ``mode`` int to ``wp_cuda_graph_begin_capture`` (and the CPU-only stub); the mode int is mapped to ``cudaStreamCaptureMode*`` inside ``warp.cu``. When ``external=True`` the capture was already opened by the caller and the mode argument is ignored.

## Description

<!-- What does this PR change and why? -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

<!-- How did you verify these changes? Example commands, test names,
     or manual steps. -->

## Bug fix

<!-- If this is a bug fix, provide a minimal code example that reproduces
     the issue WITHOUT this PR applied. Delete this section if not applicable. -->

```python
import warp as wp
# Code that demonstrates the bug
```

## New feature / enhancement

<!-- If this is a new feature or enhancement, provide a code example showing
     what this PR enables. Delete this section if not applicable. -->

```python
import warp as wp
# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top-level API exposes CaptureMode with Global, ThreadLocal (default), and Relaxed options.
  * Capture APIs and context manager accept a capture_mode parameter; selected mode is recorded and reused across pause/resume cycles. CPU captures ignore the mode; external captures are recorded but handled differently.

* **Tests**
  * Added tests validating CUDA graph capture behavior for the new capture modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->