### PR TITLE
Add CUDA build matrix

### DIFF
--- a/.github/workflows/build-warp-builder-images.yml
+++ b/.github/workflows/build-warp-builder-images.yml
@@ -38,15 +38,15 @@ jobs:
             manylinux: manylinux_2_34_aarch64
             manylinux_image: quay.io/pypa/manylinux_2_34_aarch64:latest
             targetarch: aarch64
-          # CUDA 13.2.0 builds
-          - cuda_version: '13.2.0'
+          # CUDA 13.0.2 builds
+          - cuda_version: '13.0.2'
             arch: x86_64
             runner: ubuntu-latest
             platform: linux/amd64
             manylinux: manylinux_2_28_x86_64
             manylinux_image: quay.io/pypa/manylinux_2_28_x86_64:latest
             targetarch: x86_64
-          - cuda_version: '13.2.0'
+          - cuda_version: '13.0.2'
             arch: aarch64
             runner: ubuntu-24.04-arm
             platform: linux/arm64
@@ -150,10 +150,10 @@ jobs:
           - cuda_version: '12.9.1'
             arch: aarch64
             runner: ubuntu-24.04-arm
-          - cuda_version: '13.2.0'
+          - cuda_version: '13.0.2'
             arch: x86_64
             runner: ubuntu-latest
-          - cuda_version: '13.2.0'
+          - cuda_version: '13.0.2'
             arch: aarch64
             runner: ubuntu-24.04-arm
     
@@ -249,7 +249,7 @@ jobs:
           IMAGE_BASE="ghcr.io/${OWNER_LOWER}/warp-builder"
           
           # Create manifests for both CUDA versions
-          for CUDA_VERSION in "12.9.1" "13.2.0"; do
+          for CUDA_VERSION in "12.9.1" "13.0.2"; do
             BASE_TAG="cuda${CUDA_VERSION}-llvm${LLVM_VERSION_MAJOR}"
             CUDA_MAJOR=$(echo ${CUDA_VERSION} | cut -d. -f1)
             
@@ -274,8 +274,8 @@ jobs:
           # Create :latest pointing to CUDA 13
           echo "Creating :latest tag (points to CUDA 13)..."
           docker buildx imagetools create -t ${IMAGE_BASE}:latest \
-            ${IMAGE_BASE}:cuda13.2.0-llvm${LLVM_VERSION_MAJOR}-x86_64-latest \
-            ${IMAGE_BASE}:cuda13.2.0-llvm${LLVM_VERSION_MAJOR}-aarch64-latest
+            ${IMAGE_BASE}:cuda13.0.2-llvm${LLVM_VERSION_MAJOR}-x86_64-latest \
+            ${IMAGE_BASE}:cuda13.0.2-llvm${LLVM_VERSION_MAJOR}-aarch64-latest
           
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -290,7 +290,7 @@ jobs:
           IMAGE_BASE="ghcr.io/${OWNER_LOWER}/warp-builder"
           
           # Just verify they exist, don't clutter summary with inspect output
-          for CUDA_VERSION in "12.9.1" "13.2.0"; do
+          for CUDA_VERSION in "12.9.1" "13.0.2"; do
             CUDA_MAJOR=$(echo ${CUDA_VERSION} | cut -d. -f1)
             docker buildx imagetools inspect ${IMAGE_BASE}:cuda${CUDA_MAJOR} > /dev/null
             echo "✅ Verified :cuda${CUDA_MAJOR} manifest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,44 @@ jobs:
         include:
           - os: windows-2025
             platform: windows
+            cuda-version: "12.9.1"
+            artifact-name: build-artifact-windows-cuda12
+            cuda-sub-packages: '["cudart", "nvcc", "nvrtc_dev", "nvjitlink"]'
+            cuda-non-cuda-packages: ''
+          - os: windows-2025
+            platform: windows
+            cuda-version: "13.0.2"
+            artifact-name: build-artifact-windows-cuda13
             cuda-sub-packages: '["cudart", "nvcc", "nvrtc_dev", "nvjitlink"]'
             cuda-non-cuda-packages: ''
           - os: ubuntu-24.04
             platform: ubuntu-x86_64
+            cuda-version: "12.9.1"
+            artifact-name: build-artifact-ubuntu-x86_64-cuda12
+            cuda-sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
+            cuda-non-cuda-packages: '["libnvjitlink-dev"]'
+          - os: ubuntu-24.04
+            platform: ubuntu-x86_64
+            cuda-version: "13.0.2"
+            artifact-name: build-artifact-ubuntu-x86_64-cuda13
             cuda-sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
             cuda-non-cuda-packages: '["libnvjitlink-dev"]'
           - os: ubuntu-24.04-arm
             platform: ubuntu-aarch64
+            cuda-version: "12.9.1"
+            artifact-name: build-artifact-ubuntu-aarch64-cuda12
+            cuda-sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
+            cuda-non-cuda-packages: '["libnvjitlink-dev"]'
+          - os: ubuntu-24.04-arm
+            platform: ubuntu-aarch64
+            cuda-version: "13.0.2"
+            artifact-name: build-artifact-ubuntu-aarch64-cuda13
             cuda-sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
             cuda-non-cuda-packages: '["libnvjitlink-dev"]'
           - os: macos-latest
             platform: macos
+            cuda-version: ''
+            artifact-name: build-artifact-macos
             cuda-sub-packages: ''
             cuda-non-cuda-packages: ''
     steps:
@@ -64,20 +90,22 @@ jobs:
         id: cache-build
         with:
           path: warp/bin/
-          key: build-${{ matrix.platform }}-${{ hashFiles('build_lib.py', 'warp/build_dll.py', 'build_llvm.py', 'warp/native/**/*.cpp', 'warp/native/**/*.cu', 'warp/native/**/*.h', 'deps/libmathdx-deps.packman.xml') }}
+          key: build-${{ matrix.artifact-name }}-${{ matrix.cuda-version }}-${{ hashFiles('build_lib.py', 'warp/build_dll.py', 'build_llvm.py', 'warp/native/**/*.cpp', 'warp/native/**/*.cu', 'warp/native/**/*.h', 'deps/libmathdx-deps.packman.xml') }}
       
       - name: Install CTK (with non-CUDA packages)
         if: steps.cache-build.outputs.cache-hit != 'true' && matrix.cuda-sub-packages != '' && matrix.cuda-non-cuda-packages != ''
-        uses: Jimver/cuda-toolkit@1a3c14e26833ccf292b268f9a790fb47dea7b2da
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
         with:
+          cuda: ${{ matrix.cuda-version }}
           sub-packages: ${{ matrix.cuda-sub-packages }}
           non-cuda-sub-packages: ${{ matrix.cuda-non-cuda-packages }}
           method: 'network'
       
       - name: Install CTK (without non-CUDA packages)
         if: steps.cache-build.outputs.cache-hit != 'true' && matrix.cuda-sub-packages != '' && matrix.cuda-non-cuda-packages == ''
-        uses: Jimver/cuda-toolkit@c35baa1a18fd1fc9dcf47c5bd839bf30559c0bc3  # https://github.com/Jimver/cuda-toolkit/issues/395
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
         with:
+          cuda: ${{ matrix.cuda-version }}
           sub-packages: ${{ matrix.cuda-sub-packages }}
           method: 'network'
       
@@ -88,7 +116,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifact-${{ matrix.platform }}
+          name: ${{ matrix.artifact-name }}
           path: warp/bin/
           retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
       
@@ -105,12 +133,16 @@ jobs:
         include:
           - os: windows-2025
             platform: windows
+            artifact-name: build-artifact-windows-cuda12
           - os: ubuntu-24.04
             platform: ubuntu-x86_64
+            artifact-name: build-artifact-ubuntu-x86_64-cuda13
           - os: ubuntu-24.04-arm
             platform: ubuntu-aarch64
+            artifact-name: build-artifact-ubuntu-aarch64-cuda13
           - os: macos-latest
             platform: macos
+            artifact-name: build-artifact-macos
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -128,7 +160,7 @@ jobs:
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-${{ matrix.platform }}
+          name: ${{ matrix.artifact-name }}
           path: warp/bin/
       
       - name: Run Tests
@@ -165,7 +197,7 @@ jobs:
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-ubuntu-x86_64
+          name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
       
       - name: Run Debug Mode Tests (CPU)
@@ -285,7 +317,7 @@ jobs:
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-ubuntu-x86_64
+          name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
 
       - name: Run Tests
@@ -373,7 +405,7 @@ jobs:
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-ubuntu-x86_64
+          name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
 
       - name: Run Tests
@@ -442,7 +474,7 @@ jobs:
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-windows
+          name: build-artifact-windows-cuda12
           path: warp/bin/
 
       - name: Run Tests
@@ -539,7 +571,7 @@ jobs:
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-ubuntu-x86_64
+          name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
 
       - name: Run doctest
@@ -565,7 +597,7 @@ jobs:
       - name: Download Warp binaries
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-ubuntu-x86_64
+          name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
       - name: Build Sphinx documentation
         run: |
@@ -612,7 +644,7 @@ jobs:
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-ubuntu-x86_64
+          name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
       - name: Check for un-namespaced symbols
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             platform: windows
             cuda-version: "13.0.2"
             artifact-name: build-artifact-windows-cuda13
-            cuda-sub-packages: '["cudart", "nvcc", "nvrtc_dev", "nvjitlink"]'
+            cuda-sub-packages: '["cudart", "crt", "nvcc", "nvrtc_dev", "nvjitlink"]'
             cuda-non-cuda-packages: ''
           - os: ubuntu-24.04
             platform: ubuntu-x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             platform: windows
             cuda-version: "13.0.2"
             artifact-name: build-artifact-windows-cuda13
-            cuda-sub-packages: '["cudart", "crt", "nvcc", "nvrtc_dev", "nvjitlink"]'
+            cuda-sub-packages: '["cudart", "crt", "nvcc", "nvrtc_dev", "nvjitlink", "nvvm", "nvptxcompiler"]'
             cuda-non-cuda-packages: ''
           - os: ubuntu-24.04
             platform: ubuntu-x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,8 +277,19 @@ jobs:
         include:
           - runner-label: linux-amd64-gpu-h100-latest-1
             gpu-name: h100
+            artifact-name: build-artifact-ubuntu-x86_64-cuda13
+            torch-extra: torch-cu13
+            jax-extra: jax[cuda13]
           - runner-label: linux-amd64-gpu-rtxpro6000-latest-1
             gpu-name: rtxpro6000
+            artifact-name: build-artifact-ubuntu-x86_64-cuda13
+            torch-extra: torch-cu13
+            jax-extra: jax[cuda13]
+          - runner-label: linux-amd64-gpu-l4-earliest-1
+            gpu-name: l4
+            artifact-name: build-artifact-ubuntu-x86_64-cuda12
+            torch-extra: torch-cu12
+            jax-extra: jax[cuda12]
     container:
       image: ubuntu:24.04
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
@@ -317,11 +328,11 @@ jobs:
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-ubuntu-x86_64-cuda13
+          name: ${{ matrix.artifact-name }}
           path: warp/bin/
 
       - name: Run Tests
-        run: uv run --extra dev --extra torch-cu13 --with "jax[cuda13]" -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
+        run: uv run --extra dev --extra ${{ matrix.torch-extra }} --with "${{ matrix.jax-extra }}" -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
 
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,7 +485,7 @@ jobs:
       - name: Download Warp build artifact
         uses: actions/download-artifact@v4
         with:
-          name: build-artifact-windows-cuda12
+          name: build-artifact-windows-cuda13
           path: warp/bin/
 
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,7 +479,7 @@ jobs:
 
       - name: Run Tests
         # Pin usd-core to 25.5.1 to work around a frequent loading crash on Windows.
-        run: uv run --extra dev --extra torch-cu12 --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
+        run: uv run --extra dev --extra torch-cu13 --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
 
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4

--- a/docker/warp-builder/Dockerfile
+++ b/docker/warp-builder/Dockerfile
@@ -5,7 +5,7 @@
 # Supports both x86_64 and aarch64
 # This version builds LLVM from source, making it fully self-contained
 
-ARG CUDA_VERSION=13.2.0
+ARG CUDA_VERSION=13.0.2
 ARG MANYLINUX_IMAGE=quay.io/pypa/manylinux_2_28_x86_64:latest
 FROM ${MANYLINUX_IMAGE} AS base
 

--- a/docker/warp-builder/README.md
+++ b/docker/warp-builder/README.md
@@ -87,16 +87,16 @@ docker run --rm -it \
 
 **Short aliases (recommended for most users):**
 
-- `latest` - Latest build with newest CUDA version
-- `cuda13` - Latest CUDA 13.x build (currently 13.2.0 with LLVM 21)
+- `latest` - Default CUDA 13 build
+- `cuda13` - Selected CUDA 13.x build (currently 13.0.2 with LLVM 21)
 - `cuda12` - Latest CUDA 12.x build (currently 12.9.1 with LLVM 21)
 
 **Full version tags (for reproducibility):**
 
-- `cuda13.2.0-llvm21-latest` - Multi-arch, always current
-- `cuda13.2.0-llvm21-20241129` - Multi-arch, date-pinned
-- `cuda13.2.0-llvm21-x86_64-latest` - Architecture-specific
-- `cuda13.2.0-llvm21-aarch64-latest` - Architecture-specific
+- `cuda13.0.2-llvm21-latest` - Multi-arch, always current
+- `cuda13.0.2-llvm21-20241129` - Multi-arch, date-pinned
+- `cuda13.0.2-llvm21-x86_64-latest` - Architecture-specific
+- `cuda13.0.2-llvm21-aarch64-latest` - Architecture-specific
 
 **Examples:**
 
@@ -160,13 +160,13 @@ If you cannot access published images, you can build them locally:
 ```bash
 cd docker/warp-builder
 docker buildx build --platform linux/amd64 -t warp-builder:cuda13 -f Dockerfile \
-  --build-arg CUDA_VERSION=13.2.0 --load .
+  --build-arg CUDA_VERSION=13.0.2 --load .
 ```
 
 ## Image Contents
 
 - **Base:** manylinux_2_28 (x86_64) / manylinux_2_34 (aarch64)
-- **CUDA:** Configurable (supports 12.x and 13.x, default 13.2.0)
+- **CUDA:** Configurable (supports 12.x and 13.x, default 13.0.2)
   - Installed using NVIDIA's [parse_redist.py](https://github.com/NVIDIA/build-system-archive-import-examples) script to pull only the minimal components needed for building Warp
 - **LLVM:** Compiled from source at `/opt/llvm` (default 21.1.0)
 - **Python:** Managed by uv
@@ -181,7 +181,7 @@ Images are automatically built by the workflow at `.github/workflows/build-warp-
 **Each workflow run builds:**
 
 - CUDA 12.9.1 (x86_64 + aarch64)
-- CUDA 13.2.0 (x86_64 + aarch64)
+- CUDA 13.0.2 (x86_64 + aarch64)
 - All 4 builds run in parallel (~60 minutes total)
 
 **To trigger a rebuild:**

--- a/docker/warp-builder/README.md
+++ b/docker/warp-builder/README.md
@@ -94,7 +94,7 @@ docker run --rm -it \
 **Full version tags (for reproducibility):**
 
 - `cuda13.0.2-llvm21-latest` - Multi-arch, always current
-- `cuda13.0.2-llvm21-20241129` - Multi-arch, date-pinned
+- `cuda13.0.2-llvm21-YYYYMMDD` - Multi-arch, date-pinned workflow build
 - `cuda13.0.2-llvm21-x86_64-latest` - Architecture-specific
 - `cuda13.0.2-llvm21-aarch64-latest` - Architecture-specific
 
@@ -108,8 +108,10 @@ docker pull ghcr.io/nvidia/warp-builder:cuda13
 docker pull ghcr.io/nvidia/warp-builder:cuda13.0.2-llvm21-latest
 
 # Pinned to exact build date
-docker pull ghcr.io/nvidia/warp-builder:cuda13.0.2-llvm21-20241129
+docker pull ghcr.io/nvidia/warp-builder:cuda13.0.2-llvm21-YYYYMMDD
 ```
+
+Replace `YYYYMMDD` with the date from a published workflow build.
 
 All multi-arch tags work on both x86_64 and aarch64.
 

--- a/warp/examples/fem/example_kelvin_helmholtz.py
+++ b/warp/examples/fem/example_kelvin_helmholtz.py
@@ -511,7 +511,7 @@ class Example:
         self.renderer.add_field("rho", self.rho_field)
 
         # Capture CUDA graph for the simulation step
-        self.use_cuda_graph = wp.get_device().is_cuda
+        self.use_cuda_graph = wp.get_device().is_cuda and wp.is_conditional_graph_supported()
         if self.use_cuda_graph:
             with wp.ScopedCapture() as capture:
                 self.simulate()

--- a/warp/examples/fem/example_shallow_water.py
+++ b/warp/examples/fem/example_shallow_water.py
@@ -434,7 +434,7 @@ class Example:
         self.renderer.add_field("height", self.height_field)
 
         # Capture CUDA graph for the simulation step
-        self.use_cuda_graph = wp.get_device().is_cuda
+        self.use_cuda_graph = wp.get_device().is_cuda and wp.is_conditional_graph_supported()
         if self.use_cuda_graph:
             with wp.ScopedCapture() as capture:
                 self.simulate()

--- a/warp/examples/fem/example_taylor_green.py
+++ b/warp/examples/fem/example_taylor_green.py
@@ -557,7 +557,7 @@ class Example:
         # reduced launch overhead.  Before each replay, step() computes
         # the time-dependent BC contributions into the working buffers
         # (_u_bd_rhs_buf, _p_rhs) that the graph references.
-        self.use_cuda_graph = wp.get_device().is_cuda
+        self.use_cuda_graph = wp.get_device().is_cuda and wp.is_conditional_graph_supported()
         if self.use_cuda_graph:
             import gc  # noqa: PLC0415
 
@@ -649,7 +649,7 @@ class Example:
             x=self._saddle_x,
             tol=1.0e-6,
             check_every=0,
-            use_cuda_graph=True,
+            use_cuda_graph=self.use_cuda_graph,
             M=saddle.preconditioner,
         )
 

--- a/warp/examples/tile/example_tile_mlp.py
+++ b/warp/examples/tile/example_tile_mlp.py
@@ -195,6 +195,8 @@ class Example:
         loss = wp.zeros(1, dtype=float, requires_grad=True)
         output = create_array(IMG_WIDTH * IMG_HEIGHT, DIM_OUT)
 
+        wp.load_module(module=compute.module, device=wp.get_device(), block_dim=NUM_THREADS)
+
         # capture graph for whole epoch
         wp.capture_begin()
 

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -557,9 +557,24 @@ add_function_test(
     test_save_apic_false_error,
     devices=devices_with_cuda_graph_module_load,
 )
-add_function_test(TestApic, "test_save_single_kernel", test_save_single_kernel, devices=devices)
-add_function_test(TestApic, "test_save_load_round_trip", test_save_load_round_trip, devices=devices)
-add_function_test(TestApic, "test_save_load_multiple_kernels", test_save_load_multiple_kernels, devices=devices)
+add_function_test(
+    TestApic,
+    "test_save_single_kernel",
+    test_save_single_kernel,
+    devices=devices_with_cuda_graph_module_load,
+)
+add_function_test(
+    TestApic,
+    "test_save_load_round_trip",
+    test_save_load_round_trip,
+    devices=devices_with_cuda_graph_module_load,
+)
+add_function_test(
+    TestApic,
+    "test_save_load_multiple_kernels",
+    test_save_load_multiple_kernels,
+    devices=devices_with_cuda_graph_module_load,
+)
 add_function_test(TestApic, "test_save_load_memcpy", test_save_load_memcpy, devices=devices)
 add_function_test(TestApic, "test_save_load_memset", test_save_load_memset, devices=devices)
 add_function_test(
@@ -593,8 +608,18 @@ add_function_test(
     test_graph_execution_unchanged,
     devices=devices_with_cuda_graph_module_load,
 )
-add_function_test(TestApic, "test_save_load_with_param_update", test_save_load_with_param_update, devices=devices)
-add_function_test(TestApic, "test_save_load_memcpy_and_kernel", test_save_load_memcpy_and_kernel, devices=devices)
+add_function_test(
+    TestApic,
+    "test_save_load_with_param_update",
+    test_save_load_with_param_update,
+    devices=devices_with_cuda_graph_module_load,
+)
+add_function_test(
+    TestApic,
+    "test_save_load_memcpy_and_kernel",
+    test_save_load_memcpy_and_kernel,
+    devices=devices_with_cuda_graph_module_load,
+)
 add_function_test(
     TestApic, "test_save_load_fill", test_save_load_fill, devices=get_cuda_test_devices()
 )  # CPU: wp_memtile_host not recorded

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -14,7 +14,9 @@ from warp.tests.unittest_utils import (
     add_function_test,
     get_cuda_test_devices,
     get_test_devices,
+    get_test_devices_with_cuda_graph_module_load,
     get_test_devices_with_mempool,
+    get_test_devices_with_mempool_and_cuda_graph_module_load,
 )
 
 
@@ -546,31 +548,58 @@ def test_get_param_ptr(test, device):
 
 devices = get_test_devices()
 devices_with_mempool = get_test_devices_with_mempool()
+devices_with_cuda_graph_module_load = get_test_devices_with_cuda_graph_module_load()
+devices_with_mempool_and_cuda_graph_module_load = get_test_devices_with_mempool_and_cuda_graph_module_load()
 
-add_function_test(TestApic, "test_save_apic_false_error", test_save_apic_false_error, devices=devices)
+add_function_test(
+    TestApic,
+    "test_save_apic_false_error",
+    test_save_apic_false_error,
+    devices=devices_with_cuda_graph_module_load,
+)
 add_function_test(TestApic, "test_save_single_kernel", test_save_single_kernel, devices=devices)
 add_function_test(TestApic, "test_save_load_round_trip", test_save_load_round_trip, devices=devices)
 add_function_test(TestApic, "test_save_load_multiple_kernels", test_save_load_multiple_kernels, devices=devices)
 add_function_test(TestApic, "test_save_load_memcpy", test_save_load_memcpy, devices=devices)
 add_function_test(TestApic, "test_save_load_memset", test_save_load_memset, devices=devices)
-add_function_test(TestApic, "test_bindings_param_update", test_bindings_param_update, devices=devices)
+add_function_test(
+    TestApic,
+    "test_bindings_param_update",
+    test_bindings_param_update,
+    devices=devices_with_cuda_graph_module_load,
+)
 add_function_test(TestApic, "test_array_slicing", test_array_slicing, devices=devices)
-add_function_test(TestApic, "test_complex_pipeline", test_complex_pipeline, devices=devices)
-add_function_test(TestApic, "test_internal_allocation", test_internal_allocation, devices=devices_with_mempool)
+add_function_test(
+    TestApic,
+    "test_complex_pipeline",
+    test_complex_pipeline,
+    devices=devices_with_cuda_graph_module_load,
+)
+add_function_test(
+    TestApic,
+    "test_internal_allocation",
+    test_internal_allocation,
+    devices=devices_with_mempool_and_cuda_graph_module_load,
+)
 add_function_test(
     TestApic,
     "test_multiple_internal_allocations",
     test_multiple_internal_allocations,
-    devices=devices_with_mempool,
+    devices=devices_with_mempool_and_cuda_graph_module_load,
 )
-add_function_test(TestApic, "test_graph_execution_unchanged", test_graph_execution_unchanged, devices=devices)
+add_function_test(
+    TestApic,
+    "test_graph_execution_unchanged",
+    test_graph_execution_unchanged,
+    devices=devices_with_cuda_graph_module_load,
+)
 add_function_test(TestApic, "test_save_load_with_param_update", test_save_load_with_param_update, devices=devices)
 add_function_test(TestApic, "test_save_load_memcpy_and_kernel", test_save_load_memcpy_and_kernel, devices=devices)
 add_function_test(
     TestApic, "test_save_load_fill", test_save_load_fill, devices=get_cuda_test_devices()
 )  # CPU: wp_memtile_host not recorded
 add_function_test(TestApic, "test_save_load_alloc_only", test_save_load_alloc_only, devices=devices_with_mempool)
-add_function_test(TestApic, "test_get_param_ptr", test_get_param_ptr, devices=devices)
+add_function_test(TestApic, "test_get_param_ptr", test_get_param_ptr, devices=devices_with_cuda_graph_module_load)
 
 
 if __name__ == "__main__":

--- a/warp/tests/test_apic_mesh.py
+++ b/warp/tests/test_apic_mesh.py
@@ -15,7 +15,7 @@ import unittest
 import numpy as np
 
 import warp as wp
-from warp.tests.unittest_utils import add_function_test, get_test_devices
+from warp.tests.unittest_utils import add_function_test, get_test_devices_with_cuda_graph_module_load
 
 
 def create_unit_cube_mesh(device):
@@ -563,7 +563,7 @@ class TestApicMesh(unittest.TestCase):
     pass
 
 
-devices = get_test_devices()
+devices = get_test_devices_with_cuda_graph_module_load()
 
 add_function_test(TestApicMesh, "test_apic_mesh_query_point", test_apic_mesh_query_point, devices=devices)
 add_function_test(TestApicMesh, "test_apic_mesh_query_ray", test_apic_mesh_query_ray, devices=devices)

--- a/warp/tests/test_graph.py
+++ b/warp/tests/test_graph.py
@@ -11,6 +11,7 @@ import warp as wp
 from warp.tests.unittest_utils import (
     add_function_test,
     get_test_devices,
+    get_test_devices_with_cuda_graph_module_load,
     get_test_devices_with_mempool_and_cuda_graph_module_load,
 )
 
@@ -163,11 +164,27 @@ def test_graph_alloc(test, device):
 
 
 devices = get_test_devices()
+devices_with_cuda_graph_module_load = get_test_devices_with_cuda_graph_module_load()
 devices_with_mempool_and_cuda_graph_module_load = get_test_devices_with_mempool_and_cuda_graph_module_load()
 
-add_function_test(TestGraph, "test_graph_single_kernel", test_graph_single_kernel, devices=devices)
-add_function_test(TestGraph, "test_graph_multiple_kernels", test_graph_multiple_kernels, devices=devices)
-add_function_test(TestGraph, "test_graph_replay_multiple", test_graph_replay_multiple, devices=devices)
+add_function_test(
+    TestGraph,
+    "test_graph_single_kernel",
+    test_graph_single_kernel,
+    devices=devices_with_cuda_graph_module_load,
+)
+add_function_test(
+    TestGraph,
+    "test_graph_multiple_kernels",
+    test_graph_multiple_kernels,
+    devices=devices_with_cuda_graph_module_load,
+)
+add_function_test(
+    TestGraph,
+    "test_graph_replay_multiple",
+    test_graph_replay_multiple,
+    devices=devices_with_cuda_graph_module_load,
+)
 add_function_test(TestGraph, "test_graph_memcpy", test_graph_memcpy, devices=devices)
 add_function_test(TestGraph, "test_graph_memset", test_graph_memset, devices=devices)
 add_function_test(

--- a/warp/tests/test_graph.py
+++ b/warp/tests/test_graph.py
@@ -8,7 +8,11 @@ import unittest
 import numpy as np
 
 import warp as wp
-from warp.tests.unittest_utils import add_function_test, get_test_devices, get_test_devices_with_mempool
+from warp.tests.unittest_utils import (
+    add_function_test,
+    get_test_devices,
+    get_test_devices_with_mempool_and_cuda_graph_module_load,
+)
 
 
 @wp.kernel
@@ -159,14 +163,19 @@ def test_graph_alloc(test, device):
 
 
 devices = get_test_devices()
-devices_with_mempool = get_test_devices_with_mempool()
+devices_with_mempool_and_cuda_graph_module_load = get_test_devices_with_mempool_and_cuda_graph_module_load()
 
 add_function_test(TestGraph, "test_graph_single_kernel", test_graph_single_kernel, devices=devices)
 add_function_test(TestGraph, "test_graph_multiple_kernels", test_graph_multiple_kernels, devices=devices)
 add_function_test(TestGraph, "test_graph_replay_multiple", test_graph_replay_multiple, devices=devices)
 add_function_test(TestGraph, "test_graph_memcpy", test_graph_memcpy, devices=devices)
 add_function_test(TestGraph, "test_graph_memset", test_graph_memset, devices=devices)
-add_function_test(TestGraph, "test_graph_alloc", test_graph_alloc, devices=devices_with_mempool)
+add_function_test(
+    TestGraph,
+    "test_graph_alloc",
+    test_graph_alloc,
+    devices=devices_with_mempool_and_cuda_graph_module_load,
+)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/warp/tests/test_reload.py
+++ b/warp/tests/test_reload.py
@@ -277,6 +277,7 @@ def test_module_unload_during_graph_capture(test, device):
 
 devices = get_test_devices()
 cuda_devices = get_cuda_test_devices()
+devices_with_cuda_graph_module_load = get_test_devices_with_cuda_graph_module_load()
 
 
 class TestReload(unittest.TestCase):
@@ -290,10 +291,16 @@ add_function_test(TestReload, "test_reload_class", test_reload_class, devices=de
 # TODO: test_reload_references sometimes has issues running on cuda:1
 add_function_test(TestReload, "test_reload_references", test_reload_references, devices=get_test_devices("basic"))
 add_function_test(
-    TestReload, "test_graph_launch_after_module_reload", test_graph_launch_after_module_reload, devices=devices
+    TestReload,
+    "test_graph_launch_after_module_reload",
+    test_graph_launch_after_module_reload,
+    devices=devices_with_cuda_graph_module_load,
 )
 add_function_test(
-    TestReload, "test_module_unload_during_graph_capture", test_module_unload_during_graph_capture, devices=devices
+    TestReload,
+    "test_module_unload_during_graph_capture",
+    test_module_unload_during_graph_capture,
+    devices=devices_with_cuda_graph_module_load,
 )
 
 

--- a/warp/tests/unittest_utils.py
+++ b/warp/tests/unittest_utils.py
@@ -136,6 +136,27 @@ def get_test_devices_with_mempool(mode: str | None = None):
     return [d for d in get_test_devices(mode) if not d.is_cuda or d.is_mempool_supported]
 
 
+def is_cuda_graph_module_load_supported(device) -> bool:
+    """Return whether modules can be loaded during CUDA graph capture."""
+    driver_version = wp.get_cuda_driver_version()
+    return not device.is_cuda or (driver_version is not None and driver_version >= (12, 3))
+
+
+def get_test_devices_with_cuda_graph_module_load(mode: str | None = None):
+    """Like :func:`get_test_devices`, but drops CUDA devices using drivers older than 12.3.
+
+    CUDA module loading during graph capture requires a driver supporting CUDA
+    12.3 or newer. CPU devices pass through unchanged because CPU graph capture
+    uses APIC recording rather than CUDA driver graph capture.
+    """
+    return [d for d in get_test_devices(mode) if is_cuda_graph_module_load_supported(d)]
+
+
+def get_test_devices_with_mempool_and_cuda_graph_module_load(mode: str | None = None):
+    """Like :func:`get_test_devices_with_mempool`, but also gates CUDA graph module loading."""
+    return [d for d in get_test_devices_with_mempool(mode) if is_cuda_graph_module_load_supported(d)]
+
+
 def get_cuda_test_devices_with_mempool(mode=None):
     """Like :func:`get_cuda_test_devices`, but drops CUDA devices without memory pool support.
 


### PR DESCRIPTION
## Description

This PR expands GitHub Actions build coverage so the main CI workflow builds Warp with both CUDA 12.9.1 and CUDA 13.0.2 on Windows, Linux x86_64, and Linux aarch64. It also keeps the builder-image workflow and Docker docs aligned on CUDA 13.0.2 instead of 13.2.0, avoiding newer CUDA 13 toolchains while a Blackwell compiler issue remains unresolved.

The existing test jobs continue to consume the current intended artifacts: Linux and Linux ARM use CUDA 13.0.2 builds, Windows uses CUDA 12.9.1 builds. The newly added opposite-version artifacts are build-only coverage in this first pass.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `uv run --with ruamel.yaml python - <<'PY' ...` to parse `.github/workflows/ci.yml` and `.github/workflows/build-warp-builder-images.yml`
- `uv run --with ruamel.yaml python - <<'PY' ...` to verify all `download-artifact` build refs resolve to produced artifact names
- `git diff HEAD~1..HEAD --check`
- `uvx pre-commit run --files .github/workflows/ci.yml .github/workflows/build-warp-builder-images.yml docker/warp-builder/Dockerfile docker/warp-builder/README.md`

## New feature / enhancement

This enables CI build artifacts for CUDA 12 and CUDA 13 across the primary GitHub Actions build platforms without adding new GPU test lanes in the same pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated builder and CI to use CUDA 13.0.2 (replacing 13.2.0).
  * CI now builds, names, caches, and publishes CUDA-versioned artifacts across OS/architectures; tests/downloads select artifacts by CUDA-versioned names.
  * Multi-arch manifest publishing updated to include CUDA 12.9.1 and 13.0.2; `:latest` now points to CUDA 13.0.2.

* **Documentation**
  * Updated builder docs and local build instructions to reflect CUDA 13.0.2 as the default.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1455)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->