### PR TITLE
Restore PyTorch intersphinx to stable

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -337,9 +337,7 @@ intersphinx_mapping = {
     "jax": ("https://docs.jax.dev/en/latest", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "python": ("https://docs.python.org/3", None),
-    # Pinned to 2.10 because the `stable` intersphinx inventory is broken upstream.
-    # See https://github.com/pytorch/pytorch/issues/182007 — revert once fixed.
-    "pytorch": ("https://docs.pytorch.org/docs/2.10", None),
+    "pytorch": ("https://pytorch.org/docs/stable", None),
 }
 
 


### PR DESCRIPTION
The upstream issue (pytorch/pytorch#182007) has been resolved via pytorch/docs#85, which restores `objects.inv` to the `stable` alias.

This reverts the temporary pin to `/docs/2.10/` introduced in !2286.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PyTorch documentation reference to use the stable version instead of a pinned release, ensuring documentation links remain current with the latest stable PyTorch documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->