### PR TITLE
Add pluggable logging infrastructure (GH-1315, GH-1434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@
 - Add `--use-dynamic-cuda` build option to link against shared CUDA libraries instead of embedding
   them statically; the corresponding shared libraries must be present at runtime
   ([GH-1334](https://github.com/NVIDIA/warp/issues/1334)).
+- Add pluggable logging infrastructure: implement the `wp.Logger` protocol and pass it to `wp.set_logger()`,
+  or scope it temporarily with `wp.ScopedLogger`. `wp.config.log_level` controls the global verbosity threshold
+  and can be scoped temporarily with `wp.ScopedLogLevel`; all Python-side diagnostic output now routes through
+  the logger ([GH-1315](https://github.com/NVIDIA/warp/issues/1315),
+  [GH-1434](https://github.com/NVIDIA/warp/issues/1434)).
 
 ### Removed
 
@@ -43,6 +48,10 @@
   import statements from `warp.jax_experimental` to `warp.jax`. No API changes are required.
   `warp.jax_experimental` will be removed in Warp 1.16.
   ([GH-1370](https://github.com/NVIDIA/warp/issues/1370))
+- Deprecate `warp.config.verbose` and `warp.config.quiet` in favor of `warp.config.log_level`. Reading or setting
+  either flag continues to work during the deprecation window and now emits a one-time `DeprecationWarning`.
+  `warp.config.verbose_warnings` is unaffected and continues to control whether warning output includes the source
+  location ([GH-1315](https://github.com/NVIDIA/warp/issues/1315)).
 
 ### Changed
 
@@ -86,6 +95,8 @@
 - Fix memory leak with retained graph allocations ([GH-1429](https://github.com/NVIDIA/warp/issues/1429)).
 - Fix a data race in `wp.ScopedMemoryTracker.report()` that could corrupt the report when called
   concurrently from multiple threads ([GH-1415](https://github.com/NVIDIA/warp/issues/1415)).
+- Fix Warp warning emission overriding user warning filters, making deprecation warnings unsuppressible via
+  `warnings.filterwarnings()` ([GH-1315](https://github.com/NVIDIA/warp/issues/1315)).
 
 ### Documentation
 

--- a/design/unified-logging.md
+++ b/design/unified-logging.md
@@ -1,0 +1,215 @@
+# Unified Logging
+
+**Issue**: [GH-1315](https://github.com/NVIDIA/warp/issues/1315) (host-side logging infrastructure)
+
+## Motivation
+
+Warp emits host-side diagnostics during initialization, module loading, kernel
+code generation, compilation, array operations, and interop workflows. Before
+this change those messages were routed through a mix of direct `print()` calls,
+`warnings.warn()` calls, `sys.stdout` / `sys.stderr` writes, and small local
+helpers.
+
+This branch introduces one host-side logging path controlled by
+`wp.config.log_level` and a small pluggable `wp.Logger` protocol. Applications
+and frameworks can now redirect Warp's host diagnostics without Warp carrying
+application-specific integrations.
+
+Kernel-side user logging, such as a future `wp.log_*()` device builtin or device
+ring buffer, is outside the scope of this branch.
+
+## Requirements
+
+| ID  | Requirement                                                              | Priority | Notes                                      |
+| --- | ------------------------------------------------------------------------ | -------- | ------------------------------------------ |
+| R1  | Define named log-level constants in one place                            | Must     | Re-exported as `wp.LOG_*`                  |
+| R2  | Add one global threshold for Warp host diagnostics                       | Must     | `wp.config.log_level`                      |
+| R3  | Route host warnings through Python's `warnings` machinery by default     | Must     | Honors `-W`, `simplefilter()`, etc.        |
+| R4  | Provide a pluggable host logger for framework integration                | Must     | `wp.Logger`, `wp.set_logger()`             |
+| R5  | Preserve legacy `verbose` and `quiet` behavior during deprecation        | Must     | Existing callers should keep working       |
+| R6  | Avoid bundling application-specific logger adapters in Warp              | Must     | App-side adapters live outside the library |
+
+**Non-goals:**
+
+- Public host-side `wp.log_*()` functions. Warp's host emitters are internal
+  helpers in `warp._src.logger`.
+- Kernel-side logging. `wp.printf()` remains the existing kernel-side debugging
+  primitive; device-side `wp.log_*()` builtins are future work.
+- Structured or machine-readable log records. This branch focuses on routing
+  and thresholding human-readable diagnostics.
+- Built-in Omniverse Kit, `carb`, or other application-specific adapters.
+  Applications install those adapters via `wp.set_logger()`.
+
+## Design
+
+### Log-Level Constants
+
+Four levels are defined in `warp/_src/logger.py` and re-exported from
+`warp/__init__.py`. Numeric values match Python's `logging` module:
+
+| Constant         | Value | Purpose                              |
+| ---------------- | ----- | ------------------------------------ |
+| `wp.LOG_DEBUG`   | 10    | Verbose compilation/debug output     |
+| `wp.LOG_INFO`    | 20    | Informational messages               |
+| `wp.LOG_WARNING` | 30    | Warnings and deprecation notices     |
+| `wp.LOG_ERROR`   | 40    | Errors                               |
+
+`wp.config.log_level` defaults to `warp.LOG_INFO` (20). Documentation renders
+the default symbolically as `warp.LOG_INFO (20)` so readers do not have to infer
+the meaning of the raw integer.
+
+### Public API Surface
+
+The public host-side surface is:
+
+- `wp.LOG_DEBUG`, `wp.LOG_INFO`, `wp.LOG_WARNING`, `wp.LOG_ERROR` for assigning
+  or comparing `wp.config.log_level`.
+- `wp.Logger`, a runtime-checkable `Protocol` with `debug()`, `info()`,
+  `warning()`, and `error()` methods.
+- `wp.set_logger()` and `wp.get_logger()` to install or retrieve the active
+  logger. Passing `None` to `wp.set_logger()` restores Warp's built-in default.
+- `wp.ScopedLogger(logger)` to temporarily install a logger and restore the
+  previous logger on exit. Passing `None` temporarily restores the built-in
+  default.
+- `wp.ScopedLogLevel(log_level)` to temporarily override `wp.config.log_level`
+  and restore the previous level on exit.
+
+The built-in default logger remains an internal implementation detail
+(`warp._src.logger.LoggerBasic`). Users and frameworks should depend on the
+`wp.Logger` protocol, not subclass the default implementation.
+
+### Internal Emitters
+
+Warp's own diagnostics flow through internal helpers in `warp/_src/logger.py`:
+
+```python
+def log_debug(message: str) -> None: ...
+def log_info(message: str) -> None: ...
+def log_warning(message: str, category=None, stacklevel=1, once=False) -> None: ...
+def log_error(message: str) -> None: ...
+```
+
+These helpers are not re-exported as public API. Internal callers import them
+directly from `warp._src.logger`.
+
+`log_debug()` emits when either legacy `wp.config.verbose` is true or
+`wp.config.log_level <= wp.LOG_DEBUG`. Keeping both checks preserves behavior
+for code that still toggles `verbose` after `wp.init()`.
+
+`log_info()` emits when `wp.config.log_level <= wp.LOG_INFO`.
+
+`log_warning()` emits when `wp.config.log_level <= wp.LOG_WARNING`. It accepts:
+
+- `category`, passed to the logger's `warning()` method for Python warning
+  integration.
+- `stacklevel`, expressed relative to the `log_warning()` call site. The helper
+  adjusts it before dispatch, so custom logger adapters can pass the received
+  value directly to `warnings.warn(..., stacklevel=stacklevel)`.
+- `once`, which deduplicates non-deprecation warnings by `(category, message)`.
+
+`DeprecationWarning` messages are deduplicated unconditionally to preserve the
+old `warp._src.utils.warn()` behavior.
+
+`log_error()` always emits regardless of `wp.config.log_level`.
+
+### Default Logger
+
+The built-in logger routes output as follows:
+
+| Method      | Destination / behavior                                      |
+| ----------- | ------------------------------------------------------------ |
+| `debug()`   | Writes message text to `sys.stdout`                          |
+| `info()`    | Writes message text to `sys.stdout`                          |
+| `warning()` | Calls `warnings.warn()` with temporary Warp warning formatting |
+| `error()`   | Writes `Warp Error: <message>` to `sys.stderr`                |
+
+Warnings intentionally pass through Python's `warnings` machinery so existing
+filters, `-W` flags, and `warnings.simplefilter()` keep working. The default
+formatter writes warnings as `Warp <CategoryName>: <message>`. If
+`wp.config.verbose_warnings` is true, it also appends the source filename, line
+number, and source line when available.
+
+### Custom Loggers
+
+Custom loggers are duck-typed against `wp.Logger`. They must provide all four
+methods and `warning()` must accept `category` and `stacklevel` keyword
+arguments:
+
+```python
+class MyLogger:
+    def debug(self, message): ...
+    def info(self, message): ...
+    def warning(self, message, category=None, stacklevel=1): ...
+    def error(self, message): ...
+
+wp.set_logger(MyLogger())
+```
+
+Adapters that want Python warning filters should call:
+
+```python
+warnings.warn(message, category, stacklevel=stacklevel)
+```
+
+Adapters that forward to another logging system may ignore `category` and
+`stacklevel`, but then warning filtering and warning-source attribution are the
+adapter's responsibility.
+
+Warp does not ship a `LoggerKit` or other application-specific adapter. For
+example, an Omniverse Kit integration should live in the application layer and
+install itself with `wp.set_logger()`.
+
+### Deprecated Config Flags
+
+`wp.config.verbose` and `wp.config.quiet` remain available during the
+deprecation window:
+
+- External reads or writes of either flag emit a one-time `DeprecationWarning`
+  routed through the active Warp logger.
+- Internal Warp reads do not emit those access warnings.
+- `Runtime.__init__` still maps `quiet=True` to at least `wp.LOG_WARNING` and
+  `verbose=True` to `wp.LOG_DEBUG`, unless the diagnostics path is temporarily
+  suppressing the init banner.
+- Call sites that historically honored runtime changes to `verbose` continue to
+  check `wp.config.verbose or wp.config.log_level <= wp.LOG_DEBUG`.
+
+The deprecated setter does not directly mutate `log_level`; compatibility is
+handled at initialization and at the legacy verbose-sensitive call sites. This
+avoids surprising side effects while keeping existing code functional.
+
+`wp.config.verbose_warnings` is not deprecated. It only controls warning
+formatting and has no `log_level` replacement.
+
+### Migrated Call Sites
+
+This branch migrates Warp's host-side diagnostics onto the new logger path,
+including:
+
+- Initialization banners and diagnostics-related output.
+- Module load, code generation, compilation, cache, and launch diagnostics.
+- Warnings and deprecation notices previously routed through
+  `warp._src.utils.warn()` or direct `warnings.warn()` calls.
+- Error output in renderer and JAX interop paths.
+- `wp.config.print_launches` output, which now goes through the active logger.
+
+API deprecation warnings converted to `log_warning()` pass an explicit
+`stacklevel` so default Python filters attribute them to user call sites instead
+of internal Warp files.
+
+## Testing Strategy
+
+- **Logger protocol and routing:** Verify `set_logger()` / `get_logger()`,
+  `ScopedLogger`, duck-typed custom loggers, validation failures, default logger
+  stdout/stderr routing, and restoration semantics.
+- **Level gating:** Verify `LOG_DEBUG`, `LOG_INFO`, `LOG_WARNING`, and
+  `LOG_ERROR` thresholds, including the legacy `verbose` compatibility path.
+- **Warnings:** Verify Python warning filters still work with the default
+  logger, custom warning adapters receive a `warnings.warn()`-ready stack level,
+  duplicate deprecation warnings are suppressed, and deprecation warnings remain
+  visible under default filters when attributed to user call sites.
+- **Deprecated config flags:** Verify external `verbose` / `quiet` access emits
+  one-time warnings through the active logger, respects `log_level`, and does
+  not warn for internal Warp callers.
+- **Integration:** Verify print-launch output, diagnostics banner suppression,
+  CUDA compiler verbosity, and JAX FFI debug gates use the new logging behavior
+  without dropping legacy `verbose` support.

--- a/docs/_templates/autosummary/base.rst
+++ b/docs/_templates/autosummary/base.rst
@@ -1,0 +1,9 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+{# Keep this inline while there is one display-only override. If more config
+   defaults need symbolic annotations, move this to a small annotation map. #}
+.. auto{{ objtype }}:: {{ objname }}{% if fullname == "warp.config.log_level" %}
+   :annotation: : int = warp.LOG_INFO
+{% endif %}

--- a/docs/api_reference/warp.rst
+++ b/docs/api_reference/warp.rst
@@ -467,6 +467,23 @@ Timing Flags
    TIMING_MEMCPY
    TIMING_MEMSET
 
+Logging
+-------
+
+.. autosummary::
+   :nosignatures:
+   :toctree: _generated
+
+   Logger
+   ScopedLogLevel
+   ScopedLogger
+   get_logger
+   set_logger
+   LOG_DEBUG
+   LOG_ERROR
+   LOG_INFO
+   LOG_WARNING
+
 NumPy Interop
 -------------
 

--- a/docs/api_reference/warp_config.rst
+++ b/docs/api_reference/warp_config.rst
@@ -32,6 +32,7 @@ API
    lineinfo
    llvm_cuda
    load_module_max_workers
+   log_level
    max_unroll
    mode
    optimization_level

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -363,7 +363,7 @@ from typing import Any
 import numpy as np
 import warp as wp
 
-wp.config.quiet = True
+wp.config.log_level = wp.LOG_WARNING
 wp.init()
 """
 

--- a/docs/user_guide/basics.rst
+++ b/docs/user_guide/basics.rst
@@ -371,7 +371,7 @@ By default, status messages will be printed out after each module has been loade
 * How long it took to load the module in milliseconds
 * Whether the module was compiled ``(compiled)``, loaded from the cache ``(cached)``, or was unable to be loaded ``(error)``.
 
-For debugging purposes, ``wp.config.verbose = True`` can be set to also get a printout when each module load begins.
+For debugging purposes, ``wp.config.log_level = wp.LOG_DEBUG`` can be set to also get a printout when each module load begins.
 
 Here is an example illustrating the functionality of the kernel cache by running ``python -m warp.examples.tile.example_tile_cholesky``
 twice. The first time, we see:

--- a/docs/user_guide/debugging.rst
+++ b/docs/user_guide/debugging.rst
@@ -41,26 +41,123 @@ In addition, formatted C-style printing for *scalar types* is available through 
 
         wp.printf("A float value %f, an int value: %d\n", x, i)
 
-Verbose Mode and Printing Launches
-----------------------------------
+Diagnostics and Logging
+-----------------------
 
 For complex applications, it can be difficult to understand the order-of-operations that lead to a bug. To help diagnose
 these issues, Warp supports a simple option to print out all launches and arguments to the console::
 
     wp.config.print_launches = True
 
-Verbose mode can also be enabled with::
+Log Level
+^^^^^^^^^
 
-    wp.config.verbose = True
+Warp emits informational, warning, and error messages through its own logging
+infrastructure. The verbosity is controlled by a single global threshold:
 
-In verbose mode, additional messages will be printed to standard output regarding program progress and
-code generation, such as when operations may be non-differentiable.
+.. code-block:: python
 
-Verbose *warnings* can be enabled with::
+    wp.config.log_level = wp.LOG_DEBUG    # most verbose: codegen details, module loads
+    wp.config.log_level = wp.LOG_INFO     # default: init banner, compile timings
+    wp.config.log_level = wp.LOG_WARNING  # warnings and errors only
+    wp.config.log_level = wp.LOG_ERROR    # errors only
+
+Messages below the threshold are suppressed. Errors always emit regardless of
+the level.
+
+At ``wp.LOG_DEBUG``, additional messages are printed to standard output
+regarding program progress and code generation, such as when operations may be
+non-differentiable.
+
+.. note::
+    The legacy ``wp.config.verbose`` and ``wp.config.quiet`` flags are
+    deprecated. Migrate to ``wp.config.log_level``:
+
+    - ``wp.config.verbose = True`` → ``wp.config.log_level = wp.LOG_DEBUG``
+    - ``wp.config.quiet = True`` → ``wp.config.log_level = wp.LOG_WARNING``
+
+    Reading or setting either deprecated flag emits a one-time
+    ``DeprecationWarning``. During the deprecation window the flag is still
+    honored alongside ``log_level``, so existing code keeps working; remove the
+    flag once your code sets ``log_level`` directly.
+
+    ``wp.config.verbose_warnings`` is not deprecated. It is an orthogonal
+    formatting flag that controls whether warning messages include the source
+    location and has no ``log_level`` equivalent.
+
+Verbose Warnings
+^^^^^^^^^^^^^^^^
+
+To include the source location in each ``Warp UserWarning`` message, enable::
 
     wp.config.verbose_warnings = True
 
-This can be useful in identifying where a particular ``Warp UserWarning`` message is being emitted from.
+This can be useful in identifying where a particular warning is being emitted from.
+
+Custom Loggers
+^^^^^^^^^^^^^^
+
+By default Warp routes diagnostics through a built-in logger that writes
+debug and info messages to ``sys.stdout``, errors to ``sys.stderr``, and
+routes warnings through Python's :mod:`warnings` filter machinery so that
+``-W`` flags and :func:`warnings.simplefilter` work as expected.
+
+Frameworks that want to capture Warp's output can supply a custom logger.
+:class:`wp.Logger <warp.Logger>` is a runtime-checkable :class:`~typing.Protocol`,
+so any object with the four methods below works. There is no need to inherit
+from a Warp base class; framework integrators typically wrap an existing
+logger in a small adapter:
+
+.. code-block:: python
+
+    class MyLogger:
+        def debug(self, message): ...
+        def info(self, message): ...
+        def warning(self, message, category=None, stacklevel=1): ...
+        def error(self, message): ...
+
+    wp.set_logger(MyLogger())
+
+The ``warning`` method must accept the ``category`` and ``stacklevel`` keyword
+arguments even if the adapter ignores them: the internal emitter passes them
+by name, so an adapter without those parameters raises ``TypeError`` at the
+first warning. The built-in default logger uses them to integrate with
+Python's :mod:`warnings` filter machinery.
+
+To forward Warp's diagnostics into an existing :mod:`logging` pipeline, wrap
+:class:`logging.Logger` in a small adapter:
+
+.. code-block:: python
+
+    import logging
+    import warp as wp
+
+    app_logger = logging.getLogger("myapp.warp")
+
+    class StdlibAdapter:
+        def debug(self, message): app_logger.debug(message)
+        def info(self, message): app_logger.info(message)
+        def warning(self, message, category=None, stacklevel=1): app_logger.warning(message)
+        def error(self, message): app_logger.error(message)
+
+    wp.set_logger(StdlibAdapter())
+
+This routes all of Warp's output through stdlib :mod:`logging` (and any
+handlers, filters, or formatters configured on it). Note that this loses
+the default logger's integration with Python's :mod:`warnings` filter
+machinery (e.g. ``-W`` flags, :func:`warnings.filterwarnings`); the adapter
+emits warnings as plain log records instead.
+
+To temporarily install a logger, use :class:`wp.ScopedLogger <warp.ScopedLogger>`,
+which restores the previous logger on context exit:
+
+.. code-block:: python
+
+    with wp.ScopedLogger(my_capture_logger):
+        wp.launch(my_kernel, ...)  # diagnostics flow to my_capture_logger
+
+Pass ``None`` to ``wp.set_logger()`` or ``wp.ScopedLogger()`` to restore
+Warp's built-in default logger.
 
 .. _debug-mode:
 

--- a/docs/user_guide/differentiability.rst
+++ b/docs/user_guide/differentiability.rst
@@ -1412,7 +1412,7 @@ The code produces the expected output:
     b.grad = [-1. -1. -1. -1. -1. -1. -1. -1. -1. -1.]
 
 In-place multiplication and division are *not* supported and incorrect results will be obtained in the backward pass.
-A warning will be emitted during code generation if ``wp.config.verbose = True``.
+A warning will be emitted during code generation if ``wp.config.log_level = wp.LOG_DEBUG``.
 
 Vector, Matrix, and Quaternion Component Assignment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/notebooks/core_01_basics.ipynb
+++ b/notebooks/core_01_basics.ipynb
@@ -36,7 +36,7 @@
     "import numpy as np\n",
     "import warp as wp\n",
     "\n",
-    "wp.config.quiet = True\n",
+    "wp.config.log_level = wp.LOG_WARNING\n",
     "\n",
     "# Explicitly initializing Warp is not necessary but\n",
     "# we do it here to ensure everything is good to go.\n",

--- a/notebooks/core_02_generics.ipynb
+++ b/notebooks/core_02_generics.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "import warp as wp\n",
     "\n",
-    "wp.config.quiet = True\n",
+    "wp.config.log_level = wp.LOG_WARNING\n",
     "\n",
     "# Explicitly initializing Warp is not necessary but\n",
     "# we do it here to ensure everything is good to go.\n",

--- a/notebooks/core_03_points.ipynb
+++ b/notebooks/core_03_points.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np\n",
     "import warp as wp\n",
     "\n",
-    "wp.config.quiet = True\n",
+    "wp.config.log_level = wp.LOG_WARNING\n",
     "\n",
     "# Explicitly initializing Warp is not necessary but\n",
     "# we do it here to ensure everything is good to go.\n",

--- a/notebooks/core_04_meshes.ipynb
+++ b/notebooks/core_04_meshes.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "import warp as wp\n",
     "\n",
-    "wp.config.quiet = True\n",
+    "wp.config.log_level = wp.LOG_WARNING\n",
     "\n",
     "# Explicitly initializing Warp is not necessary but\n",
     "# we do it here to ensure everything is good to go.\n",

--- a/notebooks/core_05_volumes.ipynb
+++ b/notebooks/core_05_volumes.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "import warp as wp\n",
     "\n",
-    "wp.config.quiet = True\n",
+    "wp.config.log_level = wp.LOG_WARNING\n",
     "\n",
     "# Explicitly initializing Warp is not necessary but\n",
     "# we do it here to ensure everything is good to go.\n",

--- a/notebooks/pytorch_01_basics.ipynb
+++ b/notebooks/pytorch_01_basics.ipynb
@@ -26,7 +26,7 @@
     "import numpy as np\n",
     "import torch\n",
     "\n",
-    "wp.config.quiet = True\n",
+    "wp.config.log_level = wp.LOG_WARNING\n",
     "\n",
     "# Explicitly initializing Warp is not necessary but\n",
     "# we do it here to ensure everything is good to go.\n",

--- a/notebooks/pytorch_02_custom_operators.ipynb
+++ b/notebooks/pytorch_02_custom_operators.ipynb
@@ -38,7 +38,7 @@
     "# Requires PyTorch 2.4+\n",
     "import torch\n",
     "\n",
-    "wp.config.quiet = True\n",
+    "wp.config.log_level = wp.LOG_WARNING\n",
     "\n",
     "# Explicitly initializing Warp is not necessary but\n",
     "# we do it here to ensure everything is good to go.\n",

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -391,6 +391,22 @@ from warp._src.utils import TIMING_GRAPH as TIMING_GRAPH
 from warp._src.utils import TIMING_ALL as TIMING_ALL
 
 
+# category: Logging
+
+from warp._src.logger import LOG_DEBUG as LOG_DEBUG
+from warp._src.logger import LOG_INFO as LOG_INFO
+from warp._src.logger import LOG_WARNING as LOG_WARNING
+from warp._src.logger import LOG_ERROR as LOG_ERROR
+
+from warp._src.logger import Logger as Logger
+
+from warp._src.logger import set_logger as set_logger
+from warp._src.logger import get_logger as get_logger
+
+from warp._src.utils import ScopedLogger as ScopedLogger
+from warp._src.utils import ScopedLogLevel as ScopedLogLevel
+
+
 # category: NumPy Interop
 
 from warp._src.types import dtype_from_numpy as dtype_from_numpy

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -201,6 +201,15 @@ from warp._src.utils import TIMING_MEMCPY as TIMING_MEMCPY
 from warp._src.utils import TIMING_MEMSET as TIMING_MEMSET
 from warp._src.utils import TIMING_GRAPH as TIMING_GRAPH
 from warp._src.utils import TIMING_ALL as TIMING_ALL
+from warp._src.logger import LOG_DEBUG as LOG_DEBUG
+from warp._src.logger import LOG_INFO as LOG_INFO
+from warp._src.logger import LOG_WARNING as LOG_WARNING
+from warp._src.logger import LOG_ERROR as LOG_ERROR
+from warp._src.logger import Logger as Logger
+from warp._src.logger import set_logger as set_logger
+from warp._src.logger import get_logger as get_logger
+from warp._src.utils import ScopedLogger as ScopedLogger
+from warp._src.utils import ScopedLogLevel as ScopedLogLevel
 from warp._src.types import dtype_from_numpy as dtype_from_numpy
 from warp._src.types import dtype_to_numpy as dtype_to_numpy
 from warp._src.context import from_numpy as from_numpy

--- a/warp/_src/build.py
+++ b/warp/_src/build.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 
 import warp.config
+from warp._src.logger import LOG_DEBUG
 from warp._src.thirdparty import appdirs
 from warp._src.types import *
 
@@ -81,7 +82,7 @@ def build_cuda(
             None,
             config == "debug",
             optimization_level,
-            warp.config.verbose,
+            warp.config.verbose or warp.config.log_level <= LOG_DEBUG,
             verify_fp,
             fast_math,
             fuse_fp,
@@ -195,9 +196,9 @@ def init_kernel_cache(path=None):
         except OSError:
             has_stale = False
         if has_stale:
-            from warp._src.utils import warn  # noqa: PLC0415
+            from warp._src.logger import log_warning  # noqa: PLC0415
 
-            warn(
+            log_warning(
                 f"Kernel cache artifacts from a previous Warp version were found in '{base_dir}'. "
                 f"These will be ignored. You can safely delete them.",
             )
@@ -265,7 +266,9 @@ def safe_rename(src, dst, attempts=5, delay=0.1):
                 if i < attempts - 1:
                     time.sleep(delay)
                 else:
-                    print(
+                    from warp._src.logger import log_error  # noqa: PLC0415
+
+                    log_error(
                         f"Could not update Warp cache with compiled binaries, trying to rename {src} to {dst}, error {e}"
                     )
                     raise e

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -12,6 +12,7 @@ from typing import Any
 import warp._src.build
 import warp._src.context
 from warp._src.codegen import Reference, Var, get_arg_value, strip_reference
+from warp._src.logger import log_warning
 from warp._src.types import *
 
 from .context import add_builtin
@@ -3147,16 +3148,12 @@ def tile_load_tuple_value_func(arg_types: Mapping[str, type], arg_values: Mappin
 
     if arg_values.get("aligned"):
         if arg_values["storage"] == "register":
-            from warp._src.utils import warn  # noqa: PLC0415
-
-            warn(
+            log_warning(
                 "tile_load() with aligned=True has no effect for storage='register'. "
                 "The aligned parameter only affects shared memory tiles."
             )
         elif arg_values["storage"] == "shared" and len(shape) < 2:
-            from warp._src.utils import warn  # noqa: PLC0415
-
-            warn(
+            log_warning(
                 "tile_load() with aligned=True has no effect for 1D shared tiles. "
                 "The vectorized path requires 2D+ tiles."
             )
@@ -3426,16 +3423,12 @@ def tile_store_value_func(arg_types, arg_values):
 
     if arg_values.get("aligned"):
         if t.storage == "register":
-            from warp._src.utils import warn  # noqa: PLC0415
-
-            warn(
+            log_warning(
                 "tile_store() with aligned=True has no effect for register tiles. "
                 "The aligned parameter only affects shared memory tiles."
             )
         elif t.storage == "shared" and len(t.shape) < 2:
-            from warp._src.utils import warn  # noqa: PLC0415
-
-            warn(
+            log_warning(
                 "tile_store() with aligned=True has no effect for 1D shared tiles. "
                 "The vectorized path requires 2D+ tiles."
             )

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -21,6 +21,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import Any, ClassVar, get_args, get_origin
 
 import warp.config
+from warp._src.logger import log_debug, log_warning
 from warp._src.types import *
 
 _wp_module_name_ = "warp.codegen"
@@ -379,11 +380,11 @@ def _make_struct_field_setter(cls, field: str, var_type: type):
             setattr(inst._ctype, field, value)
         else:
             if is_scalar(value):
-                warp._src.utils.warn(
+                log_warning(
                     f"Implicit conversion from a scalar type to the composite type "
                     f"`{type_repr(var_type)}` for struct field '{field}' is deprecated. "
                     f"Use an explicit conversion, e.g.: `{type_repr(var_type)}(...)`.",
-                    DeprecationWarning,
+                    category=DeprecationWarning,
                     stacklevel=3,
                 )
             # conversion from list/tuple, ndarray, etc.
@@ -803,12 +804,12 @@ class Var:
         # detect if we are writing to an array after reading from it within the same kernel
         if self.is_read and warp._src.codegen.options.get("verify_autograd_array_access", False):
             if "kernel_name" in kwargs and "filename" in kwargs and "lineno" in kwargs:
-                print(
-                    f"Warning: Array passed to argument {self.label} in kernel {kwargs['kernel_name']} at {kwargs['filename']}:{kwargs['lineno']} is being written to after it has been read from within the same kernel. This may corrupt gradient computation in the backward pass."
+                log_warning(
+                    f"Array passed to argument {self.label} in kernel {kwargs['kernel_name']} at {kwargs['filename']}:{kwargs['lineno']} is being written to after it has been read from within the same kernel. This may corrupt gradient computation in the backward pass."
                 )
             else:
-                print(
-                    f"Warning: Array {self} is being written to after it has been read from within the same kernel. This may corrupt gradient computation in the backward pass."
+                log_warning(
+                    f"Array {self} is being written to after it has been read from within the same kernel. This may corrupt gradient computation in the backward pass."
                 )
         self.is_write = True
 
@@ -1813,8 +1814,9 @@ class Adjoint:
         # Warn if this kernel has backward enabled, since the gradient call
         # is forward-only and won't participate in automatic differentiation.
         if adj.used_by_backward_kernel:
-            msg = f'Warning: grad() call for function "{func.key}" is used in a kernel with enable_backward=True. The gradient call does NOT participate in automatic differentiation - gradients will not flow through this call in the backward pass.'
-            print(msg)
+            log_warning(
+                f'grad() call for function "{func.key}" is used in a kernel with enable_backward=True. The gradient call does NOT participate in automatic differentiation - gradients will not flow through this call in the backward pass.'
+            )
 
         # Ensure the function is built so its adjoint code exists.
         if not func.is_builtin():
@@ -2520,11 +2522,11 @@ class Adjoint:
             var2 = adj.symbols[sym]
 
             if var1 != var2:
-                if warp.config.verbose and not adj.custom_reverse_mode:
+                if not adj.custom_reverse_mode:
                     lineno = adj.lineno + adj.fun_lineno
                     line = adj.source_lines[adj.lineno]
-                    msg = f'Warning: detected mutated variable {sym} during a dynamic for-loop in function "{adj.fun_name}" at {adj.filename}:{lineno}: this may not be a differentiable operation.\n{line}\n'
-                    print(msg)
+                    msg = f'Warning: detected mutated variable {sym} during a dynamic for-loop in function "{adj.fun_name}" at {adj.filename}:{lineno}: this may not be a differentiable operation.\n{line}'
+                    log_debug(msg)
 
                 if var1.constant is not None:
                     raise WarpCodegenError(
@@ -2653,23 +2655,21 @@ class Adjoint:
             # Always unroll if the loop contains static expressions
             if contains_static:
                 # Forced unrolling for loops with static expressions regardless of max_unroll
-                if warp.config.verbose and max_iters > max_unroll:
-                    print(
+                if max_iters > max_unroll:
+                    log_debug(
                         f"Notice: Forcing unroll of loop with {max_iters} iterations because it contains wp.static expressions."
                     )
                 return range(start, end, step)
 
             # Apply max_unroll check only for regular loops (no static expressions)
             if max_iters > max_unroll:
-                if warp.config.verbose:
-                    print(
-                        f"Warning: fixed-size loop count of {max_iters} is larger than the module 'max_unroll' limit of {max_unroll}, will generate dynamic loop."
-                    )
+                log_debug(
+                    f"Warning: fixed-size loop count of {max_iters} is larger than the module 'max_unroll' limit of {max_unroll}, will generate dynamic loop."
+                )
                 ok_to_unroll = False
 
             elif adj.contains_break(loop.body):
-                if warp.config.verbose:
-                    print("Warning: 'break' or 'continue' found in loop body, will generate dynamic loop.")
+                log_debug("Warning: 'break' or 'continue' found in loop body, will generate dynamic loop.")
                 ok_to_unroll = False
 
             if ok_to_unroll:
@@ -3608,12 +3608,12 @@ class Adjoint:
                 attr = adj.add_builtin_call("indexref", [target, *indices])
                 adj.add_builtin_call("store", [attr, rhs])
 
-                if warp.config.verbose and not adj.custom_reverse_mode:
+                if not adj.custom_reverse_mode:
                     lineno = adj.lineno + adj.fun_lineno
                     line = adj.source_lines[adj.lineno]
                     node_source = adj.get_node_source(lhs.value)
-                    print(
-                        f"Warning: mutating {node_source} in function {adj.fun_name} at {adj.filename}:{lineno}: this is a non-differentiable operation.\n{line}\n"
+                    log_debug(
+                        f"Warning: mutating {node_source} in function {adj.fun_name} at {adj.filename}:{lineno}: this is a non-differentiable operation.\n{line}"
                     )
             else:
                 if adj.builder_options.get("enable_vector_component_overwrites", False):
@@ -3678,11 +3678,11 @@ class Adjoint:
             else:
                 adj.add_builtin_call("assign", [attr, rhs])
 
-            if warp.config.verbose and not adj.custom_reverse_mode:
+            if not adj.custom_reverse_mode:
                 lineno = adj.lineno + adj.fun_lineno
                 line = adj.source_lines[adj.lineno]
-                msg = f'Warning: detected mutated struct {attr.label} during function "{adj.fun_name}" at {adj.filename}:{lineno}: this is a non-differentiable operation.\n{line}\n'
-                print(msg)
+                msg = f'Warning: detected mutated struct {attr.label} during function "{adj.fun_name}" at {adj.filename}:{lineno}: this is a non-differentiable operation.\n{line}'
+                log_debug(msg)
 
     def emit_Return(adj, node):
         if node.value is None:
@@ -3894,8 +3894,7 @@ class Adjoint:
                     if adj.builder_options.get("verify_autograd_array_access", False):
                         target.mark_write(kernel_name=kernel_name, filename=filename, lineno=lineno)
                 else:
-                    if warp.config.verbose:
-                        print(f"Warning: in-place op {node.op} is not differentiable")
+                    log_debug(f"Warning: in-place op {node.op} is not differentiable")
                     augassign_subscript(target, indices)
                     return
 
@@ -3916,8 +3915,7 @@ class Adjoint:
                 elif isinstance(node.op, ast.BitXor):
                     adj.add_builtin_call("bit_xor_inplace", [target, *indices, rhs])
                 else:
-                    if warp.config.verbose:
-                        print(f"Warning: in-place op {node.op} is not differentiable")
+                    log_debug(f"Warning: in-place op {node.op} is not differentiable")
                     augassign_subscript(target, indices)
                     return
 
@@ -3933,8 +3931,7 @@ class Adjoint:
                 elif isinstance(node.op, ast.BitXor):
                     adj.add_builtin_call("tile_bit_xor_inplace", [target, *indices, rhs])
                 else:
-                    if warp.config.verbose:
-                        print(f"Warning: in-place op {node.op} is not differentiable")
+                    log_debug(f"Warning: in-place op {node.op} is not differentiable")
                     augassign_subscript(target, indices)
                     return
 
@@ -4232,8 +4229,7 @@ class Adjoint:
             value = eval(code_to_eval, vars_dict)
             if isinstance(value, (enum.IntEnum, enum.IntFlag)):
                 value = int(value)
-            if warp.config.verbose:
-                print(f"Evaluated static command: {static_code} = {value}")
+            log_debug(f"Evaluated static command: {static_code} = {value}")
         except NameError as e:
             raise WarpCodegenError(
                 f"Error evaluating static expression: {e}. Make sure all variables used in the static expression are constant."

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -64,6 +64,7 @@ import warp._src.build
 import warp._src.codegen
 import warp.config
 from warp._src.codegen import WarpCodegenTypeError, synchronized
+from warp._src.logger import LOG_DEBUG, LOG_WARNING, get_logger, log_debug, log_error, log_info, log_warning
 from warp._src.texture import Texture1D, Texture2D, Texture3D, texture1d_t, texture2d_t, texture3d_t
 from warp._src.types import Array, launch_bounds_t, type_repr
 
@@ -863,8 +864,7 @@ class Kernel:
             return ovl
 
         # Log that we're creating a new overload (will trigger module hash change and recompilation)
-        if warp.config.verbose:
-            print(f"[Kernel.add_overload] Creating new overload for {self.key}: {sig}")
+        log_debug(f"[Kernel.add_overload] Creating new overload for {self.key}: {sig}")
 
         arg_names = list(self.adj.arg_types.keys())
         template_types = list(self.adj.arg_types.values())
@@ -1441,8 +1441,7 @@ def kernel(
             # This can happen when the same kernel is compiled for multiple devices
             existing_module = user_modules.get(k.module.name)
             if existing_module is not None:
-                if warp.config.verbose:
-                    print(f"[wp.kernel] Reusing existing unique module: {k.module.name}")
+                log_debug(f"[wp.kernel] Reusing existing unique module: {k.module.name}")
 
                 # The kernel must already exist in the module (same hash means same content)
                 existing_kernel_same_key = existing_module.kernels.get(k.key)
@@ -1458,7 +1457,7 @@ def kernel(
                 # user_modules and will not be compiled. Returning the existing kernel ensures
                 # its .module points to the registered, compiled module, and its .hash stays
                 # in sync with ModuleHasher updates (e.g., resolving static expressions).
-                if warp.config.verbose:
+                if warp.config.verbose or warp.config.log_level <= warp.LOG_DEBUG:
                     # Show number of overloads if this is a generic kernel
                     overload_info = ""
                     if existing_kernel_same_key.is_generic:
@@ -1466,7 +1465,7 @@ def kernel(
                         overload_info = (
                             f" (generic kernel with {num_overloads} overload{'s' if num_overloads != 1 else ''})"
                         )
-                    print(f"[wp.kernel]   Reusing existing kernel object for {k.key}{overload_info}")
+                    log_debug(f"[wp.kernel]   Reusing existing kernel object for {k.key}{overload_info}")
                 k = existing_kernel_same_key
 
                 # Reset skip_build flag for all kernels when reusing a module.
@@ -1478,8 +1477,7 @@ def kernel(
                 # This is the first time we've seen this kernel
                 # Register the new unique module in the global registry
                 user_modules[k.module.name] = k.module
-                if warp.config.verbose:
-                    print(f"[wp.kernel] Created new unique module: {k.module.name}")
+                log_debug(f"[wp.kernel] Created new unique module: {k.module.name}")
 
         k = functools.update_wrapper(k, f)
         return k
@@ -2046,19 +2044,27 @@ class ModuleHasher:
                         old_hash = ovl.hash
                         ovl.hash = self.hash_kernel(ovl)
                         # Only log hash changes when old hash was not None (unexpected changes)
-                        if warp.config.verbose and old_hash is not None and old_hash != ovl.hash:
+                        if (
+                            (warp.config.verbose or warp.config.log_level <= warp.LOG_DEBUG)
+                            and old_hash is not None
+                            and old_hash != ovl.hash
+                        ):
                             old_str = old_hash.hex()[:8]
                             new_str = ovl.hash.hex()[:8] if ovl.hash else "None"
-                            print(f"[ModuleHasher] Generic kernel hash changed: {ovl.key} ({old_str} -> {new_str})")
+                            log_debug(f"[ModuleHasher] Generic kernel hash changed: {ovl.key} ({old_str} -> {new_str})")
             else:
                 if not kernel.adj.skip_build:
                     old_hash = kernel.hash
                     kernel.hash = self.hash_kernel(kernel)
                     # Only log hash changes when old hash was not None (unexpected changes)
-                    if warp.config.verbose and old_hash is not None and old_hash != kernel.hash:
+                    if (
+                        (warp.config.verbose or warp.config.log_level <= warp.LOG_DEBUG)
+                        and old_hash is not None
+                        and old_hash != kernel.hash
+                    ):
                         old_str = old_hash.hex()[:8]
                         new_str = kernel.hash.hex()[:8] if kernel.hash else "None"
-                        print(f"[ModuleHasher] Kernel hash changed: {kernel.key} ({old_str} -> {new_str})")
+                        log_debug(f"[ModuleHasher] Kernel hash changed: {kernel.key} ({old_str} -> {new_str})")
 
         # include all unique kernels in the module hash
         for kernel_hash in sorted(self.unique_kernels.keys()):
@@ -2474,15 +2480,15 @@ class ModuleExec:
             max_smem_bytes = self.device.max_shared_memory_per_block
 
             if not runtime.core.wp_cuda_configure_kernel_shared_memory(forward_kernel, forward_smem_bytes):
-                print(
-                    f"Warning: Failed to configure kernel dynamic shared memory for this device, tried to configure {forward_name} kernel for {forward_smem_bytes} bytes, but maximum available is {max_smem_bytes}"
+                log_warning(
+                    f"Failed to configure kernel dynamic shared memory for this device, tried to configure {forward_name} kernel for {forward_smem_bytes} bytes, but maximum available is {max_smem_bytes}"
                 )
 
             if options["enable_backward"] and not runtime.core.wp_cuda_configure_kernel_shared_memory(
                 backward_kernel, backward_smem_bytes
             ):
-                print(
-                    f"Warning: Failed to configure kernel dynamic shared memory for this device, tried to configure {backward_name} kernel for {backward_smem_bytes} bytes, but maximum available is {max_smem_bytes}"
+                log_warning(
+                    f"Failed to configure kernel dynamic shared memory for this device, tried to configure {backward_name} kernel for {backward_smem_bytes} bytes, but maximum available is {max_smem_bytes}"
                 )
 
             hooks = KernelHooks(forward_kernel, backward_kernel, forward_smem_bytes, backward_smem_bytes)
@@ -3000,9 +3006,7 @@ class Module:
             opt = 2 if is_cpu else 3
 
         if opt != 3 and not is_cpu and runtime.toolkit_version is not None and runtime.toolkit_version < (12, 9):
-            warp._src.utils.warn(
-                "Optimization level other than 3 has no effect on CUDA versions prior to 12.9.", once=True
-            )
+            log_warning("Optimization level other than 3 has no effect on CUDA versions prior to 12.9.", once=True)
 
         # build CPU
         if is_cpu:
@@ -3019,7 +3023,9 @@ class Module:
                 output_path = os.path.join(build_dir, output_name)
 
                 # build object code
-                with warp.ScopedTimer("Compile x86", active=warp.config.verbose):
+                with warp.ScopedTimer(
+                    "Compile x86", active=(warp.config.verbose or warp.config.log_level <= warp.LOG_DEBUG)
+                ):
                     warp._src.build.build_cpu(
                         output_path,
                         source_code_path,
@@ -3029,7 +3035,7 @@ class Module:
                         fuse_fp=options["fuse_fp"],
                         extra_flags=options["cpu_compiler_flags"],
                         optimization_level=opt,
-                        verbose=warp.config.verbose,
+                        verbose=warp.config.verbose or warp.config.log_level <= warp.LOG_DEBUG,
                         use_precompiled_headers=options["use_precompiled_headers"],
                         pch_dir=runtime.get_clang_pch_dir() if options["use_precompiled_headers"] else None,
                         block_dim=options["block_dim"],
@@ -3060,7 +3066,7 @@ class Module:
                 # generate PTX or CUBIN
                 with warp.ScopedTimer(
                     f"Compile CUDA (arch={options['output_arch']}{arch_suffix}, mode={mode}, block_dim={options['block_dim']})",
-                    active=warp.config.verbose,
+                    active=(warp.config.verbose or warp.config.log_level <= warp.LOG_DEBUG),
                 ):
                     warp._src.build.build_cuda(
                         source_code_path,
@@ -3138,7 +3144,7 @@ class Module:
                 pass
             except Exception as e:
                 # We don't need source_code_path to be copied successfully to proceed, so warn and keep running
-                warp._src.utils.warn(f"Exception when renaming {source_code_path}: {e}")
+                log_warning(f"Exception when renaming {source_code_path}: {e}")
 
             # clean up build_dir used for this process regardless
             shutil.rmtree(build_dir, ignore_errors=True)
@@ -3168,10 +3174,10 @@ class Module:
             if self.options["strip_hash"] or (exec.module_hash == current_hash):
                 return exec
             # else: Hash mismatch means module changed, need to recompile
-            if warp.config.verbose:
+            if warp.config.verbose or warp.config.log_level <= warp.LOG_DEBUG:
                 old_str = exec.module_hash.hex()[:8] if exec.module_hash else "None"
                 new_str = current_hash.hex()[:8] if current_hash else "None"
-                print(f"[Module.load] Module hash changed, recompiling: {self.name} ({old_str} -> {new_str})")
+                log_debug(f"[Module.load] Module hash changed, recompiling: {self.name} ({old_str} -> {new_str})")
 
         # quietly avoid repeated build attempts to reduce error spew
         if device.context in self.failed_builds:
@@ -3189,10 +3195,13 @@ class Module:
             else f"Module {self.name} load on device '{device}'"
         )
 
-        if warp.config.verbose:
+        if warp.config.verbose or warp.config.log_level <= warp.LOG_DEBUG:
             module_load_timer_name += f" (block_dim={active_block_dim})"
 
-        with warp.ScopedTimer(module_load_timer_name, active=not warp.config.quiet) as module_load_timer:
+        with warp.ScopedTimer(
+            module_load_timer_name,
+            active=not warp.config.quiet and warp.config.log_level <= warp.LOG_INFO,
+        ) as module_load_timer:
             # -----------------------------------------------------------
             # Determine binary path and build if necessary
 
@@ -3282,9 +3291,9 @@ class Module:
     def get_kernel_hooks(self, kernel, device: Device) -> KernelHooks:
         module_exec = self.execs.get((device.context, self.options["block_dim"]))
         if module_exec is not None:
-            if warp.config.verbose:
+            if warp.config.verbose or warp.config.log_level <= warp.LOG_DEBUG:
                 kernel_hash_str = kernel.hash.hex()[:8] if kernel.hash else "None"
-                print(f"[Module.get_kernel_hooks] Looking up kernel: {kernel.key} (hash: {kernel_hash_str})")
+                log_debug(f"[Module.get_kernel_hooks] Looking up kernel: {kernel.key} (hash: {kernel_hash_str})")
             return module_exec.get_kernel_hooks(kernel)
         else:
             raise RuntimeError(f"Module is not loaded on device {device}")
@@ -3574,7 +3583,7 @@ class Event:
             )
 
             if ipc_handle_buffer.raw == bytes(64):
-                warp._src.utils.warn("IPC event handle appears to be invalid. Was interprocess=True used?")
+                log_warning("IPC event handle appears to be invalid. Was interprocess=True used?")
 
             return ipc_handle_buffer.raw
 
@@ -4051,9 +4060,9 @@ class Device:
 
                 return psutil.virtual_memory().total
             except ModuleNotFoundError:
-                warp._src.utils.warn(
+                log_warning(
                     "Please install the 'psutil' package to query CPU memory information.",
-                    UserWarning,
+                    category=UserWarning,
                     stacklevel=2,
                     once=True,
                 )
@@ -4076,9 +4085,9 @@ class Device:
 
                 return psutil.virtual_memory().free
             except ModuleNotFoundError:
-                warp._src.utils.warn(
+                log_warning(
                     "Please install the 'psutil' package to query CPU memory information.",
-                    UserWarning,
+                    category=UserWarning,
                     stacklevel=2,
                     once=True,
                 )
@@ -4493,6 +4502,31 @@ class Runtime:
                 "or upgrade to Apple Silicon hardware (ARM64)."
             )
 
+        if warp.config.quiet:
+            if not warp.config._deprecated_quiet_warning_seen:
+                log_warning(
+                    "warp.config.quiet is deprecated; "
+                    "use warp.config.log_level = warp.LOG_WARNING to suppress the init banner.",
+                    category=DeprecationWarning,
+                    once=True,
+                )
+                warp.config._deprecated_quiet_warning_seen = True
+            # Honor the legacy flag during the deprecation window without
+            # clobbering an explicit user log_level that's already at least
+            # this restrictive.
+            if warp.config.log_level < LOG_WARNING:
+                warp.config.log_level = LOG_WARNING
+        if warp.config.verbose:
+            if not warp.config._deprecated_verbose_warning_seen:
+                log_warning(
+                    "warp.config.verbose is deprecated; use warp.config.log_level = warp.LOG_DEBUG instead.",
+                    category=DeprecationWarning,
+                    once=True,
+                )
+                warp.config._deprecated_verbose_warning_seen = True
+            if not warp.config._suppress_verbose_log_level_mapping and warp.config.log_level > LOG_DEBUG:
+                warp.config.log_level = LOG_DEBUG
+
         bin_path = os.path.join(warp_home, "bin")
 
         if os.name == "nt":
@@ -4572,19 +4606,19 @@ class Runtime:
                 if clang_version_ptr:
                     clang_version = clang_version_ptr.decode("utf-8")
                     if clang_version != warp.config.version:
-                        warp._src.utils.warn(
+                        log_warning(
                             f"Version mismatch detected in warp-clang library.\n"
                             f"  Expected Warp version: {warp.config.version}\n"
                             f"  Loaded warp-clang library version: {clang_version}\n"
                             f"  This may occur due to environment variables or multiple Warp installations."
                         )
                 else:
-                    warp._src.utils.warn(
+                    log_warning(
                         "warp-clang version check returned NULL.\n"
                         "  This may indicate a corrupted or incompatible library."
                     )
             else:
-                warp._src.utils.warn(
+                log_warning(
                     "warp-clang library does not support version checking.\n"
                     "  This may indicate an older or mismatched library version."
                 )
@@ -5846,7 +5880,7 @@ class Runtime:
                     setattr(self.core.ctypes, name, getattr(self.core, name))
                     setattr(self.core, name, getattr(fastcall, name))
         except Exception as e:
-            warp._src.utils.warn(f"Failed to load _warp_fastcall module: {e}. Falling back to ctypes.")
+            log_warning(f"Failed to load _warp_fastcall module: {e}. Falling back to ctypes.")
 
         # Initialize with version verification
         error = self.core.wp_init(warp.config.version.encode("utf-8"))
@@ -5968,7 +6002,7 @@ class Runtime:
         self.tape = None
 
         # print device and version information
-        if not warp.config.quiet:
+        if not warp.config.quiet and warp.config.log_level <= warp.LOG_INFO:
             greeting = []
 
             greeting.append(f"Warp {warp.config.version} initialized:")
@@ -6059,7 +6093,7 @@ class Runtime:
             greeting.append("   Kernel cache:")
             greeting.append(f"     {warp.config.kernel_cache_dir}")
 
-            print("\n".join(greeting))
+            log_info("\n".join(greeting))
 
         if cuda_device_count > 0:
             # ensure initialization did not change the initial context (e.g. querying available memory)
@@ -6078,11 +6112,11 @@ class Runtime:
                 # This should not happen on any system officially supported by Warp.  UVA is not available
                 # on 32-bit Windows, which we don't support.  Nonetheless, we should check and report a
                 # warning out of abundance of caution.  It may help with debugging a broken VM setup etc.
-                warp._src.utils.warn(
+                log_warning(
                     f"\n   Support for Unified Virtual Addressing (UVA) was not detected on devices {devices_without_uva}."
                 )
             if devices_without_mempool:
-                warp._src.utils.warn(
+                log_warning(
                     f"\n   Support for CUDA memory pools was not detected on devices {devices_without_mempool}."
                     "\n   This prevents memory allocations in CUDA graphs and may result in poor performance."
                     "\n   Is the UVM driver enabled?"
@@ -6099,7 +6133,7 @@ class Runtime:
                     f"but the installed CUDA driver version is {self.driver_version[0]}.{self.driver_version[1]}."
                 )
                 msg.append("Visit https://nvidia.github.io/warp/user_guide/installation.html for guidance.")
-                warp._src.utils.warn("\n   ".join(msg))
+                log_warning("\n   ".join(msg))
 
     def _get_or_create_pch_dir(self) -> str:
         """Return a per-thread temporary directory for precompiled header files.
@@ -7168,7 +7202,7 @@ class RegisteredGLBuffer:
                 self.warp_buffer = None
                 self.warp_buffer_cpu = None
                 if not RegisteredGLBuffer.__fallback_warning_shown:
-                    warp._src.utils.warn(
+                    log_warning(
                         "Could not register GL buffer since CUDA/OpenGL interoperability is not available. Falling back to copy operations between the Warp array and the OpenGL buffer.",
                     )
                     RegisteredGLBuffer.__fallback_warning_shown = True
@@ -7802,11 +7836,11 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
         else:
             # try constructing the required value from the argument (handles tuple / list, Gf.Vec3 case)
             if warp._src.types.is_scalar(value):
-                warp._src.utils.warn(
+                log_warning(
                     f"Implicit conversion from a scalar type to the composite type "
                     f"`{type_str(arg_type)}` for kernel parameter '{arg_name}' is deprecated. "
                     f"Use an explicit conversion, e.g.: `{type_str(arg_type)}(...)`.",
-                    DeprecationWarning,
+                    category=DeprecationWarning,
                     stacklevel=4,
                 )
             try:
@@ -7877,7 +7911,6 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
             else:
                 return arg_type._type_(value)
         except Exception as e:
-            print(e)
             raise RuntimeError(
                 "Error launching kernel, unable to pack kernel parameter type "
                 f"{type(value)} for param {arg_name}, expected {arg_type}"
@@ -8297,7 +8330,7 @@ def launch(
 
     # debugging aid
     if warp.config.print_launches:
-        print(f"kernel: {kernel.key} dim: {dim} inputs: {inputs} outputs: {outputs} device: {device}")
+        get_logger().info(f"kernel: {kernel.key} dim: {dim} inputs: {inputs} outputs: {outputs} device: {device}")
 
     # construct launch bounds
     bounds = launch_bounds_t(dim)
@@ -8524,8 +8557,8 @@ def launch(
             try:
                 runtime.verify_cuda_device(device)
             except Exception as e:
-                print(f"Error launching kernel: {kernel.key} on device {device}")
-                raise e
+                log_error(f"Error launching kernel: {kernel.key} on device {device}: {e}")
+                raise
 
     # record on tape if one is active
     if runtime.tape and record_tape:
@@ -9082,9 +9115,7 @@ def compile_aot_module(
 
     # Warn if there are generic kernels without overloads
     if no_overloads:
-        from warp._src.utils import warn  # noqa: PLC0415
-
-        warn(
+        log_warning(
             f"Generic kernels without overloads will be skipped during AOT compilation. "
             f"Add overloads using wp.overload() or the @wp.overload decorator to compile them. "
             f"Kernels without overloads: {', '.join(no_overloads)}",
@@ -9114,11 +9145,13 @@ def compile_aot_module(
         aot_targets_cpu = get_device(device).is_cpu
 
     if aot_targets_cpu and _uses_march_native(resolved_cpu_flags):
-        warp._src.utils.warn(
+        log_warning(
             "compile_aot_module: CPU module is being compiled with -march=native. "
             "The result requires this CPU's instruction set extensions "
             "and may not run on CPUs with fewer features. "
             "Set cpu_compiler_flags='' for a portable build.",
+            category=UserWarning,
+            stacklevel=2,
             once=True,
         )
 
@@ -10974,7 +11007,7 @@ def export_stubs(file):  # pragma: no cover
 
         # Warn if doc strings differ
         if not all(f.doc == first.doc for f in overloads):
-            warp._src.utils.warn(
+            log_warning(
                 f"Merging overloads for '{first.key}' with differing docstrings. "
                 "Consider aligning docstrings for consistency.",
                 stacklevel=3,
@@ -11576,12 +11609,17 @@ def print_diagnostics() -> dict:
     # If runtime not yet initialized, suppress the init greeting since
     # diagnostics output already subsumes all greeting info.
     if runtime is None:
-        old_quiet = warp.config.quiet
-        warp.config.quiet = True
+        from warp._src.utils import ScopedLogLevel  # noqa: PLC0415
+
+        suppress_verbose_log_level_mapping = warp.config._suppress_verbose_log_level_mapping
         try:
-            init()
+            warp.config._suppress_verbose_log_level_mapping = True
+            with ScopedLogLevel(warp.LOG_WARNING):
+                init()
         finally:
-            warp.config.quiet = old_quiet
+            warp.config._suppress_verbose_log_level_mapping = suppress_verbose_log_level_mapping
+        if warp.config.verbose and warp.config.log_level > warp.LOG_DEBUG:
+            warp.config.log_level = warp.LOG_DEBUG
 
     def _version_str(ver):
         """Format a (major, minor) version tuple as 'major.minor', or None."""

--- a/warp/_src/fem/cache.py
+++ b/warp/_src/fem/cache.py
@@ -14,8 +14,8 @@ import warp as wp
 from warp._src.codegen import Struct, StructInstance, get_annotations
 from warp._src.fem.operator import Integrand
 from warp._src.fem.types import Domain, Field
+from warp._src.logger import log_warning
 from warp._src.types import get_type_code, type_repr, type_scalar_type, type_size, type_size_in_bytes, type_to_warp
-from warp._src.utils import warn
 
 _wp_module_name_ = "warp.fem.cache"
 
@@ -224,7 +224,7 @@ def populate_argument_struct(value_struct: StructInstance, values: dict[str, Any
 
     missing_values = Args.vars.keys() - values.keys()
     if missing_values:
-        warn(
+        log_warning(
             f"Missing values for parameter(s) '{', '.join(missing_values)}' of the function '{func_name}', will be zero-initialized"
         )
 

--- a/warp/_src/fem/integrate.py
+++ b/warp/_src/fem/integrate.py
@@ -48,9 +48,10 @@ from warp._src.fem.types import (
     make_free_sample,
 )
 from warp._src.fem.utils import type_zero_element
+from warp._src.logger import log_warning
 from warp._src.sparse import BsrMatrix, bsr_set_from_triplets, bsr_zeros
 from warp._src.types import is_array, type_length, type_repr, type_scalar_type, type_size, type_to_warp
-from warp._src.utils import array_cast, warn
+from warp._src.utils import array_cast
 
 __all__ = ["integrate", "interpolate"]
 
@@ -450,7 +451,7 @@ def _check_domain_operators(integrand: Integrand, domain: GeometryDomain, domain
     if (
         operator.lookup in domain_operators or operator.partition_lookup in domain_operators
     ) and not domain.supports_lookup(device):
-        warn(
+        log_warning(
             f"{integrand.name}: using lookup() operator on a '{domain.geometry.name}.{domain.element_kind.name}' domain that does not support it. "
             "If relevant, check that the geometry's BVH has been built for this device (see `Geometry.build_bvh()`, `Geometry.update_bvh()`)."
         )
@@ -1466,7 +1467,7 @@ def _launch_integrate_kernel(
             )
 
             if test.TAYLOR_DOF_COUNT == 0:
-                warn(
+                log_warning(
                     f"Test field is never evaluated in integrand '{integrand.name}', result will be zero",
                     category=UserWarning,
                     stacklevel=2,
@@ -1588,7 +1589,7 @@ def _launch_integrate_kernel(
         )
 
         if test.TAYLOR_DOF_COUNT * trial.TAYLOR_DOF_COUNT == 0:
-            warn(
+            log_warning(
                 f"Test and/or trial fields are never evaluated in integrand '{integrand.name}', result will be zero",
                 category=UserWarning,
                 stacklevel=2,
@@ -2745,7 +2746,7 @@ def _launch_interpolate_kernel(
     qp_index_count = quadrature.total_point_count()
 
     if qp_eval_count != qp_index_count and dest is not None:
-        warn(
+        log_warning(
             f"Quadrature used for interpolation of {integrand.name} has different number of evaluation and indexed points, this may lead to incorrect results",
             category=UserWarning,
             stacklevel=2,
@@ -2887,16 +2888,18 @@ def interpolate(
     if quadrature is not None:
         if at is not None:
             raise ValueError("Cannot pass both `at` and the deprecated `quadrature` argument")
-        warn(
+        log_warning(
             "The `quadrature` argument of `fem.interpolate` is deprecated and will be removed in Warp 1.15. Please use `at` instead.",
-            DeprecationWarning,
+            category=DeprecationWarning,
+            stacklevel=2,
         )
     if domain is not None:
         if at is not None:
             raise ValueError("Cannot pass both `at` and the deprecated `domain` argument")
-        warn(
+        log_warning(
             "The `domain` argument of `fem.interpolate` is deprecated and will be removed in Warp 1.15. Please use `at` instead.",
-            DeprecationWarning,
+            category=DeprecationWarning,
+            stacklevel=2,
         )
 
     arguments = _parse_integrand_arguments(integrand, fields)

--- a/warp/_src/fem/space/__init__.py
+++ b/warp/_src/fem/space/__init__.py
@@ -4,10 +4,12 @@
 # isort: skip_file
 
 from enum import Enum
-from warp._src.utils import warn
+
+import warp as wp
 import warp._src.fem.domain as _domain
 import warp._src.fem.geometry as _geometry
 import warp._src.fem.polynomial as _polynomial
+from warp._src.logger import log_warning
 
 from .function_space import FunctionSpace
 from .basis_function_space import CollocatedFunctionSpace, ContravariantFunctionSpace, CovariantFunctionSpace
@@ -61,10 +63,11 @@ def make_space_restriction(
     """
 
     if space is not None:
-        warn(
+        log_warning(
             "The `space` argument of `make_space_restriction` is deprecated and will be removed in Warp 1.15. "
             "Please use `space_partition` or `space_topology` instead.",
-            DeprecationWarning,
+            category=DeprecationWarning,
+            stacklevel=2,
         )
 
     if space_partition is None:

--- a/warp/_src/fem/space/partition.py
+++ b/warp/_src/fem/space/partition.py
@@ -8,7 +8,7 @@ from warp._src.fem import cache
 from warp._src.fem.geometry import GeometryPartition, WholeGeometryPartition
 from warp._src.fem.types import NULL_ELEMENT_INDEX, NULL_NODE_INDEX
 from warp._src.fem.utils import compress_node_indices
-from warp._src.utils import warn
+from warp._src.logger import log_warning
 
 from .function_space import FunctionSpace
 from .topology import SpaceTopology
@@ -432,10 +432,11 @@ def make_space_partition(
     """
 
     if space is not None:
-        warn(
+        log_warning(
             "The `space` argument of `make_space_partition` is deprecated and will be removed in Warp 1.15. "
             "Please use `space_topology` instead.",
-            DeprecationWarning,
+            category=DeprecationWarning,
+            stacklevel=2,
         )
 
     if space_topology is None:

--- a/warp/_src/jax/custom_call.py
+++ b/warp/_src/jax/custom_call.py
@@ -7,8 +7,8 @@ from functools import reduce
 import warp as wp
 from warp._src.context import type_str
 from warp._src.jax import get_jax_device
+from warp._src.logger import log_warning
 from warp._src.types import array_t, launch_bounds_t, matches_array_class, strides_from_shape
-from warp._src.utils import warn
 
 _wp_module_name_ = "warp.jax.custom_call"
 
@@ -61,7 +61,7 @@ def jax_kernel(kernel, launch_dims=None, quiet=False):
 
     # deprecation warning
     if jax.__version_info__ >= (0, 5, 0) and not quiet:
-        warn(
+        log_warning(
             "This version of jax_kernel() is deprecated and will not be supported with newer JAX versions. "
             "Please use the newer FFI version instead (warp.jax.ffi.jax_kernel). "
             "As of Warp release 1.10, the FFI version is the default implementation of jax_kernel(). "

--- a/warp/_src/jax/ffi.py
+++ b/warp/_src/jax/ffi.py
@@ -17,6 +17,7 @@ import warp as wp
 from warp._src.codegen import get_full_arg_spec, make_full_qualified_name
 from warp._src.context import CudaMemcpyKind
 from warp._src.jax import get_jax_device
+from warp._src.logger import log_warning
 from warp._src.types import (
     array_t,
     launch_bounds_t,
@@ -25,7 +26,6 @@ from warp._src.types import (
     type_size_in_bytes,
     type_to_warp,
 )
-from warp._src.utils import warn
 
 from .xla_ffi import *
 
@@ -1320,7 +1320,7 @@ def jax_kernel(
                 try:
                     gi.zero_()
                 except Exception as e:
-                    warn(f"Failed to zero gradient array: {e}", stacklevel=2)
+                    log_warning(f"Failed to zero gradient array: {e}", stacklevel=2)
                     raise e
 
         # The same _resolve_launch_dims() is used here so that the adjoint

--- a/warp/_src/logger.py
+++ b/warp/_src/logger.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Logging infrastructure for Warp.
+
+Provides a pluggable logger interface (:class:`Logger`) and an internal
+default implementation. Frameworks can supply custom loggers via
+:func:`warp.set_logger`.
+"""
+
+import linecache
+import sys
+import warnings
+from typing import Protocol, runtime_checkable
+
+LOG_DEBUG = 10
+"""Log level for verbose compilation and debugging output."""
+
+LOG_INFO = 20
+"""Log level for informational messages (init banner, launch info)."""
+
+LOG_WARNING = 30
+"""Log level for warnings and deprecation notices."""
+
+LOG_ERROR = 40
+"""Log level for error messages."""
+
+
+@runtime_checkable
+class Logger(Protocol):
+    """Protocol for Warp loggers.
+
+    Any object with ``debug``, ``info``, ``warning``, and ``error`` methods
+    matching these signatures can be used as a Warp logger.  Frameworks
+    register an instance via :func:`warp.set_logger`.
+    """
+
+    def debug(self, message: str) -> None:
+        """Emit a debug-level message."""
+        ...
+
+    def info(self, message: str) -> None:
+        """Emit an info-level message."""
+        ...
+
+    def warning(self, message: str, category=None, stacklevel: int = 1) -> None:
+        """Emit a warning-level message.
+
+        Implementations should typically call ``warnings.warn(message, category,
+        stacklevel=stacklevel)`` to integrate with Python's warning filter
+        machinery. The provided ``stacklevel`` is already adjusted for direct
+        use with ``warnings.warn()``.
+        """
+        ...
+
+    def error(self, message: str) -> None:
+        """Emit an error-level message."""
+        ...
+
+
+def _validate_logger(logger):
+    # Protocol isinstance only checks attribute presence, not that they are
+    # callable -- an object with debug=None would otherwise pass and fail
+    # later inside an emitter.
+    if (
+        not isinstance(logger, Logger)
+        or not callable(getattr(logger, "debug", None))
+        or not callable(getattr(logger, "info", None))
+        or not callable(getattr(logger, "warning", None))
+        or not callable(getattr(logger, "error", None))
+    ):
+        raise TypeError(
+            "logger must implement the Logger protocol "
+            "(debug(message), info(message), warning(message, category, stacklevel), error(message)), "
+            f"got {type(logger)!r}"
+        )
+
+
+def _format_warning(message, category, filename, lineno, line=None):
+    """Format a Warp warning, optionally including source location."""
+    import warp.config  # noqa: PLC0415 -- circular: logger.py is imported before config in warp/__init__.py
+
+    s = f"Warp {category.__name__}: {message}"
+    if warp.config.verbose_warnings:
+        s += f" ({filename}:{lineno})"
+        if line is None:
+            try:
+                line = linecache.getline(filename, lineno)
+            except Exception:
+                line = None
+        if line:
+            s += f"\n  {line.strip()}"
+    return s + "\n"
+
+
+def _warp_showwarning_stderr(message, category, filename, lineno, file=None, line=None):
+    """Format and write a Warp warning to sys.stderr."""
+    sys.stderr.write(_format_warning(message, category, filename, lineno, line))
+
+
+class LoggerBasic:
+    """Default Warp logger.
+
+    Routes debug/info to ``sys.stdout`` and warnings/errors to ``sys.stderr``.
+    Warnings go through ``warnings.warn()`` to respect user-configured filters.
+    """
+
+    def debug(self, message: str) -> None:
+        sys.stdout.write(message + "\n")
+
+    def info(self, message: str) -> None:
+        sys.stdout.write(message + "\n")
+
+    def warning(self, message: str, category=None, stacklevel: int = 1) -> None:
+        with warnings.catch_warnings():
+            warnings.showwarning = _warp_showwarning_stderr
+            warnings.warn(message, category, stacklevel=stacklevel)
+
+    def error(self, message: str) -> None:
+        sys.stderr.write("Warp Error: " + message + "\n")
+
+
+# Module-level logger state
+_active_logger: Logger = LoggerBasic()
+_warnings_seen: set = set()
+
+
+def set_logger(logger: Logger | None) -> None:
+    """Set the active Warp logger.
+
+    Any object satisfying the :class:`Logger` protocol can be used. Frameworks
+    typically wrap their existing logging machinery (e.g. Omniverse Kit's
+    ``carb``) in a small adapter class with the four methods.
+
+    Pass ``None`` to restore Warp's built-in default logger.
+
+    Args:
+        logger: An object satisfying the :class:`Logger` protocol, or ``None``.
+
+    Raises:
+        TypeError: If ``logger`` does not satisfy the :class:`Logger` protocol.
+    """
+    global _active_logger
+    if logger is None:
+        _active_logger = LoggerBasic()
+        return
+    _validate_logger(logger)
+    _active_logger = logger
+
+
+def get_logger() -> Logger:
+    """Return the active Warp logger."""
+    return _active_logger
+
+
+def log_debug(message: str) -> None:
+    """Emit a debug-level message if debug logging or legacy verbose mode is enabled."""
+    import warp.config  # noqa: PLC0415
+
+    if warp.config.verbose or warp.config.log_level <= LOG_DEBUG:
+        _active_logger.debug(message)
+
+
+def log_info(message: str) -> None:
+    """Emit an info-level message if ``warp.config.log_level <= LOG_INFO``."""
+    import warp.config  # noqa: PLC0415
+
+    if warp.config.log_level <= LOG_INFO:
+        _active_logger.info(message)
+
+
+def log_warning(message: str, category=None, stacklevel=1, once=False) -> None:
+    """Emit a warning-level message if ``warp.config.log_level <= LOG_WARNING``.
+
+    Args:
+        message: Warning text.
+        category: Warning category (e.g., ``DeprecationWarning``).
+        stacklevel: Stack frames to skip for location reporting.
+        once: If ``True``, suppress subsequent calls with the same
+            ``(category, message)`` pair regardless of call site.
+    """
+    import warp.config  # noqa: PLC0415
+
+    if warp.config.log_level > LOG_WARNING:
+        return
+
+    # DeprecationWarnings are deduplicated unconditionally to match the legacy
+    # warn() helper this replaced; ``once=True`` extends that to other categories.
+    dedup = once or category is DeprecationWarning
+    if dedup and (category, message) in _warnings_seen:
+        return
+
+    # +2: skip the logger adapter and log_warning() so warning locations point
+    # at the caller. Custom logger adapters can pass this directly to
+    # warnings.warn().
+    _active_logger.warning(message, category=category, stacklevel=stacklevel + 2)
+
+    if dedup:
+        _warnings_seen.add((category, message))
+
+
+def log_error(message: str) -> None:
+    """Emit an error-level message. Always emits regardless of log level."""
+    _active_logger.error(message)

--- a/warp/_src/render/imgui_manager.py
+++ b/warp/_src/render/imgui_manager.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import warp as wp
+from warp._src.logger import log_warning
 
 _wp_module_name_ = "warp.render.imgui_manager"
 
@@ -20,7 +21,7 @@ class ImGuiManager:
             self.is_available = True
         except ImportError:
             self.is_available = False
-            print('Warning: imgui not found. To use the UI, please install it with: pip install "imgui[pyglet]"')
+            log_warning('ImGui not found. To use the UI, please install it with: pip install "imgui[pyglet]"')
             return
 
         self.imgui.create_context()
@@ -60,13 +61,13 @@ class ImGuiManager:
             import tkinter as tk  # noqa: PLC0415
             from tkinter import filedialog  # noqa: PLC0415
         except ImportError:
-            print("Warning: tkinter not found. To use the file dialog, please install it.")
+            log_warning("tkinter not found. To use the file dialog, please install it.")
             return None
 
         try:
             root = tk.Tk()
         except tk.TclError:
-            print("Warning: no display found - cannot open file dialog.")
+            log_warning("No display found - cannot open file dialog.")
             return None
 
         root.withdraw()  # Hide the main window
@@ -86,13 +87,13 @@ class ImGuiManager:
             import tkinter as tk  # noqa: PLC0415
             from tkinter import filedialog  # noqa: PLC0415
         except ImportError:
-            print("Warning: tkinter not found. To use the file dialog, please install it.")
+            log_warning("tkinter not found. To use the file dialog, please install it.")
             return None
 
         try:
             root = tk.Tk()
         except tk.TclError:
-            print("Warning: no display found - cannot open file dialog.")
+            log_warning("No display found - cannot open file dialog.")
             return None
 
         root.withdraw()  # Hide the main window

--- a/warp/_src/render/render_opengl.py
+++ b/warp/_src/render/render_opengl.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 import numpy as np
 
 import warp as wp
+from warp._src.logger import log_error
 
 from .utils import tab10_color_map
 
@@ -659,7 +660,7 @@ def check_gl_error():
 
     error = gl.glGetError()
     if error != gl.GL_NO_ERROR:
-        print(f"OpenGL error: {error}")
+        log_error(f"OpenGL error: {error}")
 
 
 class ShapeInstancer:
@@ -1728,7 +1729,7 @@ class OpenGLRenderer:
             )
 
             if gl.glCheckFramebufferStatus(gl.GL_FRAMEBUFFER) != gl.GL_FRAMEBUFFER_COMPLETE:
-                print("Framebuffer is not complete!", flush=True)
+                log_error("Framebuffer is not complete!")
                 gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
                 sys.exit(1)
 

--- a/warp/_src/render/render_usd.py
+++ b/warp/_src/render/render_usd.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 import warp as wp
-from warp._src.utils import warn
+from warp._src.logger import log_error, log_info, log_warning
 
 if TYPE_CHECKING:
     from pxr import Usd
@@ -112,7 +112,7 @@ class UsdRenderer:
         elif isinstance(stage, Usd.Stage):
             self.stage = stage
         else:
-            print("Failed to create stage in renderer. Please construct with stage path or stage object.")
+            log_error("Failed to create stage in renderer. Please construct with stage path or stage object.")
         self.up_axis = up_axis.upper()
         self.fps = float(fps)
         self.time = 0.0
@@ -1031,11 +1031,12 @@ class UsdRenderer:
             This method references non-existent attributes (`self.model` and `self.body_names`)
             and will be removed in a future release.
         """
-        warn(
+        log_warning(
             "UsdRenderer.update_body_transforms() is deprecated and non-functional. "
             "It references attributes that do not exist (self.model, self.body_names) "
             "and will be removed in a future release.",
             category=DeprecationWarning,
+            stacklevel=2,
         )
         # Original broken code preserved for now
         from pxr import Sdf, UsdGeom  # noqa: PLC0415
@@ -1062,9 +1063,9 @@ class UsdRenderer:
         try:
             self.stage.Save()
         except Exception as e:
-            print("Failed to save USD stage:", e)
+            log_error(f"Failed to save USD stage: {e}")
             return False
 
         file_path = self.stage.GetRootLayer().realPath
-        print(f"Saved the USD stage file at `{file_path}`")
+        log_info(f"Saved the USD stage file at '{file_path}'")
         return True

--- a/warp/_src/sparse.py
+++ b/warp/_src/sparse.py
@@ -11,6 +11,7 @@ from numpy import eye
 
 import warp as wp
 import warp._src.utils
+from warp._src.logger import log_warning
 from warp._src.types import (
     Array,
     Cols,
@@ -192,9 +193,10 @@ class BsrMatrix(Generic[_BlockType]):
 
         Deprecated; prefer :meth:`notify_nnz_changed` instead, which will make sure to resize arrays if necessary.
         """
-        wp._src.utils.warn(
+        log_warning(
             "The `copy_nnz_async` method is deprecated and will be removed in a future version. Prefer `notify_nnz_changed` instead.",
-            DeprecationWarning,
+            category=DeprecationWarning,
+            stacklevel=2,
         )
         self._copy_nnz_async()
 

--- a/warp/_src/tape.py
+++ b/warp/_src/tape.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from collections import defaultdict, namedtuple
 
 import warp as wp
+from warp._src.logger import log_warning
 
 _wp_module_name_ = "warp.tape"
 
@@ -114,12 +115,12 @@ class Tape:
                 enable_backward = launch[0].options.get("enable_backward")
                 if enable_backward is False:
                     msg = f"Running the tape backwards may produce incorrect gradients because recorded kernel {launch[0].key} is configured with the option 'enable_backward=False'."
-                    wp._src.utils.warn(msg)
+                    log_warning(msg)
                 elif enable_backward is None:
                     enable_backward = launch[0].module.options.get("enable_backward")
                     if enable_backward is False:
                         msg = f"Running the tape backwards may produce incorrect gradients because recorded kernel {launch[0].key} is defined in a module with the option 'enable_backward=False' set."
-                        wp._src.utils.warn(msg)
+                        log_warning(msg)
 
                 kernel = launch[0]
                 dim = launch[1]

--- a/warp/_src/texture.py
+++ b/warp/_src/texture.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 
     from warp._src.context import DeviceLike
 
+from warp._src.logger import log_warning
 from warp._src.types import (
     array,
     float16,
@@ -696,11 +697,10 @@ class Texture:
     def copy_from_array(self, src: array):
         """Copy from a CUDA Warp array into this texture's CUDA array.
         Deprecated, use ``Texture.copy_from()`` method instead."""
-        import warp._src.utils  # noqa: PLC0415
 
-        warp._src.utils.warn(
+        log_warning(
             "The Texture.copy_from_array() method is deprecated, use Texture.copy_from() instead.",
-            DeprecationWarning,
+            category=DeprecationWarning,
             stacklevel=2,
         )
 
@@ -709,11 +709,10 @@ class Texture:
     def copy_to_array(self, dst: array):
         """Copy from this texture's CUDA array into a CUDA Warp array.
         Deprecated, use ``Texture.copy_to()`` method instead."""
-        import warp._src.utils  # noqa: PLC0415
 
-        warp._src.utils.warn(
+        log_warning(
             "The Texture.copy_to_array() method is deprecated, use Texture.copy_to() instead.",
-            DeprecationWarning,
+            category=DeprecationWarning,
             stacklevel=2,
         )
 

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -31,6 +31,7 @@ import numpy.typing as npt
 
 import warp
 import warp.config
+from warp._src.logger import log_warning
 
 _wp_module_name_ = "warp.types"
 
@@ -3181,7 +3182,7 @@ class array(Array[DType, NDim]):
             else:
                 # Warn if the data type is compatible with the requested dtype
                 if not np_dtype_is_compatible(data_dtype_np, dtype):
-                    warp._src.utils.warn(
+                    log_warning(
                         f"The input data type {data_dtype_np} does not appear to be "
                         f"compatible with the requested dtype {dtype}. If "
                         "data-type sizes do not match, then this may lead to memory-access violations."
@@ -3971,12 +3972,12 @@ class array(Array[DType, NDim]):
         """Detect if we are writing to an array that has already been read from."""
         if self._is_read:
             if "arg_name" in kwargs and "kernel_name" in kwargs and "filename" in kwargs and "lineno" in kwargs:
-                print(
-                    f"Warning: Array {self} passed to argument {kwargs['arg_name']} in kernel {kwargs['kernel_name']} at {kwargs['filename']}:{kwargs['lineno']} is being written to but has already been read from in a previous launch. This may corrupt gradient computation in the backward pass."
+                log_warning(
+                    f"Array {self} passed to argument {kwargs['arg_name']} in kernel {kwargs['kernel_name']} at {kwargs['filename']}:{kwargs['lineno']} is being written to but has already been read from in a previous launch. This may corrupt gradient computation in the backward pass."
                 )
             else:
-                print(
-                    f"Warning: Array {self} is being written to but has already been read from in a previous launch. This may corrupt gradient computation in the backward pass."
+                log_warning(
+                    f"Array {self} is being written to but has already been read from in a previous launch. This may corrupt gradient computation in the backward pass."
                 )
 
     def _apic_ensure_tracked(self):
@@ -4095,7 +4096,7 @@ class array(Array[DType, NDim]):
         if is_bf16 and not _suppress_bfloat16_warning:
             ml_bf16 = _get_ml_dtypes_bfloat16()
             if ml_bf16 is None:
-                warp._src.utils.warn(
+                log_warning(
                     "bfloat16 arrays are returned as np.uint16 (raw bit representation) "
                     "because NumPy does not natively support bfloat16. "
                     "Use wp.to_torch() or wp.to_jax() for frameworks that support bfloat16 natively, "
@@ -4563,7 +4564,7 @@ def from_ptr(ptr, length, dtype=None, shape=None, device=None):
     See Also:
         :class:`array`, :func:`from_ipc_handle`
     """
-    warp._src.utils.warn(
+    log_warning(
         """This version of wp.from_ptr() is deprecated. OmniGraph
     applications should use from_omni_graph_ptr() instead. To create an array
     from a C pointer, use the array constructor and pass the ptr argument as a
@@ -4572,6 +4573,7 @@ def from_ptr(ptr, length, dtype=None, shape=None, device=None):
     ptr=ctypes.cast(pointer, ctypes.POINTER(ctypes.c_size_t)).contents.value.
     Be sure to also specify the dtype and shape parameters.""",
         category=DeprecationWarning,
+        stacklevel=2,
     )
 
     return array(
@@ -5432,7 +5434,7 @@ class Bvh:
 
         if self.device.is_cpu:
             if constructor == BvhConstructor.LBVH:
-                warp._src.utils.warn(
+                log_warning(
                     "LBVH constructor is not available for a CPU tree. Falling back to SAH constructor.", stacklevel=2
                 )
                 constructor = BvhConstructor.SAH
@@ -5526,14 +5528,14 @@ class Bvh:
 
         if self.device.is_cpu:
             if constructor == BvhConstructor.LBVH:
-                warp._src.utils.warn(
+                log_warning(
                     "LBVH constructor is not available for a CPU tree. Falling back to SAH constructor.", stacklevel=2
                 )
                 constructor = BvhConstructor.SAH
             self.runtime.core.wp_bvh_rebuild_host(self.id, constructor)
         else:
             if constructor != BvhConstructor.LBVH:
-                warp._src.utils.warn(
+                log_warning(
                     "In-place rebuild method on the CUDA device only supports LBVH constructor. Falling back to LBVH constructor.",
                     stacklevel=2,
                 )
@@ -5647,7 +5649,7 @@ class Mesh:
 
         if self.device.is_cpu:
             if bvh_constructor == BvhConstructor.LBVH:
-                warp._src.utils.warn(
+                log_warning(
                     "LBVH constructor is not available for a CPU tree. Falling back to SAH constructor.", stacklevel=2
                 )
                 bvh_constructor = BvhConstructor.SAH

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -6,12 +6,10 @@ from __future__ import annotations
 import cProfile
 import ctypes
 import gc
-import linecache
 import os
 import sys
 import threading
 import time
-import warnings
 from collections.abc import Callable
 from types import ModuleType
 from typing import Any
@@ -21,56 +19,15 @@ import numpy as np
 import warp as wp
 import warp._src.context
 import warp._src.types
+from warp._src import logger as _logger_module
 from warp._src.context import Allocator, CaptureMode, DeviceLike, _validate_allocator
+from warp._src.logger import Logger, LoggerBasic, _validate_logger, get_logger, log_debug, set_logger
 from warp._src.types import Array, DType, type_repr, types_equal
 
 _wp_module_name_ = "warp.utils"
 
-warnings_seen = set()
-
 # Cache for wp.map(): (func_name, input_descriptors, output_type_descriptor) -> (out_dtypes, kernel)
 map_cache: dict[tuple, tuple] = {}
-
-
-def warp_showwarning(message, category, filename, lineno, file=None, line=None):
-    """Version of warnings.showwarning that always prints to sys.stdout."""
-
-    if warp.config.verbose_warnings:
-        s = f"Warp {category.__name__}: {message} ({filename}:{lineno})\n"
-
-        if line is None:
-            try:
-                line = linecache.getline(filename, lineno)
-            except Exception:
-                # When a warning is logged during Python shutdown, linecache
-                # and the import machinery don't work anymore
-                line = None
-
-        if line:
-            line = line.strip()
-            s += f"  {line}\n"
-    else:
-        # simple warning
-        s = f"Warp {category.__name__}: {message}\n"
-
-    sys.stdout.write(s)
-
-
-def warn(message, category=None, stacklevel=1, once=False):
-    if (category, message) in warnings_seen:
-        return
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("default")  # Change the filter in this process
-        warnings.showwarning = warp_showwarning
-        warnings.warn(
-            message,
-            category,
-            stacklevel=stacklevel + 1,  # Increment stacklevel by 1 since we are in a wrapper
-        )
-
-    if category is DeprecationWarning or once:
-        warnings_seen.add((category, message))
 
 
 # expand a 7-vec to a tuple of arrays
@@ -1433,9 +1390,8 @@ class ScopedTimer:
             if self.print:
                 ScopedTimer._thread_local.indent += 1
 
-                if warp.config.verbose:
-                    indent = "    " * ScopedTimer._thread_local.indent
-                    print(f"{indent}{self.name} ...", flush=True)
+                indent = "    " * ScopedTimer._thread_local.indent
+                log_debug(f"{indent}{self.name} ...")
 
             self.start = time.perf_counter_ns()
 
@@ -1473,12 +1429,17 @@ class ScopedTimer:
 
                 if self.timing_results:
                     self.report_func(self.timing_results, indent=indent)
-                    print()
 
+                # Route the timer's final output through the active logger so
+                # that custom loggers capture it.  Callers
+                # pass ``active=`` to gate by log_level themselves; bypass the
+                # log_level threshold here so an explicitly enabled timer
+                # always emits.
+                logger = get_logger()
                 if self.extra_msg:
-                    print(f"{indent}{self.name} took {self.elapsed:.2f} ms {self.extra_msg}")
+                    logger.info(f"{indent}{self.name} took {self.elapsed:.2f} ms {self.extra_msg}")
                 else:
-                    print(f"{indent}{self.name} took {self.elapsed:.2f} ms")
+                    logger.info(f"{indent}{self.name} took {self.elapsed:.2f} ms")
 
                 ScopedTimer._thread_local.indent -= 1
 
@@ -1549,6 +1510,74 @@ class ScopedAllocator:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.device._custom_allocator = self.saved
+
+
+class ScopedLogger:
+    """Context manager to temporarily install a custom logger.
+
+    On context exit, the previous logger is restored.
+
+    Args:
+        logger: A :class:`~warp.Logger`-compatible object, or ``None`` to
+            temporarily restore Warp's built-in default logger.
+
+    Example:
+        .. code-block:: python
+
+            with wp.ScopedLogger(my_capture_logger):
+                wp.launch(...)  # diagnostics flow to my_capture_logger
+
+    See Also:
+        :func:`warp.set_logger`, :func:`warp.get_logger`
+    """
+
+    def __init__(self, logger: Logger | None):
+        if logger is not None:
+            _validate_logger(logger)
+        self.logger = logger
+
+    def __enter__(self):
+        self.saved = get_logger()
+        set_logger(self.logger if self.logger is not None else LoggerBasic())
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Restore by direct assignment rather than set_logger() to avoid
+        # re-validating the saved logger; a TypeError raised here would mask
+        # any in-flight exception propagating through the context.
+        _logger_module._active_logger = self.saved
+
+
+class ScopedLogLevel:
+    """Context manager to temporarily override :data:`warp.config.log_level`.
+
+    On context exit, the previous value is restored.
+
+    Args:
+        log_level: The log level to set inside the scope. Use one of
+            :data:`~warp.LOG_DEBUG`, :data:`~warp.LOG_INFO`,
+            :data:`~warp.LOG_WARNING`, or :data:`~warp.LOG_ERROR`.
+
+    Example:
+        .. code-block:: python
+
+            with wp.ScopedLogLevel(wp.LOG_WARNING):
+                wp.init()  # banner suppressed inside the scope
+
+    See Also:
+        :data:`warp.config.log_level`
+    """
+
+    def __init__(self, log_level: int):
+        self.log_level = log_level
+
+    def __enter__(self):
+        self.saved = wp.config.log_level
+        wp.config.log_level = self.log_level
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        wp.config.log_level = self.saved
 
 
 # Allow temporarily enabling/disabling mempool access

--- a/warp/config.py
+++ b/warp/config.py
@@ -29,6 +29,10 @@ _suppress_verbose_log_level_mapping = False
 
 def _is_internal_warp_config_access() -> bool:
     try:
+        # Temporary verbose/quiet migration hook. Frame depth 3 assumes:
+        # _is_internal_warp_config_access -> _warn_deprecated_config_access
+        # -> module __getattribute__/__setattr__ -> caller. Remove this when
+        # verbose/quiet are removed.
         module_name = _sys._getframe(3).f_globals.get("__name__", "")
     except ValueError:
         return False

--- a/warp/config.py
+++ b/warp/config.py
@@ -14,7 +14,68 @@ setting documentation for details.
 For information on module-level and kernel-level settings, see :doc:`/user_guide/configuration`.
 """
 
+import sys as _sys
+import types as _types
+
+from warp._src.logger import LOG_INFO as _LOG_INFO
+from warp._src.logger import log_warning as _log_warning
+
 _wp_module_name_ = "warp.config"
+
+_deprecated_verbose_warning_seen = False
+_deprecated_quiet_warning_seen = False
+_suppress_verbose_log_level_mapping = False
+
+
+def _is_internal_warp_config_access() -> bool:
+    try:
+        module_name = _sys._getframe(3).f_globals.get("__name__", "")
+    except ValueError:
+        return False
+    return module_name == "warp" or module_name.startswith("warp.")
+
+
+def _warn_deprecated_config_access(name: str) -> None:
+    global _deprecated_verbose_warning_seen, _deprecated_quiet_warning_seen
+
+    if _is_internal_warp_config_access():
+        return
+
+    if name == "verbose":
+        if _deprecated_verbose_warning_seen:
+            return
+        message = "warp.config.verbose is deprecated; use warp.config.log_level = warp.LOG_DEBUG instead."
+    elif name == "quiet":
+        if _deprecated_quiet_warning_seen:
+            return
+        message = (
+            "warp.config.quiet is deprecated; use warp.config.log_level = warp.LOG_WARNING to suppress the init banner."
+        )
+    else:
+        return
+
+    _log_warning(message, category=DeprecationWarning, stacklevel=3)
+    if name == "verbose":
+        _deprecated_verbose_warning_seen = True
+    else:
+        _deprecated_quiet_warning_seen = True
+
+
+class _ConfigModule(_types.ModuleType):
+    def __getattribute__(self, name):
+        if name in ("verbose", "quiet"):
+            _warn_deprecated_config_access(name)
+        return super().__getattribute__(name)
+
+    def __setattr__(self, name, value):
+        if name in ("verbose", "quiet"):
+            _warn_deprecated_config_access(name)
+        super().__setattr__(name, value)
+
+
+def _install_config_module_hooks() -> None:
+    _sys.modules[__name__].__class__ = _ConfigModule
+
 
 version: str = "1.14.0.dev0"
 """Warp version string"""
@@ -71,7 +132,12 @@ This setting can be overridden at the module level by setting the ``"optimizatio
 """
 
 verbose: bool = False
-"""Enable detailed logging during code generation and compilation."""
+"""Enable detailed logging during code generation and compilation.
+
+.. deprecated::
+    Use ``warp.config.log_level = warp.LOG_DEBUG`` instead. Reading or setting
+    this flag emits a ``DeprecationWarning`` for external callers.
+"""
 
 verbose_warnings: bool = False
 """Enable extended warning messages with source location information."""
@@ -79,7 +145,18 @@ verbose_warnings: bool = False
 quiet: bool = False
 """Disable Warp module initialization messages.
 
-Error messages and warnings remain unaffected.
+.. deprecated::
+    Use ``warp.config.log_level = warp.LOG_WARNING`` instead. Reading or setting
+    this flag emits a ``DeprecationWarning`` for external callers.
+"""
+
+log_level: int = _LOG_INFO
+"""Log level threshold for Warp's logging infrastructure.
+
+Messages below this level are suppressed. Use the ``LOG_DEBUG``, ``LOG_INFO``,
+``LOG_WARNING``, and ``LOG_ERROR`` constants from the ``warp`` module.
+
+Default is ``warp.LOG_INFO`` (20).
 """
 
 verify_autograd_array_access: bool = False
@@ -311,3 +388,6 @@ _git_commit_hash: str | None = None
 
 Set automatically by CI, do not modify.
 """
+
+
+_install_config_module_hooks()

--- a/warp/examples/benchmarks/benchmark_gemm.py
+++ b/warp/examples/benchmarks/benchmark_gemm.py
@@ -136,7 +136,7 @@ if __name__ == "__main__":
 
     configs = list(product(tile_m, tile_n, tile_k, block))
 
-    wp.config.quiet = True
+    wp.config.log_level = wp.LOG_WARNING
 
     # header
     print(

--- a/warp/examples/benchmarks/benchmark_tile_load_store.py
+++ b/warp/examples/benchmarks/benchmark_tile_load_store.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    wp.config.quiet = True
+    wp.config.log_level = wp.LOG_WARNING
     wp.init()
     wp.set_module_options({"fast_math": True, "enable_backward": False})
 

--- a/warp/examples/benchmarks/benchmark_tile_sort.py
+++ b/warp/examples/benchmarks/benchmark_tile_sort.py
@@ -35,7 +35,7 @@ def create_test_kernel(KEY_TYPE, MAX_SORT_LENGTH):
 
 
 if __name__ == "__main__":
-    wp.config.quiet = True
+    wp.config.log_level = wp.LOG_WARNING
     wp.init()
     wp.clear_kernel_cache()
     wp.set_module_options({"fast_math": True, "enable_backward": False})

--- a/warp/examples/distributed/example_jacobi_mpi.py
+++ b/warp/examples/distributed/example_jacobi_mpi.py
@@ -27,7 +27,7 @@ from mpi4py import MPI
 
 import warp as wp
 
-wp.config.quiet = True  # Suppress wp.init() output
+wp.config.log_level = wp.LOG_WARNING  # Suppress wp.init() info/debug output
 
 
 tol = 1e-8

--- a/warp/examples/fem/example_apic_fluid.py
+++ b/warp/examples/fem/example_apic_fluid.py
@@ -8,6 +8,7 @@
 # grid and the PicQuadrature class.
 ###########################################################################
 
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
@@ -17,7 +18,6 @@ import warp as wp
 import warp.examples.fem.utils as fem_example_utils
 import warp.fem as fem
 import warp.render
-from warp._src.utils import warn
 from warp.fem import Domain, Field, Sample, at_node, div, grad, integrand
 from warp.sparse import BsrMatrix, bsr_mm, bsr_mv, bsr_transposed
 
@@ -238,7 +238,7 @@ class Example:
                     screen_height=1024,
                 )
         except Exception as err:
-            warn(f"Could not initialize OpenGL renderer: {err}.")
+            warnings.warn(f"Could not initialize OpenGL renderer: {err}.", stacklevel=2)
 
         try:
             if stage_path:
@@ -348,7 +348,7 @@ class Example:
                 inv_volume,
                 pressure_field.dof_values,
                 velocity_field.dof_values,
-                quiet=not wp.config.verbose,
+                quiet=wp.config.log_level > wp.LOG_DEBUG,
             )
 
             # (A)PIC advection

--- a/warp/examples/fem/example_convection_diffusion.py
+++ b/warp/examples/fem/example_convection_diffusion.py
@@ -121,7 +121,7 @@ class Example:
 
         # Solve linear system
         fem_example_utils.bsr_cg(
-            self._matrix, x=self._phi_field.dof_values, b=rhs, quiet=not wp.config.verbose, tol=1.0e-12
+            self._matrix, x=self._phi_field.dof_values, b=rhs, quiet=wp.config.log_level > wp.LOG_DEBUG, tol=1.0e-12
         )
 
     def render(self):

--- a/warp/examples/fem/example_convection_diffusion_dg.py
+++ b/warp/examples/fem/example_convection_diffusion_dg.py
@@ -145,7 +145,9 @@ class Example:
         )
 
         phi = wp.zeros_like(rhs)
-        fem_example_utils.bsr_cg(self._matrix, b=rhs, x=phi, method="bicgstab", quiet=not wp.config.verbose)
+        fem_example_utils.bsr_cg(
+            self._matrix, b=rhs, x=phi, method="bicgstab", quiet=wp.config.log_level > wp.LOG_DEBUG
+        )
         wp.utils.array_cast(in_array=phi, out_array=self._phi_field.dof_values)
 
         # for visualization purposes only

--- a/warp/examples/fem/example_navier_stokes.py
+++ b/warp/examples/fem/example_navier_stokes.py
@@ -189,7 +189,7 @@ class Example:
             x_p=x_p,
             b_u=u_rhs,
             b_p=p_rhs,
-            quiet=not wp.config.verbose,
+            quiet=wp.config.log_level > wp.LOG_DEBUG,
         )
 
         wp.utils.array_cast(in_array=x_u, out_array=self._u_field.dof_values)

--- a/warp/examples/fem/example_nonconforming_contact.py
+++ b/warp/examples/fem/example_nonconforming_contact.py
@@ -255,7 +255,7 @@ class Example:
         # solve
         x = wp.zeros_like(u_rhs)
         wp.utils.array_cast(in_array=u_field.dof_values, out_array=x)
-        fem_example_utils.bsr_cg(stiffness_matrix, b=u_rhs, x=x, tol=1.0e-6, quiet=not wp.config.verbose)
+        fem_example_utils.bsr_cg(stiffness_matrix, b=u_rhs, x=x, tol=1.0e-6, quiet=wp.config.log_level > wp.LOG_DEBUG)
 
         # Extract result
         stress = stress_matrix @ x

--- a/warp/examples/fem/example_streamlines.py
+++ b/warp/examples/fem/example_streamlines.py
@@ -10,12 +10,13 @@
 #
 ###########################################################################
 
+import warnings
+
 import numpy as np
 
 import warp as wp
 import warp.examples.fem.utils as fem_example_utils
 import warp.fem as fem
-from warp._src.utils import warn
 from warp.examples.fem.example_apic_fluid import divergence_form, solve_incompressibility
 
 
@@ -214,7 +215,7 @@ class Example:
                     draw_axis=False,
                 )
             except Exception as err:
-                warn(f"Could not initialize OpenGL renderer: {err}")
+                warnings.warn(f"Could not initialize OpenGL renderer: {err}", stacklevel=2)
                 pass
 
     def step(self):

--- a/warp/examples/fem/utils.py
+++ b/warp/examples/fem/utils.py
@@ -6,13 +6,13 @@ import gc
 import os
 import sys
 import time
+import warnings
 from typing import Any
 
 import numpy as np
 
 import warp as wp
 import warp.fem as fem
-from warp._src.utils import warn
 from warp.optim.linear import LinearOperator, aslinearoperator, bicgstab, cg, cr, gmres, preconditioner
 from warp.render import UsdRenderer
 from warp.sparse import BsrMatrix, bsr_get_diag, bsr_mv, bsr_transposed
@@ -716,7 +716,7 @@ class Plot:
             try:
                 return self._plot_matplotlib(options, save=save)
             except ModuleNotFoundError:
-                warn("pyvista or matplotlib must be installed to visualize solution results")
+                warnings.warn("pyvista or matplotlib must be installed to visualize solution results", stacklevel=2)
 
     def _plot_pyvista(self, options: dict[str, Any], save: str | None = None):
         import pyvista  # noqa: PLC0415

--- a/warp/jax_experimental/_deprecation.py
+++ b/warp/jax_experimental/_deprecation.py
@@ -3,9 +3,9 @@
 
 
 def warn_deprecated_jax_experimental_namespace(old_path: str, new_path: str) -> None:
-    from warp._src.utils import warn  # noqa: PLC0415
+    from warp._src.logger import log_warning  # noqa: PLC0415
 
-    warn(
+    log_warning(
         f"The `{old_path}` namespace is deprecated and will be removed in Warp 1.16. Use `{new_path}` instead.",
         DeprecationWarning,
         stacklevel=2,

--- a/warp/tests/aot/test_module_aot.py
+++ b/warp/tests/aot/test_module_aot.py
@@ -413,7 +413,7 @@ def test_generic_kernel_no_overloads_with_regular_kernel(test, device):
     )
 
     # This should succeed with a warning about the generic kernel without overloads
-    with contextlib.redirect_stdout(io.StringIO()) as f:
+    with contextlib.redirect_stderr(io.StringIO()) as f:
         wp.compile_aot_module(warp.tests.aot.aux_test_mixed_regular_and_generic, device)
 
     # Verify a warning was issued
@@ -447,7 +447,7 @@ def test_mixed_generic_kernels_some_without_overloads(test, device):
     )
 
     # This should succeed with a warning about the generic kernel without overloads
-    with contextlib.redirect_stdout(io.StringIO()) as f:
+    with contextlib.redirect_stderr(io.StringIO()) as f:
         wp.compile_aot_module(warp.tests.aot.aux_test_mixed_generic_kernels, device, strip_hash=False)
 
     # Verify a warning was issued

--- a/warp/tests/cuda/test_ipc.py
+++ b/warp/tests/cuda/test_ipc.py
@@ -40,7 +40,7 @@ def test_ipc_event_missing_interprocess_flag(test, device):
     e1 = wp.Event(device, interprocess=False)
 
     try:
-        capture = StdOutCapture()
+        capture = StdErrCapture()
         capture.begin()
         ipc_handle = e1.ipc_handle()
     finally:

--- a/warp/tests/fem/test_fem_integrate.py
+++ b/warp/tests/fem/test_fem_integrate.py
@@ -4,6 +4,7 @@
 import contextlib
 import io
 import unittest
+import warnings
 
 import numpy as np
 
@@ -580,7 +581,8 @@ class TestFemIntegrate(unittest.TestCase):
         device = "cpu"
 
         def assert_deprecation_mentions_warp_1_15(callback):
-            with contextlib.redirect_stdout(io.StringIO()) as output:
+            with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()) as output:
+                warnings.simplefilter("always", DeprecationWarning)
                 result = callback()
 
             self.assertIn("will be removed in Warp 1.15", output.getvalue())

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -9,6 +9,7 @@ import io
 import os
 import sys
 import unittest
+import warnings
 from functools import partial
 from typing import Any
 
@@ -107,9 +108,9 @@ def _clear_jax_namespace_modules():
 
 
 def _clear_jax_experimental_warning_cache():
-    wp._src.utils.warnings_seen = {
+    wp._src.logger._warnings_seen = {
         entry
-        for entry in wp._src.utils.warnings_seen
+        for entry in wp._src.logger._warnings_seen
         if not (
             entry[0] is DeprecationWarning
             and isinstance(entry[1], str)
@@ -120,9 +121,10 @@ def _clear_jax_experimental_warning_cache():
 
 def _import_deprecated_jax_namespace(module_name):
     _clear_jax_experimental_warning_cache()
-    with contextlib.redirect_stdout(io.StringIO()) as stdout:
+    with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()) as stderr:
+        warnings.simplefilter("always", DeprecationWarning)
         module = importlib.import_module(module_name)
-    return module, stdout.getvalue()
+    return module, stderr.getvalue()
 
 
 def test_jax_namespace_imports(test, device):

--- a/warp/tests/matrix/test_mat_constructors.py
+++ b/warp/tests/matrix/test_mat_constructors.py
@@ -17,12 +17,18 @@ from warp.tests.unittest_utils import *
 kernel_cache = {}
 
 
+_prev_log_level = None
+
+
 def setUpModule():
-    wp.config.quiet = True
+    global _prev_log_level
+    _prev_log_level = wp.config.log_level
+    wp.config.log_level = wp.LOG_WARNING
 
 
 def tearDownModule():
-    wp.config.quiet = False
+    if _prev_log_level is not None:
+        wp.config.log_level = _prev_log_level
 
 
 def test_constructors(test, device, dtype, register_kernels=False):

--- a/warp/tests/test_diagnostics.py
+++ b/warp/tests/test_diagnostics.py
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib.metadata
+import subprocess
+import sys
+import textwrap
 import unittest
 
 import warp as wp
@@ -101,6 +104,28 @@ class TestDiagnostics(unittest.TestCase):
             self.assertIsInstance(cuda_dev["memory_gb"], float)
             self.assertIsInstance(cuda_dev["mempool_enabled"], bool)
             self.assertRegex(cuda_dev["pci_bus_id"], r"^[0-9A-F]+:[0-9A-F]+:[0-9A-F]+$")
+
+    def test_print_diagnostics_suppresses_init_banner_with_deprecated_verbose(self):
+        script = textwrap.dedent(
+            """
+            import contextlib
+            import io
+            import warnings
+            import warp as wp
+
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            wp.config.verbose = True
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                wp.print_diagnostics()
+            assert wp.config.log_level == wp.LOG_DEBUG, wp.config.log_level
+            print(output.getvalue().splitlines()[0])
+            """
+        )
+
+        result = subprocess.run([sys.executable, "-c", script], check=True, capture_output=True, text=True)
+        first_line = result.stdout.strip()
+        self.assertEqual(first_line, "Software")
 
     def test_nanovdb_version(self):
         version = get_nanovdb_version()

--- a/warp/tests/test_graph.py
+++ b/warp/tests/test_graph.py
@@ -3,6 +3,7 @@
 
 """Tests for graph capture and replay on CPU and CUDA devices."""
 
+import ctypes
 import gc
 import time
 import unittest
@@ -32,7 +33,22 @@ def add_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float), output: wp.ar
 
 
 class TestGraph(unittest.TestCase):
-    pass
+    def test_cuda_graph_memory_bindings(self):
+        core = wp._src.context.runtime.core
+
+        def get_ctypes_binding(name):
+            bindings = getattr(core, "ctypes", None)
+            if bindings is not None and hasattr(bindings, name):
+                return getattr(bindings, name)
+            return getattr(core, name)
+
+        get_current = get_ctypes_binding("wp_cuda_device_get_graph_mem_current")
+        trim = get_ctypes_binding("wp_cuda_device_graph_mem_trim")
+
+        self.assertEqual(get_current.argtypes, [ctypes.c_int])
+        self.assertIs(get_current.restype, ctypes.c_uint64)
+        self.assertEqual(trim.argtypes, [ctypes.c_int])
+        self.assertIsNone(trim.restype)
 
 
 def test_graph_single_kernel(test, device):

--- a/warp/tests/test_kernel_cache.py
+++ b/warp/tests/test_kernel_cache.py
@@ -43,7 +43,7 @@ class TestKernelCache(unittest.TestCase):
         """Warn when the unversioned base directory contains stale wp_ artifacts."""
         with tempfile.TemporaryDirectory() as tmp:
             os.makedirs(os.path.join(tmp, "wp_stale_module"))
-            with patch("warp._src.utils.warn") as mock_warn:
+            with patch("warp._src.logger.log_warning") as mock_warn:
                 warp._src.build.init_kernel_cache(path=tmp)
                 mock_warn.assert_called_once()
                 self.assertIn("previous Warp version", mock_warn.call_args[0][0])
@@ -51,7 +51,7 @@ class TestKernelCache(unittest.TestCase):
     def test_no_stale_artifacts_warning(self):
         """No warning when the base directory is clean."""
         with tempfile.TemporaryDirectory() as tmp:
-            with patch("warp._src.utils.warn") as mock_warn:
+            with patch("warp._src.logger.log_warning") as mock_warn:
                 warp._src.build.init_kernel_cache(path=tmp)
                 mock_warn.assert_not_called()
 

--- a/warp/tests/test_logger.py
+++ b/warp/tests/test_logger.py
@@ -1,0 +1,576 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+import warnings
+from types import SimpleNamespace
+
+import warp
+import warp as wp
+from warp._src import build as _build_module
+from warp._src import logger as _logger_module
+from warp._src.logger import LoggerBasic, log_debug, log_error, log_warning
+
+
+@wp.kernel
+def _print_launches_test_kernel():
+    pass
+
+
+class _NoOpLogger:
+    def debug(self, message):
+        pass
+
+    def info(self, message):
+        pass
+
+    def warning(self, message, category=None, stacklevel=1):
+        pass
+
+    def error(self, message):
+        pass
+
+
+class TestLogger(unittest.TestCase):
+    def _clear_deprecated_config_warnings(self):
+        wp.config._deprecated_verbose_warning_seen = False
+        wp.config._deprecated_quiet_warning_seen = False
+        _logger_module._warnings_seen.clear()
+
+    def test_log_level_constants(self):
+        self.assertEqual(wp.LOG_DEBUG, 10)
+        self.assertEqual(wp.LOG_INFO, 20)
+        self.assertEqual(wp.LOG_WARNING, 30)
+        self.assertEqual(wp.LOG_ERROR, 40)
+
+    def test_logger_protocol_cannot_be_instantiated(self):
+        with self.assertRaises(TypeError):
+            wp.Logger()
+
+    def test_loggerkit_not_exported_from_warp_utils(self):
+        self.assertFalse(hasattr(wp.utils, "LoggerKit"))
+
+    def test_deprecated_config_verbose_read_warns_for_external_callers(self):
+        self._clear_deprecated_config_warnings()
+        namespace = {"wp": wp, "__name__": "external_app"}
+        original_verbose_warnings = wp.config.verbose_warnings
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            wp.config.verbose_warnings = True
+            with warnings.catch_warnings():
+                warnings.simplefilter("always", DeprecationWarning)
+                exec(
+                    compile("value = wp.config.verbose\nagain = wp.config.verbose", "/tmp/external_app.py", "exec"),
+                    namespace,
+                )
+            output = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+            wp.config.verbose_warnings = original_verbose_warnings
+
+        self.assertIsInstance(namespace["value"], bool)
+        self.assertEqual(namespace["again"], namespace["value"])
+        self.assertEqual(output.count("warp.config.verbose is deprecated"), 1)
+        self.assertIn("/tmp/external_app.py", output)
+
+    def test_deprecated_config_quiet_assignment_warns_for_external_callers(self):
+        self._clear_deprecated_config_warnings()
+        original_quiet = wp.config.__dict__["quiet"]
+        original_verbose_warnings = wp.config.verbose_warnings
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            wp.config.verbose_warnings = True
+            namespace = {"wp": wp, "__name__": "external_app"}
+            with warnings.catch_warnings():
+                warnings.simplefilter("always", DeprecationWarning)
+                exec(compile("wp.config.quiet = True", "/tmp/external_app.py", "exec"), namespace)
+            output = sys.stderr.getvalue()
+
+            self.assertTrue(wp.config.__dict__["quiet"])
+            self.assertEqual(output.count("warp.config.quiet is deprecated"), 1)
+            self.assertIn("/tmp/external_app.py", output)
+        finally:
+            sys.stderr = old_stderr
+            wp.config.verbose_warnings = original_verbose_warnings
+            wp.config.__dict__["quiet"] = original_quiet
+
+    def test_deprecated_config_access_does_not_warn_for_warp_callers(self):
+        self._clear_deprecated_config_warnings()
+        namespace = {"wp": wp, "__name__": "warp._src.fake_internal"}
+        with warnings.catch_warnings(record=True) as recorded:
+            warnings.simplefilter("always", DeprecationWarning)
+            exec(
+                compile(
+                    "value = wp.config.verbose\nwp.config.quiet = wp.config.quiet",
+                    "/tmp/fake_internal.py",
+                    "exec",
+                ),
+                namespace,
+            )
+
+        self.assertIsInstance(namespace["value"], bool)
+        self.assertEqual(recorded, [])
+
+    def test_deprecated_config_access_routes_to_active_logger(self):
+        class CaptureLogger:
+            def __init__(self):
+                self.warnings = []
+
+            def debug(self, message):
+                pass
+
+            def info(self, message):
+                pass
+
+            def warning(self, message, category=None, stacklevel=1):
+                self.warnings.append((message, category, stacklevel))
+
+            def error(self, message):
+                pass
+
+        self._clear_deprecated_config_warnings()
+        logger = CaptureLogger()
+        original_logger = wp.get_logger()
+        original_quiet = wp.config.__dict__["quiet"]
+        try:
+            wp.set_logger(logger)
+            namespace = {"wp": wp, "__name__": "external_app"}
+            with warnings.catch_warnings(record=True) as recorded:
+                warnings.simplefilter("always", DeprecationWarning)
+                exec(compile("wp.config.quiet = True", "/tmp/external_app.py", "exec"), namespace)
+        finally:
+            wp.config.__dict__["quiet"] = original_quiet
+            wp.set_logger(original_logger)
+
+        self.assertEqual(recorded, [])
+        self.assertEqual(len(logger.warnings), 1)
+        message, category, _stacklevel = logger.warnings[0]
+        self.assertIn("warp.config.quiet is deprecated", message)
+        self.assertEqual(category, DeprecationWarning)
+
+    def test_deprecated_config_access_respects_log_level(self):
+        self._clear_deprecated_config_warnings()
+        original_level = wp.config.__dict__["log_level"]
+        try:
+            wp.config.__dict__["log_level"] = wp.LOG_ERROR
+            namespace = {"wp": wp, "__name__": "external_app"}
+            with warnings.catch_warnings(record=True) as recorded:
+                warnings.simplefilter("always", DeprecationWarning)
+                exec(compile("value = wp.config.verbose", "/tmp/external_app.py", "exec"), namespace)
+        finally:
+            wp.config.__dict__["log_level"] = original_level
+
+        self.assertEqual(recorded, [])
+
+    def test_set_logger_accepts_duck_typed_object(self):
+        """Logger is a Protocol -- any object with the four methods works."""
+
+        class DuckLogger:
+            def debug(self, message):
+                pass
+
+            def info(self, message):
+                pass
+
+            def warning(self, message, category=None, stacklevel=1):
+                pass
+
+            def error(self, message):
+                pass
+
+        original = wp.get_logger()
+        try:
+            wp.set_logger(DuckLogger())
+            self.assertIsInstance(wp.get_logger(), DuckLogger)
+        finally:
+            wp.set_logger(original)
+
+    def test_set_logger_rejects_object_missing_methods(self):
+        class NotALogger:
+            def debug(self, message):
+                pass
+
+            # missing info, warning, error
+
+        with self.assertRaises(TypeError):
+            wp.set_logger(NotALogger())
+
+    def test_basic_logger_debug_writes_to_stdout(self):
+        logger = LoggerBasic()
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            logger.debug("test debug msg")
+            output = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old_stdout
+        self.assertEqual(output, "test debug msg\n")
+
+    def test_basic_logger_info_writes_to_stdout(self):
+        logger = LoggerBasic()
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            logger.info("test info msg")
+            output = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old_stdout
+        self.assertEqual(output, "test info msg\n")
+
+    def test_basic_logger_error_writes_to_stderr(self):
+        logger = LoggerBasic()
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            logger.error("something broke")
+            output = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+        self.assertEqual(output, "Warp Error: something broke\n")
+
+    def test_basic_logger_warning_respects_filters(self):
+        """GH-1315: user warning filters must not be overridden."""
+        logger = LoggerBasic()
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            old_stderr = sys.stderr
+            sys.stderr = io.StringIO()
+            try:
+                logger.warning("old API", category=DeprecationWarning, stacklevel=1)
+                output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+        self.assertEqual(output, "", "DeprecationWarning should have been suppressed")
+
+    def test_set_get_logger(self):
+        original = wp.get_logger()
+        try:
+            self.assertIsInstance(original, LoggerBasic)
+            logger = _NoOpLogger()
+            wp.set_logger(logger)
+            self.assertIs(wp.get_logger(), logger)
+        finally:
+            wp.set_logger(original)
+
+    def test_set_logger_validates_type(self):
+        with self.assertRaises(TypeError):
+            wp.set_logger("not a logger")
+
+    def test_set_logger_none_resets_to_basic_logger(self):
+        original = wp.get_logger()
+        try:
+            wp.set_logger(_NoOpLogger())
+            self.assertIsInstance(wp.get_logger(), _NoOpLogger)
+            wp.set_logger(None)
+            self.assertIsInstance(wp.get_logger(), LoggerBasic)
+        finally:
+            wp.set_logger(original)
+
+    def test_scoped_logger_swaps_and_restores(self):
+        original = wp.get_logger()
+        logger = _NoOpLogger()
+        with wp.ScopedLogger(logger) as scope:
+            self.assertIs(scope.logger, logger)
+            self.assertIs(wp.get_logger(), logger)
+        self.assertIs(wp.get_logger(), original)
+
+    def test_scoped_logger_restores_on_exception(self):
+        original = wp.get_logger()
+        with self.assertRaises(RuntimeError):
+            with wp.ScopedLogger(_NoOpLogger()):
+                raise RuntimeError("boom")
+        self.assertIs(wp.get_logger(), original)
+
+    def test_scoped_logger_none_uses_basic_logger(self):
+        original = wp.get_logger()
+        wp.set_logger(_NoOpLogger())
+        try:
+            with wp.ScopedLogger(None):
+                self.assertIsInstance(wp.get_logger(), LoggerBasic)
+        finally:
+            wp.set_logger(original)
+
+    def test_scoped_log_level_swaps_and_restores(self):
+        original = wp.config.log_level
+        try:
+            wp.config.log_level = wp.LOG_INFO
+            with wp.ScopedLogLevel(wp.LOG_ERROR):
+                self.assertEqual(wp.config.log_level, wp.LOG_ERROR)
+            self.assertEqual(wp.config.log_level, wp.LOG_INFO)
+        finally:
+            wp.config.log_level = original
+
+    def test_scoped_log_level_restores_on_exception(self):
+        original = wp.config.log_level
+        try:
+            wp.config.log_level = wp.LOG_INFO
+            with self.assertRaises(RuntimeError):
+                with wp.ScopedLogLevel(wp.LOG_ERROR):
+                    raise RuntimeError("boom")
+            self.assertEqual(wp.config.log_level, wp.LOG_INFO)
+        finally:
+            wp.config.log_level = original
+
+    def test_log_debug_gated_by_level(self):
+        original_level = warp.config.log_level
+        original_verbose = warp.config.verbose
+        warp.config.log_level = wp.LOG_WARNING
+        warp.config.verbose = False
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            log_debug("should not appear")
+            output = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old_stdout
+            warp.config.log_level = original_level
+            warp.config.verbose = original_verbose
+        self.assertEqual(output, "")
+
+    def test_log_debug_honors_deprecated_verbose_flag_at_call_time(self):
+        original_level = warp.config.log_level
+        original_verbose = warp.config.verbose
+        warp.config.log_level = wp.LOG_WARNING
+        warp.config.verbose = True
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            log_debug("debug via verbose")
+            output = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old_stdout
+            warp.config.log_level = original_level
+            warp.config.verbose = original_verbose
+        self.assertEqual(output, "debug via verbose\n")
+
+    def test_cuda_build_honors_deprecated_verbose_flag_at_call_time(self):
+        original_level = warp.config.__dict__["log_level"]
+        original_verbose = warp.config.__dict__["verbose"]
+        original_runtime = _build_module.warp._src.context.runtime
+        captured = {}
+
+        def compile_cuda(*args):
+            captured["verbose"] = args[9]
+            return 0
+
+        try:
+            warp.config.log_level = wp.LOG_WARNING
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                warp.config.verbose = True
+            _build_module.warp._src.context.runtime = SimpleNamespace(
+                core=SimpleNamespace(wp_cuda_compile_program=compile_cuda)
+            )
+            with tempfile.TemporaryDirectory() as tmpdir:
+                cu_path = f"{tmpdir}/kernel.cu"
+                output_path = f"{tmpdir}/kernel.ptx"
+                with open(cu_path, "w") as cu_file:
+                    cu_file.write("// empty test kernel\n")
+                _build_module.build_cuda(cu_path, 80, output_path, pch_dir=None)
+        finally:
+            _build_module.warp._src.context.runtime = original_runtime
+            warp.config.__dict__["log_level"] = original_level
+            warp.config.__dict__["verbose"] = original_verbose
+
+        self.assertTrue(captured["verbose"])
+
+    def test_log_debug_emits_at_debug_level(self):
+        original_level = warp.config.log_level
+        warp.config.log_level = wp.LOG_DEBUG
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            log_debug("debug msg")
+            output = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old_stdout
+            warp.config.log_level = original_level
+        self.assertEqual(output, "debug msg\n")
+
+    def test_log_error_always_emits(self):
+        """log_error ignores log_level -- errors are never suppressed."""
+        original_level = warp.config.log_level
+        warp.config.log_level = wp.LOG_ERROR + 10
+        old_stderr = sys.stderr
+        sys.stderr = io.StringIO()
+        try:
+            log_error("critical failure")
+            output = sys.stderr.getvalue()
+        finally:
+            sys.stderr = old_stderr
+            warp.config.log_level = original_level
+        self.assertIn("critical failure", output)
+
+    def test_log_warning_once_deduplicates(self):
+        saved_warnings = _logger_module._warnings_seen.copy()
+        _logger_module._warnings_seen.clear()
+        with warnings.catch_warnings():
+            warnings.resetwarnings()
+            old_stderr = sys.stderr
+            sys.stderr = io.StringIO()
+            try:
+                log_warning("dup warning", category=UserWarning, once=True)
+                log_warning("dup warning", category=UserWarning, once=True)
+                output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+                _logger_module._warnings_seen.clear()
+                _logger_module._warnings_seen.update(saved_warnings)
+        self.assertEqual(output.count("dup warning"), 1)
+
+    def test_custom_logger_warning_stacklevel_points_to_external_caller(self):
+        class WarningsLogger:
+            def debug(self, message):
+                pass
+
+            def info(self, message):
+                pass
+
+            def warning(self, message, category=None, stacklevel=1):
+                warnings.warn(message, category, stacklevel=stacklevel)
+
+            def error(self, message):
+                pass
+
+        original = wp.get_logger()
+        try:
+            wp.set_logger(WarningsLogger())
+            namespace = {"log_warning": log_warning, "UserWarning": UserWarning}
+            with warnings.catch_warnings(record=True) as recorded:
+                warnings.simplefilter("always", UserWarning)
+                exec(
+                    compile(
+                        "log_warning('custom logger warning', category=UserWarning)",
+                        "/tmp/external_warning_caller.py",
+                        "exec",
+                    ),
+                    namespace,
+                )
+        finally:
+            wp.set_logger(original)
+
+        self.assertEqual(len(recorded), 1)
+        self.assertEqual(recorded[0].filename, "/tmp/external_warning_caller.py")
+
+    def test_from_ptr_deprecation_warning_visible_to_default_filter(self):
+        script = textwrap.dedent(
+            """
+            import warp as wp
+
+            try:
+                wp.from_ptr(0, 0, dtype=wp.float32)
+            except TypeError:
+                pass
+            """
+        )
+
+        result = subprocess.run([sys.executable, "-c", script], check=True, capture_output=True, text=True)
+        self.assertIn("Warp DeprecationWarning: This version of wp.from_ptr()", result.stderr)
+
+    def test_print_launches_routes_to_active_logger(self):
+        class CaptureLogger:
+            def __init__(self):
+                self.infos = []
+
+            def debug(self, message):
+                pass
+
+            def info(self, message):
+                self.infos.append(message)
+
+            def warning(self, message, category=None, stacklevel=1):
+                pass
+
+            def error(self, message):
+                pass
+
+        logger = CaptureLogger()
+        original_logger = wp.get_logger()
+        original_print_launches = wp.config.print_launches
+        old_stdout = sys.stdout
+        sys.stdout = io.StringIO()
+        try:
+            wp.set_logger(logger)
+            wp.config.print_launches = True
+            wp.launch(_print_launches_test_kernel, dim=0, device="cpu")
+            stdout_output = sys.stdout.getvalue()
+        finally:
+            sys.stdout = old_stdout
+            wp.config.print_launches = original_print_launches
+            wp.set_logger(original_logger)
+
+        self.assertEqual(stdout_output, "")
+        self.assertTrue(any("kernel: _print_launches_test_kernel" in message for message in logger.infos))
+
+    def test_log_warning_deprecation_warnings_deduplicate_without_once(self):
+        """DeprecationWarnings are deduplicated even when ``once`` is not passed,
+        matching the legacy ``warn()`` helper this replaced."""
+        saved = _logger_module._warnings_seen.copy()
+        _logger_module._warnings_seen.clear()
+        with warnings.catch_warnings():
+            warnings.resetwarnings()
+            old_stderr = sys.stderr
+            sys.stderr = io.StringIO()
+            try:
+                log_warning("legacy api", category=DeprecationWarning)
+                log_warning("legacy api", category=DeprecationWarning)
+                output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+                _logger_module._warnings_seen.clear()
+                _logger_module._warnings_seen.update(saved)
+        self.assertEqual(output.count("legacy api"), 1)
+
+    def test_scoped_logger_exit_tolerates_mutated_saved_logger(self):
+        """``ScopedLogger.__exit__`` must restore the saved logger without
+        re-validating it; otherwise a TypeError would mask any in-flight
+        exception propagating through the context."""
+
+        class MutableLogger:
+            def debug(self, message):
+                pass
+
+            def info(self, message):
+                pass
+
+            def warning(self, message, category=None, stacklevel=1):
+                pass
+
+            def error(self, message):
+                pass
+
+        original = wp.get_logger()
+        outer = MutableLogger()
+        wp.set_logger(outer)
+        try:
+            with wp.ScopedLogger(MutableLogger()):
+                # Break the saved logger after entering the scope; __exit__
+                # must still restore it without raising.
+                outer.debug = None
+            self.assertIs(wp.get_logger(), outer)
+        finally:
+            wp.set_logger(original)
+
+    def test_gh1315_user_filters_respected(self):
+        """Verify that warnings.filterwarnings('ignore') suppresses Warp warnings."""
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            old_stderr = sys.stderr
+            sys.stderr = io.StringIO()
+            try:
+                log_warning("deprecated thing", category=DeprecationWarning)
+                output = sys.stderr.getvalue()
+            finally:
+                sys.stderr = old_stderr
+        self.assertEqual(output, "", "DeprecationWarning should have been suppressed by user filter")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/warp/tests/test_logger.py
+++ b/warp/tests/test_logger.py
@@ -8,6 +8,7 @@ import tempfile
 import textwrap
 import unittest
 import warnings
+from pathlib import Path
 from types import SimpleNamespace
 
 import warp
@@ -37,6 +38,13 @@ class _NoOpLogger:
 
 
 class TestLogger(unittest.TestCase):
+    def setUp(self):
+        self._source_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._source_dir.cleanup)
+
+    def _source_path(self, filename):
+        return str(Path(self._source_dir.name) / filename)
+
     def _clear_deprecated_config_warnings(self):
         wp.config._deprecated_verbose_warning_seen = False
         wp.config._deprecated_quiet_warning_seen = False
@@ -58,6 +66,7 @@ class TestLogger(unittest.TestCase):
     def test_deprecated_config_verbose_read_warns_for_external_callers(self):
         self._clear_deprecated_config_warnings()
         namespace = {"wp": wp, "__name__": "external_app"}
+        external_app_path = self._source_path("external_app.py")
         original_verbose_warnings = wp.config.verbose_warnings
         old_stderr = sys.stderr
         sys.stderr = io.StringIO()
@@ -66,7 +75,7 @@ class TestLogger(unittest.TestCase):
             with warnings.catch_warnings():
                 warnings.simplefilter("always", DeprecationWarning)
                 exec(
-                    compile("value = wp.config.verbose\nagain = wp.config.verbose", "/tmp/external_app.py", "exec"),
+                    compile("value = wp.config.verbose\nagain = wp.config.verbose", external_app_path, "exec"),
                     namespace,
                 )
             output = sys.stderr.getvalue()
@@ -77,12 +86,13 @@ class TestLogger(unittest.TestCase):
         self.assertIsInstance(namespace["value"], bool)
         self.assertEqual(namespace["again"], namespace["value"])
         self.assertEqual(output.count("warp.config.verbose is deprecated"), 1)
-        self.assertIn("/tmp/external_app.py", output)
+        self.assertIn(external_app_path, output)
 
     def test_deprecated_config_quiet_assignment_warns_for_external_callers(self):
         self._clear_deprecated_config_warnings()
         original_quiet = wp.config.__dict__["quiet"]
         original_verbose_warnings = wp.config.verbose_warnings
+        external_app_path = self._source_path("external_app.py")
         old_stderr = sys.stderr
         sys.stderr = io.StringIO()
         try:
@@ -90,12 +100,12 @@ class TestLogger(unittest.TestCase):
             namespace = {"wp": wp, "__name__": "external_app"}
             with warnings.catch_warnings():
                 warnings.simplefilter("always", DeprecationWarning)
-                exec(compile("wp.config.quiet = True", "/tmp/external_app.py", "exec"), namespace)
+                exec(compile("wp.config.quiet = True", external_app_path, "exec"), namespace)
             output = sys.stderr.getvalue()
 
             self.assertTrue(wp.config.__dict__["quiet"])
             self.assertEqual(output.count("warp.config.quiet is deprecated"), 1)
-            self.assertIn("/tmp/external_app.py", output)
+            self.assertIn(external_app_path, output)
         finally:
             sys.stderr = old_stderr
             wp.config.verbose_warnings = original_verbose_warnings
@@ -104,12 +114,13 @@ class TestLogger(unittest.TestCase):
     def test_deprecated_config_access_does_not_warn_for_warp_callers(self):
         self._clear_deprecated_config_warnings()
         namespace = {"wp": wp, "__name__": "warp._src.fake_internal"}
+        fake_internal_path = self._source_path("fake_internal.py")
         with warnings.catch_warnings(record=True) as recorded:
             warnings.simplefilter("always", DeprecationWarning)
             exec(
                 compile(
                     "value = wp.config.verbose\nwp.config.quiet = wp.config.quiet",
-                    "/tmp/fake_internal.py",
+                    fake_internal_path,
                     "exec",
                 ),
                 namespace,
@@ -139,12 +150,13 @@ class TestLogger(unittest.TestCase):
         logger = CaptureLogger()
         original_logger = wp.get_logger()
         original_quiet = wp.config.__dict__["quiet"]
+        external_app_path = self._source_path("external_app.py")
         try:
             wp.set_logger(logger)
             namespace = {"wp": wp, "__name__": "external_app"}
             with warnings.catch_warnings(record=True) as recorded:
                 warnings.simplefilter("always", DeprecationWarning)
-                exec(compile("wp.config.quiet = True", "/tmp/external_app.py", "exec"), namespace)
+                exec(compile("wp.config.quiet = True", external_app_path, "exec"), namespace)
         finally:
             wp.config.__dict__["quiet"] = original_quiet
             wp.set_logger(original_logger)
@@ -161,9 +173,10 @@ class TestLogger(unittest.TestCase):
         try:
             wp.config.__dict__["log_level"] = wp.LOG_ERROR
             namespace = {"wp": wp, "__name__": "external_app"}
+            external_app_path = self._source_path("external_app.py")
             with warnings.catch_warnings(record=True) as recorded:
                 warnings.simplefilter("always", DeprecationWarning)
-                exec(compile("value = wp.config.verbose", "/tmp/external_app.py", "exec"), namespace)
+                exec(compile("value = wp.config.verbose", external_app_path, "exec"), namespace)
         finally:
             wp.config.__dict__["log_level"] = original_level
 
@@ -443,12 +456,13 @@ class TestLogger(unittest.TestCase):
         try:
             wp.set_logger(WarningsLogger())
             namespace = {"log_warning": log_warning, "UserWarning": UserWarning}
+            warning_caller_path = self._source_path("external_warning_caller.py")
             with warnings.catch_warnings(record=True) as recorded:
                 warnings.simplefilter("always", UserWarning)
                 exec(
                     compile(
                         "log_warning('custom logger warning', category=UserWarning)",
-                        "/tmp/external_warning_caller.py",
+                        warning_caller_path,
                         "exec",
                     ),
                     namespace,
@@ -457,7 +471,7 @@ class TestLogger(unittest.TestCase):
             wp.set_logger(original)
 
         self.assertEqual(len(recorded), 1)
-        self.assertEqual(recorded[0].filename, "/tmp/external_warning_caller.py")
+        self.assertEqual(recorded[0].filename, warning_caller_path)
 
     def test_from_ptr_deprecation_warning_visible_to_default_filter(self):
         script = textwrap.dedent(

--- a/warp/tests/test_options.py
+++ b/warp/tests/test_options.py
@@ -50,7 +50,7 @@ def test_options_backward_1(test, device):
     with tape:
         wp.launch(scale, dim=1, inputs=[x, y], device=device)
 
-    with contextlib.redirect_stdout(io.StringIO()) as f:
+    with contextlib.redirect_stderr(io.StringIO()) as f:
         tape.backward(y)
 
     expected = f"Warp UserWarning: Running the tape backwards may produce incorrect gradients because recorded kernel {scale.key} is defined in a module with the option 'enable_backward=False' set.\n"
@@ -97,7 +97,7 @@ def test_options_backward_4(test, device):
     with tape:
         wp.launch(scale_2, dim=1, inputs=[x, y], device=device)
 
-    with contextlib.redirect_stdout(io.StringIO()) as f:
+    with contextlib.redirect_stderr(io.StringIO()) as f:
         tape.backward(y)
 
     expected = f"Warp UserWarning: Running the tape backwards may produce incorrect gradients because recorded kernel {scale_2.key} is configured with the option 'enable_backward=False'.\n"
@@ -256,25 +256,54 @@ class TestOptions(unittest.TestCase):
         old_flags = wp.config.cpu_compiler_flags
 
         # Clear once-per-session warning dedup so the warning fires in this test
-        saved_warnings = wp._src.utils.warnings_seen.copy()
-        wp._src.utils.warnings_seen.clear()
+        saved_warnings = wp._src.logger._warnings_seen.copy()
+        wp._src.logger._warnings_seen.clear()
 
         try:
             wp.config.cpu_compiler_flags = None  # resolves to -march=native
             module.hashers.clear()
 
-            stdout_capture = io.StringIO()
-            with contextlib.redirect_stdout(stdout_capture):
+            stderr_capture = io.StringIO()
+            with contextlib.redirect_stderr(stderr_capture):
                 with tempfile.TemporaryDirectory() as tmpdir:
                     wp.compile_aot_module(module, device="cpu", module_dir=tmpdir)
 
-            output = stdout_capture.getvalue()
+            output = stderr_capture.getvalue()
             self.assertIn("-march=native", output)
             self.assertIn("cpu_compiler_flags=''", output)
         finally:
             wp.config.cpu_compiler_flags = old_flags
             module.hashers.clear()
-            wp._src.utils.warnings_seen.update(saved_warnings)
+            wp._src.logger._warnings_seen.update(saved_warnings)
+
+    def test_cpu_isa_aot_warning_metadata(self):
+        """compile_aot_module CPU -march=native warning must carry warning metadata."""
+        module = wp.get_module(__name__)
+        old_flags = wp.config.cpu_compiler_flags
+
+        try:
+            wp.config.cpu_compiler_flags = None  # resolves to -march=native
+            module.hashers.clear()
+
+            with (
+                tempfile.TemporaryDirectory() as tmpdir,
+                patch("warp._src.context.log_warning") as mock_log_warning,
+                patch.object(module, "_compile"),
+            ):
+                wp.compile_aot_module(module, device="cpu", module_dir=tmpdir)
+
+            warning_call = next(
+                call
+                for call in mock_log_warning.call_args_list
+                if call.args
+                and call.args[0].startswith("compile_aot_module: CPU module is being compiled with -march=native.")
+            )
+            self.assertIs(warning_call.kwargs.get("category"), UserWarning)
+            self.assertEqual(warning_call.kwargs.get("stacklevel"), 2)
+            self.assertIs(warning_call.kwargs.get("once"), True)
+        finally:
+            wp.config.cpu_compiler_flags = old_flags
+            module.hashers.clear()
 
     def test_get_caller_module_name_error_message(self):
         """_get_caller_module_name should raise RuntimeError with a helpful message when all fallbacks fail."""

--- a/warp/tests/test_overwrite.py
+++ b/warp/tests/test_overwrite.py
@@ -40,7 +40,7 @@ def test_kernel_read_kernel_write(test, device):
 
         tape = wp.Tape()
 
-        with contextlib.redirect_stdout(io.StringIO()) as f:
+        with contextlib.redirect_stderr(io.StringIO()) as f:
             with tape:
                 wp.launch(square_kernel, a.shape, inputs=[a], outputs=[b], device=device)
                 wp.launch(overwrite_kernel_a, c.shape, inputs=[c], outputs=[a], device=device)
@@ -83,7 +83,7 @@ def test_kernel_write_kernel_read_kernel_write(test, device):
         c = wp.zeros_like(a)
         d = wp.zeros_like(a)
 
-        with contextlib.redirect_stdout(io.StringIO()) as f:
+        with contextlib.redirect_stderr(io.StringIO()) as f:
             with tape:
                 wp.launch(double_kernel, a.shape, inputs=[a], outputs=[b], device=device)
                 wp.launch(triple_kernel, b.shape, inputs=[b], outputs=[c], device=device)
@@ -122,7 +122,7 @@ def test_kernel_read_kernel_writeread(test, device):
 
         tape = wp.Tape()
 
-        with contextlib.redirect_stdout(io.StringIO()) as f:
+        with contextlib.redirect_stderr(io.StringIO()) as f:
             with tape:
                 wp.launch(read_kernel, dim=5, inputs=[a, b], device=device)
                 wp.launch(writeread_kernel, dim=5, inputs=[a, d, c], device=device)
@@ -153,7 +153,7 @@ def test_kernel_writeread_kernel_write(test, device):
 
         tape = wp.Tape()
 
-        with contextlib.redirect_stdout(io.StringIO()) as f:
+        with contextlib.redirect_stderr(io.StringIO()) as f:
             with tape:
                 wp.launch(writeread_kernel, dim=5, inputs=[a, b, c], device=device)
                 wp.launch(write_kernel, dim=5, inputs=[a, d], device=device)
@@ -370,7 +370,7 @@ def test_in_place_operators_warning(test, device):
     try:
         wp.config.verify_autograd_array_access = True
 
-        with contextlib.redirect_stdout(io.StringIO()) as f:
+        with contextlib.redirect_stderr(io.StringIO()) as f:
 
             @wp.kernel
             def inplace_c(x: wp.array(dtype=float)):
@@ -398,7 +398,7 @@ def test_kernel_readwrite(test, device):
     try:
         wp.config.verify_autograd_array_access = True
 
-        with contextlib.redirect_stdout(io.StringIO()) as f:
+        with contextlib.redirect_stderr(io.StringIO()) as f:
 
             @wp.kernel
             def readwrite_kernel(a: wp.array(dtype=float), b: wp.array(dtype=float)):
@@ -426,7 +426,7 @@ def test_kernel_read_func_write(test, device):
     try:
         wp.config.verify_autograd_array_access = True
 
-        with contextlib.redirect_stdout(io.StringIO()) as f:
+        with contextlib.redirect_stderr(io.StringIO()) as f:
 
             @wp.func
             def write_func_2(x: wp.array(dtype=float), idx: int):

--- a/warp/tests/test_utils.py
+++ b/warp/tests/test_utils.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
-import inspect
 import io
 import unittest
+import warnings
 
+from warp._src.logger import log_warning
 from warp.tests.unittest_utils import *
 
 
@@ -342,52 +343,40 @@ devices = get_test_devices()
 
 class TestUtils(unittest.TestCase):
     def test_warn(self):
+        # Clear any state from prior tests in the same process.
+        from warp._src import logger as _logger  # noqa: PLC0415
+
+        _logger._warnings_seen.clear()
+
         # Multiple warnings get printed out each time.
-        with contextlib.redirect_stdout(io.StringIO()) as f:
-            wp._src.utils.warn("hello, world!")
-            wp._src.utils.warn("hello, world!")
+        with contextlib.redirect_stderr(io.StringIO()) as f:
+            log_warning("hello, world!")
+            log_warning("hello, world!")
 
         expected = "Warp UserWarning: hello, world!\nWarp UserWarning: hello, world!\n"
 
         self.assertEqual(f.getvalue(), expected)
 
-        # Test verbose warnings
-        saved_verbosity = wp.config.verbose_warnings
-        try:
-            wp.config.verbose_warnings = True
-            with contextlib.redirect_stdout(io.StringIO()) as f:
-                frame_info = inspect.getframeinfo(inspect.currentframe())
-                wp._src.utils.warn("hello, world!")
-                wp._src.utils.warn("hello, world!")
+        # Multiple similar DeprecationWarnings with once=True get printed out only once.
+        with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()) as f:
+            warnings.simplefilter("always")
+            log_warning("once_msg_utils_test", category=DeprecationWarning, once=True)
+            log_warning("once_msg_utils_test", category=DeprecationWarning, once=True)
 
-            expected = (
-                f"Warp UserWarning: hello, world! ({frame_info.filename}:{frame_info.lineno + 1})\n"
-                '  wp._src.utils.warn("hello, world!")\n'
-                f"Warp UserWarning: hello, world! ({frame_info.filename}:{frame_info.lineno + 2})\n"
-                '  wp._src.utils.warn("hello, world!")\n'
-            )
-
-            self.assertEqual(f.getvalue(), expected)
-
-        finally:
-            # make sure to restore warning verbosity
-            wp.config.verbose_warnings = saved_verbosity
-
-        # Multiple similar deprecation warnings get printed out only once.
-        with contextlib.redirect_stdout(io.StringIO()) as f:
-            wp._src.utils.warn("hello, world!", category=DeprecationWarning)
-            wp._src.utils.warn("hello, world!", category=DeprecationWarning)
-
-        expected = "Warp DeprecationWarning: hello, world!\n"
+        expected = "Warp DeprecationWarning: once_msg_utils_test\n"
 
         self.assertEqual(f.getvalue(), expected)
 
-        # Multiple different deprecation warnings get printed out each time.
-        with contextlib.redirect_stdout(io.StringIO()) as f:
-            wp._src.utils.warn("foo", category=DeprecationWarning)
-            wp._src.utils.warn("bar", category=DeprecationWarning)
+        # Clear once-seen state for next sub-test.
+        _logger._warnings_seen.clear()
 
-        expected = "Warp DeprecationWarning: foo\nWarp DeprecationWarning: bar\n"
+        # Multiple different DeprecationWarnings with once=True get printed out each time.
+        with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()) as f:
+            warnings.simplefilter("always")
+            log_warning("foo_once_utils_test", category=DeprecationWarning, once=True)
+            log_warning("bar_once_utils_test", category=DeprecationWarning, once=True)
+
+        expected = "Warp DeprecationWarning: foo_once_utils_test\nWarp DeprecationWarning: bar_once_utils_test\n"
 
         self.assertEqual(f.getvalue(), expected)
 
@@ -498,7 +487,7 @@ class TestUtils(unittest.TestCase):
             with wp.ScopedTimer("hello", detailed=True):
                 pass
 
-        self.assertRegex(f.getvalue(), r"^         4 function calls in \d+\.\d+ seconds")
+        self.assertRegex(f.getvalue(), r"^         \d+ function calls in \d+\.\d+ seconds")
         self.assertRegex(f.getvalue(), r"hello took \d+\.\d+ ms$")
 
 

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -179,6 +179,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.test_launch import TestLaunch
     from warp.tests.test_lerp import TestLerp
     from warp.tests.test_linear_solvers import TestLinearSolvers
+    from warp.tests.test_logger import TestLogger
     from warp.tests.test_lvalue import TestLValue
     from warp.tests.test_math import TestMath
     from warp.tests.test_module_contamination import TestModuleContamination
@@ -311,6 +312,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestLaunch,
         TestLerp,
         TestLinearSolvers,
+        TestLogger,
         TestLValue,
         TestMarchingCubes,
         TestMat,


### PR DESCRIPTION
## Description

Adds a unified, pluggable logging infrastructure for Warp's host-side
diagnostics (compilation messages, deprecation warnings, errors). All
Python-side output now routes through a single `wp.Logger` protocol,
controlled by a new `wp.config.log_level` knob.

- `wp.LOG_DEBUG`, `wp.LOG_INFO`, `wp.LOG_WARNING`, `wp.LOG_ERROR` constants.
- `wp.Logger` runtime-checkable `Protocol`; framework integrators implement
  the four methods on any object (no inheritance required).
- `wp.set_logger()` / `wp.get_logger()` / `wp.ScopedLogger` for installation
  and scoped overrides.
- `wp.utils.LoggerKit` for Omniverse Kit hosts (routes through Carbonite).
- The default implementation is internal (`warp._src.logger.LoggerBasic`)
  and not part of the public API; pass `None` to `wp.set_logger()` to
  restore it.

Existing diagnostic call sites have been migrated to the internal
`log_debug` / `log_info` / `log_warning` / `log_error` emitters in
`warp/_src/logger.py`.

`wp.config.verbose` and `wp.config.quiet` are deprecated in favor of
`wp.config.log_level`. Both continue to work during the deprecation window
and emit a one-time `DeprecationWarning` at runtime initialization.
`wp.config.verbose_warnings` is unaffected (it is an orthogonal formatting
flag and has no `log_level` equivalent).

Design notes are in `design/unified-logging.md`.

Closes #1315 and #1434.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- New `warp/tests/test_logger.py` covers level constants, the `Logger`
  protocol, default-logger output routing, warning-filter integration,
  `set_logger` / `get_logger`, `ScopedLogger` lifecycle, and `LoggerKit`'s
  Carb path. Run with: `uv run warp/tests/test_logger.py`
- Verified the hoisted `log_warning` import in `warp/_src/builtins.py` and
  the launch-error log changes in `warp/_src/context.py` with:
  `uv run --extra dev -m warp.tests -s autodetect -k TestTileLoad -k TestLaunch`
- Built the docs: `uv run --extra docs build_docs.py`

## New feature / enhancement

```python
import warp as wp

# Adjust verbosity
wp.config.log_level = wp.LOG_DEBUG    # most verbose
wp.config.log_level = wp.LOG_WARNING  # warnings and errors only

# Plug in a custom logger (any object satisfying wp.Logger works)
class CaptureLogger:
    def __init__(self):
        self.records = []
    def debug(self, msg):
        self.records.append(("debug", msg))
    def info(self, msg):
        self.records.append(("info", msg))
    def warning(self, msg, category=None, stacklevel=1):
        self.records.append(("warning", msg))
    def error(self, msg):
        self.records.append(("error", msg))

capture = CaptureLogger()
with wp.ScopedLogger(capture):
    wp.launch(my_kernel, ...)

# Inside Omniverse Kit
wp.set_logger(wp.utils.LoggerKit())
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pluggable unified logging: log-level constants, global log_level, ScopedLogger/ScopedLogLevel, and a Kit adapter for Omniverse hosts.

* **Behavior Changes**
  * Deprecates verbose/quiet in favor of log_level; diagnostics now use structured logging and honor global/per-module verbosity.

* **Bug Fixes**
  * Warning emission now respects Python warning filters and supports proper deduplication.

* **Documentation**
  * Docs, examples, notebooks, and tests updated to reflect the new logging system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->