### PR TITLE
Install OpenGL build deps in cpp test env (GH-1400)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -730,7 +730,7 @@ linux-x86_64 asv:
 # Ensure cpp examples compile and run
 linux-x86_64 cpp examples test:
   stage: test
-  image: ${CI_REGISTRY_IMAGE}/warp-cpp-test-env:12.9.1-ubuntu24.04
+  image: ${CI_REGISTRY_IMAGE}/warp-cpp-test-env:12.9.1-ubuntu24.04-gl
   needs: [linux-x86_64 build]
   extends:
     - .ipp_lnx_x86_64_gpu

--- a/docker/warp-cpp-test-env/Dockerfile
+++ b/docker/warp-cpp-test-env/Dockerfile
@@ -108,6 +108,15 @@ ENV PATH=/usr/local/cuda/bin:${PATH} \
 # Verify installations
 RUN nvcc --version && uv --version && cmake --version
 
+# Build dependencies for OpenGL/GLFW C++ examples
+# (02_apic_visualization, 03_apic_visualization_cpu). GLFW is fetched and built
+# from source via CMake FetchContent and needs X11 + GL development headers.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgl1-mesa-dev \
+        xorg-dev \
+        libxkbcommon-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /workspace
 
 # Metadata labels


### PR DESCRIPTION
## Summary

- Adds `libgl1-mesa-dev xorg-dev libxkbcommon-dev` to `warp-cpp-test-env` so the C++ APIC examples (which use GLFW + OpenGL via `FetchContent`) actually configure on the CI image instead of `return()`ing early at `find_package(OpenGL QUIET)`.
- Bumps the image tag to `12.9.1-ubuntu24.04-gl` to force CI runners to pull the new layers.

This is prerequisite #1 for fixing GH-1400. The example-side fixes will follow in a separate PR once the new image is live in the registry.

## Test plan

- [ ] New image built and pushed to the registry under tag `12.9.1-ubuntu24.04-gl`.
- [ ] `linux-x86_64 cpp examples test` job runs against the new image on this PR; the existing `00_cubin_launch` and `01_source_include` tests still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment to include graphics and display libraries, enabling proper compilation and execution of C++ visualization examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->