### PR TITLE
ci: enable auto_sync_draft for copy-pr-bot

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,3 +1,3 @@
 enabled: true
-auto_sync_draft: false
+auto_sync_draft: true
 auto_sync_ready: true


### PR DESCRIPTION
Flips `auto_sync_draft` to `true` in `.github/copy-pr-bot.yaml` so draft PRs are auto-synced by copy-pr-bot.

Intentionally left as a draft to confirm the new setting picks up the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic synchronization for draft pull requests in the repository workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1457)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->