### PR TITLE
Add Python 3.10 multi-GPU CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,94 @@ jobs:
           flags: unittests,linux,${{ matrix.gpu-name }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-warp-gpu-linux-mgpu-python310:
+    runs-on: linux-amd64-gpu-rtxpro6000-latest-2
+    needs: [build-warp, gpu-changes]
+    if: |
+      github.repository == 'NVIDIA/warp' && (
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/release-') ||
+        needs.gpu-changes.outputs.gpu_relevant == 'true'
+      )
+    permissions:
+      contents: read
+    container:
+      image: ubuntu:24.04
+      options: -u root --security-opt seccomp=unconfined --shm-size 16g
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    env:
+      UV_PYTHON: "3.10"
+    timeout-minutes: 60
+    steps:
+      - name: Display GPU information
+        run: nvidia-smi
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
+      - name: Install system dependencies
+        # curl and gpg are required by codecov/codecov-action@v6 to download and verify the uploader.
+        run: |
+          apt-get update
+          apt-get install -y git git-lfs curl gpg
+          git lfs install
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: "0.11.3"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Download Warp build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact-ubuntu-x86_64
+          path: warp/bin/
+
+      - name: Run Tests
+        run: uv run --extra dev --extra torch-cu13 --with "jax[cuda13]" -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
+
+      - name: Test Summary
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        with:
+          paths: "rspec.xml"
+          show: "fail"
+        if: always()
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          disable_search: true
+          files: ./rspec.xml
+          report_type: test_results
+          flags: unittests,linux,rtxpro6000,mgpu,py310
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          disable_search: true
+          files: ./coverage.xml
+          flags: unittests,linux,rtxpro6000,mgpu,py310
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   test-warp-gpu-windows:
     runs-on: windows-amd64-gpu-rtxpro6000-latest-1
     needs: [build-warp, gpu-changes]


### PR DESCRIPTION
## Description

Adds a dedicated Linux multi-GPU GitHub Actions job that runs the Warp test suite with Python 3.10 on the two-GPU RTX PRO 6000 runner. The job uses the Ubuntu build artifact and CUDA 13-compatible JAX and PyTorch extras.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `uvx pre-commit run --files .github/workflows/ci.yml`
- `git diff --check -- .github/workflows/ci.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline with additional GPU testing job for enhanced testing coverage on RTX Pro 6000 hardware with Python 3.10 and CUDA 13 support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1450)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->