### PR TITLE
Fix cuBQL BVH on devices without CUDA mempool support (GH-1430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@
   ([GH-583](https://github.com/NVIDIA/warp/issues/583),
   [GH-248](https://github.com/NVIDIA/warp/issues/248),
   [GH-1174](https://github.com/NVIDIA/warp/issues/1174)).
+- Fix cuBQL mesh BVH construction and refit on CUDA devices without memory pool support
+  ([GH-1430](https://github.com/NVIDIA/warp/issues/1430)).
 
 ### Documentation
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -5086,10 +5086,14 @@ class Runtime:
             self.core.wp_mesh_destroy_device.argtypes = [ctypes.c_uint64]
 
             self.core.wp_mesh_refit_host.argtypes = [ctypes.c_uint64]
+            self.core.wp_mesh_refit_host.restype = None
             self.core.wp_mesh_refit_device.argtypes = [ctypes.c_uint64]
+            self.core.wp_mesh_refit_device.restype = ctypes.c_int
 
             self.core.wp_mesh_set_points_host.argtypes = [ctypes.c_uint64, warp._src.types.array_t]
+            self.core.wp_mesh_set_points_host.restype = None
             self.core.wp_mesh_set_points_device.argtypes = [ctypes.c_uint64, warp._src.types.array_t]
+            self.core.wp_mesh_set_points_device.restype = ctypes.c_int
 
             self.core.wp_mesh_set_velocities_host.argtypes = [ctypes.c_uint64, warp._src.types.array_t]
             self.core.wp_mesh_set_velocities_device.argtypes = [ctypes.c_uint64, warp._src.types.array_t]

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -5677,6 +5677,12 @@ class Mesh:
                 bvh_leaf_size,
             )
 
+        if not self.id:
+            error_string = self.runtime.get_error_string()
+            if error_string:
+                raise RuntimeError(f"Failed to create mesh: {error_string}")
+            raise RuntimeError("Failed to create mesh")
+
     def __del__(self):
         if not self.id:
             return
@@ -5701,7 +5707,11 @@ class Mesh:
         if self.device.is_cpu:
             self.runtime.core.wp_mesh_refit_host(self.id)
         else:
-            self.runtime.core.wp_mesh_refit_device(self.id)
+            if not self.runtime.core.wp_mesh_refit_device(self.id):
+                error_string = self.runtime.get_error_string()
+                if error_string:
+                    raise RuntimeError(f"Failed to refit mesh: {error_string}")
+                raise RuntimeError("Failed to refit mesh")
             self.runtime.verify_cuda_device(self.device)
 
     @property
@@ -5733,7 +5743,11 @@ class Mesh:
         if self.device.is_cpu:
             self.runtime.core.wp_mesh_set_points_host(self.id, points_new.__ctype__())
         else:
-            self.runtime.core.wp_mesh_set_points_device(self.id, points_new.__ctype__())
+            if not self.runtime.core.wp_mesh_set_points_device(self.id, points_new.__ctype__()):
+                error_string = self.runtime.get_error_string()
+                if error_string:
+                    raise RuntimeError(f"Failed to set mesh points: {error_string}")
+                raise RuntimeError("Failed to set mesh points")
             self.runtime.verify_cuda_device(self.device)
 
     @property

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -5678,10 +5678,7 @@ class Mesh:
             )
 
         if not self.id:
-            error_string = self.runtime.get_error_string()
-            if error_string:
-                raise RuntimeError(f"Failed to create mesh: {error_string}")
-            raise RuntimeError("Failed to create mesh")
+            raise RuntimeError(f"Failed to create mesh: {self.runtime.get_error_string()}")
 
     def __del__(self):
         if not self.id:
@@ -5708,10 +5705,7 @@ class Mesh:
             self.runtime.core.wp_mesh_refit_host(self.id)
         else:
             if not self.runtime.core.wp_mesh_refit_device(self.id):
-                error_string = self.runtime.get_error_string()
-                if error_string:
-                    raise RuntimeError(f"Failed to refit mesh: {error_string}")
-                raise RuntimeError("Failed to refit mesh")
+                raise RuntimeError(f"Failed to refit mesh: {self.runtime.get_error_string()}")
             self.runtime.verify_cuda_device(self.device)
 
     @property
@@ -5744,10 +5738,7 @@ class Mesh:
             self.runtime.core.wp_mesh_set_points_host(self.id, points_new.__ctype__())
         else:
             if not self.runtime.core.wp_mesh_set_points_device(self.id, points_new.__ctype__()):
-                error_string = self.runtime.get_error_string()
-                if error_string:
-                    raise RuntimeError(f"Failed to set mesh points: {error_string}")
-                raise RuntimeError("Failed to set mesh points")
+                raise RuntimeError(f"Failed to set mesh points: {self.runtime.get_error_string()}")
             self.runtime.verify_cuda_device(self.device)
 
     @property

--- a/warp/native/bvh.cu
+++ b/warp/native/bvh.cu
@@ -7,6 +7,7 @@
 
 #include "bvh.h"
 #include "cuda_util.h"
+#include "error.h"
 #include "sort.h"
 
 #include <algorithm>
@@ -830,6 +831,15 @@ static inline void cubql_update_device_boxes(CuBQLBVH& bvh)
     );
 }
 
+static cuBQL::GpuMemoryResource& cubql_get_mem_resource()
+{
+    int ordinal = wp_cuda_context_get_device_ordinal(wp_cuda_context_get_current());
+    if (wp_cuda_device_is_mempool_supported(ordinal))
+        return cuBQL::defaultGpuMemResource();
+    static cuBQL::DeviceMemoryResource sync_resource;
+    return sync_resource;
+}
+
 void cubql_bvh_create_device(
     void* context, vec3* lowers, vec3* uppers, int num_items, int leaf_size, CuBQLBVH& bvh_device_on_host
 )
@@ -854,14 +864,37 @@ void cubql_bvh_create_device(
     bvh_device_on_host.boxes = wp_alloc_device(WP_CURRENT_CONTEXT, sizeof(cuBQL::box3f) * num_items);
     cubql_update_device_boxes(bvh_device_on_host);
 
-    cuBQL::bvh3f native;
-    cuBQL::BuildConfig build_config;
-    build_config.enableSAH();
-    build_config.makeLeafThreshold = leaf_size;
-    cuBQL::gpuBuilder(
-        native, reinterpret_cast<cuBQL::box3f*>(bvh_device_on_host.boxes), uint32_t(num_items), build_config
-    );
-    cubql_assign(bvh_device_on_host, native);
+    try {
+        cuBQL::bvh3f native;
+        cuBQL::BuildConfig build_config;
+        build_config.enableSAH();
+        build_config.makeLeafThreshold = leaf_size;
+        cuBQL::gpuBuilder(
+            native, reinterpret_cast<cuBQL::box3f*>(bvh_device_on_host.boxes), uint32_t(num_items), build_config, 0,
+            cubql_get_mem_resource()
+        );
+        cubql_assign(bvh_device_on_host, native);
+    } catch (const std::exception& e) {
+        wp::set_error_string("Warp error: cuBQL BVH build failed: %s", e.what());
+        if (bvh_device_on_host.boxes) {
+            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.boxes);
+            bvh_device_on_host.boxes = nullptr;
+        }
+        if (bvh_device_on_host.root) {
+            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.root);
+            bvh_device_on_host.root = nullptr;
+        }
+    } catch (...) {
+        wp::set_error_string("Warp error: cuBQL BVH build failed: unknown exception");
+        if (bvh_device_on_host.boxes) {
+            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.boxes);
+            bvh_device_on_host.boxes = nullptr;
+        }
+        if (bvh_device_on_host.root) {
+            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.root);
+            bvh_device_on_host.root = nullptr;
+        }
+    }
 }
 
 void cubql_bvh_destroy_device(CuBQLBVH& bvh)
@@ -870,7 +903,13 @@ void cubql_bvh_destroy_device(CuBQLBVH& bvh)
 
     if (bvh.nodes || bvh.primitive_indices) {
         cuBQL::bvh3f native = cubql_native_view(bvh);
-        cuBQL::cuda::free(native);
+        try {
+            cuBQL::cuda::free(native, 0, cubql_get_mem_resource());
+        } catch (const std::exception& e) {
+            wp::set_error_string("Warp error: cuBQL BVH free failed: %s", e.what());
+        } catch (...) {
+            wp::set_error_string("Warp error: cuBQL BVH free failed: unknown exception");
+        }
     }
 
     if (bvh.boxes) {
@@ -888,16 +927,24 @@ void cubql_bvh_destroy_device(CuBQLBVH& bvh)
     bvh.leaf_size = 0;
 }
 
-void cubql_bvh_refit_device(CuBQLBVH& bvh)
+bool cubql_bvh_refit_device(CuBQLBVH& bvh)
 {
     ContextGuard guard(bvh.context);
     if (!bvh.nodes || !bvh.boxes || bvh.num_items <= 0) {
-        return;
+        return true;
     }
 
     cubql_update_device_boxes(bvh);
     cuBQL::bvh3f native = cubql_native_view(bvh);
-    cuBQL::cuda::refit(native, reinterpret_cast<cuBQL::box3f*>(bvh.boxes));
+    try {
+        cuBQL::cuda::refit(native, reinterpret_cast<cuBQL::box3f*>(bvh.boxes), 0, cubql_get_mem_resource());
+        return true;
+    } catch (const std::exception& e) {
+        wp::set_error_string("Warp error: cuBQL BVH refit failed: %s", e.what());
+    } catch (...) {
+        wp::set_error_string("Warp error: cuBQL BVH refit failed: unknown exception");
+    }
+    return false;
 }
 
 void cubql_bvh_rebuild_device(CuBQLBVH& bvh)
@@ -906,7 +953,13 @@ void cubql_bvh_rebuild_device(CuBQLBVH& bvh)
 
     if (bvh.nodes || bvh.primitive_indices) {
         cuBQL::bvh3f old_native = cubql_native_view(bvh);
-        cuBQL::cuda::free(old_native);
+        try {
+            cuBQL::cuda::free(old_native, 0, cubql_get_mem_resource());
+        } catch (const std::exception& e) {
+            wp::set_error_string("Warp error: cuBQL BVH free failed: %s", e.what());
+        } catch (...) {
+            wp::set_error_string("Warp error: cuBQL BVH free failed: unknown exception");
+        }
     }
 
     if (bvh.num_items <= 0) {
@@ -926,12 +979,37 @@ void cubql_bvh_rebuild_device(CuBQLBVH& bvh)
     }
     cubql_update_device_boxes(bvh);
 
-    cuBQL::bvh3f native;
-    cuBQL::BuildConfig build_config;
-    build_config.enableSAH();
-    build_config.makeLeafThreshold = bvh.leaf_size;
-    cuBQL::gpuBuilder(native, reinterpret_cast<cuBQL::box3f*>(bvh.boxes), uint32_t(bvh.num_items), build_config);
-    cubql_assign(bvh, native);
+    try {
+        cuBQL::bvh3f native;
+        cuBQL::BuildConfig build_config;
+        build_config.enableSAH();
+        build_config.makeLeafThreshold = bvh.leaf_size;
+        cuBQL::gpuBuilder(
+            native, reinterpret_cast<cuBQL::box3f*>(bvh.boxes), uint32_t(bvh.num_items), build_config, 0,
+            cubql_get_mem_resource()
+        );
+        cubql_assign(bvh, native);
+    } catch (const std::exception& e) {
+        wp::set_error_string("Warp error: cuBQL BVH rebuild failed: %s", e.what());
+        bvh.nodes = nullptr;
+        bvh.num_nodes = 0;
+        bvh.primitive_indices = nullptr;
+        bvh.num_prims = 0;
+        if (bvh.root) {
+            int root_index = -1;
+            wp_memcpy_h2d(WP_CURRENT_CONTEXT, bvh.root, &root_index, sizeof(int));
+        }
+    } catch (...) {
+        wp::set_error_string("Warp error: cuBQL BVH rebuild failed: unknown exception");
+        bvh.nodes = nullptr;
+        bvh.num_nodes = 0;
+        bvh.primitive_indices = nullptr;
+        bvh.num_prims = 0;
+        if (bvh.root) {
+            int root_index = -1;
+            wp_memcpy_h2d(WP_CURRENT_CONTEXT, bvh.root, &root_index, sizeof(int));
+        }
+    }
 }
 
 #else  // WP_DISABLE_CUBQL
@@ -945,7 +1023,7 @@ void cubql_bvh_create_device(
 }
 
 void cubql_bvh_destroy_device(CuBQLBVH&) { }
-void cubql_bvh_refit_device(CuBQLBVH&) { }
+bool cubql_bvh_refit_device(CuBQLBVH&) { return true; }
 void cubql_bvh_rebuild_device(CuBQLBVH&) { }
 
 #endif  // WP_DISABLE_CUBQL
@@ -1040,7 +1118,9 @@ void wp_cubql_bvh_refit_device(uint64_t id)
     wp::CuBQLBVH bvh;
     if (wp::cubql_bvh_get_descriptor(id, bvh)) {
         ContextGuard guard(bvh.context);
-        wp::cubql_bvh_refit_device(bvh);
+        if (!wp::cubql_bvh_refit_device(bvh)) {
+            return;
+        }
         wp::cubql_bvh_add_descriptor(id, bvh);
         wp_memcpy_h2d(WP_CURRENT_CONTEXT, (void*)id, &bvh, sizeof(wp::CuBQLBVH));
     }

--- a/warp/native/bvh.cu
+++ b/warp/native/bvh.cu
@@ -864,6 +864,17 @@ void cubql_bvh_create_device(
     bvh_device_on_host.boxes = wp_alloc_device(WP_CURRENT_CONTEXT, sizeof(cuBQL::box3f) * num_items);
     cubql_update_device_boxes(bvh_device_on_host);
 
+    auto free_partial_bvh = [&]() {
+        if (bvh_device_on_host.boxes) {
+            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.boxes);
+            bvh_device_on_host.boxes = nullptr;
+        }
+        if (bvh_device_on_host.root) {
+            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.root);
+            bvh_device_on_host.root = nullptr;
+        }
+    };
+
     try {
         cuBQL::bvh3f native;
         cuBQL::BuildConfig build_config;
@@ -876,24 +887,10 @@ void cubql_bvh_create_device(
         cubql_assign(bvh_device_on_host, native);
     } catch (const std::exception& e) {
         wp::set_error_string("Warp error: cuBQL BVH build failed: %s", e.what());
-        if (bvh_device_on_host.boxes) {
-            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.boxes);
-            bvh_device_on_host.boxes = nullptr;
-        }
-        if (bvh_device_on_host.root) {
-            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.root);
-            bvh_device_on_host.root = nullptr;
-        }
+        free_partial_bvh();
     } catch (...) {
         wp::set_error_string("Warp error: cuBQL BVH build failed: unknown exception");
-        if (bvh_device_on_host.boxes) {
-            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.boxes);
-            bvh_device_on_host.boxes = nullptr;
-        }
-        if (bvh_device_on_host.root) {
-            wp_free_device(WP_CURRENT_CONTEXT, bvh_device_on_host.root);
-            bvh_device_on_host.root = nullptr;
-        }
+        free_partial_bvh();
     }
 }
 
@@ -951,6 +948,17 @@ void cubql_bvh_rebuild_device(CuBQLBVH& bvh)
 {
     ContextGuard guard(bvh.context);
 
+    auto reset_rebuilt_bvh = [&]() {
+        bvh.nodes = nullptr;
+        bvh.num_nodes = 0;
+        bvh.primitive_indices = nullptr;
+        bvh.num_prims = 0;
+        if (bvh.root) {
+            int root_index = -1;
+            wp_memcpy_h2d(WP_CURRENT_CONTEXT, bvh.root, &root_index, sizeof(int));
+        }
+    };
+
     if (bvh.nodes || bvh.primitive_indices) {
         cuBQL::bvh3f old_native = cubql_native_view(bvh);
         try {
@@ -963,14 +971,7 @@ void cubql_bvh_rebuild_device(CuBQLBVH& bvh)
     }
 
     if (bvh.num_items <= 0) {
-        bvh.nodes = nullptr;
-        bvh.primitive_indices = nullptr;
-        bvh.num_nodes = 0;
-        bvh.num_prims = 0;
-        if (bvh.root) {
-            int root_index = -1;
-            wp_memcpy_h2d(WP_CURRENT_CONTEXT, bvh.root, &root_index, sizeof(int));
-        }
+        reset_rebuilt_bvh();
         return;
     }
 
@@ -991,24 +992,10 @@ void cubql_bvh_rebuild_device(CuBQLBVH& bvh)
         cubql_assign(bvh, native);
     } catch (const std::exception& e) {
         wp::set_error_string("Warp error: cuBQL BVH rebuild failed: %s", e.what());
-        bvh.nodes = nullptr;
-        bvh.num_nodes = 0;
-        bvh.primitive_indices = nullptr;
-        bvh.num_prims = 0;
-        if (bvh.root) {
-            int root_index = -1;
-            wp_memcpy_h2d(WP_CURRENT_CONTEXT, bvh.root, &root_index, sizeof(int));
-        }
+        reset_rebuilt_bvh();
     } catch (...) {
         wp::set_error_string("Warp error: cuBQL BVH rebuild failed: unknown exception");
-        bvh.nodes = nullptr;
-        bvh.num_nodes = 0;
-        bvh.primitive_indices = nullptr;
-        bvh.num_prims = 0;
-        if (bvh.root) {
-            int root_index = -1;
-            wp_memcpy_h2d(WP_CURRENT_CONTEXT, bvh.root, &root_index, sizeof(int));
-        }
+        reset_rebuilt_bvh();
     }
 }
 

--- a/warp/native/bvh.h
+++ b/warp/native/bvh.h
@@ -622,6 +622,7 @@ void cubql_bvh_create_device(
     void* context, vec3* lowers, vec3* uppers, int num_items, int leaf_size, CuBQLBVH& bvh_device_on_host
 );
 void cubql_bvh_destroy_device(CuBQLBVH& bvh);
+// Returns true on success and false when refit fails; callers should propagate failures.
 bool cubql_bvh_refit_device(CuBQLBVH& bvh);
 void cubql_bvh_rebuild_device(CuBQLBVH& bvh);
 

--- a/warp/native/bvh.h
+++ b/warp/native/bvh.h
@@ -622,7 +622,7 @@ void cubql_bvh_create_device(
     void* context, vec3* lowers, vec3* uppers, int num_items, int leaf_size, CuBQLBVH& bvh_device_on_host
 );
 void cubql_bvh_destroy_device(CuBQLBVH& bvh);
-void cubql_bvh_refit_device(CuBQLBVH& bvh);
+bool cubql_bvh_refit_device(CuBQLBVH& bvh);
 void cubql_bvh_rebuild_device(CuBQLBVH& bvh);
 
 #endif  // WP_ENABLE_CUDA

--- a/warp/native/mesh.cpp
+++ b/warp/native/mesh.cpp
@@ -292,8 +292,8 @@ WP_API uint64_t wp_mesh_create_device(
     return 0;
 }
 WP_API void wp_mesh_destroy_device(uint64_t id) { }
-WP_API void wp_mesh_refit_device(uint64_t id) { }
-WP_API void wp_mesh_set_points_device(uint64_t id, wp::array_t<wp::vec3> points) { };
+WP_API int wp_mesh_refit_device(uint64_t id) { return 0; }
+WP_API int wp_mesh_set_points_device(uint64_t id, wp::array_t<wp::vec3> points) { return 0; };
 WP_API void wp_mesh_set_velocities_device(uint64_t id, wp::array_t<wp::vec3> points) { };
 
 

--- a/warp/native/mesh.cu
+++ b/warp/native/mesh.cu
@@ -452,10 +452,9 @@ void wp_mesh_set_velocities_device(uint64_t id, wp::array_t<wp::vec3> velocities
     wp::Mesh m;
     if (mesh_get_descriptor(id, m)) {
         if (velocities.ndim != 1 || velocities.shape[0] != m.velocities.shape[0]) {
-            fprintf(
-                stderr,
-                "The new velocities input for wp_mesh_set_velocities_device does not match the shape of the original "
-                "velocities\n"
+            wp::set_error_string(
+                "Warp error: new velocities input for wp_mesh_set_velocities_device does not match the original "
+                "velocities shape"
             );
             return;
         }
@@ -466,7 +465,7 @@ void wp_mesh_set_velocities_device(uint64_t id, wp::array_t<wp::vec3> velocities
         wp_memcpy_h2d(WP_CURRENT_CONTEXT, mesh_device, &m, sizeof(wp::Mesh));
         mesh_set_descriptor(id, m);
     } else {
-        fprintf(stderr, "The mesh id provided to wp_mesh_set_velocities_device is not valid!\n");
+        wp::set_error_string("Warp error: invalid mesh id");
         return;
     }
 }

--- a/warp/native/mesh.cu
+++ b/warp/native/mesh.cu
@@ -5,6 +5,7 @@
 
 #include "bvh.h"
 #include "cuda_util.h"
+#include "error.h"
 #include "mesh.h"
 #include "scan.h"
 
@@ -235,6 +236,25 @@ void bvh_refit_with_solid_angle_device(BVH& bvh, Mesh& mesh)
 }  // namespace wp
 
 
+static void wp_mesh_free_device_allocations(wp::Mesh& mesh, wp::Mesh* mesh_device)
+{
+    if (mesh.lowers) {
+        wp_free_device(WP_CURRENT_CONTEXT, mesh.lowers);
+        mesh.lowers = nullptr;
+    }
+    if (mesh.uppers) {
+        wp_free_device(WP_CURRENT_CONTEXT, mesh.uppers);
+        mesh.uppers = nullptr;
+    }
+    if (mesh.solid_angle_props) {
+        wp_free_device(WP_CURRENT_CONTEXT, mesh.solid_angle_props);
+        mesh.solid_angle_props = nullptr;
+    }
+    if (mesh_device) {
+        wp_free_device(WP_CURRENT_CONTEXT, mesh_device);
+    }
+}
+
 uint64_t wp_mesh_create_device(
     void* context,
     wp::array_t<wp::vec3> points,
@@ -295,17 +315,17 @@ uint64_t wp_mesh_create_device(
 #ifndef WP_DISABLE_CUBQL
     if (use_cubql) {
         wp::cubql_bvh_create_device(mesh.context, mesh.lowers, mesh.uppers, num_tris, bvh_leaf_size, mesh.cubql_bvh);
+        if ((!mesh.cubql_bvh.nodes || !mesh.cubql_bvh.primitive_indices) && num_tris > 0) {
+            wp::cubql_bvh_destroy_device(mesh.cubql_bvh);
+            wp_mesh_free_device_allocations(mesh, mesh_device);
+            return 0;
+        }
         wp_memcpy_h2d(WP_CURRENT_CONTEXT, &(mesh_device->cubql_bvh), &mesh.cubql_bvh, sizeof(wp::CuBQLBVH));
     } else
 #else
     if (use_cubql) {
         fprintf(stderr, "Warp error: cuBQL support disabled (WP_DISABLE_CUBQL)\n");
-        wp_free_device(WP_CURRENT_CONTEXT, mesh.lowers);
-        wp_free_device(WP_CURRENT_CONTEXT, mesh.uppers);
-        if (mesh.solid_angle_props) {
-            wp_free_device(WP_CURRENT_CONTEXT, mesh.solid_angle_props);
-        }
-        wp_free_device(WP_CURRENT_CONTEXT, mesh_device);
+        wp_mesh_free_device_allocations(mesh, mesh_device);
         return 0;
     }
 #endif
@@ -353,7 +373,7 @@ void wp_mesh_destroy_device(uint64_t id)
 
 void mesh_update_stats(uint64_t id) { }
 
-void wp_mesh_refit_device(uint64_t id)
+int wp_mesh_refit_device(uint64_t id)
 {
     // recompute triangle bounds
     wp::Mesh m;
@@ -383,7 +403,9 @@ void wp_mesh_refit_device(uint64_t id)
 
 #ifndef WP_DISABLE_CUBQL
         if (m.bvh_backend == wp::MESH_BVH_BACKEND_CUBQL) {
-            wp::cubql_bvh_refit_device(m.cubql_bvh);
+            if (!wp::cubql_bvh_refit_device(m.cubql_bvh)) {
+                return 0;
+            }
         } else
 #endif
             if (m.solid_angle_props) {
@@ -392,19 +414,22 @@ void wp_mesh_refit_device(uint64_t id)
         } else {
             wp::bvh_refit_device(m.bvh);
         }
+        return 1;
     }
+
+    wp::set_error_string("Warp error: invalid mesh id");
+    return 0;
 }
 
-void wp_mesh_set_points_device(uint64_t id, wp::array_t<wp::vec3> points)
+int wp_mesh_set_points_device(uint64_t id, wp::array_t<wp::vec3> points)
 {
     wp::Mesh m;
     if (mesh_get_descriptor(id, m)) {
         if (points.ndim != 1 || points.shape[0] != m.points.shape[0]) {
-            fprintf(
-                stderr,
-                "The new points input for wp_mesh_set_points_device does not match the shape of the original points!\n"
+            wp::set_error_string(
+                "Warp error: new points input for wp_mesh_set_points_device does not match the original points shape"
             );
-            return;
+            return 0;
         }
 
         m.points = points;
@@ -415,10 +440,10 @@ void wp_mesh_set_points_device(uint64_t id, wp::array_t<wp::vec3> points)
         // update the cpu copy as well
         mesh_set_descriptor(id, m);
 
-        wp_mesh_refit_device(id);
+        return wp_mesh_refit_device(id);
     } else {
-        fprintf(stderr, "The mesh id provided to wp_mesh_set_points_device is not valid!\n");
-        return;
+        wp::set_error_string("Warp error: invalid mesh id");
+        return 0;
     }
 }
 

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -131,10 +131,10 @@ WP_API uint64_t wp_mesh_create_device(
     int bvh_leaf_size
 );
 WP_API void wp_mesh_destroy_device(uint64_t id);
-WP_API void wp_mesh_refit_device(uint64_t id);
+WP_API int wp_mesh_refit_device(uint64_t id);
 
 WP_API void wp_mesh_set_points_host(uint64_t id, wp::array_t<wp::vec3> points);
-WP_API void wp_mesh_set_points_device(uint64_t id, wp::array_t<wp::vec3> points);
+WP_API int wp_mesh_set_points_device(uint64_t id, wp::array_t<wp::vec3> points);
 
 WP_API void wp_mesh_set_velocities_host(uint64_t id, wp::array_t<wp::vec3> velocities);
 WP_API void wp_mesh_set_velocities_device(uint64_t id, wp::array_t<wp::vec3> velocities);

--- a/warp/tests/geometry/test_mesh.py
+++ b/warp/tests/geometry/test_mesh.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import itertools
 import unittest
+from unittest import mock
 
 import numpy as np
 
@@ -224,10 +225,7 @@ def test_mesh_query_ray(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh"]
-        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
-        if device.is_mempool_supported:
-            constructors.append("cubql")
+        constructors = ["sah", "median", "lbvh", "cubql"]
 
     leaf_sizes = [1, 2, 4]
 
@@ -319,10 +317,7 @@ def test_mesh_refit(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh"]
-        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
-        if device.is_mempool_supported:
-            constructors.append("cubql")
+        constructors = ["sah", "median", "lbvh", "cubql"]
 
     # Ray aimed at the origin — hits the unit cube centered there
     origin = wp.vec3(0.0, 5.0, 0.0)
@@ -444,6 +439,44 @@ class TestMesh(unittest.TestCase):
         # test the scenario in which a mesh is created but not initialized before gc
         instance = wp.Mesh.__new__(wp.Mesh)
         instance.__del__()
+
+    def test_mesh_create_raises_on_native_failure(self):
+        points = wp.array(POINT_POSITIONS, dtype=wp.vec3, device="cpu")
+        indices = wp.array(RIGHT_HANDED_FACE_VERTEX_INDICES, dtype=int, device="cpu")
+        runtime = wp._src.context.runtime
+
+        with (
+            mock.patch.object(runtime.core, "wp_mesh_create_host", return_value=0),
+            mock.patch.object(runtime, "get_error_string", return_value="native failure"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Failed to create mesh: native failure"):
+                wp.Mesh(points=points, indices=indices)
+
+    def test_mesh_refit_raises_on_native_device_failure(self):
+        mesh = wp.Mesh.__new__(wp.Mesh)
+        mesh.id = 123
+        mesh.device = mock.Mock(is_cpu=False)
+        mesh.runtime = mock.Mock()
+        mesh.runtime.core.wp_mesh_refit_device.return_value = 0
+        mesh.runtime.get_error_string.return_value = "native refit failure"
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to refit mesh: native refit failure"):
+            mesh.refit()
+
+    def test_mesh_points_setter_raises_on_native_device_failure(self):
+        points = wp.array(POINT_POSITIONS, dtype=wp.vec3, device="cpu")
+        points_new = wp.array(POINT_POSITIONS, dtype=wp.vec3, device="cpu")
+
+        mesh = wp.Mesh.__new__(wp.Mesh)
+        mesh.id = 123
+        mesh.device = mock.Mock(is_cpu=False)
+        mesh._points = points
+        mesh.runtime = mock.Mock()
+        mesh.runtime.core.wp_mesh_set_points_device.return_value = 0
+        mesh.runtime.get_error_string.return_value = "native refit failure"
+
+        with self.assertRaisesRegex(RuntimeError, "Failed to set mesh points: native refit failure"):
+            mesh.points = points_new
 
 
 add_function_test(TestMesh, "test_mesh_read_properties", test_mesh_read_properties, devices=devices)

--- a/warp/tests/geometry/test_mesh_query_ray.py
+++ b/warp/tests/geometry/test_mesh_query_ray.py
@@ -208,10 +208,7 @@ def test_mesh_query_ray_grad(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh"]
-        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
-        if device.is_mempool_supported:
-            constructors.append("cubql")
+        constructors = ["sah", "median", "lbvh", "cubql"]
 
     leaf_sizes = [1, 2, 4]
 
@@ -403,10 +400,7 @@ def test_mesh_query_ray_count_intersections(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh"]
-        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
-        if device.is_mempool_supported:
-            constructors.append("cubql")
+        constructors = ["sah", "median", "lbvh", "cubql"]
 
     leaf_sizes = [1, 2, 4]
 
@@ -679,10 +673,7 @@ def test_mesh_query_ray_edge(test, device):
     if device.is_cpu:
         constructors = ["sah", "median", "cubql"]
     else:
-        constructors = ["sah", "median", "lbvh"]
-        # cuBQL allocates via cudaMallocAsync, which requires CUDA mempool support.
-        if device.is_mempool_supported:
-            constructors.append("cubql")
+        constructors = ["sah", "median", "lbvh", "cubql"]
 
     leaf_sizes = [1, 2, 4]
 


### PR DESCRIPTION
## Description

cuBQL's default memory resource (`defaultGpuMemResource()`) uses `cudaMallocAsync`, which returns `cudaErrorNotSupported` on devices lacking mempool support. cuBQL's error macro then raises `SIGINT` on Linux or throws `std::runtime_error` on Windows — both fatal since there is no exception handling at the Warp API boundary.

This PR selects cuBQL's synchronous `DeviceMemoryResource` when the device lacks mempool support, mirroring the dispatch pattern already used by `wp_alloc_device`. The explicit memory resource is passed to all cuBQL call sites (`gpuBuilder`, `cuda::refit`, `cuda::free`) to keep the allocator consistent across the BVH lifetime.

As defense-in-depth, `try/catch` blocks around cuBQL calls surface errors via `wp::set_error_string()` instead of letting C++ exceptions escape the API boundary (following the precedent in `volume_builder.cu`).

The `is_mempool_supported` guards that filtered `"cubql"` out of constructor lists in test files are removed since the root cause is now fixed. A dedicated regression test exercises cuBQL create, ray query, and refit on all devices.

Closes #1430

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `uv run python warp/tests/geometry/test_mesh.py` — all 15 tests pass
- `uv run python warp/tests/geometry/test_mesh_query_ray.py` — all 9 tests pass (6 skipped for usd-core)
- `uv run python warp/tests/geometry/test_mesh.py -k test_mesh_cubql_no_mempool` — new regression test passes on both CPU and CUDA

## Bug fix

```python
import warp as wp
wp.init()

# On a device without CUDA mempool support (e.g. TCC mode),
# this raises SIGINT on Linux or OSError 0xe06d7363 on Windows:
points = wp.array([(0,0,0),(1,0,0),(0,1,0)], dtype=wp.vec3, device="cuda:0")
indices = wp.array([0,1,2], dtype=int, device="cuda:0")
mesh = wp.Mesh(points=points, indices=indices, bvh_constructor="cubql")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and stability for BVH create/destroy/refit/rebuild; failures now report readable error strings and consistently clean up GPU and host state.
  * GPU memory-resource selection for BVH operations improved to handle devices with and without mempool support.
  * Mesh creation now raises a RuntimeError with the native error message on failure; device-side mesh allocations are freed safely.

* **Tests**
  * Expanded tests to exercise the cuBQL BVH backend across more non-CPU configurations, including a no-mempool scenario.
  * Added a test asserting mesh creation raises on native failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->