### PR TITLE
Support wp.Function parameters in user functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   to an addressable expression for use with native snippets, and allow `@wp.func_native` ref-parameter functions to
   provide manual adjoints with `adj_snippet`
   ([GH-1277](https://github.com/NVIDIA/warp/issues/1277)).
+- Add support for `wp.Function`-typed parameters in user-defined `@wp.func` functions, allowing user-defined Warp
+  functions and simple built-in Warp functions such as `wp.sin()` and `wp.min()` to be used as function targets from
+  kernels or other functions, including through defaults ([GH-1424](https://github.com/NVIDIA/warp/issues/1424)).
 - Add mipmap (texture level-of-detail) support to `wp.Texture1D`, `wp.Texture2D`, and `wp.Texture3D` via the new
   `num_mip_levels` and `mip_filter_mode` constructor parameters, and allow `wp.texture_sample()` to accept an optional
   trailing `lod` argument for controlling sampled detail level ([GH-1409](https://github.com/NVIDIA/warp/issues/1409)).

--- a/docs/user_guide/basics.rst
+++ b/docs/user_guide/basics.rst
@@ -360,6 +360,67 @@ User functions may also be overloaded by defining multiple function signatures w
     def custom(x: wp.vec3):
         return x + wp.vec3(1.0, 0.0, 0.0)
 
+.. _callable-parameters:
+
+Function Parameters
+^^^^^^^^^^^^^^^^^^^
+
+User functions can accept another user-defined Warp function or simple built-in
+Warp function by annotating the parameter as :class:`warp.Function`.
+Function targets are chosen when Warp generates code, not while the kernel is
+running. Warp compiles a separate version of the user function for each distinct
+set of target functions used at a call site. This is similar to generic
+specialization: many target combinations mean more specialized versions to
+compile, including for ``wp.grad()`` calls. The function target is chosen where
+the user function is called and can be invoked directly inside the user function
+body:
+
+.. code-block:: python
+
+    import warp as wp
+
+    @wp.func
+    def square(x: float):
+        return x * x
+
+
+    @wp.func
+    def cube(x: float):
+        return x * x * x
+
+
+    @wp.func
+    def apply(f: wp.Function, x: float):
+        return f(x)
+
+
+    @wp.kernel
+    def apply_kernel(
+        values: wp.array[float],
+        square_out: wp.array[float],
+        cube_out: wp.array[float],
+    ):
+        i = wp.tid()
+        square_out[i] = apply(square, values[i])
+        cube_out[i] = apply(cube, values[i])
+
+The :class:`warp.Function` annotation is type-erased. It does not encode or
+validate the target function signature. The target is checked only through the
+actual calls made in the function body during code generation.
+
+Function parameters may also use defaults and keyword arguments:
+
+.. code-block:: python
+
+    @wp.func
+    def apply_default(f: wp.Function = square, x: float = 0.0):
+        return f(x)
+
+Pass only user-defined :func:`@wp.func <warp.func>` functions or simple built-in
+functions such as ``wp.sin``, ``wp.cos``, ``wp.sqrt``, ``wp.add``, and ``wp.min``
+as function targets. See :doc:`limitations` for unsupported function targets and
+other restrictions.
+
 Tiles may also be passed to user functions. The function signature tile argument should include
 dtype and shape parameters to match the tile type intended to be used in the function. For example:
 

--- a/docs/user_guide/limitations.rst
+++ b/docs/user_guide/limitations.rst
@@ -37,6 +37,13 @@ Kernels and User Functions
   (e.g., ``wp.float64(wp.PI)`` or ``wp.int64(large_value)``).
 * Python ``IntFlag`` values behave like raw integers in Warp kernels: bitwise negation (``~``)
   produces the integer negation, not a masked combination of flags as in standard Python ``IntFlag`` behavior.
+* :ref:`Function parameters <callable-parameters>` in user functions only support direct inline calls with
+  user-defined :func:`@wp.func <warp.func>` functions and simple built-in Warp functions such as ``wp.sin``,
+  ``wp.cos``, ``wp.sqrt``, ``wp.add``, and ``wp.min``.
+  Arbitrary Python callables are not supported. Some built-in Warp functions, such as ``wp.printf``, cannot be used
+  as ``wp.Function`` arguments because they need special handling during kernel compilation.
+  Rebinding a function-valued local to a different function or to a non-function value is not supported.
+  User functions with ``wp.Function`` parameters also cannot define custom gradient or replay functions.
 
 A limitation of Warp is that each dimension of the grid used to launch a kernel must be representable as a 32-bit
 signed integer. Therefore, no single dimension of a grid should exceed :math:`2^{31}-1`.

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -20,6 +20,7 @@ import threading
 import types
 from collections import deque
 from collections.abc import Callable, Mapping, Sequence
+from copy import copy as shallowcopy
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, get_args, get_origin
 
@@ -1056,8 +1057,13 @@ def func_match_args(func, arg_types, kwarg_types):
         if func_arg_type is Any:
             continue
 
-        # handle function refs as a special case
-        if func_arg_type is Callable and isinstance(bound_arg_type, warp._src.context.Function):
+        # Function parameters are type-erased during overload matching. User
+        # functions spell those slots with `wp.Function`; some existing
+        # builtins spell them with `Callable` for operator arguments.
+        if isinstance(bound_arg_type, warp._src.context.Function) and (
+            warp._src.types.is_warp_function_annotation(func_arg_type)
+            or (func.is_builtin() and warp._src.types.is_builtin_callable_annotation(func_arg_type))
+        ):
             continue
 
         bound_arg_type_stripped = strip_reference(bound_arg_type)
@@ -1080,6 +1086,381 @@ def func_match_args(func, arg_types, kwarg_types):
             return False
 
     return True
+
+
+def is_regular_builtin_callable_target(func):
+    """Return whether ``func`` is a simple built-in function target.
+
+    Function parameters can specialize on built-ins that lower directly through
+    the normal built-in function path. Built-ins that need variadic handling,
+    dispatch callbacks, replay suppression, or LTO dispatch are excluded because
+    they need special codegen behavior that cannot be represented by replacing a
+    callable parameter with a direct function call.
+
+    Args:
+        func: Function object to check.
+
+    Returns:
+        ``True`` if every overload of ``func`` is supported as a function target.
+    """
+
+    if not isinstance(func, warp._src.context.Function) or not func.is_builtin():
+        return False
+
+    overloads = getattr(func, "overloads", None) or (func,)
+    for overload in overloads:
+        if (
+            not overload.is_builtin()
+            or overload.variadic
+            or overload.dispatch_func is not None
+            or overload.lto_dispatch_func is not None
+            or overload.skip_replay
+        ):
+            return False
+
+    return True
+
+
+def get_callable_arg_values(func, bound_args):
+    """Return concrete function targets for ``wp.Function`` parameters.
+
+    ``bound_args`` already includes defaults. A non-empty result means the call
+    needs a specialized clone where callable parameter names resolve directly to
+    function objects during codegen instead of runtime variables.
+
+    Args:
+        func: Function being called.
+        bound_args: Bound argument values for the call, including defaults.
+
+    Returns:
+        A mapping from function parameter names to concrete Warp functions, or
+        ``None`` when the call has no concrete function targets.
+    """
+
+    if func.is_builtin():
+        return None
+
+    callable_arg_values = {}
+
+    for name, value in bound_args.items():
+        if not warp._src.types.is_warp_function_annotation(func.input_types.get(name)):
+            continue
+
+        if not isinstance(value, warp._src.context.Function):
+            continue
+
+        if value.is_builtin() and not is_regular_builtin_callable_target(value):
+            raise WarpCodegenError(
+                "wp.Function parameters support user-defined Warp functions and simple built-in Warp functions "
+                "such as wp.sin() and wp.min(), "
+                f"but parameter '{name}' of '{func.key}' received unsupported built-in function '{value.key}'."
+            )
+
+        callable_arg_values[name] = value
+
+    if callable_arg_values:
+        return callable_arg_values
+
+    return None
+
+
+def get_default_arg_value(func, name, value):
+    """Return the codegen value for a default argument.
+
+    Function defaults are specialization inputs, not runtime constants, so they
+    stay as raw function objects. Other defaults are represented as constant
+    variables and emitted through the regular default-argument path.
+
+    Args:
+        func: Function that owns the default argument.
+        name: Parameter name for ``value``.
+        value: Python default value from the function signature.
+
+    Returns:
+        A Warp function for function defaults, otherwise a constant ``Var``.
+    """
+
+    if warp._src.types.is_warp_function_annotation(func.input_types.get(name)) and isinstance(
+        value, warp._src.context.Function
+    ):
+        # Function defaults need the same specialization path as explicit
+        # function arguments.
+        return value
+
+    return Var(None, type=type(value), constant=value)
+
+
+def bind_call_arg_nodes(func, call_node):
+    """Bind a call AST to ``func`` and return AST/default arguments by name."""
+
+    try:
+        bound_args = func.signature.bind(*call_node.args, **{kw.arg: kw.value for kw in call_node.keywords})
+    except TypeError:
+        return {}
+
+    default_args = {k: v for k, v in func.defaults.items() if k not in bound_args.arguments and v is not None}
+    apply_defaults(bound_args, default_args)
+    return bound_args.arguments
+
+
+def resolve_callable_arg_target(adj, arg_node, callable_arg_values=None):
+    """Resolve a callable argument node or default to a concrete Warp function.
+
+    Args:
+        adj: Adjoint whose symbols and globals should be used for resolution.
+        arg_node: AST node or default value bound to a function parameter.
+        callable_arg_values: Specialized function targets already bound in the
+            caller, keyed by parameter name.
+
+    Returns:
+        The resolved Warp function, or the unresolved object when resolution
+        does not produce a function.
+    """
+
+    if isinstance(arg_node, warp._src.context.Function):
+        return arg_node
+
+    if callable_arg_values and isinstance(arg_node, ast.Name):
+        callable_func = callable_arg_values.get(arg_node.id)
+        if callable_func is not None:
+            return callable_func
+
+    callable_func, _ = adj.resolve_static_expression(arg_node, eval_types=False)
+    return callable_func
+
+
+_UNRESOLVED_CALL_ARG = object()
+
+
+def resolve_call_arg_type(adj, arg_node, callable_arg_values=None):
+    """Best-effort static type resolution for call arguments during reference scans."""
+
+    if isinstance(arg_node, ast.Name):
+        if callable_arg_values:
+            callable_func = callable_arg_values.get(arg_node.id)
+            if callable_func is not None:
+                return get_arg_type(callable_func)
+
+        symbol = adj.symbols.get(arg_node.id)
+        if symbol is not None:
+            return get_arg_type(symbol)
+
+        obj = adj.resolve_external_reference(arg_node.id)
+        if obj is not None:
+            return get_arg_type(obj)
+
+        return _UNRESOLVED_CALL_ARG
+
+    if isinstance(arg_node, ast.Attribute):
+        obj, _ = adj.resolve_static_expression(arg_node, eval_types=False)
+        if obj is not None:
+            return get_arg_type(obj)
+
+        return _UNRESOLVED_CALL_ARG
+
+    if isinstance(arg_node, ast.Constant):
+        return get_arg_type(arg_node.value)
+
+    try:
+        return get_arg_type(ast.literal_eval(arg_node))
+    except (TypeError, ValueError):
+        return _UNRESOLVED_CALL_ARG
+
+
+def resolve_call_arg_types(adj, call_node, callable_arg_values=None):
+    """Return static call argument types and whether every type was resolved."""
+
+    arg_types = []
+    resolved = True
+
+    for arg_node in call_node.args:
+        if isinstance(arg_node, ast.Starred):
+            resolved = False
+            continue
+
+        arg_type = resolve_call_arg_type(adj, arg_node, callable_arg_values)
+        if arg_type is _UNRESOLVED_CALL_ARG:
+            resolved = False
+        else:
+            arg_types.append(arg_type)
+
+    kwarg_types = {}
+    for kw_node in call_node.keywords:
+        if kw_node.arg is None:
+            resolved = False
+            continue
+
+        arg_type = resolve_call_arg_type(adj, kw_node.value, callable_arg_values)
+        if arg_type is _UNRESOLVED_CALL_ARG:
+            resolved = False
+        else:
+            kwarg_types[kw_node.arg] = arg_type
+
+    return tuple(arg_types), kwarg_types, resolved
+
+
+def iter_call_func_overload_candidates(func, call_node):
+    """Yield overloads whose signatures can bind ``call_node`` arguments."""
+
+    overloads = []
+    if hasattr(func, "user_overloads"):
+        overloads.extend(func.user_overloads.values())
+    if hasattr(func, "user_templates"):
+        overloads.extend(func.user_templates.values())
+    if not overloads:
+        overloads.append(func)
+
+    yielded = set()
+    for overload in overloads:
+        if overload in yielded:
+            continue
+
+        yielded.add(overload)
+        if bind_call_arg_nodes(overload, call_node):
+            yield overload
+
+
+def resolve_grad_call_reference_func(adj, func_node, callable_arg_values=None):
+    """Return the function wrapped by a ``wp.grad(...)`` callee, if any."""
+
+    if not isinstance(func_node, ast.Call) or len(func_node.args) != 1 or func_node.keywords:
+        return None
+
+    grad_func, _ = adj.resolve_static_expression(func_node.func, eval_types=False)
+    if not adj.is_grad_expression(grad_func):
+        return None
+
+    target_func = resolve_callable_arg_target(adj, func_node.args[0], callable_arg_values)
+    if isinstance(target_func, warp._src.context.Function):
+        return target_func
+
+    return None
+
+
+def resolve_reference_call_func(adj, call_node, callable_arg_values=None):
+    """Resolve the Warp function called by ``call_node`` during reference scans."""
+
+    if callable_arg_values is None:
+        callable_arg_values = {}
+
+    func, _ = adj.resolve_static_expression(call_node.func, eval_types=False)
+    if func is None and isinstance(call_node.func, ast.Name):
+        func = callable_arg_values.get(call_node.func.id)
+
+    if func is None:
+        func = resolve_grad_call_reference_func(adj, call_node.func, callable_arg_values)
+    elif isinstance(func, warp._src.context.GradWrapper):
+        func = func.func
+
+    return func
+
+
+def iter_call_callable_arg_targets(adj, func, call_node, callable_arg_values=None):
+    """Yield Warp function targets passed to ``wp.Function`` parameters.
+
+    Args:
+        adj: Adjoint whose symbols and globals should be used for resolution.
+        func: Function object referenced by the call.
+        call_node: AST call node whose arguments may include function targets.
+        callable_arg_values: Specialized function targets already bound in the
+            caller, keyed by parameter name.
+
+    Yields:
+        Concrete Warp functions supplied to function parameters by explicit
+        arguments or defaults.
+    """
+
+    if not isinstance(func, warp._src.context.Function) or func.is_builtin():
+        return
+
+    arg_types, kwarg_types, resolved = resolve_call_arg_types(adj, call_node, callable_arg_values)
+    if resolved:
+        overload = func.get_overload(arg_types, kwarg_types)
+        func_candidates = (overload or func,)
+    else:
+        func_candidates = iter_call_func_overload_candidates(func, call_node)
+
+    yielded = set()
+    for func_candidate in func_candidates:
+        bound_arg_nodes = bind_call_arg_nodes(func_candidate, call_node)
+
+        for arg_name, arg_node in bound_arg_nodes.items():
+            if not warp._src.types.is_warp_function_annotation(func_candidate.input_types.get(arg_name)):
+                continue
+
+            callable_func = resolve_callable_arg_target(adj, arg_node, callable_arg_values)
+            if isinstance(callable_func, warp._src.context.Function) and callable_func not in yielded:
+                yielded.add(callable_func)
+                yield callable_func
+
+
+def specialize_callable_func(func, callable_arg_values):
+    """Clone ``func`` for a concrete set of function parameter targets.
+
+    Function targets affect generated code but are omitted from the native C++
+    signature, so each target set needs a cached specialization with a distinct
+    native function name. The clone keeps the original Python source and arg
+    types while storing the concrete function targets on the new adjoint.
+
+    Args:
+        func: User-defined function to specialize.
+        callable_arg_values: Mapping from function parameter names to concrete
+            Warp functions.
+
+    Returns:
+        A cached specialized clone of ``func`` for ``callable_arg_values``.
+    """
+
+    if func.custom_grad_func is not None or func.custom_replay_func is not None:
+        raise WarpCodegenError(
+            "wp.Function parameters are not supported on functions with custom gradients or replay functions: "
+            f"'{func.key}'"
+        )
+
+    specialization_key = tuple(
+        (name, callable_arg_values[name]) for name in func.input_types if name in callable_arg_values
+    )
+
+    specializations = getattr(func, "_callable_specializations", None)
+    if specializations is None:
+        specializations = {}
+        func._callable_specializations = specializations
+
+    specialized_func = specializations.get(specialization_key)
+    if specialized_func is not None:
+        return specialized_func
+
+    # The callable targets are inlined by name while being omitted from the C++
+    # function parameters, so each target set needs a distinct native name.
+    suffix_hash = hashlib.sha256()
+    suffix_hash.update(bytes(func.native_func, "utf-8"))
+    for name, callable_func in specialization_key:
+        suffix_hash.update(bytes(name, "utf-8"))
+        suffix_hash.update(bytes(callable_func.key, "utf-8"))
+        suffix_hash.update(bytes(callable_func.native_func, "utf-8"))
+
+    specialized_func = shallowcopy(func)
+    # Specialization clones should not share the parent specialization cache.
+    specialized_func.__dict__.pop("_callable_specializations", None)
+    specialized_func.native_func = f"{func.native_func}_callable_{suffix_hash.hexdigest()[:12]}"
+    specialized_func.value_func = None
+    specialized_func.adj = Adjoint(
+        func.func,
+        overload_annotations=func.adj.arg_types,
+        is_user_function=func.adj.is_user_function,
+        skip_forward_codegen=func.adj.skip_forward_codegen,
+        skip_reverse_codegen=func.adj.skip_reverse_codegen,
+        custom_reverse_mode=func.adj.custom_reverse_mode,
+        custom_reverse_num_input_args=func.adj.custom_reverse_num_input_args,
+        transformers=func.adj.transformers,
+        source=func.adj.source,
+    )
+    specialized_func.adj.callable_arg_values = dict(callable_arg_values)
+    specialized_func.adj.used_by_backward_kernel = func.adj.used_by_backward_kernel
+    specialized_func.adj.force_adjoint_codegen = func.adj.force_adjoint_codegen
+
+    specializations[specialization_key] = specialized_func
+    return specialized_func
 
 
 def get_arg_type(arg: Var | Any) -> type:
@@ -1484,7 +1865,7 @@ class Adjoint:
 
     # generate function ssa form and adjoint
     @synchronized(_codegen_lock)
-    def build(adj, builder, default_builder_options=None):
+    def build(adj, builder, default_builder_options=None, callable_arg_values=None):
         # arg Var read/write flags are held during module rebuilds, so we reset here even when skipping a build
         for arg in adj.args:
             arg.is_read = False
@@ -1492,6 +1873,9 @@ class Adjoint:
 
         if adj.skip_build:
             return
+
+        if callable_arg_values is None:
+            callable_arg_values = getattr(adj, "callable_arg_values", None)
 
         adj.builder = builder
 
@@ -1531,9 +1915,13 @@ class Adjoint:
         # tracks how much additional shared memory is required by any dependent function calls
         adj.max_required_extra_shared_memory = 0
 
-        # update symbol map for each argument
+        # Function-specialized functions replace selected argument Vars with
+        # Function objects so calls like `op(x)` resolve statically.
         for a in adj.args:
-            adj.symbols[a.label] = a
+            if callable_arg_values is not None and a.label in callable_arg_values:
+                adj.symbols[a.label] = callable_arg_values[a.label]
+            else:
+                adj.symbols[a.label] = a
 
         # recursively evaluate function body
         try:
@@ -1997,17 +2385,7 @@ class Adjoint:
 
         return ref_var
 
-    def add_call(
-        adj,
-        func,
-        args,
-        kwargs,
-        type_args,
-        min_outputs=None,
-        return_value_used=True,
-        arg_nodes=None,
-        kwarg_nodes=None,
-    ):
+    def resolve_call(adj, func, args, kwargs, type_args=None, min_outputs=None, arg_nodes=None, kwarg_nodes=None):
         # Extract the types and values passed as arguments to the function call.
         arg_types = tuple(get_arg_type(x) for x in args)
         kwarg_types = {k: get_arg_type(v) for k, v in kwargs.items()}
@@ -2022,6 +2400,9 @@ class Adjoint:
             bound_arg_nodes = func.signature.bind(*(arg_nodes or ()), **(kwarg_nodes or {})).arguments
         else:
             bound_arg_nodes = {}
+
+        if type_args is None:
+            type_args = {}
 
         # Type args are the "compile time" argument values we get from codegen.
         # For example, when calling `wp.vec3f(...)` from within a kernel,
@@ -2052,14 +2433,45 @@ class Adjoint:
 
         if func.defaults:
             default_vars = {
-                k: Var(None, type=type(v), constant=v)
+                k: get_default_arg_value(func, k, v)
                 for k, v in func.defaults.items()
                 if k not in bound_args.arguments and v is not None
             }
             apply_defaults(bound_args, default_vars)
 
         bound_args = bound_args.arguments
-        bound_arg_names = tuple(bound_args.keys())
+        callable_arg_values = get_callable_arg_values(func, bound_args)
+        if callable_arg_values is not None:
+            func = specialize_callable_func(func, callable_arg_values)
+
+        return func, bound_args, bound_arg_nodes
+
+    def add_call(
+        adj,
+        func,
+        args,
+        kwargs,
+        type_args,
+        min_outputs=None,
+        return_value_used=True,
+        arg_nodes=None,
+        kwarg_nodes=None,
+        return_resolved=False,
+    ):
+        func, bound_args, bound_arg_nodes = adj.resolve_call(
+            func,
+            args,
+            kwargs,
+            type_args,
+            min_outputs,
+            arg_nodes=arg_nodes,
+            kwarg_nodes=kwarg_nodes,
+        )
+
+        def return_value(output):
+            if return_resolved:
+                return output, func, bound_args
+            return output
 
         # Constant precision preservation: when calling a 64-bit scalar type
         # constructor with a single compile-time constant argument, emit
@@ -2090,7 +2502,7 @@ class Adjoint:
                     arg.type = func.value_type
                     arg.constant = None
                     adj.add_forward(f"var_{arg} = {constant_str(func.value_type(raw))};")
-                    return arg
+                    return return_value(arg)
 
         # if it is a user-function then build it recursively
         if not func.is_builtin():
@@ -2098,6 +2510,8 @@ class Adjoint:
             # we need to ensure its adjoint is also being generated.
             if adj.used_by_backward_kernel:
                 func.adj.used_by_backward_kernel = True
+            if adj.force_adjoint_codegen:
+                func.adj.force_adjoint_codegen = True
 
             if adj.builder is None:
                 func.build(None, adj.builder_options)
@@ -2127,9 +2541,9 @@ class Adjoint:
         # Handle the special case where a Var instance is returned from the `value_func`
         # callback, in which case we replace the call with a reference to that variable.
         if isinstance(return_type, Var):
-            return adj.register_var(return_type)
+            return return_value(adj.register_var(return_type))
         elif isinstance(return_type, Sequence) and all(isinstance(x, Var) for x in return_type):
-            return tuple(adj.register_var(x) for x in return_type)
+            return return_value(tuple(adj.register_var(x) for x in return_type))
 
         if get_origin(return_type) is tuple:
             types = get_args(return_type)
@@ -2157,7 +2571,7 @@ class Adjoint:
             func, bound_args, return_type, output, output_list, return_value_used=return_value_used
         )
         if det_output is not None:
-            return det_output
+            return return_value(det_output)
 
         # If we have a built-in that requires special handling to dispatch
         # the arguments to the underlying C++ function, then we can resolve
@@ -2167,6 +2581,7 @@ class Adjoint:
         # for example by checking whether an argument corresponds to
         # a literal value or references a variable.
         extra_shared_memory = 0
+        func_arg_names = tuple(bound_args.keys())
         if func.lto_dispatch_func is not None:
             func_args, template_args, _ltoirs, extra_shared_memory = func.lto_dispatch_func(
                 func.input_types, return_type, output_list, bound_args, options=adj.builder_options, builder=adj.builder
@@ -2174,7 +2589,13 @@ class Adjoint:
         elif func.dispatch_func is not None:
             func_args, template_args = func.dispatch_func(func.input_types, return_type, bound_args)
         else:
-            func_args = tuple(bound_args.values())
+            func_arg_names = tuple(
+                name
+                for name in bound_args
+                if func.is_builtin() or not warp._src.types.is_warp_function_annotation(func.input_types.get(name))
+            )
+            func_args = tuple(bound_args[name] for name in func_arg_names)
+            # Function parameters are specialization inputs, not C++ arguments.
             template_args = ()
 
         func_args = tuple(adj.register_var(x) for x in func_args)
@@ -2183,18 +2604,19 @@ class Adjoint:
 
         # For user functions, check which parameters are wp.ref[T] / Reference(T)
         # so we can pass pointer-shaped IR through without creating copies.
-        parameter_types = list(func.input_types.values()) if not func.is_builtin() else []
-        func_has_ref_params = any(is_reference(t) for t in parameter_types)
+        parameter_types = func.input_types if not func.is_builtin() else {}
+        func_has_ref_params = any(is_reference(t) for t in parameter_types.values())
 
         fwd_args = []
         reverse_adj_args = []
         reverse_prelude = []
         for i, func_arg in enumerate(func_args):
-            parameter_type = parameter_types[i] if i < len(parameter_types) else None
+            arg_name = func_arg_names[i] if i < len(func_arg_names) else None
+            parameter_type = parameter_types.get(arg_name)
             parameter_is_ref = is_reference(parameter_type)
 
             if parameter_is_ref:
-                arg_node = bound_arg_nodes.get(bound_arg_names[i]) if i < len(bound_arg_names) else None
+                arg_node = bound_arg_nodes.get(arg_name)
                 func_arg_var = adj.emit_addressable_reference(
                     arg_node,
                     var=func_arg,
@@ -2217,6 +2639,8 @@ class Adjoint:
             if isinstance(func_arg_var, warp._src.context.Function) and not func_arg_var.is_builtin():
                 if adj.used_by_backward_kernel:
                     func_arg_var.adj.used_by_backward_kernel = True
+                if adj.force_adjoint_codegen:
+                    func_arg_var.adj.force_adjoint_codegen = True
 
                 if adj.builder is None:
                     func_arg_var.build(None, adj.builder_options)
@@ -2311,7 +2735,7 @@ class Adjoint:
         else:
             adj.alloc_shared_extra(extra_shared_memory)
 
-        return output
+        return return_value(output)
 
     def add_builtin_call(adj, func_name, args, min_outputs=None, return_value_used=True):
         func = warp._src.context.builtin_functions[func_name]
@@ -2330,10 +2754,7 @@ class Adjoint:
             This gradient call is forward-only and does NOT participate in automatic
             differentiation.
         """
-        # Resolve the function overload based on argument types
-        arg_types = tuple(get_arg_type(x) for x in args)
-        kwarg_types = {k: get_arg_type(v) for k, v in kwargs.items()}
-        func = adj.resolve_func(func, arg_types, kwarg_types, min_outputs=None)
+        func, bound_args, _ = adj.resolve_call(func, args, kwargs)
 
         if not func.is_differentiable:
             raise WarpCodegenError(f"Cannot compute gradient of non-differentiable function '{func.key}'")
@@ -2363,20 +2784,6 @@ class Adjoint:
             elif func not in adj.builder.functions:
                 adj.builder.build_function(func)
 
-        # Get function's input types
-        input_types = func.input_types
-
-        # Bind arguments to function signature
-        bound_args = func.signature.bind(*args, **kwargs)
-        if func.defaults:
-            default_vars = {
-                k: Var(None, type=type(v), constant=v)
-                for k, v in func.defaults.items()
-                if k not in bound_args.arguments and v is not None
-            }
-            apply_defaults(bound_args, default_vars)
-        bound_args = bound_args.arguments
-
         # Get return type
         bound_arg_types = {k: get_arg_type(v) for k, v in bound_args.items()}
         bound_arg_values = {k: get_arg_value(v) for k, v in bound_args.items()}
@@ -2387,6 +2794,12 @@ class Adjoint:
 
         if return_type is None:
             raise WarpCodegenError(f"Cannot compute gradient of void function '{func.key}'")
+
+        # Function parameters are specialization inputs, not native function
+        # arguments, and their adjoints are not representable.
+        input_types = {
+            name: typ for name, typ in func.input_types.items() if not warp._src.types.is_warp_function_annotation(typ)
+        }
 
         # Load input arguments into variables
         fwd_args_loaded = [adj.load(bound_args[name]) for name in input_types.keys()]
@@ -3609,35 +4022,48 @@ class Adjoint:
         kwargs = {x.arg: adj.resolve_arg(x.value) for x in node.keywords}
         kwarg_nodes = {x.arg: x.value for x in node.keywords}
 
-        out = adj.add_call(
-            func,
-            args,
-            kwargs,
-            type_args,
-            min_outputs=min_outputs,
-            return_value_used=return_value_used,
-            arg_nodes=arg_nodes,
-            kwarg_nodes=kwarg_nodes,
-        )
-
         if adj.builder_options.get("verify_autograd_array_access", False):
-            # Extract the types and values passed as arguments to the function call.
-            arg_types = tuple(get_arg_type(x) for x in args)
-            kwarg_types = {k: get_arg_type(v) for k, v in kwargs.items()}
-
-            # Resolve the exact function signature among any existing overload.
-            resolved_func = adj.resolve_func(func, arg_types, kwarg_types, min_outputs)
+            out, resolved_func, resolved_bound_args = adj.add_call(
+                func,
+                args,
+                kwargs,
+                type_args,
+                min_outputs=min_outputs,
+                return_value_used=return_value_used,
+                arg_nodes=arg_nodes,
+                kwarg_nodes=kwarg_nodes,
+                return_resolved=True,
+            )
 
             # update arg read/write states according to what happens to that arg in the called function
             if hasattr(resolved_func, "adj"):
-                for i, arg in enumerate(args):
-                    if resolved_func.adj.args[i].is_write:
+                resolved_args_by_name = {arg.label: arg for arg in resolved_func.adj.args}
+                for name, arg in resolved_bound_args.items():
+                    if warp._src.types.is_warp_function_annotation(resolved_func.input_types.get(name)):
+                        continue
+
+                    resolved_arg = resolved_args_by_name.get(name)
+                    if resolved_arg is None or not isinstance(arg, Var):
+                        continue
+
+                    if resolved_arg.is_write:
                         kernel_name = adj.fun_name
                         filename = adj.filename
                         lineno = adj.lineno + adj.fun_lineno
                         arg.mark_write(kernel_name=kernel_name, filename=filename, lineno=lineno)
-                    if resolved_func.adj.args[i].is_read:
+                    if resolved_arg.is_read:
                         arg.mark_read()
+        else:
+            out = adj.add_call(
+                func,
+                args,
+                kwargs,
+                type_args,
+                min_outputs=min_outputs,
+                return_value_used=return_value_used,
+                arg_nodes=arg_nodes,
+                kwarg_nodes=kwarg_nodes,
+            )
 
         return out
 
@@ -5272,6 +5698,7 @@ class Adjoint:
         types: dict[Struct | type, Any] = {}
         functions: dict[warp._src.context.Function, Any] = {}
         max_dim = 0  # thread-grid dimension, inferred from wp.tid() unpack arity
+        callable_arg_values = getattr(adj, "callable_arg_values", None) or {}
 
         # Shared single traversal (see reference_nodes); resolved here at hash time.
         for node in adj.reference_nodes():
@@ -5287,10 +5714,18 @@ class Adjoint:
                     constants[".".join(path)] = obj
 
             elif isinstance(node, ast.Call):
-                func, _ = adj.resolve_static_expression(node.func, eval_types=False)
+                func = resolve_reference_call_func(adj, node, callable_arg_values)
+
                 if isinstance(func, warp._src.context.Function) and not func.is_builtin():
                     # calling user-defined function
                     functions[func] = None
+
+                    # Function targets are passed as values, so they must be
+                    # added explicitly to the function reference set. Built-in
+                    # targets are hash inputs too, but they are filtered out by
+                    # module dependency discovery because they have no module.
+                    for callable_func in iter_call_callable_arg_targets(adj, func, node, callable_arg_values):
+                        functions[callable_func] = None
                 elif isinstance(func, Struct):
                     # calling struct constructor
                     types[func] = None
@@ -6115,6 +6550,8 @@ def codegen_func(adj, c_func_name: str, device="cpu", options=None, forward_only
 
     # forward args
     for i, arg in enumerate(adj.args):
+        if warp._src.types.is_warp_function_annotation(arg.type):
+            continue
         if is_tile(arg.type) or is_tile_stack(arg.type):
             tname = f"tile_{arg.label}"
             template_params.append(tname)
@@ -6134,6 +6571,8 @@ def codegen_func(adj, c_func_name: str, device="cpu", options=None, forward_only
 
     # reverse args
     for i, arg in enumerate(adj.args):
+        if warp._src.types.is_warp_function_annotation(arg.type):
+            continue
         if adj.custom_reverse_mode and i >= adj.custom_reverse_num_input_args:
             break
         # indexed array gradients are regular arrays

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -531,6 +531,13 @@ class Function:
             args_matched = True
 
             for i in range(len(arg_types)):
+                # Function annotations stay type-erased here because
+                # specialization handles the concrete function target.
+                if warp._src.types.is_warp_function_annotation(template_types[i]) and isinstance(
+                    arg_types[i], Function
+                ):
+                    continue
+
                 if not warp._src.types.type_matches_template(arg_types[i], template_types[i]):
                     args_matched = False
                     break
@@ -539,11 +546,24 @@ class Function:
                 # instantiate this function with the specified argument types
 
                 arg_names = f.input_types.keys()
-                overload_annotations = dict(zip(arg_names, arg_types, strict=False))
+                overload_annotations = {}
+                for name, arg_type, template_type in zip(arg_names, arg_types, template_types, strict=False):
+                    if warp._src.types.is_warp_function_annotation(template_type) and isinstance(arg_type, Function):
+                        overload_annotations[name] = template_type
+                    else:
+                        overload_annotations[name] = arg_type
+
                 # add defaults
                 for k, d in f.defaults.items():
                     if k not in overload_annotations:
-                        overload_annotations[k] = warp._src.types.strip_reference(warp._src.codegen.get_arg_type(d))
+                        template_type = f.input_types[k]
+                        default_type = warp._src.types.strip_reference(warp._src.codegen.get_arg_type(d))
+                        if warp._src.types.is_warp_function_annotation(template_type) and isinstance(
+                            default_type, Function
+                        ):
+                            overload_annotations[k] = template_type
+                        else:
+                            overload_annotations[k] = default_type
 
                 ovl = shallowcopy(f)
                 ovl.adj = warp._src.codegen.Adjoint(f.func, overload_annotations, source=f.adj.source)
@@ -551,7 +571,9 @@ class Function:
                 ovl.value_func = None
                 ovl.generic_parent = f
 
-                sig = warp._src.types.get_signature(arg_types, func_name=self.key)
+                sig = warp._src.types.get_signature(
+                    list(overload_annotations.values()), func_name=self.key, arg_names=list(overload_annotations.keys())
+                )
                 self.user_overloads[sig] = ovl
 
                 return ovl
@@ -2554,6 +2576,30 @@ class ModuleHasher:
 
         return h
 
+    @staticmethod
+    def hash_builtin_function(func: Function) -> bytes:
+        """Hash the identity of a built-in function used as a specialization input.
+
+        Built-in function targets do not add module dependency edges, but they
+        still change generated code. Including their stable identity in the
+        module hash prevents a cached module compiled for one built-in target
+        from being reused after the target changes.
+
+        Args:
+            func: Built-in function to hash.
+
+        Returns:
+            Digest bytes representing the built-in function identity.
+        """
+
+        ch = hashlib.sha256()
+
+        ch.update(bytes("builtin", "utf-8"))
+        ch.update(bytes(func.key, "utf-8"))
+        ch.update(bytes(func.native_func, "utf-8"))
+
+        return ch.digest()
+
     def hash_adjoint(self, adj: warp._src.codegen.Adjoint) -> bytes:
         # NOTE: We don't cache adjoint hashes, because adjoints are always unique.
         # Even instances of generic kernels and functions have unique adjoints with
@@ -2604,7 +2650,10 @@ class ModuleHasher:
         # hash referenced functions
         for f in functions.keys():
             if f not in self.functions_in_progress:
-                ch.update(self.hash_function(f))
+                if f.is_builtin():
+                    ch.update(self.hash_builtin_function(f))
+                else:
+                    ch.update(self.hash_function(f))
 
         return ch.digest()
 
@@ -3331,6 +3380,8 @@ class Module:
                 self.references.add(ref)
                 ref.dependents.add(self)
 
+        callable_arg_values = getattr(adj, "callable_arg_values", None) or {}
+
         # scan for function calls and kernel-local function bindings. ``reference_nodes`` shares
         # a single AST traversal with Adjoint.get_references; it also yields Name/Attribute
         # nodes, which this dependency scan ignores.
@@ -3338,11 +3389,20 @@ class Module:
             if type(node) is ast.Call:
                 try:
                     # try to resolve the function
-                    func, _ = adj.resolve_static_expression(node.func, eval_types=False)
+                    func = warp._src.codegen.resolve_reference_call_func(adj, node, callable_arg_values)
 
                     # if this is a user-defined function, add a module reference
                     if isinstance(func, warp._src.context.Function) and func.module is not None:
                         add_ref(func.module)
+
+                    if isinstance(func, warp._src.context.Function) and not func.is_builtin():
+                        # Function targets can come from arguments or defaults;
+                        # either way their modules must invalidate this module.
+                        for callable_func in warp._src.codegen.iter_call_callable_arg_targets(
+                            adj, func, node, callable_arg_values
+                        ):
+                            if not callable_func.is_builtin() and callable_func.module is not None:
+                                add_ref(callable_func.module)
 
                 except Exception:
                     # Lookups may fail for builtins, but that's ok.
@@ -12307,8 +12367,8 @@ def type_str(t):
         return "None"
     elif t == Any:
         return "Any"
-    elif t == Callable:
-        return "Callable"
+    elif warp._src.types.is_warp_function_annotation(t):
+        return "Function"
     elif isinstance(t, int):
         return f"Literal[{t}]"
     elif isinstance(t, (list, tuple)):

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -7358,11 +7358,31 @@ simple_type_codes = {
 }
 
 
+def is_warp_function_annotation(annotation) -> bool:
+    """Return whether an annotation denotes a type-erased Warp function."""
+
+    function_type = getattr(warp, "Function", None)
+    if function_type is not None and annotation is function_type:
+        return True
+
+    context = getattr(getattr(warp, "_src", None), "context", None)
+    context_function_type = getattr(context, "Function", None)
+    return context_function_type is not None and annotation is context_function_type
+
+
+def is_builtin_callable_annotation(annotation) -> bool:
+    """Return whether a built-in signature uses ``Callable`` for a function slot."""
+
+    return annotation is Callable or get_origin(annotation) is Callable
+
+
 def get_type_code(arg_type) -> str:
     if arg_type is Any:
         # special case for generics
         # note: since Python 3.11 Any is a type, so we check for it first
         return "?"
+    elif is_warp_function_annotation(arg_type):
+        return "c"
     elif (
         sys.version_info < (3, 11)
         and hasattr(types, "GenericAlias")
@@ -7446,9 +7466,6 @@ def get_type_code(arg_type) -> str:
     elif arg_type == Int:
         # generic int
         return "i?"
-    elif isinstance(arg_type, Callable):
-        # TODO: elaborate on Callable type?
-        return "c"
     elif arg_type is Ellipsis:
         return "?"
     elif isinstance(arg_type, Reference):

--- a/warp/tests/aux_test_function_double.py
+++ b/warp/tests/aux_test_function_double.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Function target fixture imported as a Python module."""
+
+import warp as wp
+
+
+@wp.func
+def function_external_module_double_it(x: float):
+    return x * 2.0

--- a/warp/tests/aux_test_function_triple.py
+++ b/warp/tests/aux_test_function_triple.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Function target fixture imported as a Python module."""
+
+import warp as wp
+
+
+@wp.func
+def function_external_module_triple_it(x: float):
+    return x * 3.0

--- a/warp/tests/deterministic/test_deterministic_counter.py
+++ b/warp/tests/deterministic/test_deterministic_counter.py
@@ -250,6 +250,11 @@ def _det_set_flag(flag: wp.array[wp.int32], mask: wp.int32):
     wp.atomic_xor(flag, 0, mask)
 
 
+@wp.func
+def _det_apply_flag_function(g: wp.Function, flag: wp.array[wp.int32], mask: wp.int32):
+    g(flag, mask)
+
+
 @wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.RUN_TO_RUN})
 def counter_with_helper_atomic_xor_kernel(
     counter: wp.array[wp.int32],
@@ -259,6 +264,19 @@ def counter_with_helper_atomic_xor_kernel(
     """Counter kernel that delegates the bitwise atomic to a ``@wp.func`` helper."""
     tid = wp.tid()
     _det_set_flag(flag, 1)
+    slot = wp.atomic_add(counter, 0, 1)
+    output[slot] = tid
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.RUN_TO_RUN})
+def counter_with_function_parameter_atomic_xor_kernel(
+    counter: wp.array[wp.int32],
+    flag: wp.array[wp.int32],
+    output: wp.array[wp.int32],
+):
+    """Counter kernel that delegates a bitwise atomic through a Function parameter."""
+    tid = wp.tid()
+    _det_apply_flag_function(_det_set_flag, flag, 1)
     slot = wp.atomic_add(counter, 0, 1)
     output[slot] = tid
 
@@ -471,6 +489,32 @@ def test_counter_phase0_skips_unconsumed_bitwise_atomics(test, device):
             test.assertEqual(int(flag.numpy()[0]), 1)
             test.assertEqual(int(counter.numpy()[0]), 1)
             test.assertEqual(int(output.numpy()[0]), 0)
+
+
+def test_counter_function_parameter_unconsumed_atomic(test, device):
+    """Verify deterministic Function-parameter side-effect atomics.
+
+    This covers a two-pass deterministic counter kernel that calls a
+    ``wp.Function``-typed user function target performing an unconsumed bitwise
+    atomic. Specializing the Function target must preserve that the atomic
+    call's return value is unused, otherwise deterministic lowering treats the
+    side-effect atomic as consumed and rejects a valid kernel.
+    """
+    counter = wp.zeros(1, dtype=wp.int32, device=device)
+    flag = wp.zeros(1, dtype=wp.int32, device=device)
+    output = wp.full(1, value=-1, dtype=wp.int32, device=device)
+
+    wp.launch(
+        counter_with_function_parameter_atomic_xor_kernel,
+        dim=1,
+        inputs=[counter, flag],
+        outputs=[output],
+        device=device,
+    )
+
+    test.assertEqual(int(flag.numpy()[0]), 1)
+    test.assertEqual(int(counter.numpy()[0]), 1)
+    test.assertEqual(int(output.numpy()[0]), 0)
 
 
 def test_counter_consumed_bitwise_atomic_rejected(test, device):
@@ -974,6 +1018,7 @@ for _name in (
     "test_counter_phase0_suppresses_array_writes",
     "test_counter_phase0_preserves_local_scratch_writes",
     "test_counter_phase0_skips_unconsumed_bitwise_atomics",
+    "test_counter_function_parameter_unconsumed_atomic",
     "test_counter_consumed_bitwise_atomic_rejected",
     "test_counter_phase0_suppresses_component_stores",
     "test_counter_nonzero_initial_value",

--- a/warp/tests/test_func_parameter_targets.py
+++ b/warp/tests/test_func_parameter_targets.py
@@ -1,0 +1,832 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``wp.Function`` parameters in user-defined Warp functions.
+
+These tests live outside ``test_func.py`` because ``wp.Function`` parameter support
+needs a dedicated set of helper functions, kernels, module dependency checks,
+hashing checks, and rejection-path coverage. Keep future ``wp.Function``
+parameter tests in this module so ``test_func.py`` remains focused on general
+``@wp.func`` behavior.
+"""
+
+import unittest
+from typing import Any
+
+import numpy as np
+
+import warp as wp
+import warp.tests.aux_test_function_double as function_double_module
+import warp.tests.aux_test_function_triple as function_triple_module
+from warp.tests.unittest_utils import *
+
+
+# User-facing helpers used by the runtime tests below. Keep these examples close
+# to patterns a Warp user would write in kernels or user functions.
+@wp.func
+def function_double_it(x: float):
+    return x * 2.0
+
+
+@wp.func
+def function_triple_it(x: float):
+    return x * 3.0
+
+
+@wp.func
+def function_apply_unary(g: wp.Function, x: float):
+    return g(x)
+
+
+@wp.func
+def function_apply_generic(g: wp.Function, x: Any):
+    return g(x)
+
+
+@wp.func
+def function_apply_default(g: wp.Function = function_double_it, x: float = 3.0):
+    return g(x)
+
+
+@wp.func
+def function_apply_builtin_default(g: wp.Function = wp.sin, x: float = 0.5):
+    return g(x)
+
+
+@wp.func
+def function_apply_nested(x: float):
+    return function_apply_unary(function_double_it, x)
+
+
+@wp.func
+def function_apply_binary(g: wp.Function, x: float, y: float):
+    return g(x, y)
+
+
+@wp.func
+def function_apply_bound_parameter(g: wp.Function, x: float):
+    f = g
+    return f(x)
+
+
+@wp.func
+def function_square_it(x: float):
+    return x * x
+
+
+@wp.func
+def function_apply_for_grad(g: wp.Function, x: float):
+    return g(x)
+
+
+@wp.func
+def function_apply_builtin_for_grad(g: wp.Function, x: float):
+    return g(x)
+
+
+@wp.kernel
+def function_parameter_kernel(out: wp.array[float]):
+    out[0] = function_apply_unary(function_double_it, 3.0)
+    out[1] = function_apply_unary(function_triple_it, 4.0)
+    out[2] = function_apply_nested(7.0)
+    out[3] = function_apply_default()
+    out[4] = function_apply_unary(g=function_triple_it, x=8.0)
+    out[5] = function_apply_generic(function_double_it, 11.0)
+
+
+def test_function_parameter(test, device):
+    """Verify Function parameters accept common user-facing call patterns."""
+    out = wp.empty(6, dtype=float, device=device)
+
+    wp.launch(function_parameter_kernel, dim=1, outputs=[out], device=device)
+
+    assert_np_equal(
+        out.numpy(),
+        np.array([6.0, 12.0, 14.0, 6.0, 24.0, 22.0], dtype=np.float32),
+    )
+
+
+# ``wp.static()`` needs a global container so the kernel can resolve a function
+# target statically while exercising the local-binding composition path.
+FUNCTION_STATIC_TARGETS = {"double": function_double_it}
+
+
+@wp.kernel
+def function_parameter_local_binding_kernel(out: wp.array[float]):
+    f = function_double_it
+    out[0] = function_apply_unary(f, 3.0)
+
+    out[1] = function_apply_bound_parameter(function_triple_it, 4.0)
+
+    static_f = wp.static(FUNCTION_STATIC_TARGETS["double"])
+    out[2] = function_apply_unary(static_f, 5.0)
+
+
+def test_function_parameter_local_binding(test, device):
+    """Verify Function parameters compose with function-valued local aliases."""
+    out = wp.empty(3, dtype=float, device=device)
+
+    wp.launch(function_parameter_local_binding_kernel, dim=1, outputs=[out], device=device)
+
+    assert_np_equal(out.numpy(), np.array([6.0, 12.0, 10.0], dtype=np.float32))
+
+
+@wp.kernel
+def function_parameter_external_module_kernel(cond: wp.array(dtype=bool), out: wp.array(dtype=float)):
+    i = wp.tid()
+    if cond[i]:
+        out[i] = function_apply_unary(function_double_module.function_external_module_double_it, 3.0)
+    else:
+        out[i] = function_apply_unary(function_triple_module.function_external_module_triple_it, 3.0)
+
+
+def test_function_parameter_external_module(test, device):
+    """Verify Function parameters accept targets imported from Python modules."""
+    cond = wp.array([True, False], dtype=bool, device=device)
+    out = wp.empty(2, dtype=float, device=device)
+
+    wp.launch(function_parameter_external_module_kernel, dim=2, inputs=[cond], outputs=[out], device=device)
+
+    assert_np_equal(out.numpy(), np.array([6.0, 9.0], dtype=np.float32))
+
+
+@wp.kernel
+def function_builtin_parameter_kernel(out: wp.array(dtype=float)):
+    out[0] = function_apply_unary(wp.sin, 0.5)
+    out[1] = function_apply_unary(wp.sqrt, 9.0)
+    out[2] = function_apply_binary(wp.add, 2.0, 3.0)
+    out[3] = function_apply_binary(wp.min, 7.0, 4.0)
+    out[4] = function_apply_builtin_default()
+    out[5] = function_apply_unary(g=wp.cos, x=0.0)
+
+
+def test_function_builtin_parameter(test, device):
+    """Verify Function parameters accept simple built-in Warp functions."""
+    out = wp.empty(6, dtype=float, device=device)
+
+    wp.launch(function_builtin_parameter_kernel, dim=1, outputs=[out], device=device)
+
+    assert_np_equal(
+        out.numpy(),
+        np.array([np.sin(0.5), 3.0, 5.0, 4.0, np.sin(0.5), 1.0], dtype=np.float32),
+    )
+
+
+@wp.func
+def function_write_after_callable(g: wp.Function, dst: wp.ref[wp.float32], x: wp.float32):
+    dst = g(x)
+
+
+@wp.kernel(enable_backward=False)
+def function_ref_after_function_parameter_kernel(out: wp.array(dtype=wp.float32)):
+    function_write_after_callable(function_double_it, out[0], wp.float32(3.0))
+    function_write_after_callable(function_triple_it, out[1], wp.float32(4.0))
+
+
+def test_function_parameter_before_ref_parameter(test, device):
+    """Verify Function specialization preserves following wp.ref[T] arguments."""
+    out = wp.empty(2, dtype=wp.float32, device=device)
+
+    wp.launch(function_ref_after_function_parameter_kernel, dim=1, outputs=[out], device=device)
+
+    assert_np_equal(out.numpy(), np.array([6.0, 12.0], dtype=np.float32))
+
+
+# This global is intentionally mutated by
+# ``test_function_argument_target_affects_module_hash``. The kernel reads it as
+# a Function argument so the module hash must change when the target changes.
+FUNCTION_TARGET = function_double_it
+
+
+@wp.kernel
+def function_global_target_kernel(out: wp.array[float]):
+    out[0] = function_apply_unary(FUNCTION_TARGET, 3.0)
+
+
+FUNCTION_BUILTIN_TARGET = wp.sin
+
+
+@wp.kernel
+def function_builtin_global_target_kernel(out: wp.array[float]):
+    out[0] = function_apply_unary(FUNCTION_BUILTIN_TARGET, 0.5)
+
+
+@wp.kernel
+def function_default_target_kernel(out: wp.array[float]):
+    out[0] = function_apply_default()
+
+
+@wp.kernel
+def function_builtin_default_target_kernel(out: wp.array[float]):
+    out[0] = function_apply_builtin_default()
+
+
+FUNCTION_OVERLOAD_TARGET = function_double_it
+
+
+@wp.func
+def function_apply_overloaded(x: int):
+    return float(x)
+
+
+@wp.func
+def function_apply_overloaded(g: wp.Function, x: float):
+    return g(x)
+
+
+@wp.kernel
+def function_overloaded_global_target_kernel(out: wp.array[float]):
+    out[0] = function_apply_overloaded(FUNCTION_OVERLOAD_TARGET, 3.0)
+
+
+@wp.func
+def function_apply_overloaded_default(x: int):
+    return float(x)
+
+
+@wp.func
+def function_apply_overloaded_default(x: float, g: wp.Function = function_double_it):
+    return g(x)
+
+
+@wp.kernel
+def function_overloaded_default_target_kernel(out: wp.array[float]):
+    out[0] = function_apply_overloaded_default(3.0)
+
+
+@wp.kernel(enable_backward=False, module="unique")
+def function_grad_kernel(out: wp.array[float]):
+    out[0] = wp.grad(function_apply_for_grad)(function_square_it, 3.0)
+
+
+@wp.kernel(enable_backward=False, module="unique")
+def function_builtin_grad_kernel(out: wp.array[float]):
+    out[0] = wp.grad(function_apply_builtin_for_grad)(wp.sin, 0.5)
+
+
+@wp.func
+def function_read_array(arr: wp.array(dtype=float), i: int):
+    return arr[i]
+
+
+@wp.func
+def function_apply_array(g: wp.Function, arr: wp.array(dtype=float), i: int):
+    return g(arr, i)
+
+
+@wp.kernel(module="unique")
+def function_array_read_kernel(arr: wp.array(dtype=float), out: wp.array(dtype=float)):
+    out[0] = function_apply_array(function_read_array, arr, 0)
+
+
+# These explicit modules are part of the behavior under test. Function targets
+# from provider modules must be registered as dependencies of consumer modules so
+# provider unloads invalidate stale consumer kernels.
+FUNCTION_DEPENDENCY_EXPLICIT_PROVIDER_MODULE = wp.Module("function_dependency_explicit_provider")
+FUNCTION_DEPENDENCY_EXPLICIT_CONSUMER_MODULE = wp.Module("function_dependency_explicit_consumer")
+FUNCTION_DEPENDENCY_DEFAULT_PROVIDER_MODULE = wp.Module("function_dependency_default_provider")
+FUNCTION_DEPENDENCY_DEFAULT_CONSUMER_MODULE = wp.Module("function_dependency_default_consumer")
+FUNCTION_DEPENDENCY_LOCAL_PROVIDER_MODULE = wp.Module("function_dependency_local_provider")
+FUNCTION_DEPENDENCY_LOCAL_CONSUMER_MODULE = wp.Module("function_dependency_local_consumer")
+FUNCTION_DEPENDENCY_OVERLOAD_PROVIDER_MODULE = wp.Module("function_dependency_overload_provider")
+FUNCTION_DEPENDENCY_OVERLOAD_CONSUMER_MODULE = wp.Module("function_dependency_overload_consumer")
+FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_PROVIDER_MODULE = wp.Module("function_dependency_dynamic_overload_provider")
+FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_CONSUMER_MODULE = wp.Module("function_dependency_dynamic_overload_consumer")
+FUNCTION_DEPENDENCY_GRAD_PROVIDER_MODULE = wp.Module("function_dependency_grad_provider")
+FUNCTION_DEPENDENCY_GRAD_CONSUMER_MODULE = wp.Module("function_dependency_grad_consumer")
+FUNCTION_DEPENDENCY_EXTERNAL_CONSUMER_MODULE = wp.Module("function_dependency_external_consumer")
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_EXPLICIT_PROVIDER_MODULE)
+def function_dependency_explicit_target(x: float):
+    return x + 1.0
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_EXPLICIT_CONSUMER_MODULE)
+def function_dependency_apply_explicit(g: wp.Function, x: float):
+    return g(x)
+
+
+@wp.kernel(module=FUNCTION_DEPENDENCY_EXPLICIT_CONSUMER_MODULE)
+def function_dependency_explicit_kernel(out: wp.array[float]):
+    out[0] = function_dependency_apply_explicit(function_dependency_explicit_target, 2.0)
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_DEFAULT_PROVIDER_MODULE)
+def function_dependency_default_target(x: float):
+    return x + 1.0
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_DEFAULT_CONSUMER_MODULE)
+def function_dependency_apply_default(g: wp.Function = function_dependency_default_target, x: float = 2.0):
+    return g(x)
+
+
+@wp.kernel(module=FUNCTION_DEPENDENCY_DEFAULT_CONSUMER_MODULE)
+def function_dependency_default_kernel(out: wp.array[float]):
+    out[0] = function_dependency_apply_default()
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_LOCAL_PROVIDER_MODULE)
+def function_dependency_local_target(x: float):
+    return x + 1.0
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_LOCAL_CONSUMER_MODULE)
+def function_dependency_apply_local(g: wp.Function, x: float):
+    return g(x)
+
+
+@wp.kernel(module=FUNCTION_DEPENDENCY_LOCAL_CONSUMER_MODULE)
+def function_dependency_local_kernel(out: wp.array[float]):
+    f = function_dependency_local_target
+    out[0] = function_dependency_apply_local(f, 2.0)
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_OVERLOAD_PROVIDER_MODULE)
+def function_dependency_overload_target(x: float):
+    return x + 1.0
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_OVERLOAD_CONSUMER_MODULE)
+def function_dependency_apply_overload(x: int):
+    return float(x)
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_OVERLOAD_CONSUMER_MODULE)
+def function_dependency_apply_overload(g: wp.Function, x: float):
+    return g(x)
+
+
+@wp.kernel(module=FUNCTION_DEPENDENCY_OVERLOAD_CONSUMER_MODULE)
+def function_dependency_overload_kernel(out: wp.array[float]):
+    out[0] = function_dependency_apply_overload(function_dependency_overload_target, 2.0)
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_PROVIDER_MODULE)
+def function_dependency_dynamic_overload_double(x: float):
+    return x * 2.0
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_PROVIDER_MODULE)
+def function_dependency_dynamic_overload_triple(x: float):
+    return x * 3.0
+
+
+FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_TARGET = function_dependency_dynamic_overload_double
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_CONSUMER_MODULE)
+def function_dependency_apply_dynamic_overload(x: int):
+    return float(x)
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_CONSUMER_MODULE)
+def function_dependency_apply_dynamic_overload(g: wp.Function, x: float):
+    return g(x)
+
+
+@wp.kernel(module=FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_CONSUMER_MODULE)
+def function_dependency_dynamic_overload_kernel(vals: wp.array(dtype=float), out: wp.array(dtype=float)):
+    out[0] = function_dependency_apply_dynamic_overload(FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_TARGET, vals[0])
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_GRAD_PROVIDER_MODULE)
+def function_dependency_grad_square(x: float):
+    return x * x
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_GRAD_PROVIDER_MODULE)
+def function_dependency_grad_cube(x: float):
+    return x * x * x
+
+
+FUNCTION_DEPENDENCY_GRAD_TARGET = function_dependency_grad_square
+
+
+@wp.func(module=FUNCTION_DEPENDENCY_GRAD_CONSUMER_MODULE)
+def function_dependency_grad_apply(g: wp.Function, x: float):
+    return g(x)
+
+
+@wp.kernel(enable_backward=False, module=FUNCTION_DEPENDENCY_GRAD_CONSUMER_MODULE)
+def function_dependency_grad_nested_kernel(out: wp.array(dtype=float)):
+    out[0] = wp.grad(function_dependency_grad_apply)(FUNCTION_DEPENDENCY_GRAD_TARGET, 3.0)
+
+
+@wp.kernel(module=FUNCTION_DEPENDENCY_EXTERNAL_CONSUMER_MODULE)
+def function_dependency_external_module_kernel(cond: wp.array(dtype=bool), out: wp.array(dtype=float)):
+    i = wp.tid()
+    if cond[i]:
+        out[i] = function_apply_unary(function_double_module.function_external_module_double_it, 3.0)
+    else:
+        out[i] = function_apply_unary(function_triple_module.function_external_module_triple_it, 3.0)
+
+
+# These rejection fixtures live at module scope because custom grad and replay
+# hooks are registered against a concrete ``@wp.func`` object.
+@wp.func
+def function_custom_grad_unsupported(g: wp.Function, x: float):
+    return x
+
+
+@wp.func_grad(function_custom_grad_unsupported)
+def adj_function_custom_grad_unsupported(g: wp.Function, x: float, adj_ret: float):
+    wp.adjoint[x] += adj_ret
+
+
+@wp.func
+def function_custom_replay_unsupported(g: wp.Function, x: float):
+    return x
+
+
+@wp.func_replay(function_custom_replay_unsupported)
+def replay_function_custom_replay_unsupported(g: wp.Function, x: float):
+    return x
+
+
+class TestFuncParameterTargets(unittest.TestCase):
+    def test_function_annotation_accepts_warp_function(self):
+        """Verify ``wp.Function`` is the user-facing function annotation."""
+
+        @wp.func(module="unique")
+        def function_apply(g: wp.Function, x: float):
+            return g(x)
+
+        @wp.kernel(module="unique")
+        def function_apply_kernel(out: wp.array[float]):
+            out[0] = function_apply(function_double_it, 3.0)
+            out[1] = function_apply(wp.sin, 0.5)
+
+        out = wp.empty(2, dtype=float, device="cpu")
+
+        wp.launch(function_apply_kernel, dim=1, outputs=[out], device="cpu")
+
+        assert_np_equal(out.numpy(), np.array([6.0, np.sin(0.5)], dtype=np.float32))
+
+    def test_function_argument_target_affects_module_hash(self):
+        """Verify explicit Function targets participate in module hashes."""
+        global FUNCTION_TARGET
+
+        original_target = FUNCTION_TARGET
+        try:
+            FUNCTION_TARGET = function_double_it
+            double_hash = function_global_target_kernel.module.hash_module()
+
+            FUNCTION_TARGET = function_triple_it
+            triple_hash = function_global_target_kernel.module.hash_module()
+        finally:
+            FUNCTION_TARGET = original_target
+
+        self.assertNotEqual(double_hash, triple_hash)
+
+    def test_function_default_target_affects_module_hash(self):
+        """Verify default Function targets participate in module hashes."""
+        original_defaults = function_apply_default.defaults.copy()
+        try:
+            function_apply_default.defaults["g"] = function_double_it
+            double_hash = function_default_target_kernel.module.hash_module()
+
+            function_apply_default.defaults["g"] = function_triple_it
+            triple_hash = function_default_target_kernel.module.hash_module()
+        finally:
+            function_apply_default.defaults = original_defaults
+
+        self.assertNotEqual(double_hash, triple_hash)
+
+    def test_function_builtin_argument_target_affects_module_hash(self):
+        """Verify changing a global built-in Function target changes the module hash."""
+        global FUNCTION_BUILTIN_TARGET
+
+        original_target = FUNCTION_BUILTIN_TARGET
+        try:
+            FUNCTION_BUILTIN_TARGET = wp.sin
+            sin_hash = function_builtin_global_target_kernel.module.hash_module()
+
+            FUNCTION_BUILTIN_TARGET = wp.cos
+            cos_hash = function_builtin_global_target_kernel.module.hash_module()
+        finally:
+            FUNCTION_BUILTIN_TARGET = original_target
+
+        self.assertNotEqual(sin_hash, cos_hash)
+
+    def test_function_builtin_default_target_affects_module_hash(self):
+        """Verify changing a default built-in Function target changes the module hash."""
+        original_defaults = function_apply_builtin_default.defaults.copy()
+        try:
+            function_apply_builtin_default.defaults["g"] = wp.sin
+            sin_hash = function_builtin_default_target_kernel.module.hash_module()
+
+            function_apply_builtin_default.defaults["g"] = wp.cos
+            cos_hash = function_builtin_default_target_kernel.module.hash_module()
+        finally:
+            function_apply_builtin_default.defaults = original_defaults
+
+        self.assertNotEqual(sin_hash, cos_hash)
+
+    def test_function_overload_target_affects_module_hash(self):
+        """Verify changing a non-primary function overload target changes the module hash."""
+        global FUNCTION_OVERLOAD_TARGET
+
+        original_target = FUNCTION_OVERLOAD_TARGET
+        try:
+            FUNCTION_OVERLOAD_TARGET = function_double_it
+            double_hash = function_overloaded_global_target_kernel.module.hash_module()
+
+            FUNCTION_OVERLOAD_TARGET = function_triple_it
+            triple_hash = function_overloaded_global_target_kernel.module.hash_module()
+        finally:
+            FUNCTION_OVERLOAD_TARGET = original_target
+
+        self.assertNotEqual(double_hash, triple_hash)
+
+    def test_function_overload_default_target_affects_module_hash(self):
+        """Verify changing a non-primary function overload default changes the module hash."""
+        function_overload = function_apply_overloaded_default.get_overload([float], {})
+        original_defaults = function_overload.defaults.copy()
+        try:
+            function_overload.defaults["g"] = function_double_it
+            double_hash = function_overloaded_default_target_kernel.module.hash_module()
+
+            function_overload.defaults["g"] = function_triple_it
+            triple_hash = function_overloaded_default_target_kernel.module.hash_module()
+        finally:
+            function_overload.defaults = original_defaults
+
+        self.assertNotEqual(double_hash, triple_hash)
+
+    def test_function_dynamic_overload_target_affects_module_hash(self):
+        """Verify dynamic overload selectors keep Function targets in the module hash."""
+        global FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_TARGET
+
+        original_target = FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_TARGET
+        try:
+            FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_TARGET = function_dependency_dynamic_overload_double
+            double_hash = FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_CONSUMER_MODULE.hash_module()
+
+            FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_TARGET = function_dependency_dynamic_overload_triple
+            triple_hash = FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_CONSUMER_MODULE.hash_module()
+        finally:
+            FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_TARGET = original_target
+
+        self.assertNotEqual(double_hash, triple_hash)
+
+    def test_function_grad_target_affects_module_hash(self):
+        """Verify Function targets passed through wp.grad() affect the module hash."""
+        global FUNCTION_DEPENDENCY_GRAD_TARGET
+
+        original_target = FUNCTION_DEPENDENCY_GRAD_TARGET
+        try:
+            FUNCTION_DEPENDENCY_GRAD_TARGET = function_dependency_grad_square
+            square_hash = FUNCTION_DEPENDENCY_GRAD_CONSUMER_MODULE.hash_module()
+
+            FUNCTION_DEPENDENCY_GRAD_TARGET = function_dependency_grad_cube
+            cube_hash = FUNCTION_DEPENDENCY_GRAD_CONSUMER_MODULE.hash_module()
+        finally:
+            FUNCTION_DEPENDENCY_GRAD_TARGET = original_target
+
+        self.assertNotEqual(square_hash, cube_hash)
+
+    def test_function_grad_call(self):
+        """Verify wp.grad() specializes functions with Function targets."""
+
+        out = wp.empty(1, dtype=float, device="cpu")
+
+        wp.launch(function_grad_kernel, dim=1, outputs=[out], device="cpu")
+
+        assert_np_equal(out.numpy(), np.array([6.0], dtype=np.float32))
+
+    def test_function_builtin_grad_call(self):
+        """Verify wp.grad() specializes functions with built-in Function targets."""
+
+        out = wp.empty(1, dtype=float, device="cpu")
+
+        wp.launch(function_builtin_grad_kernel, dim=1, outputs=[out], device="cpu")
+
+        assert_np_equal(out.numpy(), np.array([np.cos(0.5)], dtype=np.float32))
+
+    def test_function_target_array_read_tracks_access(self):
+        """Verify Function target array reads propagate to tape access tracking."""
+
+        original = wp.config.verify_autograd_array_access
+        wp.config.verify_autograd_array_access = True
+        try:
+            arr = wp.array([2.0], dtype=float, device="cpu")
+            out = wp.empty(1, dtype=float, device="cpu")
+
+            with wp.Tape():
+                wp.launch(function_array_read_kernel, dim=1, inputs=[arr], outputs=[out], device="cpu")
+
+            self.assertTrue(arr._is_read)
+        finally:
+            wp.config.verify_autograd_array_access = original
+
+    def test_function_wrong_return_annotation_reports_error(self):
+        """Verify Function calls report annotated return type errors."""
+
+        @wp.func
+        def function_wrong_return_annotation(g: wp.Function, x: float) -> int:
+            return g(x)
+
+        @wp.kernel(module="unique")
+        def function_wrong_return_annotation_kernel(out: wp.array[float]):
+            out[0] = float(function_wrong_return_annotation(function_double_it, 2.0))
+
+        out = wp.empty(1, dtype=float, device="cpu")
+
+        with self.assertRaisesRegex(
+            wp.WarpCodegenError,
+            r"The function `function_wrong_return_annotation` has its return type "
+            r"annotated as `int` but the code returns a value of type `float32`.",
+        ):
+            wp.launch(function_wrong_return_annotation_kernel, dim=1, outputs=[out], device="cpu")
+
+    def test_function_argument_target_updates_module_dependents(self):
+        """Verify Function targets register provider modules as dependencies.
+
+        Explicit arguments, default arguments, and kernel-local aliases exercise
+        the paths where function targets can otherwise be missed during module
+        reference discovery.
+        """
+
+        def unload_recursive(module, visited):
+            module.unload()
+            visited.add(module)
+            for dependent in module.dependents:
+                if dependent not in visited:
+                    unload_recursive(dependent, visited)
+
+        def no_inputs():
+            return []
+
+        cases = (
+            (
+                "explicit",
+                FUNCTION_DEPENDENCY_EXPLICIT_PROVIDER_MODULE,
+                FUNCTION_DEPENDENCY_EXPLICIT_CONSUMER_MODULE,
+                function_dependency_explicit_kernel,
+                no_inputs,
+                3.0,
+            ),
+            (
+                "default",
+                FUNCTION_DEPENDENCY_DEFAULT_PROVIDER_MODULE,
+                FUNCTION_DEPENDENCY_DEFAULT_CONSUMER_MODULE,
+                function_dependency_default_kernel,
+                no_inputs,
+                3.0,
+            ),
+            (
+                "local",
+                FUNCTION_DEPENDENCY_LOCAL_PROVIDER_MODULE,
+                FUNCTION_DEPENDENCY_LOCAL_CONSUMER_MODULE,
+                function_dependency_local_kernel,
+                no_inputs,
+                3.0,
+            ),
+            (
+                "overload",
+                FUNCTION_DEPENDENCY_OVERLOAD_PROVIDER_MODULE,
+                FUNCTION_DEPENDENCY_OVERLOAD_CONSUMER_MODULE,
+                function_dependency_overload_kernel,
+                no_inputs,
+                3.0,
+            ),
+            (
+                "dynamic overload",
+                FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_PROVIDER_MODULE,
+                FUNCTION_DEPENDENCY_DYNAMIC_OVERLOAD_CONSUMER_MODULE,
+                function_dependency_dynamic_overload_kernel,
+                lambda: [wp.array([2.0], dtype=float, device="cpu")],
+                4.0,
+            ),
+            (
+                "grad",
+                FUNCTION_DEPENDENCY_GRAD_PROVIDER_MODULE,
+                FUNCTION_DEPENDENCY_GRAD_CONSUMER_MODULE,
+                function_dependency_grad_nested_kernel,
+                no_inputs,
+                6.0,
+            ),
+        )
+
+        for name, provider_module, consumer_module, kernel, make_inputs, expected in cases:
+            with self.subTest(name=name):
+                out = wp.empty(1, dtype=float, device="cpu")
+                wp.launch(kernel, dim=1, inputs=make_inputs(), outputs=[out], device="cpu")
+
+                assert_np_equal(out.numpy(), np.array([expected], dtype=np.float32))
+                self.assertIn(provider_module, consumer_module.references)
+                self.assertIn(consumer_module, provider_module.dependents)
+                self.assertTrue(consumer_module.hashers)
+
+                unload_recursive(provider_module, visited=set())
+
+                self.assertFalse(consumer_module.hashers)
+
+    def test_function_external_module_targets_update_dependents(self):
+        """Verify module-qualified Function targets register provider modules."""
+
+        def unload_recursive(module, visited):
+            module.unload()
+            visited.add(module)
+            for dependent in module.dependents:
+                if dependent not in visited:
+                    unload_recursive(dependent, visited)
+
+        cond = wp.array([True, False], dtype=bool, device="cpu")
+        out = wp.empty(2, dtype=float, device="cpu")
+
+        wp.launch(function_dependency_external_module_kernel, dim=2, inputs=[cond], outputs=[out], device="cpu")
+
+        assert_np_equal(out.numpy(), np.array([6.0, 9.0], dtype=np.float32))
+
+        consumer_module = FUNCTION_DEPENDENCY_EXTERNAL_CONSUMER_MODULE
+        provider_modules = (
+            function_double_module.function_external_module_double_it.module,
+            function_triple_module.function_external_module_triple_it.module,
+        )
+
+        for provider_module in provider_modules:
+            self.assertIn(provider_module, consumer_module.references)
+            self.assertIn(consumer_module, provider_module.dependents)
+
+        self.assertTrue(consumer_module.hashers)
+
+        unload_recursive(provider_modules[0], visited=set())
+
+        self.assertFalse(consumer_module.hashers)
+
+    def test_function_custom_grad_rejected(self):
+        """Verify Function-specialized functions reject custom grad and replay hooks."""
+
+        @wp.kernel(module="unique")
+        def custom_grad_rejection_kernel(out: wp.array[float]):
+            out[0] = function_custom_grad_unsupported(function_double_it, 2.0)
+
+        @wp.kernel(module="unique")
+        def custom_replay_rejection_kernel(out: wp.array[float]):
+            out[0] = function_custom_replay_unsupported(function_double_it, 2.0)
+
+        for kernel in (custom_grad_rejection_kernel, custom_replay_rejection_kernel):
+            with self.subTest(kernel=kernel.key):
+                out = wp.empty(1, dtype=float, device="cpu")
+
+                with self.assertRaisesRegex(
+                    wp.WarpCodegenError,
+                    "Function parameters.*custom gradients or replay functions",
+                ):
+                    wp.launch(kernel, dim=1, outputs=[out], device="cpu")
+
+    def test_function_non_regular_builtin_target_rejected(self):
+        """Verify Function parameters reject built-ins that need special dispatch."""
+
+        @wp.kernel(module="unique")
+        def function_non_regular_builtin_target_kernel(out: wp.array[float]):
+            out[0] = function_apply_unary(wp.printf, 0.5)
+
+        out = wp.empty(1, dtype=float, device="cpu")
+
+        with self.assertRaisesRegex(
+            wp.WarpCodegenError,
+            "unsupported built-in function 'printf'",
+        ):
+            wp.launch(function_non_regular_builtin_target_kernel, dim=1, outputs=[out], device="cpu")
+
+
+devices = get_test_devices()
+
+add_function_test(
+    TestFuncParameterTargets,
+    func=test_function_parameter,
+    name="test_function_parameter",
+    devices=devices,
+)
+add_function_test(
+    TestFuncParameterTargets,
+    func=test_function_parameter_local_binding,
+    name="test_function_parameter_local_binding",
+    devices=devices,
+)
+add_function_test(
+    TestFuncParameterTargets,
+    func=test_function_parameter_external_module,
+    name="test_function_parameter_external_module",
+    devices=devices,
+)
+add_function_test(
+    TestFuncParameterTargets,
+    func=test_function_builtin_parameter,
+    name="test_function_builtin_parameter",
+    devices=devices,
+)
+add_function_test(
+    TestFuncParameterTargets,
+    func=test_function_parameter_before_ref_parameter,
+    name="test_function_parameter_before_ref_parameter",
+    devices=devices,
+)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -184,6 +184,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.test_fast_math import TestFastMath
     from warp.tests.test_fp16 import TestFp16
     from warp.tests.test_func import TestFunc
+    from warp.tests.test_func_parameter_targets import TestFuncParameterTargets
     from warp.tests.test_future_annotations import TestFutureAnnotations
     from warp.tests.test_generics import TestGenerics
     from warp.tests.test_grad import TestGrad
@@ -332,6 +333,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestFemShape,
         TestFp16,
         TestFunc,
+        TestFuncParameterTargets,
         TestFutureAnnotations,
         TestGenerics,
         TestGrad,
@@ -487,6 +489,7 @@ def debug_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader):
     from warp.tests.test_fast_math import TestFastMath
     from warp.tests.test_fp16 import TestFp16
     from warp.tests.test_func import TestFunc
+    from warp.tests.test_func_parameter_targets import TestFuncParameterTargets
     from warp.tests.test_generics import TestGenerics
     from warp.tests.test_grad import TestGrad
     from warp.tests.test_grad_customs import TestGradCustoms
@@ -524,6 +527,7 @@ def debug_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader):
         TestEnum,
         TestFastMath,
         TestFunc,
+        TestFuncParameterTargets,
         TestGenerics,
         TestMath,
         TestModuleHashing,


### PR DESCRIPTION
## Description

Closes #1424.

This PR adds phase-one support for annotating user-defined `@wp.func` function parameters with `wp.Function`. A `wp.Function` parameter names a Warp function selected at specialization time, so helper functions can call user-defined or supported built-in Warp functions passed by kernels or other functions.

Function targets are specialization inputs, not runtime values. User functions are specialized for the concrete target, function parameters are omitted from generated runtime signatures, and targets participate in module hashing and dependency invalidation.

## Changes

- Add `wp.Function` as the public annotation for function-valued user function parameters.
- Specialize user-defined functions for targets passed through explicit arguments, keyword arguments, defaults, local aliases, nested calls, and `wp.static(...)`.
- Allow supported simple built-in Warp functions such as `wp.sin()`, `wp.sqrt()`, `wp.add()`, and `wp.min()` as function targets.
- Include function targets in module hashes and dependency discovery so rebinding or unloading provider modules invalidates dependent generated code.
- Update generated stubs, user guide docs, limitations, changelog, and focused regression coverage in `warp/tests/test_func_parameter_targets.py`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Function parameter coverage lives in `warp/tests/test_func_parameter_targets.py` and is included in the default and debug unittest suites. The suite covers user-defined targets, simple built-in targets, defaults, keyword arguments, generic helpers, local aliases, nested calls, `wp.static(...)` targets, `wp.grad()` specialization, target return validation, module hashing, and dependency invalidation across imported provider modules.

Validation performed:

- `WARP_CACHE_PATH=/tmp/warp-cache-function-rename-module uv run warp/tests/test_func_parameter_targets.py`
- `WARP_CACHE_PATH=/tmp/warp-cache-function-rename-suite uv run --extra dev -m warp.tests -s autodetect -k TestFuncParameterTargets`
- `WARP_CACHE_PATH=/tmp/warp-cache-function-rename-precommit uvx pre-commit run --files CHANGELOG.md docs/user_guide/basics.rst docs/user_guide/limitations.rst warp/__init__.pyi warp/_src/codegen.py warp/_src/context.py warp/_src/types.py warp/tests/unittest_suites.py warp/tests/aux_test_function_double.py warp/tests/aux_test_function_triple.py warp/tests/test_func_parameter_targets.py`
- `WARP_CACHE_PATH=/tmp/warp-cache-function-marker-docs uv run --extra docs build_docs.py 2>&1 | tee /tmp/build_docs.log`

## Bug fix

Without this PR, Warp functions cannot be passed through user-defined `@wp.func` helpers like this:

```python
import warp as wp


@wp.func
def double_it(x: float):
    return x * 2.0


@wp.func
def apply(g: wp.Function, x: float):
    return g(x)


@wp.kernel
def k(out: wp.array[float]):
    out[0] = apply(double_it, 3.0)
```

## New feature / enhancement

`wp.Function` parameters can be used for generic helpers that dispatch to different Warp function targets at specialization time:

```python
import warp as wp


@wp.func
def square(x: float):
    return x * x


@wp.func
def cube(x: float):
    return x * x * x


@wp.func
def apply(g: wp.Function, x: float):
    return g(x)


@wp.kernel
def k(values: wp.array[float], square_out: wp.array[float], cube_out: wp.array[float]):
    i = wp.tid()
    x = values[i]
    square_out[i] = apply(square, x)
    cube_out[i] = apply(g=cube, x=x)
```
