### PR TITLE
Fix test-warp-doctest dubious-ownership git failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -433,6 +433,13 @@ jobs:
         with:
           lfs: true
 
+      - name: Mark workspace as a safe git directory
+        # actions/checkout sets safe.directory in a temporary HOME that is
+        # discarded after the step. Subsequent steps that invoke git (here:
+        # build_docs.py invoking pre-commit) need their own persistent entry
+        # to avoid "dubious ownership" errors when the container runs as root.
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:


### PR DESCRIPTION
## Description

The \`test-warp-doctest\` job has been failing on \`main\` with:

\`\`\`
INFO: Formatting __init__.pyi (a 'Failed' message in the output below is expected)
An error has occurred: FatalError: git failed. Is it installed, and are you in a Git repository directory?
Check the log at /github/home/.cache/pre-commit/pre-commit.log
\`\`\`

\`actions/checkout@v4\` registers the workspace as a `safe.directory` under a *temporary* HOME (\`/__w/_temp/...\`) that is discarded after the step completes. When \`build_docs.py\` later invokes pre-commit, pre-commit shells out to git from a different (persistent) HOME, and the persistent global gitconfig has no \`safe.directory\` entry. Inside the container running as root, git then refuses to operate on the workspace with a "dubious ownership" error.

This PR adds an explicit step after checkout that writes \`safe.directory\` into the persistent global gitconfig so subsequent steps that invoke git work as expected.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- Verify on this PR that the \`test-warp-doctest\` CI job runs to completion (the step it was failing in is "Run doctest").
- The fix is targeted to the \`test-warp-doctest\` job because it is the only container-running-as-root job that invokes git after checkout (via \`build_docs.py\` → pre-commit). Other container-running jobs (\`test-warp-gpu-linux\`) don't shell out to git in user steps and are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to improve testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->