### PR TITLE
Compile bvh.cpp and scan.cpp as individual units

### DIFF
--- a/build_lib.py
+++ b/build_lib.py
@@ -488,6 +488,8 @@ def main(argv: list[str] | None = None) -> int:
         # build warp.dll
         cpp_sources = [
             "native/warp.cpp",
+            "native/bvh.cpp",
+            "native/scan.cpp",
             "native/apic.cpp",
             "native/alloc_tracker.cpp",
             "native/crt.cpp",

--- a/warp/native/scan.cpp
+++ b/warp/native/scan.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "warp.h"
+
 #include "scan.h"
 
 #include <numeric>

--- a/warp/native/warp.cpp
+++ b/warp/native/warp.cpp
@@ -945,12 +945,6 @@ WP_API void wp_array_fill_host(void* arr_ptr, int arr_type, const void* value_pt
 }
 
 
-// impl. files
-// TODO: compile as separate translation units
-#include "bvh.cpp"
-#include "scan.cpp"
-
-
 // stubs for platforms where there is no CUDA
 #if !WP_ENABLE_CUDA
 


### PR DESCRIPTION
## Description

We noticed the non-idiomatic pattern of pulling `.cpp` file into other `.cpp` files. It obfuscates include-order dependencies and makes each file harder to compile or reuse on its own.

Therefore, we've isolated the two files in question into their own compilation unit, and removed the problematic `#include`s.

## Test plan

<!-- How did you verify these changes? Example commands, test names,
     or manual steps. -->

Covered by existing build tests.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build system updated to include additional core library components for native builds.
  * Internal compilation structure reorganized to streamline the build and reduce redundant translation-unit handling.
  * Cleaned up stray artifacts and redundant includes to improve repository hygiene and build determinism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->