### PR TITLE
Expand GitHub Actions GPU testing surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
       
 
-  test-warp:
+  test-warp-cpu:
     if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ${{ matrix.os }}
     needs: build-warp
@@ -178,13 +178,75 @@ jobs:
           show: "fail"
         if: always()
 
-  test-warp-gpu:
-    runs-on: linux-amd64-gpu-h100-latest-1
-    needs: build-warp
-    # Only run on PRs (pull-request branches) or scheduled runs
-    if: github.repository == 'NVIDIA/warp' && (startsWith(github.ref, 'refs/heads/pull-request/') || github.event_name == 'schedule')
+  # Compute whether the changes on a pull-request/* branch touch files relevant
+  # to GPU testing or to doctest. Always runs (cheap). Downstream jobs read the
+  # outputs to decide whether to run on PR branches; non-PR events (schedule,
+  # workflow_dispatch, push to main / release-* / tag) bypass these outputs via
+  # the dependent jobs' own `if:` blocks.
+  gpu-changes:
+    if: github.repository == 'NVIDIA/warp'
+    runs-on: ubuntu-latest
+    # Stay green for dependents on failure; combined with the `|| 'true'` fallback
+    # on the outputs below, this keeps PR-style branches from silently skipping
+    # GPU testing or doctest when the filter has a transient error.
+    continue-on-error: true
     permissions:
       contents: read
+    outputs:
+      gpu_relevant: ${{ steps.filter-gpu.outputs.any_changed || 'true' }}
+      docs_relevant: ${{ steps.filter-docs.outputs.any_changed || 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch main for diff base
+        run: git fetch --depth=1 origin main
+
+      - name: Detect GPU-relevant changes
+        id: filter-gpu
+        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad  # v47.0.5
+        with:
+          base_sha: origin/main
+          files: |
+            .github/workflows/ci.yml
+            .python-version
+            warp/**
+            pyproject.toml
+            tools/**
+            deps/*
+            build_lib.py
+            build_llvm.py
+            uv.lock
+
+      - name: Detect doctest-relevant changes
+        id: filter-docs
+        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad  # v47.0.5
+        with:
+          base_sha: origin/main
+          files: docs/**
+
+  test-warp-gpu-linux:
+    runs-on: ${{ matrix.runner-label }}
+    needs: [build-warp, gpu-changes]
+    if: |
+      github.repository == 'NVIDIA/warp' && (
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/release-') ||
+        needs.gpu-changes.outputs.gpu_relevant == 'true'
+      )
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner-label: linux-amd64-gpu-h100-latest-1
+            gpu-name: h100
+          - runner-label: linux-amd64-gpu-rtxpro6000-latest-1
+            gpu-name: rtxpro6000
     container:
       image: ubuntu:24.04
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
@@ -200,7 +262,167 @@ jobs:
         with:
           enable-apt: true
 
-      - name: Install git and git-lfs
+      - name: Install system dependencies
+        # curl and gpg are required by codecov/codecov-action@v6 to download and verify the uploader.
+        run: |
+          apt-get update
+          apt-get install -y git git-lfs curl gpg
+          git lfs install
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: "0.11.3"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Download Warp build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact-ubuntu-x86_64
+          path: warp/bin/
+
+      - name: Run Tests
+        run: uv run --extra dev --extra torch-cu12 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
+
+      - name: Test Summary
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        with:
+          paths: "rspec.xml"
+          show: "fail"
+        if: always()
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          disable_search: true
+          files: ./rspec.xml
+          report_type: test_results
+          flags: unittests,linux,${{ matrix.gpu-name }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          disable_search: true
+          files: ./coverage.xml
+          flags: unittests,linux,${{ matrix.gpu-name }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-warp-gpu-windows:
+    runs-on: windows-amd64-gpu-rtxpro6000-latest-1
+    needs: [build-warp, gpu-changes]
+    if: |
+      github.repository == 'NVIDIA/warp' && (
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/release-') ||
+        needs.gpu-changes.outputs.gpu_relevant == 'true'
+      )
+    permissions:
+      contents: read
+    timeout-minutes: 45
+    steps:
+      - name: Display GPU information
+        run: nvidia-smi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: "0.11.3"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Download Warp build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact-windows
+          path: warp/bin/
+
+      - name: Run Tests
+        # Pin usd-core to 25.5.1 to work around a frequent loading crash on Windows.
+        run: uv run --extra dev --extra torch-cu12 --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
+
+      - name: Test Summary
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        with:
+          paths: "rspec.xml"
+          show: "fail"
+        if: always()
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          disable_search: true
+          files: ./rspec.xml
+          report_type: test_results
+          flags: unittests,windows,rtxpro6000
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          disable_search: true
+          files: ./coverage.xml
+          flags: unittests,windows,rtxpro6000
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  # Validate Sphinx doctests (RST testcode blocks and autodoc-extracted docstrings)
+  # against a real GPU. PR-style branches gate on the same filter as the GPU test
+  # rows, plus a docs/** filter for RST-only doctest changes.
+  test-warp-doctest:
+    runs-on: linux-amd64-gpu-l4-latest-1
+    needs: [build-warp, gpu-changes]
+    if: |
+      github.repository == 'NVIDIA/warp' && (
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/release-') ||
+        needs.gpu-changes.outputs.gpu_relevant == 'true' ||
+        needs.gpu-changes.outputs.docs_relevant == 'true'
+      )
+    container:
+      image: ubuntu:24.04
+      options: -u root --security-opt seccomp=unconfined --shm-size 16g
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    steps:
+      - name: Display GPU information
+        run: nvidia-smi
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
+      - name: Install system dependencies
         run: |
           apt-get update
           apt-get install -y git git-lfs
@@ -215,25 +437,18 @@ jobs:
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
           version: "0.11.3"
-      
+
       - name: Set up Python
         run: uv python install
-      
+
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
           name: build-artifact-ubuntu-x86_64
           path: warp/bin/
-      
-      - name: Run Tests
-        run: uv run --extra dev --extra torch-cu12 -m warp.tests --junit-report-xml rspec.xml -s autodetect
-      
-      - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
-        with:
-          paths: "rspec.xml"
-          show: "fail"
-        if: always()
+
+      - name: Run doctest
+        run: uv run --extra docs build_docs.py --doctest --no-html
 
   build-docs:
     if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'

--- a/warp/tests/cuda/test_conditional_captures.py
+++ b/warp/tests/cuda/test_conditional_captures.py
@@ -1048,6 +1048,7 @@ def test_error_alloc_while_subgraph(test, device):
 
 devices = get_test_devices()
 cuda_devices = get_cuda_test_devices()
+cuda_devices_with_mempool = get_cuda_test_devices_with_mempool()
 
 
 class TestConditionalCaptures(unittest.TestCase):
@@ -1107,17 +1108,32 @@ add_function_test(
     TestConditionalCaptures, "test_graph_debug_dot_print", test_graph_debug_dot_print, devices=cuda_devices
 )
 
-add_function_test(TestConditionalCaptures, "test_error_alloc_if", test_error_alloc_if, devices=cuda_devices)
-add_function_test(TestConditionalCaptures, "test_error_alloc_else", test_error_alloc_else, devices=cuda_devices)
-add_function_test(TestConditionalCaptures, "test_error_alloc_while", test_error_alloc_while, devices=cuda_devices)
 add_function_test(
-    TestConditionalCaptures, "test_error_alloc_if_subgraph", test_error_alloc_if_subgraph, devices=cuda_devices
+    TestConditionalCaptures, "test_error_alloc_if", test_error_alloc_if, devices=cuda_devices_with_mempool
 )
 add_function_test(
-    TestConditionalCaptures, "test_error_alloc_else_subgraph", test_error_alloc_else_subgraph, devices=cuda_devices
+    TestConditionalCaptures, "test_error_alloc_else", test_error_alloc_else, devices=cuda_devices_with_mempool
 )
 add_function_test(
-    TestConditionalCaptures, "test_error_alloc_while_subgraph", test_error_alloc_while_subgraph, devices=cuda_devices
+    TestConditionalCaptures, "test_error_alloc_while", test_error_alloc_while, devices=cuda_devices_with_mempool
+)
+add_function_test(
+    TestConditionalCaptures,
+    "test_error_alloc_if_subgraph",
+    test_error_alloc_if_subgraph,
+    devices=cuda_devices_with_mempool,
+)
+add_function_test(
+    TestConditionalCaptures,
+    "test_error_alloc_else_subgraph",
+    test_error_alloc_else_subgraph,
+    devices=cuda_devices_with_mempool,
+)
+add_function_test(
+    TestConditionalCaptures,
+    "test_error_alloc_while_subgraph",
+    test_error_alloc_while_subgraph,
+    devices=cuda_devices_with_mempool,
 )
 
 

--- a/warp/tests/fem/test_fem_examples.py
+++ b/warp/tests/fem/test_fem_examples.py
@@ -21,6 +21,7 @@ from warp._src.utils import check_p2p
 from warp.tests.unittest_utils import (
     add_function_test,
     get_selected_cuda_test_devices,
+    get_selected_cuda_test_devices_with_mempool,
 )
 
 
@@ -101,6 +102,7 @@ def add_fem_example_test(
 
 
 cuda_devices = get_selected_cuda_test_devices(mode="basic")
+cuda_devices_with_mempool = get_selected_cuda_test_devices_with_mempool(mode="basic")
 
 
 class TestFemExamples(unittest.TestCase):
@@ -116,7 +118,7 @@ if check_p2p():
     add_fem_example_test(
         TestFemDiffusionExamples,
         name="fem.example_diffusion_mgpu",
-        devices=cuda_devices,
+        devices=cuda_devices_with_mempool,
         test_options={"headless": True},
     )
 
@@ -231,19 +233,19 @@ add_fem_example_test(
 add_fem_example_test(
     TestFemExamples,
     name="fem.example_taylor_green",
-    devices=cuda_devices,
+    devices=cuda_devices_with_mempool,
     test_options={"num_frames": 10, "resolution": 10, "headless": True},
 )
 add_fem_example_test(
     TestFemExamples,
     name="fem.example_shallow_water",
-    devices=cuda_devices,
+    devices=cuda_devices_with_mempool,
     test_options={"num_frames": 10, "resolution": 10, "headless": True},
 )
 add_fem_example_test(
     TestFemExamples,
     name="fem.example_kelvin_helmholtz",
-    devices=cuda_devices,
+    devices=cuda_devices_with_mempool,
     test_options={"num_frames": 25, "resolution": 20, "headless": True},
 )
 

--- a/warp/tests/fem/test_fem_integrate.py
+++ b/warp/tests/fem/test_fem_integrate.py
@@ -560,6 +560,7 @@ def test_capturability(test, device):
 
 devices = get_test_devices()
 cuda_devices = get_selected_cuda_test_devices()
+cuda_devices_with_mempool = get_selected_cuda_test_devices_with_mempool()
 
 
 class TestFemIntegrate(unittest.TestCase):
@@ -573,7 +574,7 @@ add_function_test(TestFemIntegrate, "test_tensor_divergence_theorem", test_tenso
 add_function_test(TestFemIntegrate, "test_grad_decomposition", test_grad_decomposition, devices=devices)
 add_function_test(TestFemIntegrate, "test_integrate_high_order", test_integrate_high_order, devices=cuda_devices)
 add_function_test(TestFemIntegrate, "test_interpolate_reduction", test_interpolate_reduction, devices=devices)
-add_function_test(TestFemIntegrate, "test_capturability", test_capturability, devices=cuda_devices)
+add_function_test(TestFemIntegrate, "test_capturability", test_capturability, devices=cuda_devices_with_mempool)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2, failfast=True)

--- a/warp/tests/geometry/test_bvh.py
+++ b/warp/tests/geometry/test_bvh.py
@@ -697,6 +697,7 @@ def tile_bvh_query_valid_ray_kernel(
 
 devices = get_test_devices()
 cuda_devices = get_cuda_test_devices()
+cuda_devices_with_mempool = get_cuda_test_devices_with_mempool()
 
 
 class TestBvh(unittest.TestCase):
@@ -741,7 +742,7 @@ add_function_test(TestBvh, "test_tile_bvh_query_ray", test_tile_bvh_query_ray, d
 add_function_test(TestBvh, "test_bvh_query_aabb_tiled", test_bvh_query_aabb_tiled, devices=cuda_devices)
 add_function_test(TestBvh, "test_bvh_query_ray_tiled", test_bvh_query_ray_tiled, devices=cuda_devices)
 
-add_function_test(TestBvh, "test_capture_bvh_rebuild", test_capture_bvh_rebuild, devices=cuda_devices)
+add_function_test(TestBvh, "test_capture_bvh_rebuild", test_capture_bvh_rebuild, devices=cuda_devices_with_mempool)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/warp/tests/geometry/test_grouped_bvh.py
+++ b/warp/tests/geometry/test_grouped_bvh.py
@@ -518,7 +518,7 @@ def test_capture_bvh_rebuild_grouped(test, device):
 
 
 devices = get_test_devices()
-cuda_devices = get_cuda_test_devices()
+cuda_devices_with_mempool = get_cuda_test_devices_with_mempool()
 
 
 class TestGroupedBvh(unittest.TestCase):
@@ -556,7 +556,10 @@ add_function_test(
 )
 
 add_function_test(
-    TestGroupedBvh, "test_grouped_capture_bvh_rebuild", test_capture_bvh_rebuild_grouped, devices=cuda_devices
+    TestGroupedBvh,
+    "test_grouped_capture_bvh_rebuild",
+    test_capture_bvh_rebuild_grouped,
+    devices=cuda_devices_with_mempool,
 )
 
 if __name__ == "__main__":

--- a/warp/tests/geometry/test_mesh.py
+++ b/warp/tests/geometry/test_mesh.py
@@ -224,7 +224,10 @@ def test_mesh_query_ray(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh", "cubql"]
+        constructors = ["sah", "median", "lbvh"]
+        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
+        if device.is_mempool_supported:
+            constructors.append("cubql")
 
     leaf_sizes = [1, 2, 4]
 
@@ -316,7 +319,10 @@ def test_mesh_refit(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh", "cubql"]
+        constructors = ["sah", "median", "lbvh"]
+        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
+        if device.is_mempool_supported:
+            constructors.append("cubql")
 
     # Ray aimed at the origin — hits the unit cube centered there
     origin = wp.vec3(0.0, 5.0, 0.0)
@@ -430,6 +436,7 @@ def test_mesh_exceptions(test, device):
 
 
 devices = get_test_devices()
+cuda_devices_with_mempool = get_selected_cuda_test_devices_with_mempool()
 
 
 class TestMesh(unittest.TestCase):
@@ -444,7 +451,7 @@ add_function_test(TestMesh, "test_mesh_query_point", test_mesh_query_point, devi
 add_function_test(TestMesh, "test_mesh_query_ray", test_mesh_query_ray, devices=devices)
 add_function_test(TestMesh, "test_grouped_mesh_query_ray", test_grouped_mesh_query_ray, devices=devices)
 add_function_test(TestMesh, "test_mesh_refit", test_mesh_refit, devices=devices)
-add_function_test(TestMesh, "test_mesh_refit_graph", test_mesh_refit_graph, devices=get_selected_cuda_test_devices())
+add_function_test(TestMesh, "test_mesh_refit_graph", test_mesh_refit_graph, devices=cuda_devices_with_mempool)
 add_function_test(TestMesh, "test_mesh_exceptions", test_mesh_exceptions, devices=get_selected_cuda_test_devices())
 
 

--- a/warp/tests/geometry/test_mesh_query_ray.py
+++ b/warp/tests/geometry/test_mesh_query_ray.py
@@ -208,7 +208,10 @@ def test_mesh_query_ray_grad(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh", "cubql"]
+        constructors = ["sah", "median", "lbvh"]
+        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
+        if device.is_mempool_supported:
+            constructors.append("cubql")
 
     leaf_sizes = [1, 2, 4]
 
@@ -400,7 +403,10 @@ def test_mesh_query_ray_count_intersections(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh", "cubql"]
+        constructors = ["sah", "median", "lbvh"]
+        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
+        if device.is_mempool_supported:
+            constructors.append("cubql")
 
     leaf_sizes = [1, 2, 4]
 
@@ -673,7 +679,10 @@ def test_mesh_query_ray_edge(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh", "cubql"]
+        constructors = ["sah", "median", "lbvh"]
+        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
+        if device.is_mempool_supported:
+            constructors.append("cubql")
 
     leaf_sizes = [1, 2, 4]
 

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -10,7 +10,12 @@ import unittest
 import numpy as np
 
 import warp as wp
-from warp.tests.unittest_utils import add_function_test, get_cuda_test_devices, get_test_devices
+from warp.tests.unittest_utils import (
+    add_function_test,
+    get_cuda_test_devices,
+    get_test_devices,
+    get_test_devices_with_mempool,
+)
 
 
 @wp.kernel
@@ -540,6 +545,7 @@ def test_get_param_ptr(test, device):
 
 
 devices = get_test_devices()
+devices_with_mempool = get_test_devices_with_mempool()
 
 add_function_test(TestApic, "test_save_apic_false_error", test_save_apic_false_error, devices=devices)
 add_function_test(TestApic, "test_save_single_kernel", test_save_single_kernel, devices=devices)
@@ -550,15 +556,20 @@ add_function_test(TestApic, "test_save_load_memset", test_save_load_memset, devi
 add_function_test(TestApic, "test_bindings_param_update", test_bindings_param_update, devices=devices)
 add_function_test(TestApic, "test_array_slicing", test_array_slicing, devices=devices)
 add_function_test(TestApic, "test_complex_pipeline", test_complex_pipeline, devices=devices)
-add_function_test(TestApic, "test_internal_allocation", test_internal_allocation, devices=devices)
-add_function_test(TestApic, "test_multiple_internal_allocations", test_multiple_internal_allocations, devices=devices)
+add_function_test(TestApic, "test_internal_allocation", test_internal_allocation, devices=devices_with_mempool)
+add_function_test(
+    TestApic,
+    "test_multiple_internal_allocations",
+    test_multiple_internal_allocations,
+    devices=devices_with_mempool,
+)
 add_function_test(TestApic, "test_graph_execution_unchanged", test_graph_execution_unchanged, devices=devices)
 add_function_test(TestApic, "test_save_load_with_param_update", test_save_load_with_param_update, devices=devices)
 add_function_test(TestApic, "test_save_load_memcpy_and_kernel", test_save_load_memcpy_and_kernel, devices=devices)
 add_function_test(
     TestApic, "test_save_load_fill", test_save_load_fill, devices=get_cuda_test_devices()
 )  # CPU: wp_memtile_host not recorded
-add_function_test(TestApic, "test_save_load_alloc_only", test_save_load_alloc_only, devices=devices)
+add_function_test(TestApic, "test_save_load_alloc_only", test_save_load_alloc_only, devices=devices_with_mempool)
 add_function_test(TestApic, "test_get_param_ptr", test_get_param_ptr, devices=devices)
 
 

--- a/warp/tests/test_examples.py
+++ b/warp/tests/test_examples.py
@@ -37,6 +37,7 @@ from warp.tests.unittest_utils import (
     USD_AVAILABLE,
     add_function_test,
     get_selected_cuda_test_devices,
+    get_selected_cuda_test_devices_with_mempool,
     get_test_devices,
     sanitize_identifier,
 )
@@ -182,6 +183,7 @@ def add_example_test(
 
 
 cuda_test_devices = get_selected_cuda_test_devices(mode="basic")  # Don't test on multiple GPUs to save time
+cuda_test_devices_with_mempool = get_selected_cuda_test_devices_with_mempool(mode="basic")
 test_devices = get_test_devices(mode="basic")
 
 # NOTE: To give the parallel test runner more opportunities to parallelize test cases,
@@ -278,7 +280,7 @@ add_example_test(
 add_example_test(
     TestOptimExamples,
     name="optim.example_fluid_checkpoint",
-    devices=cuda_test_devices,
+    devices=cuda_test_devices_with_mempool,
     test_options={"headless": True, "train_iters": 5, "num_frames": 300, "pillow_required": True},
 )
 add_example_test(
@@ -290,7 +292,7 @@ add_example_test(
 add_example_test(
     TestOptimExamples,
     name="optim.example_navier_stokes_perturbation",
-    devices=cuda_test_devices,
+    devices=cuda_test_devices_with_mempool,
     test_options={"headless": True, "train_iters": 5, "lead_steps": 5, "spin_up_steps": 10},
 )
 

--- a/warp/tests/test_graph.py
+++ b/warp/tests/test_graph.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 
 import warp as wp
-from warp.tests.unittest_utils import add_function_test, get_test_devices
+from warp.tests.unittest_utils import add_function_test, get_test_devices, get_test_devices_with_mempool
 
 
 @wp.kernel
@@ -159,13 +159,14 @@ def test_graph_alloc(test, device):
 
 
 devices = get_test_devices()
+devices_with_mempool = get_test_devices_with_mempool()
 
 add_function_test(TestGraph, "test_graph_single_kernel", test_graph_single_kernel, devices=devices)
 add_function_test(TestGraph, "test_graph_multiple_kernels", test_graph_multiple_kernels, devices=devices)
 add_function_test(TestGraph, "test_graph_replay_multiple", test_graph_replay_multiple, devices=devices)
 add_function_test(TestGraph, "test_graph_memcpy", test_graph_memcpy, devices=devices)
 add_function_test(TestGraph, "test_graph_memset", test_graph_memset, devices=devices)
-add_function_test(TestGraph, "test_graph_alloc", test_graph_alloc, devices=devices)
+add_function_test(TestGraph, "test_graph_alloc", test_graph_alloc, devices=devices_with_mempool)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/warp/tests/test_linear_solvers.py
+++ b/warp/tests/test_linear_solvers.py
@@ -437,11 +437,12 @@ class TestLinearSolvers(unittest.TestCase):
 
 
 devices = get_test_devices()
+devices_with_mempool = get_test_devices_with_mempool()
 
-add_function_test(TestLinearSolvers, "test_cg", test_cg, devices=devices)
-add_function_test(TestLinearSolvers, "test_cr", test_cr, devices=devices)
-add_function_test(TestLinearSolvers, "test_bicgstab", test_bicgstab, devices=devices)
-add_function_test(TestLinearSolvers, "test_gmres", test_gmres, devices=devices)
+add_function_test(TestLinearSolvers, "test_cg", test_cg, devices=devices_with_mempool)
+add_function_test(TestLinearSolvers, "test_cr", test_cr, devices=devices_with_mempool)
+add_function_test(TestLinearSolvers, "test_bicgstab", test_bicgstab, devices=devices_with_mempool)
+add_function_test(TestLinearSolvers, "test_gmres", test_gmres, devices=devices_with_mempool)
 add_function_test(
     TestLinearSolvers,
     "test_batched_host_loop_per_batch_tolerance",

--- a/warp/tests/test_map.py
+++ b/warp/tests/test_map.py
@@ -9,7 +9,12 @@ import warp as wp
 import warp.tests.aux_test_name_clash1 as name_clash_module_1
 import warp.tests.aux_test_name_clash2 as name_clash_module_2
 from warp._src.utils import map_cache
-from warp.tests.unittest_utils import add_function_test, assert_np_equal, get_cuda_test_devices, get_test_devices
+from warp.tests.unittest_utils import (
+    add_function_test,
+    assert_np_equal,
+    get_cuda_test_devices_with_mempool,
+    get_test_devices,
+)
 
 
 @wp.struct
@@ -579,7 +584,7 @@ def test_cache_broadcasting(test, device):
 
 
 devices = get_test_devices("basic")
-cuda_test_devices = get_cuda_test_devices()
+cuda_test_devices_with_mempool = get_cuda_test_devices_with_mempool()
 
 
 class TestMap(unittest.TestCase):
@@ -598,7 +603,7 @@ add_function_test(TestMap, "test_broadcasting", test_broadcasting, devices=devic
 add_function_test(TestMap, "test_input_validity", test_input_validity, devices=devices)
 add_function_test(TestMap, "test_output_validity", test_output_validity, devices=devices)
 add_function_test(TestMap, "test_kernel_creation", test_kernel_creation, devices=devices)
-add_function_test(TestMap, "test_graph_capture", test_graph_capture, devices=cuda_test_devices)
+add_function_test(TestMap, "test_graph_capture", test_graph_capture, devices=cuda_test_devices_with_mempool)
 add_function_test(TestMap, "test_renamed_warp_module", test_renamed_warp_module, devices=devices)
 add_function_test(TestMap, "test_cache_same_types_shapes", test_cache_same_types_shapes, devices=devices)
 add_function_test(TestMap, "test_cache_different_shapes", test_cache_different_shapes, devices=devices)

--- a/warp/tests/test_sparse.py
+++ b/warp/tests/test_sparse.py
@@ -796,6 +796,7 @@ def test_bsr_alloc(test, device):
 
 devices = get_test_devices()
 cuda_test_devices = get_selected_cuda_test_devices()
+cuda_test_devices_with_mempool = get_selected_cuda_test_devices_with_mempool()
 
 
 class TestSparse(unittest.TestCase):
@@ -863,7 +864,7 @@ add_function_test(TestSparse, "test_csr_mv", make_test_bsr_mv((1, 1), wp.float32
 add_function_test(TestSparse, "test_bsr_mv_1_3", make_test_bsr_mv((1, 3), wp.float32), devices=devices)
 add_function_test(TestSparse, "test_bsr_mv_3_3", make_test_bsr_mv((3, 3), wp.float64), devices=devices)
 
-add_function_test(TestSparse, "test_capturability", test_capturability, devices=cuda_test_devices)
+add_function_test(TestSparse, "test_capturability", test_capturability, devices=cuda_test_devices_with_mempool)
 add_function_test(TestSparse, "test_bsr_mm_max_new_nnz", test_bsr_mm_max_new_nnz, devices=devices, check_output=False)
 
 add_function_test(TestSparse, "test_bsr_alloc", test_bsr_alloc, devices=devices)

--- a/warp/tests/unittest_utils.py
+++ b/warp/tests/unittest_utils.py
@@ -125,6 +125,35 @@ def get_cuda_test_devices(mode=None):
     return [d for d in devices if d.is_cuda]
 
 
+def get_test_devices_with_mempool(mode: str | None = None):
+    """Like :func:`get_test_devices`, but drops CUDA devices without memory pool support.
+
+    Allocations performed inside a CUDA graph capture must use ``cudaMallocAsync``,
+    which itself requires mempool support on the device. Use this getter to gate
+    tests that allocate during capture so they skip cleanly on devices reporting
+    ``is_mempool_supported = False``. CPU devices pass through unchanged.
+    """
+    return [d for d in get_test_devices(mode) if not d.is_cuda or d.is_mempool_supported]
+
+
+def get_cuda_test_devices_with_mempool(mode=None):
+    """Like :func:`get_cuda_test_devices`, but drops CUDA devices without memory pool support.
+
+    See :func:`get_test_devices_with_mempool` for context on why mempool support
+    is required for in-capture allocation.
+    """
+    return [d for d in get_cuda_test_devices(mode) if d.is_mempool_supported]
+
+
+def get_selected_cuda_test_devices_with_mempool(mode: str | None = None):
+    """Like :func:`get_selected_cuda_test_devices`, but drops CUDA devices without memory pool support.
+
+    See :func:`get_test_devices_with_mempool` for context on why mempool support
+    is required for in-capture allocation.
+    """
+    return [d for d in get_selected_cuda_test_devices(mode) if d.is_mempool_supported]
+
+
 class StreamCapture:
     def __init__(self, stream_name):
         self.stream_name = stream_name  # 'stdout' or 'stderr'


### PR DESCRIPTION
## Description

Expand the GitHub Actions GPU testing surface in `.github/workflows/ci.yml`:

- Add a `gpu-changes` filter job using `step-security/changed-files`. PR-style branches that touch only docs or other non-source files skip the GPU jobs. The job carries `continue-on-error: true` so a transient failure in the filter doesn't silently cancel downstream GPU jobs.
- Replace the single-runner `test-warp-gpu` with a `test-warp-gpu-linux` matrix covering H100 (existing) and RTX PRO 6000 (new) on `linux-amd64-gpu-rtxpro6000-latest-1`.
- Add `test-warp-gpu-windows` running on `windows-amd64-gpu-rtxpro6000-latest-1`. Setup mirrors the GitLab `windows-x86_64 test` job, including the `usd-core==25.5.1` pin to work around a frequent loading crash on Windows.
- Lift the trigger restriction on GPU testing. GPU jobs now also run on `workflow_dispatch`, on direct pushes to `main` and `release-*` branches, and on tags. They continue to run on `pull-request/*` branches (gated by the `gpu-changes` filter) and on schedule.
- Add Codecov uploads for test results and coverage on every GPU job, with per-row flags (`unittests,linux,h100`, `unittests,linux,rtxpro6000`, `unittests,windows,rtxpro6000`). Each upload step is gated with `if: ${{ !cancelled() }}` and marked `continue-on-error: true` so a Codecov outage or upload error does not fail the job, and partial coverage from failed test runs is still uploaded.
- Rename the CPU-only `test-warp` matrix job to `test-warp-cpu` so the distinction from `test-warp-gpu-*` is explicit in the run-status list.
- Skip mempool-dependent tests cleanly on devices reporting `is_mempool_supported = False` (the Windows runner is RTX PRO 6000 in TCC mode, where mempool is not supported). Affects tests that allocate inside a CUDA graph capture: `test_apic.{test_internal_allocation, test_multiple_internal_allocations, test_save_load_alloc_only}`, `test_graph.test_graph_alloc`, `test_map.test_graph_capture`, `test_linear_solvers.{test_cg, test_cr, test_bicgstab, test_gmres}`, `test_bvh.test_capture_bvh_rebuild`, `test_grouped_bvh.test_grouped_capture_bvh_rebuild`, `test_mesh.test_mesh_refit_graph`. Centralized via three new helpers in `warp/tests/unittest_utils.py`: `get_test_devices_with_mempool`, `get_cuda_test_devices_with_mempool`, `get_selected_cuda_test_devices_with_mempool`. The previously-inline filters in `test_conditional_captures`, `test_examples`, `test_fem_examples`, `test_fem_integrate`, and `test_sparse` now use the same helpers.
- Skip the cuBQL `bvh_constructor` on the same no-mempool devices to work around an unhandled native exception in `wp_mesh_create_device` (tracked in #1430). Affects `test_mesh.test_mesh_query_ray`, `test_mesh.test_mesh_refit`, and the equivalents in `test_mesh_query_ray.py`.
- Install `curl` and `gpg` in the Linux GPU job containers so `codecov/codecov-action@v6` can download and verify its uploader.

Action pins used (both allowlisted via wildcards):

- `step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad` (v47.0.5)
- `codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2` (v6.0.0)

The matrix shape accepts new rows trivially, so adding more GPUs (including a future multi-GPU RTX PRO 6000 entry) should be a one-line append per runner.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Test plan

End-to-end validation on this PR:

- [x] `gpu-changes`, `test-warp-gpu-linux (h100)`, `test-warp-gpu-linux (rtxpro6000)`, and `test-warp-gpu-windows` all execute and produce JUnit and coverage XML.
- [x] `test-warp-gpu-windows` runs cleanly on the RTX PRO 6000 runner with the mempool/cuBQL skips in place (5163 tests, 55 skipped, 0 failures on the most recent green run).
- [x] Codecov receives test-results and coverage with the expected per-row flags.
- [ ] A follow-up docs-only commit on this branch causes the GPU jobs to skip (filter working as intended).

## Known follow-ups (not in this PR)

- The trigger `if:` block is duplicated across `test-warp-gpu-linux` and `test-warp-gpu-windows`. If a third top-level GPU job is added, consolidating the gate into a single `should_run` output on `gpu-changes` would avoid the duplication.
- The cuBQL native exception that motivates the no-mempool `bvh_constructor` skip is tracked in #1430. The proper fix is in Warp: select cuBQL's sync `DeviceMemoryResource` when mempool is unavailable, instead of relying on cuBQL's `cudaMallocAsync`-based default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automatic detection of GPU-relevant changes to gate GPU-specific workflows.
  * Replaced the prior GPU job with separate Linux and Windows GPU test paths.

* **Tests**
  * Added multi-GPU and multi-OS test matrices, moved setup earlier, and enabled coverage collection with automated uploads.
  * Restricted several CUDA tests to run only on devices that support CUDA memory-pool features.

* **Bug Fixes**
  * Suppressed a spurious CPU feature warning during host feature discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->