### PR TITLE
Use job-level Codecov flags

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,3 +4,7 @@ coverage:
     patch: off
 
 comment: false
+
+flag_management:
+  default_rules:
+    carryforward: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ name: CI
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
   workflow_dispatch:
   push:
     tags:
@@ -349,7 +352,7 @@ jobs:
           disable_search: true
           files: ./rspec.xml
           report_type: test_results
-          flags: unittests,linux,${{ matrix.gpu-name }}
+          flags: test-warp-gpu-linux-${{ matrix.gpu-name }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage reports to Codecov
@@ -359,7 +362,7 @@ jobs:
         with:
           disable_search: true
           files: ./coverage.xml
-          flags: unittests,linux,${{ matrix.gpu-name }}
+          flags: test-warp-gpu-linux-${{ matrix.gpu-name }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-warp-gpu-linux-mgpu-python310:
@@ -437,7 +440,7 @@ jobs:
           disable_search: true
           files: ./rspec.xml
           report_type: test_results
-          flags: unittests,linux,rtxpro6000,mgpu,py310
+          flags: test-warp-gpu-linux-mgpu-python310
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage reports to Codecov
@@ -447,7 +450,7 @@ jobs:
         with:
           disable_search: true
           files: ./coverage.xml
-          flags: unittests,linux,rtxpro6000,mgpu,py310
+          flags: test-warp-gpu-linux-mgpu-python310
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-warp-gpu-windows:
@@ -507,7 +510,7 @@ jobs:
           disable_search: true
           files: ./rspec.xml
           report_type: test_results
-          flags: unittests,windows,rtxpro6000
+          flags: test-warp-gpu-windows-rtxpro6000
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage reports to Codecov
@@ -517,7 +520,7 @@ jobs:
         with:
           disable_search: true
           files: ./coverage.xml
-          flags: unittests,windows,rtxpro6000
+          flags: test-warp-gpu-windows-rtxpro6000
           token: ${{ secrets.CODECOV_TOKEN }}
 
   # Validate Sphinx doctests (RST testcode blocks and autodoc-extracted docstrings)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,6 +27,8 @@ jobs:
   # - Symbol namespace validation
   ci:
     uses: ./.github/workflows/ci.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Static analysis with cppcheck (runs independently, doesn't need build artifacts)
   cppcheck:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -446,10 +446,6 @@ linux-x86_64 test:
     - export WARP_DISABLE_P2P_TESTS=1
   script:
     - uv run --extra dev --extra torch-cu12 --with "jax[cuda12]" -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
-    # Upload report to Codecov
-    - git config --global --add safe.directory $CI_PROJECT_DIR
-    - uvx --from codecov-cli codecovcli --verbose upload-process --git-service github --disable-search -t $CODECOV_TOKEN -r NVIDIA/warp --plugin pycoverage -F unittests -f coverage.xml
-    - uvx --from codecov-cli codecovcli --verbose upload-process --git-service github --disable-search -t $CODECOV_TOKEN -r NVIDIA/warp --report-type test_results -f rspec.xml
 
 # A temporary job for testing on Blackwell until more runners are available
 linux-x86_64-blackwell test:
@@ -503,12 +499,6 @@ windows-x86_64 test:
     - |
       $env:PATH = "$env:CI_PROJECT_DIR\_uv;$env:PATH"
       uv run --extra dev --extra torch-cu12 --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
-    # Upload report to Codecov
-    - git config --global --add safe.directory $env:CI_PROJECT_DIR
-    - |
-      & "$env:CI_PROJECT_DIR\_uv\uvx.exe" --from codecov-cli codecovcli --verbose upload-process --git-service github --disable-search -t $CODECOV_TOKEN -r NVIDIA/warp --plugin pycoverage -F unittests -f coverage.xml
-    - |
-      & "$env:CI_PROJECT_DIR\_uv\uvx.exe" --from codecov-cli codecovcli --verbose upload-process --git-service github --disable-search -t $CODECOV_TOKEN -r NVIDIA/warp --report-type test_results -f rspec.xml
 
 # Optional multi-GPU Windows job (likely longer queue time)
 windows-x86_64 test mgpu:


### PR DESCRIPTION
## Description

This PR updates Codecov reporting so GitHub coverage uploads are grouped by the CI job that produced them. The GPU coverage jobs now use one job-level flag per upload instead of overlapping test/platform/hardware flags.

It also enables Codecov flag management with `carryforward: false`, keeps the existing non-blocking Codecov behavior, removes Codecov CLI uploads from GitLab CI, and passes repository secrets into the reusable GitHub CI workflow used by copied PR branches.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `curl --silent --show-error --fail --data-binary @.github/codecov.yml https://codecov.io/validate`
- `git diff --check -- .github/workflows/pr.yml .github/workflows/ci.yml .gitlab-ci.yml .github/codecov.yml`
- `uvx pre-commit run --files .github/workflows/pr.yml .github/workflows/ci.yml .gitlab-ci.yml .github/codecov.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Codecov flag management to stop carrying forward flag rules across runs.
  * Standardized GPU/platform test coverage flags and updated CI to forward Codecov credentials into reusable workflows.
  * Removed inline Codecov upload steps from CI jobs and disabled P2P tests in the Linux test job.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1465)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->