### PR TITLE
debug: H100 tile hang reproduction (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,421 +1,71 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
 name: CI
 
 on:
   workflow_call:
   workflow_dispatch:
   push:
-    tags:
-      - v*
     branches:
-      - main
-      - release-*
-  schedule: # Schedule workflow only runs on the default branch
-    - cron: "45 9 * * *"
+      - debug/*
 
 env:
-  PYTHONFAULTHANDLER: "1" # Dump tracebacks on fatal signals (SIGSEGV, SIGABRT, etc.)
+  PYTHONFAULTHANDLER: "1"
 
 jobs:
   build-warp:
-    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-2025
-            platform: windows
-            cuda-sub-packages: '["cudart", "nvcc", "nvrtc_dev", "nvjitlink"]'
-            cuda-non-cuda-packages: ''
-          - os: ubuntu-24.04
-            platform: ubuntu-x86_64
-            cuda-sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
-            cuda-non-cuda-packages: '["libnvjitlink-dev"]'
-          - os: ubuntu-24.04-arm
-            platform: ubuntu-aarch64
-            cuda-sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
-            cuda-non-cuda-packages: '["libnvjitlink-dev"]'
-          - os: macos-latest
-            platform: macos
-            cuda-sub-packages: ''
-            cuda-non-cuda-packages: ''
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           lfs: true
-      
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
         with:
           version: "0.11.3"
-      
       - name: Set up Python
         run: uv python install
-      
       - name: Cache build artifacts
-        if: matrix.platform != 'macos'
         uses: actions/cache@v4
         id: cache-build
         with:
           path: warp/bin/
-          key: build-${{ matrix.platform }}-${{ hashFiles('build_lib.py', 'warp/build_dll.py', 'build_llvm.py', 'warp/native/**/*.cpp', 'warp/native/**/*.cu', 'warp/native/**/*.h', 'deps/libmathdx-deps.packman.xml') }}
-      
-      - name: Install CTK (with non-CUDA packages)
-        if: steps.cache-build.outputs.cache-hit != 'true' && matrix.cuda-sub-packages != '' && matrix.cuda-non-cuda-packages != ''
+          key: build-ubuntu-x86_64-${{ hashFiles('build_lib.py', 'warp/build_dll.py', 'build_llvm.py', 'warp/native/**/*.cpp', 'warp/native/**/*.cu', 'warp/native/**/*.h', 'deps/libmathdx-deps.packman.xml') }}
+      - name: Install CTK
+        if: steps.cache-build.outputs.cache-hit != 'true'
         uses: Jimver/cuda-toolkit@1a3c14e26833ccf292b268f9a790fb47dea7b2da
         with:
-          sub-packages: ${{ matrix.cuda-sub-packages }}
-          non-cuda-sub-packages: ${{ matrix.cuda-non-cuda-packages }}
+          sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
+          non-cuda-sub-packages: '["libnvjitlink-dev"]'
           method: 'network'
-      
-      - name: Install CTK (without non-CUDA packages)
-        if: steps.cache-build.outputs.cache-hit != 'true' && matrix.cuda-sub-packages != '' && matrix.cuda-non-cuda-packages == ''
-        uses: Jimver/cuda-toolkit@c35baa1a18fd1fc9dcf47c5bd839bf30559c0bc3  # https://github.com/Jimver/cuda-toolkit/issues/395
-        with:
-          sub-packages: ${{ matrix.cuda-sub-packages }}
-          method: 'network'
-      
       - name: Build Warp
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: uv run build_lib.py
-      
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifact-${{ matrix.platform }}
-          path: warp/bin/
-          retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
-      
-
-  test-warp-cpu:
-    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
-    runs-on: ${{ matrix.os }}
-    needs: build-warp
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: windows-2025
-            platform: windows
-          - os: ubuntu-24.04
-            platform: ubuntu-x86_64
-          - os: ubuntu-24.04-arm
-            platform: ubuntu-aarch64
-          - os: macos-latest
-            platform: macos
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-      
-      - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
-        with:
-          version: "0.11.3"
-      
-      - name: Set up Python
-        run: uv python install
-      
-      - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifact-${{ matrix.platform }}
-          path: warp/bin/
-      
-      - name: Run Tests
-        run: uv run --extra dev -m warp.tests --junit-report-xml rspec.xml -s autodetect
-      
-      - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
-        with:
-          paths: "rspec.xml"
-          show: "fail"
-        if: always()
-
-  test-warp-debug:
-    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
-    runs-on: ubuntu-24.04
-    needs: build-warp
-    permissions:
-      contents: read
-    timeout-minutes: 30
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-      
-      - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
-        with:
-          version: "0.11.3"
-      
-      - name: Set up Python
-        run: uv python install
-      
-      - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
-        with:
           name: build-artifact-ubuntu-x86_64
           path: warp/bin/
-      
-      - name: Run Debug Mode Tests (CPU)
-        run: uv run --extra dev -m warp.tests --junit-report-xml rspec.xml --suite debug --warp-debug --failfast
-      
-      - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
-        with:
-          paths: "rspec.xml"
-          show: "fail"
-        if: always()
+          retention-days: 1
 
-  # Compute whether the changes on a pull-request/* branch touch files relevant
-  # to GPU testing or to doctest. Always runs (cheap). Downstream jobs read the
-  # outputs to decide whether to run on PR branches; non-PR events (schedule,
-  # workflow_dispatch, push to main / release-* / tag) bypass these outputs via
-  # the dependent jobs' own `if:` blocks.
-  gpu-changes:
-    if: github.repository == 'NVIDIA/warp'
-    runs-on: ubuntu-latest
-    # Stay green for dependents on failure; combined with the `|| 'true'` fallback
-    # on the outputs below, this keeps PR-style branches from silently skipping
-    # GPU testing or doctest when the filter has a transient error.
-    continue-on-error: true
-    permissions:
-      contents: read
-    outputs:
-      gpu_relevant: ${{ steps.filter-gpu.outputs.any_changed || 'true' }}
-      docs_relevant: ${{ steps.filter-docs.outputs.any_changed || 'true' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Fetch main for diff base
-        run: git fetch --depth=1 origin main
-
-      - name: Detect GPU-relevant changes
-        id: filter-gpu
-        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad  # v47.0.5
-        with:
-          base_sha: origin/main
-          files: |
-            .github/workflows/ci.yml
-            .python-version
-            warp/**
-            pyproject.toml
-            tools/**
-            deps/*
-            build_lib.py
-            build_llvm.py
-            uv.lock
-
-      - name: Detect doctest-relevant changes
-        id: filter-docs
-        uses: step-security/changed-files@2e07db73e5ccdb319b9a6c7766bd46d39d304bad  # v47.0.5
-        with:
-          base_sha: origin/main
-          files: docs/**
-
-  test-warp-gpu-linux:
-    runs-on: ${{ matrix.runner-label }}
-    needs: [build-warp, gpu-changes]
-    if: |
-      github.repository == 'NVIDIA/warp' && (
-        github.event_name == 'schedule' ||
-        github.event_name == 'workflow_dispatch' ||
-        startsWith(github.ref, 'refs/tags/') ||
-        github.ref == 'refs/heads/main' ||
-        startsWith(github.ref, 'refs/heads/release-') ||
-        needs.gpu-changes.outputs.gpu_relevant == 'true'
-      )
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner-label: linux-amd64-gpu-h100-latest-1
-            gpu-name: h100
-          - runner-label: linux-amd64-gpu-rtxpro6000-latest-1
-            gpu-name: rtxpro6000
+  test-tile-cpu-h100:
+    runs-on: linux-amd64-gpu-h100-latest-1
+    needs: build-warp
+    if: github.repository == 'NVIDIA/warp' || github.repository == 'shi-eric/warp'
     container:
       image: ubuntu:24.04
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    timeout-minutes: 45
+    timeout-minutes: 30
     steps:
-      - name: Display GPU information
-        run: nvidia-smi
-
-      - name: Setup proxy cache
-        uses: nv-gha-runners/setup-proxy-cache@main
-        with:
-          enable-apt: true
-
-      - name: Install system dependencies
-        # curl and gpg are required by codecov/codecov-action@v6 to download and verify the uploader.
+      - name: Display system info
         run: |
-          apt-get update
-          apt-get install -y git git-lfs curl gpg
-          git lfs install
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
-        with:
-          version: "0.11.3"
-
-      - name: Set up Python
-        run: uv python install
-
-      - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifact-ubuntu-x86_64
-          path: warp/bin/
-
-      - name: Run Tests
-        run: uv run --extra dev --extra torch-cu12 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
-
-      - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
-        with:
-          paths: "rspec.xml"
-          show: "fail"
-        if: always()
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
-        with:
-          disable_search: true
-          files: ./rspec.xml
-          report_type: test_results
-          flags: unittests,linux,${{ matrix.gpu-name }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload coverage reports to Codecov
-        if: ${{ !cancelled() }}
-        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
-        with:
-          disable_search: true
-          files: ./coverage.xml
-          flags: unittests,linux,${{ matrix.gpu-name }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  test-warp-gpu-windows:
-    runs-on: windows-amd64-gpu-rtxpro6000-latest-1
-    needs: [build-warp, gpu-changes]
-    if: |
-      github.repository == 'NVIDIA/warp' && (
-        github.event_name == 'schedule' ||
-        github.event_name == 'workflow_dispatch' ||
-        startsWith(github.ref, 'refs/tags/') ||
-        github.ref == 'refs/heads/main' ||
-        startsWith(github.ref, 'refs/heads/release-') ||
-        needs.gpu-changes.outputs.gpu_relevant == 'true'
-      )
-    permissions:
-      contents: read
-    timeout-minutes: 45
-    steps:
-      - name: Display GPU information
-        run: nvidia-smi
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
-        with:
-          version: "0.11.3"
-
-      - name: Set up Python
-        run: uv python install
-
-      - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifact-windows
-          path: warp/bin/
-
-      - name: Run Tests
-        # Pin usd-core to 25.5.1 to work around a frequent loading crash on Windows.
-        run: uv run --extra dev --extra torch-cu12 --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
-
-      - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
-        with:
-          paths: "rspec.xml"
-          show: "fail"
-        if: always()
-
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
-        with:
-          disable_search: true
-          files: ./rspec.xml
-          report_type: test_results
-          flags: unittests,windows,rtxpro6000
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload coverage reports to Codecov
-        if: ${{ !cancelled() }}
-        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
-        with:
-          disable_search: true
-          files: ./coverage.xml
-          flags: unittests,windows,rtxpro6000
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  # Validate Sphinx doctests (RST testcode blocks and autodoc-extracted docstrings)
-  # against a real GPU. PR-style branches gate on the same filter as the GPU test
-  # rows, plus a docs/** filter for RST-only doctest changes.
-  test-warp-doctest:
-    runs-on: linux-amd64-gpu-l4-latest-1
-    needs: [build-warp, gpu-changes]
-    if: |
-      github.repository == 'NVIDIA/warp' && (
-        github.event_name == 'schedule' ||
-        github.event_name == 'workflow_dispatch' ||
-        startsWith(github.ref, 'refs/tags/') ||
-        github.ref == 'refs/heads/main' ||
-        startsWith(github.ref, 'refs/heads/release-') ||
-        needs.gpu-changes.outputs.gpu_relevant == 'true' ||
-        needs.gpu-changes.outputs.docs_relevant == 'true'
-      )
-    container:
-      image: ubuntu:24.04
-      options: -u root --security-opt seccomp=unconfined --shm-size 16g
-      env:
-        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    permissions:
-      contents: read
-    timeout-minutes: 30
-    steps:
-      - name: Display GPU information
-        run: nvidia-smi
+          cat /proc/cpuinfo | grep "model name" | head -1
+          nproc
+          free -h
+          nvidia-smi || true
 
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
@@ -433,15 +83,8 @@ jobs:
         with:
           lfs: true
 
-      - name: Mark workspace as a safe git directory
-        # actions/checkout sets safe.directory in a temporary HOME that is
-        # discarded after the step. Subsequent steps that invoke git (here:
-        # build_docs.py invoking pre-commit) need their own persistent entry
-        # to avoid "dubious ownership" errors when the container runs as root.
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
         with:
           version: "0.11.3"
 
@@ -454,123 +97,29 @@ jobs:
           name: build-artifact-ubuntu-x86_64
           path: warp/bin/
 
-      - name: Run doctest
-        run: uv run --extra docs build_docs.py --doctest --no-html
-
-  build-docs:
-    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
-    runs-on: ubuntu-latest
-    needs: build-warp
-    permissions:
-      contents: read
-    outputs:
-      artifact-url: ${{ steps.build-docs-output.outputs.artifact-url }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
-        with:
-          version: "0.11.3"
-      - name: Set up Python
-        run: uv python install
-      - name: Download Warp binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifact-ubuntu-x86_64
-          path: warp/bin/
-      - name: Build Sphinx documentation
+      - name: Run tile tests ONLY (serial, with per-test timeout)
         run: |
-          uv run --extra docs build_docs.py
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        id: build-docs-output
-        with:
-          name: build-docs-output
-          path: |
-            warp/__init__.pyi
-            docs/api_reference
-            docs/language_reference
-          retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
+          uv run --extra dev python -m warp.tests \
+            -k "test_tile" \
+            -j 1 \
+            --failfast \
+            -s autodetect
+        timeout-minutes: 20
 
-  check-build-docs-output:
-    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
-    runs-on: ubuntu-latest
-    needs: build-docs
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Download build_docs.py output
-        uses: actions/download-artifact@v4
-        with:
-          name: build-docs-output
-          path: .
-      - name: Check API reference docs
-        env:
-          ARTIFACT_URL: ${{ needs.build-docs.outputs.artifact-url }}
-        run: >
-          git diff --exit-code docs/api_reference docs/language_reference ||
-          (echo "Please run build_docs.py (or download from $ARTIFACT_URL) and add docs/api_reference and docs/language_reference to your pull request." && false)
-
-  check-unnamespaced-symbols:
-    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
-    runs-on: ubuntu-latest
-    needs: build-warp
-    permissions:
-      contents: read
-    steps:
-      - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifact-ubuntu-x86_64
-          path: warp/bin/
-      - name: Check for un-namespaced symbols
+      - name: Run tile tests ONLY (parallel j=4, stress test)
+        if: success()
         run: |
-          echo "Checking for un-namespaced symbols..."
-          LIBRARIES_TO_CHECK="warp/bin/warp.so warp/bin/warp-clang.so"
-          found_symbols=""
+          uv run --extra dev python -m warp.tests \
+            -k "test_tile" \
+            -j 4 \
+            --failfast \
+            -s autodetect
+        timeout-minutes: 20
 
-          for lib in $LIBRARIES_TO_CHECK; do
-            echo "--> Checking $lib"
-            if [ ! -f "$lib" ]; then
-              echo "ERROR: $lib not found"
-              found_symbols="true"
-              continue
-            fi
-            output=$(readelf -Ws "$lib" | awk '$7 ~ /^[0-9]+$/ && $8 !~ /^(_?wp_|PyInit__warp_)/ {print $8}' | grep -Ev '^(_Z|__|\.)' || true)
-            
-            if [ -n "$output" ]; then
-              echo "ERROR: Found un-namespaced symbols in $lib:"
-              echo "$output"
-              found_symbols="true"
-            fi
-          done
-
-          if [ -n "$found_symbols" ]; then
-            echo "FAIL: Un-namespaced symbols detected. Please prefix them with 'wp_' or '_wp_'."
-            exit 1
-          fi
-
-          echo "SUCCESS: All symbols are correctly namespaced."
-
-  # Validate that the type stub file (warp/__init__.pyi) passes static type checking.
-  type-check-stubs:
-    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
-        with:
-          version: "0.11.3"
-      - name: Set up Python
-        run: uv python install
-      - name: Run pyright on stub file
-        run: uvx pyright warp/__init__.pyi
-      - name: Run mypy on stub file
-        run: uvx mypy warp/__init__.pyi --follow-imports=silent
+      - name: Run full test suite (parallel, reproduce CI conditions)
+        if: success()
+        run: |
+          uv run --extra dev python -m warp.tests \
+            --failfast \
+            -s autodetect
+        timeout-minutes: 40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,10 @@ jobs:
           path: warp/bin/
           retention-days: 1
 
-  test-tile-cpu-h100:
+  test-tile-serial:
     runs-on: linux-amd64-gpu-h100-latest-1
     needs: build-warp
-    if: github.repository == 'NVIDIA/warp' || github.repository == 'shi-eric/warp'
+    if: github.repository == 'NVIDIA/warp'
     container:
       image: ubuntu:24.04
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
@@ -97,29 +97,68 @@ jobs:
           name: build-artifact-ubuntu-x86_64
           path: warp/bin/
 
-      - name: Run tile tests ONLY (serial, with per-test timeout)
+      - name: Run tile tests serial (j=1) - baseline
         run: |
           uv run --extra dev python -m warp.tests \
             -k "test_tile" \
             -j 1 \
             --failfast \
             -s autodetect
-        timeout-minutes: 20
+        timeout-minutes: 25
 
-      - name: Run tile tests ONLY (parallel j=4, stress test)
-        if: success()
+  test-tile-parallel:
+    runs-on: linux-amd64-gpu-h100-latest-1
+    needs: build-warp
+    if: github.repository == 'NVIDIA/warp'
+    container:
+      image: ubuntu:24.04
+      options: -u root --security-opt seccomp=unconfined --shm-size 16g
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    timeout-minutes: 30
+    steps:
+      - name: Display system info
+        run: |
+          cat /proc/cpuinfo | grep "model name" | head -1
+          nproc
+          free -h
+          nvidia-smi || true
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y git git-lfs
+          git lfs install
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+        with:
+          version: "0.11.3"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Download Warp build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact-ubuntu-x86_64
+          path: warp/bin/
+
+      - name: Run tile tests parallel (j=0, all cores) - contention test
         run: |
           uv run --extra dev python -m warp.tests \
             -k "test_tile" \
-            -j 4 \
+            -j 0 \
             --failfast \
             -s autodetect
-        timeout-minutes: 20
-
-      - name: Run full test suite (parallel, reproduce CI conditions)
-        if: success()
-        run: |
-          uv run --extra dev python -m warp.tests \
-            --failfast \
-            -s autodetect
-        timeout-minutes: 40
+        timeout-minutes: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
           path: warp/bin/
           retention-days: 1
 
-  test-tile-serial:
+  # Test with enable_tiles_in_stack_memory=True (default since v1.13, suspected corruption source)
+  test-tile-stack-true:
     runs-on: linux-amd64-gpu-h100-latest-1
     needs: build-warp
     if: github.repository == 'NVIDIA/warp'
@@ -58,7 +59,7 @@ jobs:
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Display system info
         run: |
@@ -97,16 +98,15 @@ jobs:
           name: build-artifact-ubuntu-x86_64
           path: warp/bin/
 
-      - name: Run tile tests serial (j=1) - baseline
+      - name: Run full suite with enable_tiles_in_stack_memory=True (default)
         run: |
-          uv run --extra dev python -m warp.tests \
-            -k "test_tile" \
-            -j 1 \
+          uv run --extra dev --extra torch-cu12 -m warp.tests \
             --failfast \
             -s autodetect
-        timeout-minutes: 25
+        timeout-minutes: 40
 
-  test-tile-parallel:
+  # Test with enable_tiles_in_stack_memory=False (BSS path, zero-init, should mask corruption)
+  test-tile-stack-false:
     runs-on: linux-amd64-gpu-h100-latest-1
     needs: build-warp
     if: github.repository == 'NVIDIA/warp'
@@ -115,7 +115,7 @@ jobs:
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Display system info
         run: |
@@ -154,11 +154,14 @@ jobs:
           name: build-artifact-ubuntu-x86_64
           path: warp/bin/
 
-      - name: Run tile tests parallel (j=0, all cores) - contention test
+      - name: Patch config to disable stack memory for tiles
         run: |
-          uv run --extra dev python -m warp.tests \
-            -k "test_tile" \
-            -j 0 \
+          sed -i 's/enable_tiles_in_stack_memory: bool | None = True/enable_tiles_in_stack_memory: bool | None = False/' warp/config.py
+          grep "enable_tiles_in_stack_memory" warp/config.py
+
+      - name: Run full suite with enable_tiles_in_stack_memory=False (BSS, safe)
+        run: |
+          uv run --extra dev --extra torch-cu12 -m warp.tests \
             --failfast \
             -s autodetect
-        timeout-minutes: 25
+        timeout-minutes: 40

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,101 +1,18 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
 name: Pull Request
 
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
-
-env:
-  PYTHONFAULTHANDLER: "1" # Dump tracebacks on fatal signals (SIGSEGV, SIGABRT, etc.)
+      - "debug/*"
 
 concurrency:
-  group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  # Call the main CI workflow which includes:
-  # - Multi-platform build and test (Windows, Ubuntu x86_64, Ubuntu ARM64, macOS)
-  # - GPU testing on H100 (for PRs and scheduled runs)
-  # - Documentation build and validation
-  # - Generated files checks (exports.h, version.h)
-  # - Symbol namespace validation
   ci:
     uses: ./.github/workflows/ci.yml
-
-  # Static analysis with cppcheck (runs independently, doesn't need build artifacts)
-  cppcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      
-      - name: Cache cppcheck build directory
-        uses: actions/cache@v4
-        with:
-          path: _build/.cppcheck
-          key: cppcheck-${{ github.run_id }}
-          restore-keys: |
-            cppcheck-
-      
-      - name: Set up Miniforge
-        run: |
-          wget -q -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-          bash Miniforge3.sh -b -p "${HOME}/conda"
-          echo "${HOME}/conda/bin" >> $GITHUB_PATH
-      
-      - name: Install cppcheck
-        run: |
-          source "${HOME}/conda/etc/profile.d/conda.sh"
-          conda activate
-          conda install cppcheck --channel conda-forge -y
-          mkdir -p _build/.cppcheck
-          cppcheck --version
-      
-      - name: Run cppcheck
-        run: |
-          source "${HOME}/conda/etc/profile.d/conda.sh"
-          conda activate
-          cppcheck \
-            --inline-suppr \
-            --cppcheck-build-dir=_build/.cppcheck \
-            --enable=warning \
-            --quiet \
-            --error-exitcode=1 \
-            -j $(nproc) \
-            --suppress=*:warp/native/nanovdb/* \
-            --suppress=*:warp/native/cuBQL/* \
-            --suppress=normalCheckLevelMaxBranches \
-            warp
-      
-      - name: Generate XML report
-        if: always()
-        run: |
-          source "${HOME}/conda/etc/profile.d/conda.sh"
-          conda activate
-          cppcheck \
-            --inline-suppr \
-            --cppcheck-build-dir=_build/.cppcheck \
-            --enable=warning \
-            --quiet \
-            --xml \
-            --xml-version=2 \
-            -j $(nproc) \
-            --suppress=*:warp/native/nanovdb/* \
-            --suppress=*:warp/native/cuBQL/* \
-            --suppress=normalCheckLevelMaxBranches \
-            warp \
-            2> cppcheck-report.xml
-      
-      - name: Upload cppcheck report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: cppcheck-report
-          path: cppcheck-report.xml
-          retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}


### PR DESCRIPTION
**This PR is for debugging only — do not merge.**

Minimal workflow to characterize the H100 tile CPU hang observed in CI timeouts.

Three-stage test on H100 runner:
1. **Tile tests serial (j=1)** — baseline. If this hangs → deterministic bug.
2. **Tile tests parallel (j=4)** — tile-only contention. If this hangs but #1 passes → contention-triggered.
3. **Full test suite parallel** — reproduce exact CI conditions. If only this hangs → cross-module contention.

Related: All 6 recent H100 timeout failures end in tile CPU tests that start but never complete.

Context: https://gist.github.com/shi-eric/cd31760f5a008dcce68381a8d8c17bad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined CI flows, restricted triggers, consolidated redundant jobs, and standardized artifact retention and concurrency behavior to simplify pipelines and shorten run time.
  * Removed legacy static-analysis job and several outdated workflow steps.

* **Tests**
  * Reworked GPU testing into containerized H100 tile-stack runs with two variants (stack-true and stack-false) executing the full test suite and collecting system info.
  * Cleaned up containerized doctest setup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->