### PR TITLE
Consolidate HashGrid query API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,9 +58,16 @@
   either flag continues to work during the deprecation window and now emits a one-time `DeprecationWarning`.
   `warp.config.verbose_warnings` is unaffected and continues to control whether warning output includes the source
   location ([GH-1315](https://github.com/NVIDIA/warp/issues/1315)).
+- Deprecate `wp.HashGridQueryH` and `wp.HashGridQueryD`; use `wp.HashGridQuery` instead.
+  The legacy aliases remain available during the deprecation period for compatibility
+  ([GH-1452](https://github.com/NVIDIA/warp/issues/1452)).
 
 ### Changed
 
+- Consolidate the documented `wp.HashGrid` query API around `wp.HashGridQuery`. Query
+  objects returned by `wp.hash_grid_query()` now appear as `wp.HashGridQuery` in
+  generated docs and stubs regardless of the grid coordinate precision
+  ([GH-1452](https://github.com/NVIDIA/warp/issues/1452)).
 - Reduce overhead of converting `wp.float16` values to and from Python `float`. Building from source on Linux now
   requires `libpython3-dev` for the Python C headers (`Python.h`); the build checks for them up front and reports an
   actionable error when missing ([GH-1339](https://github.com/NVIDIA/warp/issues/1339)).

--- a/docs/api_reference/warp.rst
+++ b/docs/api_reference/warp.rst
@@ -224,8 +224,6 @@ Spatial Acceleration
    BvhQueryTiled
    HashGrid
    HashGridQuery
-   HashGridQueryD
-   HashGridQueryH
    Mesh
    MeshQueryAABB
    MeshQueryAABBTiled

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -669,6 +669,31 @@ def resolve_wp_aliases(app, env, node, contnode):
     return None
 
 
+def resolve_public_builtin_aliases(app, env, node, contnode):
+    """Resolve public ``warp.*`` built-in refs to their generated documents."""
+    reftarget = node.get("reftarget", "")
+    if node.get("reftype") != "func" or not reftarget.startswith("warp."):
+        return None
+
+    builtin_name = reftarget[5:]
+    if "." in builtin_name:
+        return None
+
+    from warp._src.context import builtin_functions  # noqa: PLC0415
+
+    if builtin_name not in builtin_functions:
+        return None
+
+    new_target = f"warp._src.lang.{builtin_name}"
+    node["reftarget"] = new_target
+
+    domain = env.get_domain("py")
+    result = domain.resolve_xref(env, node.get("refdoc", ""), app.builder, "func", new_target, node, contnode)
+
+    node["reftarget"] = reftarget
+    return result
+
+
 def generate_reference_docs(app):
     """Generate API and language reference .rst files before Sphinx reads sources."""
     docs.generate_reference.run()
@@ -704,6 +729,7 @@ def setup(app):
     app.connect("autodoc-process-docstring", populate_reexported_docstrings)
     app.connect("autodoc-process-signature", rewrite_wp_aliases)
     app.connect("missing-reference", resolve_wp_aliases)
+    app.connect("missing-reference", resolve_public_builtin_aliases)
     # Lower priority runs first; this must precede TocTreeCollector
     # (default 500) so the autosummary wrappers are gone before it
     # populates `env.tocs`.

--- a/docs/user_guide/runtime.rst
+++ b/docs/user_guide/runtime.rst
@@ -2038,6 +2038,10 @@ and :func:`wp.hash_grid_query_next() <warp._src.lang.hash_grid_query_next>` as f
 
         output[tid] = sum
 
+Helper functions that take hash grid query objects should annotate the query argument with the matching grid coordinate
+precision, for example ``wp.HashGridQuery[wp.float64]``. The unparameterized ``wp.HashGridQuery`` denotes the default
+``wp.float32`` query type.
+
 .. note::
     The ``HashGrid`` query will give back all points in *cells* that fall inside the query radius.
     When there are hash conflicts it means that some points outside of query radius will be returned, and users should

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -180,8 +180,6 @@ from warp._src.types import Volume as Volume
 from warp._src.types import BvhQuery as BvhQuery
 from warp._src.types import BvhQueryTiled as BvhQueryTiled
 from warp._src.types import HashGridQuery as HashGridQuery
-from warp._src.types import HashGridQueryD as HashGridQueryD
-from warp._src.types import HashGridQueryH as HashGridQueryH
 from warp._src.types import MeshQueryAABB as MeshQueryAABB
 from warp._src.types import MeshQueryAABBTiled as MeshQueryAABBTiled
 from warp._src.types import MeshQueryPoint as MeshQueryPoint
@@ -489,6 +487,26 @@ from . import utils as utils
 from warp._src.math import *
 from warp._src.marching_cubes import MarchingCubes as MarchingCubes
 from warp._src.context import RegisteredGLBuffer as RegisteredGLBuffer
+
+
+def __getattr__(name):
+    if name == "HashGridQueryH":
+        dtype = float16
+    elif name == "HashGridQueryD":
+        dtype = float64
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from warp._src.logger import log_warning  # noqa: PLC0415
+    from warp._src.types import hash_grid_query_type  # noqa: PLC0415
+
+    log_warning(
+        f"warp.{name} is deprecated and will be removed in a future release. "
+        "Use warp.HashGridQuery in public type references; query objects are returned by warp.hash_grid_query().",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return hash_grid_query_type(dtype)
 
 
 __version__ = config.version

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -72,8 +72,6 @@ from warp._src.types import Volume as Volume
 from warp._src.types import BvhQuery as BvhQuery
 from warp._src.types import BvhQueryTiled as BvhQueryTiled
 from warp._src.types import HashGridQuery as HashGridQuery
-from warp._src.types import HashGridQueryD as HashGridQueryD
-from warp._src.types import HashGridQueryH as HashGridQueryH
 from warp._src.types import MeshQueryAABB as MeshQueryAABB
 from warp._src.types import MeshQueryAABBTiled as MeshQueryAABBTiled
 from warp._src.types import MeshQueryPoint as MeshQueryPoint
@@ -4803,23 +4801,25 @@ def hash_grid_query(id: uint64, point: vec3f, max_dist: float32) -> HashGridQuer
     ...
 
 @over
-def hash_grid_query(id: uint64, point: vec3h, max_dist: float16) -> HashGridQueryH:
+def hash_grid_query(id: uint64, point: vec3h, max_dist: float16) -> HashGridQuery:
     """Construct a point query against a :class:`warp.HashGrid` (float16 precision).
 
     This query can be used to iterate over all neighboring points within a fixed radius from the query point."""
     ...
 
 @over
-def hash_grid_query(id: uint64, point: vec3d, max_dist: float64) -> HashGridQueryD:
+def hash_grid_query(id: uint64, point: vec3d, max_dist: float64) -> HashGridQuery:
     """Construct a point query against a :class:`warp.HashGrid` (float64 precision).
 
     This query can be used to iterate over all neighboring points within a fixed radius from the query point."""
     ...
 
-def hash_grid_query_next(query: HashGridQuery | HashGridQueryH | HashGridQueryD, index: int32) -> bool:
+def hash_grid_query_next(query: HashGridQuery, index: int32) -> bool:
     """Move to the next point in the hash grid query.
 
-    The index of the current neighbor is stored in ``index``, returns ``False`` if there are no more neighbors."""
+    Supports query objects returned by :func:`wp.hash_grid_query() <warp.hash_grid_query>` for all hash grid
+    coordinate precisions. The index of the current neighbor is stored in ``index``; returns ``False`` if there are no
+    more neighbors."""
     ...
 
 def hash_grid_point_id(id: uint64, index: int32) -> int:

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -8101,15 +8101,17 @@ def _add_hash_grid_query_builtins(vec_type, scalar_type, query_type, precision_d
         group="Geometry",
         doc="""Move to the next point in the hash grid query.
 
-    The index of the current neighbor is stored in ``index``, returns ``False`` if there are no more neighbors.""",
+    Supports query objects returned by :func:`wp.hash_grid_query() <warp.hash_grid_query>` for all hash grid
+    coordinate precisions. The index of the current neighbor is stored in ``index``; returns ``False`` if there are no
+    more neighbors.""",
         export=False,
         is_differentiable=False,
     )
 
 
-_add_hash_grid_query_builtins(vec3, float, HashGridQuery)
-_add_hash_grid_query_builtins(vec3h, float16, HashGridQueryH, "float16")
-_add_hash_grid_query_builtins(vec3d, float64, HashGridQueryD, "float64")
+_add_hash_grid_query_builtins(vec3, float, hash_grid_query_type(float32))
+_add_hash_grid_query_builtins(vec3h, float16, hash_grid_query_type(float16), "float16")
+_add_hash_grid_query_builtins(vec3d, float64, hash_grid_query_type(float64), "float64")
 
 add_builtin(
     "hash_grid_point_id",
@@ -8257,7 +8259,11 @@ add_builtin(
     hidden=True,
     is_differentiable=False,
 )
-for query_type in (HashGridQuery, HashGridQueryH, HashGridQueryD):
+for query_type in (
+    hash_grid_query_type(float16),
+    hash_grid_query_type(float32),
+    hash_grid_query_type(float64),
+):
     add_builtin(
         "iter_next",
         input_types={"query": query_type},

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -10508,6 +10508,8 @@ def type_str(t):
         return f"Tile[{type_str(t.dtype)}, {type_str(t.shape)}]"
     elif warp._src.types.is_tile_stack(t):
         return f"TileStack[{type_str(t.dtype)}, {type_str(t.capacity)}]"
+    elif warp._src.types.type_is_hash_grid_query(t):
+        return t._wp_public_name_
 
     return t.__name__
 
@@ -10674,8 +10676,6 @@ def export_functions_rst(file):  # pragma: no cover
         ("mesh_query_point", "MeshQueryPoint"),
         ("mesh_query_ray", "MeshQueryRay"),
         ("hash_grid_query", "HashGridQuery"),
-        ("hash_grid_query", "HashGridQueryH"),
-        ("hash_grid_query", "HashGridQueryD"),
     )
 
     for k, g in groups.items():
@@ -10876,9 +10876,20 @@ def export_stubs(file):  # pragma: no cover
     init_import_lines = []
     init_other_lines = []
 
+    skip_runtime_dunder_getattr = False
     for line in init_lines:
+        if skip_runtime_dunder_getattr:
+            if line and not line[0].isspace():
+                skip_runtime_dunder_getattr = False
+            else:
+                continue
+
         if line.startswith("#"):
             continue  # Skip comment lines from __init__.py
+
+        if line.startswith("def __getattr__("):
+            skip_runtime_dunder_getattr = True
+            continue
 
         # Check if this line is a top-level import statement (no leading whitespace).
         # Indented imports inside function bodies (e.g., in __getattr__) are not top-level imports.
@@ -11292,6 +11303,23 @@ def export_stubs(file):  # pragma: no cover
                     continue
 
             result.append((f, None))
+
+        # After public type rendering, distinct internal overloads may share the
+        # same stub signature. Keep the first generated signature.
+        seen_signatures = set()
+        deduped = []
+        for f, type_overrides in result:
+            args = tuple(
+                type_overrides[k] if type_overrides and k in type_overrides else type_str(v)
+                for k, v in f.input_types.items()
+            )
+            sig = (args, get_return_type_str(f))
+            if sig in seen_signatures:
+                continue
+            seen_signatures.add(sig)
+            deduped.append((f, type_overrides))
+
+        result = deduped
 
         return result
 

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -2163,21 +2163,49 @@ class MeshQueryAABBTiled:
 
 # definition just for kernel type (cannot be a parameter), see hashgrid.h
 class HashGridQuery:
-    """Object used to track state during neighbor traversal (float32)."""
+    """Object used to track state during :class:`warp.HashGrid` neighbor traversal.
+
+    Query objects are returned by :func:`warp.hash_grid_query`; users normally do not construct them directly.
+    Use ``warp.HashGridQuery[dtype]`` in function annotations when the query's coordinate precision must be
+    explicit, for example ``warp.HashGridQuery[warp.float64]``.
+    """
 
     _wp_native_name_ = "hash_grid_query_f"
+    _wp_public_name_ = "HashGridQuery"
+    _wp_query_dtype_ = float32
+
+    @classmethod
+    def __class_getitem__(cls, dtype):
+        return hash_grid_query_type(dtype)
 
 
-class HashGridQueryH:
-    """Object used to track state during neighbor traversal (float16)."""
-
+class _HashGridQueryH(HashGridQuery):
     _wp_native_name_ = "hash_grid_query_h"
+    _wp_query_dtype_ = float16
 
 
-class HashGridQueryD:
-    """Object used to track state during neighbor traversal (float64)."""
-
+class _HashGridQueryD(HashGridQuery):
     _wp_native_name_ = "hash_grid_query_d"
+    _wp_query_dtype_ = float64
+
+
+_hash_grid_query_types = {
+    float16: _HashGridQueryH,
+    float32: HashGridQuery,
+    float64: _HashGridQueryD,
+}
+
+
+def hash_grid_query_type(dtype):
+    dtype = type_to_warp(dtype)
+    query_type = _hash_grid_query_types.get(dtype)
+    if query_type is None:
+        raise TypeError(f"Unsupported dtype {dtype} for HashGridQuery. Supported types: float16, float32, float64")
+    return query_type
+
+
+def type_is_hash_grid_query(t):
+    return isinstance(t, type) and getattr(t, "_wp_public_name_", None) == "HashGridQuery"
 
 
 # maximum number of dimensions, must match array.h
@@ -7121,9 +7149,9 @@ simple_type_codes = {
     shape_t: "sh",
     range_t: "rg",
     launch_bounds_t: "lb",
-    HashGridQuery: "hgq",
-    HashGridQueryH: "hgqh",
-    HashGridQueryD: "hgqd",
+    hash_grid_query_type(float16): "hgqh",
+    hash_grid_query_type(float32): "hgq",
+    hash_grid_query_type(float64): "hgqd",
     MeshQueryAABB: "mqa",
     MeshQueryPoint: "mqp",
     MeshQueryRay: "mqr",

--- a/warp/tests/geometry/test_hash_grid.py
+++ b/warp/tests/geometry/test_hash_grid.py
@@ -1,12 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import contextlib
+import io
 import unittest
+import warnings
 from typing import Any
 
 import numpy as np
 
 import warp as wp
+from warp._src import logger as _logger_module
 from warp.tests.unittest_utils import *
 
 dim_x = 128
@@ -45,6 +49,158 @@ def count_neighbors(grid: wp.uint64, radius: Any, points: wp.array[Any], counts:
 count_neighbors_f16 = wp.overload(count_neighbors, [wp.uint64, wp.float16, wp.array[wp.vec3h], wp.array[int]])
 count_neighbors_f32 = wp.overload(count_neighbors, [wp.uint64, wp.float32, wp.array[wp.vec3f], wp.array[int]])
 count_neighbors_f64 = wp.overload(count_neighbors, [wp.uint64, wp.float64, wp.array[wp.vec3d], wp.array[int]])
+
+
+_saved_warnings_seen = _logger_module._warnings_seen.copy()
+try:
+    with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()):
+        warnings.simplefilter("always", DeprecationWarning)
+        LegacyHashGridQueryH = wp.HashGridQueryH
+        LegacyHashGridQueryD = wp.HashGridQueryD
+finally:
+    _logger_module._warnings_seen.clear()
+    _logger_module._warnings_seen.update(_saved_warnings_seen)
+
+
+@wp.func
+def closest_hashgrid_neighbor_float16(
+    query: wp.HashGridQuery[wp.float16], center: wp.vec3h, points: wp.array[wp.vec3h], radius: wp.float16
+):
+    best = int(-1)
+    best_dist_sq = radius * radius
+    index = int(0)
+
+    while wp.hash_grid_query_next(query, index):
+        offset = points[index] - center
+        dist_sq = wp.dot(offset, offset)
+        if dist_sq <= best_dist_sq:
+            best = index
+            best_dist_sq = dist_sq
+
+    return best
+
+
+@wp.func
+def closest_hashgrid_neighbor_float32(
+    query: wp.HashGridQuery[wp.float32], center: wp.vec3f, points: wp.array[wp.vec3f], radius: wp.float32
+):
+    best = int(-1)
+    best_dist_sq = radius * radius
+    index = int(0)
+
+    while wp.hash_grid_query_next(query, index):
+        offset = points[index] - center
+        dist_sq = wp.dot(offset, offset)
+        if dist_sq <= best_dist_sq:
+            best = index
+            best_dist_sq = dist_sq
+
+    return best
+
+
+@wp.func
+def closest_hashgrid_neighbor_float64(
+    query: wp.HashGridQuery[wp.float64], center: wp.vec3d, points: wp.array[wp.vec3d], radius: wp.float64
+):
+    best = int(-1)
+    best_dist_sq = radius * radius
+    index = int(0)
+
+    while wp.hash_grid_query_next(query, index):
+        offset = points[index] - center
+        dist_sq = wp.dot(offset, offset)
+        if dist_sq <= best_dist_sq:
+            best = index
+            best_dist_sq = dist_sq
+
+    return best
+
+
+@wp.func
+def closest_hashgrid_neighbor_legacy_float16(
+    query: LegacyHashGridQueryH, center: wp.vec3h, points: wp.array[wp.vec3h], radius: wp.float16
+):
+    best = int(-1)
+    best_dist_sq = radius * radius
+    index = int(0)
+
+    while wp.hash_grid_query_next(query, index):
+        offset = points[index] - center
+        dist_sq = wp.dot(offset, offset)
+        if dist_sq <= best_dist_sq:
+            best = index
+            best_dist_sq = dist_sq
+
+    return best
+
+
+@wp.func
+def closest_hashgrid_neighbor_legacy_float64(
+    query: LegacyHashGridQueryD, center: wp.vec3d, points: wp.array[wp.vec3d], radius: wp.float64
+):
+    best = int(-1)
+    best_dist_sq = radius * radius
+    index = int(0)
+
+    while wp.hash_grid_query_next(query, index):
+        offset = points[index] - center
+        dist_sq = wp.dot(offset, offset)
+        if dist_sq <= best_dist_sq:
+            best = index
+            best_dist_sq = dist_sq
+
+    return best
+
+
+@wp.kernel
+def closest_hashgrid_neighbor_kernel_float16(
+    grid: wp.uint64,
+    query_points: wp.array[wp.vec3h],
+    points: wp.array[wp.vec3h],
+    radius: wp.float16,
+    closest: wp.array[int],
+    closest_legacy: wp.array[int],
+):
+    tid = wp.tid()
+    center = query_points[tid]
+    query = wp.hash_grid_query(grid, center, radius)
+    legacy_query = wp.hash_grid_query(grid, center, radius)
+
+    closest[tid] = closest_hashgrid_neighbor_float16(query, center, points, radius)
+    closest_legacy[tid] = closest_hashgrid_neighbor_legacy_float16(legacy_query, center, points, radius)
+
+
+@wp.kernel
+def closest_hashgrid_neighbor_kernel_float32(
+    grid: wp.uint64,
+    query_points: wp.array[wp.vec3f],
+    points: wp.array[wp.vec3f],
+    radius: wp.float32,
+    closest: wp.array[int],
+):
+    tid = wp.tid()
+    center = query_points[tid]
+    query = wp.hash_grid_query(grid, center, radius)
+
+    closest[tid] = closest_hashgrid_neighbor_float32(query, center, points, radius)
+
+
+@wp.kernel
+def closest_hashgrid_neighbor_kernel_float64(
+    grid: wp.uint64,
+    query_points: wp.array[wp.vec3d],
+    points: wp.array[wp.vec3d],
+    radius: wp.float64,
+    closest: wp.array[int],
+    closest_legacy: wp.array[int],
+):
+    tid = wp.tid()
+    center = query_points[tid]
+    query = wp.hash_grid_query(grid, center, radius)
+    legacy_query = wp.hash_grid_query(grid, center, radius)
+
+    closest[tid] = closest_hashgrid_neighbor_float64(query, center, points, radius)
+    closest_legacy[tid] = closest_hashgrid_neighbor_legacy_float64(legacy_query, center, points, radius)
 
 
 @wp.func
@@ -269,6 +425,71 @@ def test_hashgrid_multiprecision(test, device):
             assert_np_equal(counts_arr.numpy(), expected_counts)
 
 
+def test_hashgrid_query_func_annotations(test, device):
+    """Pass live hash grid queries to helper functions that choose the nearest point within a query radius."""
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.2, 0.0, 0.0],
+            [0.8, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    query_points = np.array(
+        [
+            [0.18, 0.0, 0.0],
+            [0.72, 0.0, 0.0],
+            [1.7, 0.0, 0.0],
+            [5.0, 0.0, 0.0],
+        ],
+        dtype=np.float64,
+    )
+    expected_closest = np.array([1, 2, 3, -1], dtype=np.int32)
+
+    cases = [
+        (wp.float16, wp.vec3h, closest_hashgrid_neighbor_kernel_float16, True),
+        (wp.float32, wp.vec3f, closest_hashgrid_neighbor_kernel_float32, False),
+        (wp.float64, wp.vec3d, closest_hashgrid_neighbor_kernel_float64, True),
+    ]
+
+    for scalar_dtype, vec3_dtype, kernel, has_legacy_alias in cases:
+        with test.subTest(dtype=scalar_dtype.__name__):
+            points_arr = wp.array(points, dtype=vec3_dtype, device=device)
+            query_points_arr = wp.array(query_points, dtype=vec3_dtype, device=device)
+            closest = wp.empty(len(query_points), dtype=int, device=device)
+
+            grid = wp.HashGrid(16, 16, 16, device, dtype=scalar_dtype)
+            grid.build(points_arr, 0.5)
+
+            if has_legacy_alias:
+                closest_legacy = wp.empty(len(query_points), dtype=int, device=device)
+                wp.launch(
+                    kernel=kernel,
+                    dim=len(query_points),
+                    inputs=[
+                        wp.uint64(grid.id),
+                        query_points_arr,
+                        points_arr,
+                        scalar_dtype(0.35),
+                        closest,
+                        closest_legacy,
+                    ],
+                    device=device,
+                )
+
+                assert_np_equal(closest_legacy.numpy(), expected_closest)
+            else:
+                wp.launch(
+                    kernel=kernel,
+                    dim=len(query_points),
+                    inputs=[wp.uint64(grid.id), query_points_arr, points_arr, scalar_dtype(0.35), closest],
+                    device=device,
+                )
+
+            assert_np_equal(closest.numpy(), expected_closest)
+
+
 def test_hashgrid_invalid_dtype(test, device):
     """Test that HashGrid rejects invalid dtypes."""
     with test.assertRaises(TypeError):
@@ -443,11 +664,54 @@ class TestHashGrid(unittest.TestCase):
         instance = wp.HashGrid.__new__(wp.HashGrid)
         instance.__del__()
 
+    def test_hashgrid_query_public_type_surface(self):
+        query_h = wp._src.types.hash_grid_query_type(wp.float16)
+        query_f = wp._src.types.hash_grid_query_type(wp.float32)
+        query_d = wp._src.types.hash_grid_query_type(wp.float64)
+
+        self.assertIs(query_f, wp.HashGridQuery)
+        self.assertIsNot(query_h, query_f)
+        self.assertIsNot(query_d, query_f)
+
+        self.assertEqual(wp._src.context.type_str(query_h), "HashGridQuery")
+        self.assertEqual(wp._src.context.type_str(query_f), "HashGridQuery")
+        self.assertEqual(wp._src.context.type_str(query_d), "HashGridQuery")
+
+        public_names = dir(wp)
+        self.assertIn("HashGridQuery", public_names)
+        self.assertNotIn("HashGridQueryH", public_names)
+        self.assertNotIn("HashGridQueryD", public_names)
+
+    def test_hashgrid_query_legacy_aliases_warn(self):
+        saved_warnings = _logger_module._warnings_seen.copy()
+        _logger_module._warnings_seen.clear()
+
+        try:
+            with warnings.catch_warnings(), contextlib.redirect_stderr(io.StringIO()) as stderr:
+                warnings.simplefilter("always", DeprecationWarning)
+                query_h = wp.HashGridQueryH
+                query_d = wp.HashGridQueryD
+
+            output = stderr.getvalue()
+        finally:
+            _logger_module._warnings_seen.clear()
+            _logger_module._warnings_seen.update(saved_warnings)
+
+        self.assertIs(query_h, wp._src.types.hash_grid_query_type(wp.float16))
+        self.assertIs(query_d, wp._src.types.hash_grid_query_type(wp.float64))
+        self.assertIn("Warp DeprecationWarning", output)
+        self.assertIn("HashGridQueryH", output)
+        self.assertIn("HashGridQueryD", output)
+        self.assertIn("warp.hash_grid_query()", output)
+
 
 add_function_test(TestHashGrid, "test_hashgrid_query", test_hashgrid_query, devices=devices)
 add_function_test(TestHashGrid, "test_hashgrid_inputs", test_hashgrid_inputs, devices=devices)
 add_function_test(TestHashGrid, "test_hashgrid_multiple_streams", test_hashgrid_multiple_streams, devices=cuda_devices)
 add_function_test(TestHashGrid, "test_hashgrid_multiprecision", test_hashgrid_multiprecision, devices=devices)
+add_function_test(
+    TestHashGrid, "test_hashgrid_query_func_annotations", test_hashgrid_query_func_annotations, devices=devices
+)
 add_function_test(TestHashGrid, "test_hashgrid_invalid_dtype", test_hashgrid_invalid_dtype, devices=devices)
 add_function_test(
     TestHashGrid, "test_hashgrid_build_invalid_radius", test_hashgrid_build_invalid_radius, devices=devices


### PR DESCRIPTION
## Description

Consolidates the public HashGrid query surface so docs and stubs expose `wp.HashGridQuery` for all coordinate precisions. The dtype-specific query types remain internal for codegen, while `wp.HashGridQueryH` and `wp.HashGridQueryD` continue to forward with deprecation warnings for compatibility.

Closes #1452.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `uv run warp/tests/geometry/test_hash_grid.py`
- `uv run --extra docs build_docs.py 2>&1 | tee /tmp/build_docs.log`
- `uvx pre-commit run --files warp/_src/types.py warp/_src/builtins.py warp/_src/context.py warp/__init__.py warp/__init__.pyi docs/api_reference/warp.rst warp/tests/geometry/test_hash_grid.py CHANGELOG.md`

## New feature / enhancement

`wp.hash_grid_query()` now appears consistently as returning `wp.HashGridQuery` in generated documentation and stubs, regardless of whether the underlying `wp.HashGrid` uses `wp.float16`, `wp.float32`, or `wp.float64` coordinates.

```python
import warp as wp

query: wp.HashGridQuery = wp.hash_grid_query(grid, point, max_dist)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Deprecated wp.HashGridQueryH and wp.HashGridQueryD; use wp.HashGridQuery. Accessing legacy names now emits a deprecation warning directing to wp.hash_grid_query().

* **Documentation**
  * Consolidated API and generated docs to present hash-grid queries under wp.HashGridQuery; user guide clarifies using wp.HashGridQuery[dtype] with explicit precision.

* **Tests**
  * Added tests verifying public type surface and deprecation warnings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1453)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->