### PR TITLE
Fix APIC C++ examples on Linux (GH-1400)

### DIFF
--- a/warp/examples/cpp/02_apic_visualization/CMakeLists.txt
+++ b/warp/examples/cpp/02_apic_visualization/CMakeLists.txt
@@ -22,6 +22,42 @@ enable_testing()
 # Find CUDA
 find_package(CUDAToolkit REQUIRED)
 
+# Find Warp native directory
+# Default: assume repository checkout (examples are in warp/examples/cpp/)
+if(NOT DEFINED WARP_NATIVE_DIR)
+    set(WARP_NATIVE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../native")
+endif()
+
+# Resolve to absolute path and verify
+get_filename_component(WARP_INCLUDE "${WARP_NATIVE_DIR}" ABSOLUTE)
+if(NOT EXISTS "${WARP_INCLUDE}/builtin.h")
+    message(FATAL_ERROR
+        "Could not find Warp native directory at: ${WARP_INCLUDE}\n"
+        "Set WARP_NATIVE_DIR to override (e.g., cmake -DWARP_NATIVE_DIR=/path/to/warp/native)")
+endif()
+
+# Find Warp library
+# Default: look in warp/bin directory (repository structure)
+if(NOT DEFINED WARP_BIN_DIR)
+    set(WARP_BIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../bin")
+endif()
+get_filename_component(WARP_BIN_ABS "${WARP_BIN_DIR}" ABSOLUTE)
+
+# Try to find warp library
+find_library(WARP_LIB
+    NAMES warp warp.so warp.dll
+    HINTS ${WARP_BIN_ABS}
+    PATHS ENV WARP_PATH
+    PATH_SUFFIXES bin lib
+)
+
+if(NOT WARP_LIB)
+    message(FATAL_ERROR
+        "Could not find Warp library (warp.dll / warp.so / libwarp.dylib)\n"
+        "Hints searched: ${WARP_BIN_ABS}\n"
+        "Set WARP_BIN_DIR to the directory containing the warp library")
+endif()
+
 # Find OpenGL (optional — skip this example on headless CI systems)
 find_package(OpenGL QUIET)
 if(NOT OPENGL_FOUND)
@@ -60,42 +96,6 @@ if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/generated/wave_sim.wrp")
         "  python capture_wave.py\n"
         "or:\n"
         "  uv run capture_wave.py")
-endif()
-
-# Find Warp native directory
-# Default: assume repository checkout (examples are in warp/examples/cpp/)
-if(NOT DEFINED WARP_NATIVE_DIR)
-    set(WARP_NATIVE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../native")
-endif()
-
-# Resolve to absolute path and verify
-get_filename_component(WARP_INCLUDE "${WARP_NATIVE_DIR}" ABSOLUTE)
-if(NOT EXISTS "${WARP_INCLUDE}/builtin.h")
-    message(FATAL_ERROR
-        "Could not find Warp native directory at: ${WARP_INCLUDE}\n"
-        "Set WARP_NATIVE_DIR to override (e.g., cmake -DWARP_NATIVE_DIR=/path/to/warp/native)")
-endif()
-
-# Find Warp library
-# Default: look in warp/bin directory (repository structure)
-if(NOT DEFINED WARP_BIN_DIR)
-    set(WARP_BIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../bin")
-endif()
-get_filename_component(WARP_BIN_ABS "${WARP_BIN_DIR}" ABSOLUTE)
-
-# Try to find warp library
-find_library(WARP_LIB
-    NAMES warp warp.dll
-    HINTS ${WARP_BIN_ABS}
-    PATHS ENV WARP_PATH
-    PATH_SUFFIXES bin lib
-)
-
-if(NOT WARP_LIB)
-    message(FATAL_ERROR
-        "Could not find Warp library (warp.dll / libwarp.so)\n"
-        "Hints searched: ${WARP_BIN_ABS}\n"
-        "Set WARP_BIN_DIR to the directory containing the warp library")
 endif()
 
 # Add executable

--- a/warp/examples/cpp/02_apic_visualization/CMakeLists.txt
+++ b/warp/examples/cpp/02_apic_visualization/CMakeLists.txt
@@ -58,6 +58,16 @@ if(NOT WARP_LIB)
         "Set WARP_BIN_DIR to the directory containing the warp library")
 endif()
 
+# Wrap the resolved library path in an IMPORTED target so CMake passes the
+# full path to the linker verbatim. Otherwise CMake converts an absolute
+# path like /path/to/warp.so to "-L/path/to -lwarp", which fails on Linux
+# because the library lacks the conventional lib<name>.so prefix.
+add_library(warp::runtime UNKNOWN IMPORTED)
+set_target_properties(warp::runtime PROPERTIES
+    IMPORTED_LOCATION "${WARP_LIB}"
+    IMPORTED_NO_SONAME TRUE
+)
+
 # Find OpenGL (optional — skip this example on headless CI systems)
 find_package(OpenGL QUIET)
 if(NOT OPENGL_FOUND)
@@ -122,7 +132,7 @@ target_link_libraries(02_apic_visualization
     OpenGL::GL
     glfw
     glad
-    ${WARP_LIB}
+    warp::runtime
 )
 
 # On Windows, copy the warp DLL to the output directory
@@ -140,5 +150,8 @@ message(STATUS "Warp include: ${WARP_INCLUDE}")
 message(STATUS "Warp library: ${WARP_LIB}")
 message(STATUS "CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
-# Add test that runs the example (disabled by default since it requires GUI)
-# add_test(NAME apic_visualization_test COMMAND $<TARGET_FILE:02_apic_visualization>)
+# Add headless smoke test (uses --smoke to skip GUI; needs a CUDA-capable runtime).
+add_test(NAME apic_visualization_smoke
+    COMMAND $<TARGET_FILE:02_apic_visualization> --smoke
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_tests_properties(apic_visualization_smoke PROPERTIES LABELS "cpp_example")

--- a/warp/examples/cpp/02_apic_visualization/Makefile
+++ b/warp/examples/cpp/02_apic_visualization/Makefile
@@ -55,7 +55,7 @@ NVCC_FLAGS := -std=c++17 \
 
 # Platform-specific linker flags
 ifeq ($(UNAME_S),Linux)
-    LDFLAGS := -lcuda -lcudart -lGL -lglfw -L$(WARP_LIB) -lwarp -Wl,-rpath,$(WARP_LIB)
+    LDFLAGS := -lcuda -lcudart -lGL -lglfw -L$(WARP_LIB) -l:warp.so -Wl,-rpath,$(WARP_LIB)
 else ifeq ($(UNAME_S),Darwin)
     $(error macOS is not supported - CUDA not available on macOS)
 else

--- a/warp/examples/cpp/02_apic_visualization/main.cu
+++ b/warp/examples/cpp/02_apic_visualization/main.cu
@@ -273,9 +273,12 @@ int main(int argc, char** argv)
 
     // Parse command line
     const char* graph_path = "generated/wave_sim";
+    bool smoke = false;
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--graph") == 0 && i + 1 < argc) {
             graph_path = argv[++i];
+        } else if (strcmp(argv[i], "--smoke") == 0) {
+            smoke = true;
         }
     }
 
@@ -313,6 +316,26 @@ int main(int argc, char** argv)
         const char* name = wp_apic_get_param_name(graph, i);
         size_t size = wp_apic_get_param_size(graph, name);
         printf("  [%d] %s: %zu bytes\n", i, name, size);
+    }
+
+    if (smoke) {
+        cudaGraphExec_t exec = (cudaGraphExec_t)wp_apic_get_cuda_graph_exec(graph);
+        if (!exec) {
+            fprintf(stderr, "Failed to get graph executable: %s\n", wp_get_error_string());
+            wp_apic_destroy_graph(graph);
+            return 1;
+        }
+        cudaStream_t stream;
+        CHECK_CUDA(cudaStreamCreate(&stream));
+        const int kSmokeIterations = 10;
+        for (int i = 0; i < kSmokeIterations; i++) {
+            CHECK_CUDA(cudaGraphLaunch(exec, stream));
+        }
+        CHECK_CUDA(cudaStreamSynchronize(stream));
+        CHECK_CUDA(cudaStreamDestroy(stream));
+        printf("smoke OK (%d graph launches)\n", kSmokeIterations);
+        wp_apic_destroy_graph(graph);
+        return 0;
     }
 
     // Initialize GLFW

--- a/warp/examples/cpp/03_apic_visualization_cpu/CMakeLists.txt
+++ b/warp/examples/cpp/03_apic_visualization_cpu/CMakeLists.txt
@@ -38,6 +38,16 @@ if(NOT WARP_LIB)
         "Set WARP_BIN_DIR to the directory containing the warp library")
 endif()
 
+# Wrap the resolved library path in an IMPORTED target so CMake passes the
+# full path to the linker verbatim. Otherwise CMake converts an absolute
+# path like /path/to/warp.so to "-L/path/to -lwarp", which fails on Linux
+# because the library lacks the conventional lib<name>.so prefix.
+add_library(warp::runtime UNKNOWN IMPORTED)
+set_target_properties(warp::runtime PROPERTIES
+    IMPORTED_LOCATION "${WARP_LIB}"
+    IMPORTED_NO_SONAME TRUE
+)
+
 # Find OpenGL (optional — skip this example on headless CI systems)
 find_package(OpenGL QUIET)
 if(NOT OPENGL_FOUND)
@@ -91,7 +101,7 @@ target_link_libraries(03_apic_visualization_cpu
     OpenGL::GL
     glfw
     glad
-    ${WARP_LIB}
+    warp::runtime
 )
 
 # On Windows, copy the warp DLLs to the output directory
@@ -110,3 +120,9 @@ endif()
 
 message(STATUS "Warp include: ${WARP_INCLUDE}")
 message(STATUS "Warp library: ${WARP_LIB}")
+
+# Add headless smoke test (uses --smoke to skip GUI).
+add_test(NAME apic_visualization_cpu_smoke
+    COMMAND $<TARGET_FILE:03_apic_visualization_cpu> --smoke
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set_tests_properties(apic_visualization_cpu_smoke PROPERTIES LABELS "cpp_example")

--- a/warp/examples/cpp/03_apic_visualization_cpu/CMakeLists.txt
+++ b/warp/examples/cpp/03_apic_visualization_cpu/CMakeLists.txt
@@ -6,6 +6,38 @@ project(apic_visualization_cpu CXX)
 
 enable_testing()
 
+# Find Warp native directory
+if(NOT DEFINED WARP_NATIVE_DIR)
+    set(WARP_NATIVE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../native")
+endif()
+
+get_filename_component(WARP_INCLUDE "${WARP_NATIVE_DIR}" ABSOLUTE)
+if(NOT EXISTS "${WARP_INCLUDE}/builtin.h")
+    message(FATAL_ERROR
+        "Could not find Warp native directory at: ${WARP_INCLUDE}\n"
+        "Set WARP_NATIVE_DIR to override (e.g., cmake -DWARP_NATIVE_DIR=/path/to/warp/native)")
+endif()
+
+# Find Warp library
+if(NOT DEFINED WARP_BIN_DIR)
+    set(WARP_BIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../bin")
+endif()
+get_filename_component(WARP_BIN_ABS "${WARP_BIN_DIR}" ABSOLUTE)
+
+find_library(WARP_LIB
+    NAMES warp warp.so warp.dll
+    HINTS ${WARP_BIN_ABS}
+    PATHS ENV WARP_PATH
+    PATH_SUFFIXES bin lib
+)
+
+if(NOT WARP_LIB)
+    message(FATAL_ERROR
+        "Could not find Warp library (warp.dll / warp.so / libwarp.dylib)\n"
+        "Hints searched: ${WARP_BIN_ABS}\n"
+        "Set WARP_BIN_DIR to the directory containing the warp library")
+endif()
+
 # Find OpenGL (optional — skip this example on headless CI systems)
 find_package(OpenGL QUIET)
 if(NOT OPENGL_FOUND)
@@ -44,38 +76,6 @@ if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/generated/wave_sim.wrp")
         "  python capture_wave.py\n"
         "or:\n"
         "  uv run capture_wave.py")
-endif()
-
-# Find Warp native directory
-if(NOT DEFINED WARP_NATIVE_DIR)
-    set(WARP_NATIVE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../native")
-endif()
-
-get_filename_component(WARP_INCLUDE "${WARP_NATIVE_DIR}" ABSOLUTE)
-if(NOT EXISTS "${WARP_INCLUDE}/builtin.h")
-    message(FATAL_ERROR
-        "Could not find Warp native directory at: ${WARP_INCLUDE}\n"
-        "Set WARP_NATIVE_DIR to override (e.g., cmake -DWARP_NATIVE_DIR=/path/to/warp/native)")
-endif()
-
-# Find Warp library
-if(NOT DEFINED WARP_BIN_DIR)
-    set(WARP_BIN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../bin")
-endif()
-get_filename_component(WARP_BIN_ABS "${WARP_BIN_DIR}" ABSOLUTE)
-
-find_library(WARP_LIB
-    NAMES warp warp.dll
-    HINTS ${WARP_BIN_ABS}
-    PATHS ENV WARP_PATH
-    PATH_SUFFIXES bin lib
-)
-
-if(NOT WARP_LIB)
-    message(FATAL_ERROR
-        "Could not find Warp library (warp.dll / libwarp.so)\n"
-        "Hints searched: ${WARP_BIN_ABS}\n"
-        "Set WARP_BIN_DIR to the directory containing the warp library")
 endif()
 
 # Add executable (pure C++ — no CUDA required)

--- a/warp/examples/cpp/03_apic_visualization_cpu/Makefile
+++ b/warp/examples/cpp/03_apic_visualization_cpu/Makefile
@@ -51,7 +51,7 @@ CXX_FLAGS := -std=c++17 \
 
 # Platform-specific linker flags
 ifeq ($(UNAME_S),Linux)
-    LDFLAGS := -ldl -lGL -lglfw -L$(WARP_LIB) -lwarp -Wl,-rpath,$(WARP_LIB)
+    LDFLAGS := -ldl -lGL -lglfw -L$(WARP_LIB) -l:warp.so -Wl,-rpath,$(WARP_LIB)
 else ifeq ($(UNAME_S),Darwin)
     LDFLAGS := -ldl -framework OpenGL -lglfw -L$(WARP_LIB) -lwarp -Wl,-rpath,$(WARP_LIB)
 else

--- a/warp/examples/cpp/03_apic_visualization_cpu/main.cpp
+++ b/warp/examples/cpp/03_apic_visualization_cpu/main.cpp
@@ -373,9 +373,12 @@ int main(int argc, char** argv)
     printf("=== APIC Wave Simulation Example (CPU) ===\n\n");
 
     const char* graph_path = "generated/wave_sim";
+    bool smoke = false;
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--graph") == 0 && i + 1 < argc)
             graph_path = argv[++i];
+        else if (strcmp(argv[i], "--smoke") == 0)
+            smoke = true;
     }
 
     // Initialize Warp runtime
@@ -413,6 +416,20 @@ int main(int argc, char** argv)
         const char* name = wp_apic_get_param_name(graph, i);
         size_t size = wp_apic_get_param_size(graph, name);
         printf("  [%d] %s: %zu bytes\n", i, name, size);
+    }
+
+    if (smoke) {
+        const int kSmokeIterations = 10;
+        for (int i = 0; i < kSmokeIterations; i++) {
+            if (!wp_apic_cpu_replay_graph(graph)) {
+                fprintf(stderr, "CPU graph replay failed at iteration %d\n", i);
+                wp_apic_destroy_graph(graph);
+                return 1;
+            }
+        }
+        printf("smoke OK (%d replay iterations)\n", kSmokeIterations);
+        wp_apic_destroy_graph(graph);
+        return 0;
     }
 
     // Initialize GLFW

--- a/warp/examples/cpp/03_apic_visualization_cpu/main.cpp
+++ b/warp/examples/cpp/03_apic_visualization_cpu/main.cpp
@@ -261,7 +261,7 @@ bool load_warp_clang()
     g_wp_load_obj = (wp_load_obj_fn)GetProcAddress(lib, "wp_load_obj");
     g_wp_lookup = (wp_lookup_fn)GetProcAddress(lib, "wp_lookup");
 #else
-    const char* lib_name = "libwarp-clang.so";
+    const char* lib_name = "warp-clang.so";
 #ifdef __APPLE__
     lib_name = "libwarp-clang.dylib";
 #endif

--- a/warp/examples/cpp/test_examples.sh
+++ b/warp/examples/cpp/test_examples.sh
@@ -83,22 +83,28 @@ for example_dir in "${SCRIPT_DIR}"/*/; do
     if [[ ! -d "${example_dir}" ]] || [[ "$(basename "${example_dir}")" = "build" ]]; then
         continue
     fi
-    
+
     example_name=$(basename "${example_dir}")
-    
-    # Only process examples that have a compile_kernel.py
+
+    # APIC examples ship capture_wave.py instead of compile_kernel.py;
+    # both are pre-build Python scripts that produce inputs the C++ build needs.
     if [[ -f "${example_dir}/compile_kernel.py" ]]; then
-        echo "- Compiling ${example_name}..."
-        cd "${example_dir}"
-        if command -v uv &> /dev/null; then
-            uv run compile_kernel.py || { echo "ERROR: Failed to compile kernel for ${example_name}" >&2; exit 1; }
-        else
-            python3 compile_kernel.py || { echo "ERROR: Failed to compile kernel for ${example_name}" >&2; exit 1; }
-        fi
-        cd "${SCRIPT_DIR}"
+        prebuild_script="compile_kernel.py"
+    elif [[ -f "${example_dir}/capture_wave.py" ]]; then
+        prebuild_script="capture_wave.py"
     else
-        echo "- Skipping ${example_name} (no compile_kernel.py)"
+        echo "- Skipping ${example_name} (no compile_kernel.py or capture_wave.py)"
+        continue
     fi
+
+    echo "- Running ${prebuild_script} for ${example_name}..."
+    cd "${example_dir}"
+    if command -v uv &> /dev/null; then
+        uv run "${prebuild_script}" || { echo "ERROR: ${prebuild_script} failed for ${example_name}" >&2; exit 1; }
+    else
+        python3 "${prebuild_script}" || { echo "ERROR: ${prebuild_script} failed for ${example_name}" >&2; exit 1; }
+    fi
+    cd "${SCRIPT_DIR}"
 done
 echo ""
 


### PR DESCRIPTION
## Summary

Fixes the C++ APIC examples (`02_apic_visualization`, `03_apic_visualization_cpu`) which currently fail to build on Linux on `release-1.13`. Targets `release-1.13` first because that branch already has the `fastcall.cpp` revert from #1399 — the `main`-branch fix is blocked on that landing there. See [the GH-1400 update comment](https://github.com/NVIDIA/warp/issues/1400#issuecomment-4340025975) for context.

Two commits:

1. **`Fix APIC C++ example library lookup on Linux`** — five-site naming alignment with `build_lib.py`'s prefix-less `warp.so` / `warp-clang.so` Linux artifacts:
   - CMake `find_library(NAMES warp warp.so warp.dll …)` so the bare `warp.so` is matched.
   - Makefile linux LDFLAGS use `-l:warp.so` (GNU ld literal-name extension).
   - `03_apic_visualization_cpu/main.cpp` `dlopen("warp-clang.so")` (was `libwarp-clang.so`).
   - Reorder warp-library lookup above the `find_package(OpenGL QUIET)` gate so configure fails loudly even on hosts without GL.
   - Widened `FATAL_ERROR` enumerates all three platform variants.

2. **`Add CTest smoke coverage for APIC C++ examples`** — make the existing `linux-x86_64 cpp examples test` job actually exercise these examples:
   - `--smoke` argv branch in both `main.cu` / `main.cpp` runs the meaningful warp paths (load graph → load CPU modules → query params → replay 10×) and exits before any `glfwInit()`.
   - `add_test(NAME apic_visualization_smoke / apic_visualization_cpu_smoke …)` with the `cpp_example` label.
   - `test_examples.sh` extended to run `capture_wave.py` alongside the existing `compile_kernel.py` convention so `.wrp` inputs are produced before the C++ build step.
   - Wraps the resolved warp library in an `UNKNOWN IMPORTED` CMake target so `target_link_libraries` passes the absolute path verbatim — otherwise CMake auto-converts `/path/to/warp.so` to `-L/path/to -lwarp` and the link fails the same way as the original Makefile bug.

The `warp-cpp-test-env` image already has the OpenGL/X11 build deps (committed via `88781e9d9` on `main`; the rebuilt `12.9.1-ubuntu24.04`-tagged image was pushed to the registry, and `release-1.13` references the same tag). No CI image change is needed in this PR.

Out of scope: #1399 (Python C ABI symbols leaking into `warp.so`). That issue is independent at the cause level but is a hard prerequisite for the same fix on `main`.

## Test plan

- [x] Local: `uv run build_lib.py --quick && cd warp/examples/cpp && bash test_examples.sh` — all 4 CTest entries pass:
  - `cubin_launch_test` (existing)
  - `source_include_test` (existing)
  - `apic_visualization_smoke` (new) — `smoke OK (10 graph launches)`
  - `apic_visualization_cpu_smoke` (new) — `smoke OK (10 replay iterations)`
- [ ] CI: `linux-x86_64 cpp examples test` job picks up the two new tests.