### PR TITLE
Reject bfloat16 accumulator tiles in tile_matmul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@
 
 ### Fixed
 
+- Reject `bfloat16` accumulator tiles in `wp.tile_matmul()` uniformly across the cuBLASDx and scalar
+  matmul backends. cuBLASDx allows only `float16`, `float32`, or `float64` as the accumulator
+  precision, and the scalar fallback's bf16 accumulator was silently lossy for non-trivial K. The
+  `out` tile is always an accumulator. When the backward pass is enabled, `a` and `b` are also
+  accumulators for `adjA` and `adjB`. As a consequence, `bfloat16` `a`/`b` inputs are not supported
+  together with the backward pass in `wp.tile_matmul()`
+  ([GH-1427](https://github.com/NVIDIA/warp/issues/1427)).
+
 ### Documentation
 
 ## [1.13.0] - 2026-05-04

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -12891,6 +12891,23 @@ def tile_matmul_lto_dispatch_func(
             "tile_matmul() arguments must be tiles of float16, bfloat16, float32 or float64, vec2h, vec2f, vec2d entries"
         )
 
+    # Reject bfloat16 as the accumulator precision uniformly across all backends. cuBLASDx
+    # disallows bf16 accumulators (see cublasdx::detail::blas_description::is_accumulator_precision_allowed),
+    # and the scalar-matmul fallback's bf16 accumulator is silently lossy for non-trivial K. Forward
+    # uses 'out' as the accumulator. If backward is enabled, 'a' and 'b' are accumulators for adjA, adjB.
+    if out.type.dtype == bfloat16:
+        raise TypeError(
+            "tile_matmul() does not support a bfloat16 'out' tile. "
+            "The 'out' tile is the accumulator, and the allowed accumulator dtypes are float16, "
+            "float32, and float64."
+        )
+    if options["enable_backward"] and (a.type.dtype == bfloat16 or b.type.dtype == bfloat16):
+        raise TypeError(
+            "tile_matmul() does not support bfloat16 'a' or 'b' tiles when the backward pass is enabled. "
+            "Backward passes use 'a' and 'b' as accumulators for adjA and adjB respectively, and the "
+            "allowed accumulator dtypes are float16, float32, and float64."
+        )
+
     if (
         (a.type.shape[1] != b.type.shape[0])
         or (a.type.shape[0] != out.type.shape[0])

--- a/warp/tests/tile/test_tile_matmul.py
+++ b/warp/tests/tile/test_tile_matmul.py
@@ -84,10 +84,6 @@ wp.overload(
     tile_gemm, {"A": wp.array2d(dtype=wp.float16), "B": wp.array2d(dtype=wp.float16), "C": wp.array2d(dtype=wp.float16)}
 )
 wp.overload(
-    tile_gemm,
-    {"A": wp.array2d(dtype=wp.bfloat16), "B": wp.array2d(dtype=wp.bfloat16), "C": wp.array2d(dtype=wp.bfloat16)},
-)
-wp.overload(
     tile_gemm, {"A": wp.array2d(dtype=wp.float32), "B": wp.array2d(dtype=wp.float32), "C": wp.array2d(dtype=wp.float32)}
 )
 wp.overload(
@@ -225,6 +221,27 @@ def bf16_to_f32_kernel(input: wp.array2d(dtype=wp.bfloat16), output: wp.array2d(
     output[i, j] = wp.float32(input[i, j])
 
 
+# bfloat16 inputs require a wider accumulator: cuBLASDx allows only float16, float32, or float64
+# as the accumulator precision. The kernel goes in its own module with enable_backward=False so
+# that backward LTOs (which would use bfloat16 accumulators for adjA, adjB) are not generated.
+@wp.kernel(module="unique", module_options={"enable_backward": False})
+def tile_gemm_bf16(A: wp.array2d(dtype=wp.bfloat16), B: wp.array2d(dtype=wp.bfloat16), C: wp.array2d(dtype=wp.float32)):
+    i, j = wp.tid()
+
+    sum = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+
+    K = A.shape[1]
+    count = int(K / TILE_K)
+
+    for k in range(0, count):
+        a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(i * TILE_M, k * TILE_K))
+        b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(k * TILE_K, j * TILE_N))
+
+        wp.tile_matmul(a, b, sum)
+
+    wp.tile_store(C, sum, offset=(i * TILE_M, j * TILE_N))
+
+
 def test_tile_gemm_bf16(test, device):
     M = TILE_M * 7
     K = TILE_K * 6
@@ -239,22 +256,18 @@ def test_tile_gemm_bf16(test, device):
     B_f32 = wp.array(B, device=device)
     A_wp = wp.zeros((M, K), dtype=wp.bfloat16, device=device)
     B_wp = wp.zeros((K, N), dtype=wp.bfloat16, device=device)
-    C_wp = wp.zeros((M, N), dtype=wp.bfloat16, device=device)
+    C_wp = wp.zeros((M, N), dtype=wp.float32, device=device)
 
     wp.launch(f32_to_bf16_kernel, dim=(M, K), inputs=[A_f32, A_wp], device=device)
     wp.launch(f32_to_bf16_kernel, dim=(K, N), inputs=[B_f32, B_wp], device=device)
 
     wp.launch_tiled(
-        tile_gemm,
+        tile_gemm_bf16,
         dim=(int(M / TILE_M), int(N / TILE_N)),
         inputs=[A_wp, B_wp, C_wp],
         block_dim=TILE_DIM,
         device=device,
     )
-
-    # Convert result back to float32 for comparison
-    C_f32 = wp.zeros((M, N), dtype=wp.float32, device=device)
-    wp.launch(bf16_to_f32_kernel, dim=(M, N), inputs=[C_wp, C_f32], device=device)
 
     # Quantize reference inputs through bfloat16 to match what the kernel sees
     A_ref = wp.zeros((M, K), dtype=wp.float32, device=device)
@@ -262,7 +275,7 @@ def test_tile_gemm_bf16(test, device):
     wp.launch(bf16_to_f32_kernel, dim=(M, K), inputs=[A_wp, A_ref], device=device)
     wp.launch(bf16_to_f32_kernel, dim=(K, N), inputs=[B_wp, B_ref], device=device)
 
-    np.testing.assert_allclose(C_f32.numpy(), A_ref.numpy() @ B_ref.numpy(), rtol=1.0e-2)
+    np.testing.assert_allclose(C_wp.numpy(), A_ref.numpy() @ B_ref.numpy(), rtol=1.0e-2)
 
 
 class TestTileMatmul(unittest.TestCase):


### PR DESCRIPTION
## Description

cuBLASDx only allows `float16`, `float32`, or `float64` as the accumulator precision (see `cublasdx::detail::blas_description::is_accumulator_precision_allowed`). The constraint was tightened into a `static_assert` in the cuBLASDx that ships with libmathdx 0.3.2 (cu13), so the bf16 `tile_matmul` path added in #1332 stopped compiling on cu13. The cu12 toolchain compiled the same code but produced silently lossy results because bf16 has only 8 mantissa bits, so reductions over non-trivial K diverge.

The cu13 GitLab job is build-only at the moment (per the comment in `.gitlab/ci/cuda-13-build.yml`: *"No testing until GitLab runners have CUDA 13"*), so the regression was not caught in CI when #1332 went in.

This PR rejects bf16 accumulator tiles uniformly across the cuBLASDx and scalar matmul backends. The unified rule keeps the support matrix consistent across cu12 / cu13 and across CPU / GPU, and prevents the scalar fallback from silently producing degraded results. The forward pass uses `out` as the accumulator; when backward is enabled, `a` and `b` are also accumulators for `adjA` and `adjB`, so bf16 `a` / `b` inputs are not compatible with autodiff in `tile_matmul` today.

A more complete answer for the bf16 + autodiff case (internal fp32 promotion of the backward accumulators with cast-on-store) requires changes to `tile_matmul_acc` and the LTO dispatch and is left as a follow-up.

closes #1427

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

```bash
uv run warp/tests/tile/test_tile_matmul.py
```

All 21 tests pass on CPU and on both `cuda:0` / `cuda:1` (RTX 3090, sm_86) under CUDA Toolkit 13.0 / libmathdx 0.3.2 / cuBLASDx 0.6.0. Pushing here to additionally exercise the H100 GitHub Actions job.

## Bug fix

Without this PR, on a Warp build linked against libmathdx 0.3.2 (cu13):

```python
import warp as wp

@wp.kernel
def k(A: wp.array2d(dtype=wp.bfloat16), B: wp.array2d(dtype=wp.bfloat16), C: wp.array2d(dtype=wp.bfloat16)):
    i, j = wp.tid()
    s = wp.tile_zeros(shape=(8, 4), dtype=A.dtype)
    a = wp.tile_load(A, shape=(8, 8), offset=(i * 8, 0))
    b = wp.tile_load(B, shape=(8, 4), offset=(0, j * 4))
    wp.tile_matmul(a, b, s)
    wp.tile_store(C, s, offset=(i * 8, j * 4))

A = wp.zeros((8, 8), dtype=wp.bfloat16, device="cuda:0")
B = wp.zeros((8, 4), dtype=wp.bfloat16, device="cuda:0")
C = wp.zeros((8, 4), dtype=wp.bfloat16, device="cuda:0")
wp.launch_tiled(k, dim=(1, 1), inputs=[A, B, C], block_dim=64, device="cuda:0")
```

Fails at module load with NVRTC `static_assert` from `cublasdx/detail/blas_description.hpp(456)`:

```
error: static assertion failed with "Accumulator precision must be one of the following:
    int32_t, uint32_t, int64_t, uint64_t, __half, float, double, please consult docs for more information"
```

With this PR, the kernel raises a clear Warp-level `TypeError` at codegen time pointing the user at the allowed accumulator dtypes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * tile_matmul now enforces stricter bfloat16 handling by rejecting bfloat16 accumulators and disallowing bfloat16 inputs during backward differentiation.

* **New Features**
  * Added tile_gemm_bf16 kernel supporting bfloat16 inputs with float32 accumulator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->