### PR TITLE
Fix L4 CUDA graph capture tests

### DIFF
--- a/warp/tests/test_array.py
+++ b/warp/tests/test_array.py
@@ -3859,7 +3859,7 @@ def test_graph_fill_vecmat(test, device):
         captures = []
         for i, arr in enumerate(arrays):
             scalar_value = i + 1
-            with wp.ScopedCapture() as capture:
+            with wp.ScopedCapture(force_module_load=False) as capture:
                 _fill_vecmat(arr, scalar_value)
             captures.append(capture)
 

--- a/warp/tests/test_graph.py
+++ b/warp/tests/test_graph.py
@@ -646,7 +646,7 @@ def test_cuda_graph_topo_alloc_sequential(test, device):
     #   node2
 
     with wp.ScopedDevice(device):
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             alloc1 = _insert_alloc()
             node1 = _insert_node()
             alloc2 = _insert_alloc()
@@ -679,7 +679,7 @@ def test_cuda_graph_topo_alloc_sequential_free(test, device):
     #   node3
 
     with wp.ScopedDevice(device):
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             alloc1 = _insert_alloc()
             node1 = _insert_node()
             free1 = _insert_free(alloc1)
@@ -711,7 +711,7 @@ def test_cuda_graph_topo_alloc_side_stream_independent(test, device):
     #   node2
 
     with wp.ScopedDevice(device):
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             node1 = _insert_node()
             with wp.ScopedStream(wp.Stream()):
                 alloc = _insert_alloc()
@@ -740,7 +740,7 @@ def test_cuda_graph_topo_alloc_side_stream_independent_free(test, device):
 
     with wp.ScopedDevice(device):
         stream1 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             node1 = _insert_node()
             with wp.ScopedStream(stream1):
                 alloc = _insert_alloc()
@@ -772,7 +772,7 @@ def test_cuda_graph_topo_alloc_side_stream_joined(test, device):
     with wp.ScopedDevice(device) as device:
         stream0 = device.stream
         stream1 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             node1 = _insert_node()
             with wp.ScopedStream(stream1):
                 alloc = _insert_alloc()
@@ -803,7 +803,7 @@ def test_cuda_graph_topo_alloc_fork(test, device):
 
     with wp.ScopedDevice(device):
         stream1 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             alloc1 = _insert_alloc()
             node1 = _insert_node()
             # fork
@@ -844,7 +844,7 @@ def test_cuda_graph_topo_alloc_fork_free_on_main(test, device):
 
     with wp.ScopedDevice(device):
         stream1 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             alloc1 = _insert_alloc()
             node1 = _insert_node()
             # fork
@@ -892,7 +892,7 @@ def test_cuda_graph_topo_alloc_fork_free_on_side(test, device):
 
     with wp.ScopedDevice(device):
         stream1 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             alloc1 = _insert_alloc()
             node1 = _insert_node()
             # fork
@@ -931,7 +931,7 @@ def test_cuda_graph_topo_alloc_parallel_streams(test, device):
     with wp.ScopedDevice(device):
         stream1 = wp.Stream()
         stream2 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             with wp.ScopedStream(stream1):
                 alloc1 = _insert_alloc()
                 node1 = _insert_node()
@@ -962,7 +962,7 @@ def test_cuda_graph_topo_alloc_parallel_streams_free_on_sides(test, device):
     with wp.ScopedDevice(device):
         stream1 = wp.Stream()
         stream2 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             with wp.ScopedStream(stream1):
                 alloc1 = _insert_alloc()
                 node1 = _insert_node()
@@ -997,7 +997,7 @@ def test_cuda_graph_topo_alloc_parallel_streams_free_on_main(test, device):
     with wp.ScopedDevice(device):
         stream1 = wp.Stream()
         stream2 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             with wp.ScopedStream(stream1):
                 alloc1 = _insert_alloc()
                 node1 = _insert_node()
@@ -1033,7 +1033,7 @@ def test_cuda_graph_topo_alloc_parallel_streams_free_on_other(test, device):
         stream1 = wp.Stream()
         stream2 = wp.Stream()
         stream3 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             with wp.ScopedStream(stream1):
                 alloc1 = _insert_alloc()
                 node1 = _insert_node()
@@ -1079,7 +1079,7 @@ def test_cuda_graph_topo_alloc_parallel_streams_joined(test, device):
         stream0 = device.stream
         stream1 = wp.Stream()
         stream2 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             with wp.ScopedStream(stream1):
                 alloc1 = _insert_alloc()
                 node1 = _insert_node()
@@ -1131,7 +1131,7 @@ def test_cuda_graph_topo_alloc_nested_streams_chain(test, device):
     with wp.ScopedDevice(device):
         stream1 = wp.Stream()
         stream2 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             alloc1 = _insert_alloc()
             node1 = _insert_node()
             with wp.ScopedStream(stream1):
@@ -1176,7 +1176,7 @@ def test_cuda_graph_topo_alloc_nested_streams_chain_free(test, device):
     with wp.ScopedDevice(device):
         stream1 = wp.Stream()
         stream2 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             alloc1 = _insert_alloc()
             node1 = _insert_node()
             with wp.ScopedStream(stream1):
@@ -1220,7 +1220,7 @@ def test_cuda_graph_topo_alloc_free_serializes_dependent_streams_only(test, devi
         stream2 = wp.Stream()
         stream3 = wp.Stream()
         stream4 = wp.Stream()
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             # stream1 and stream2 are independent of the alloc
             with wp.ScopedStream(stream1):
                 node1 = _insert_node()


### PR DESCRIPTION
## Description

This PR fixes intermittent GitHub L4 CUDA graph failures. On CUDA
drivers older than 12.3, graph capture forces module loading. Reused
parallel test workers can still have expected-failing codegen modules
registered, so unrelated graph topology tests fail while preloading them.

The affected captures only exercise graph allocation topology or replay
behavior, so they now pass `force_module_load=False`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- [x] `uv run -m unittest warp.tests.test_array.TestArray.test_graph_fill_vecmat_cuda_0 warp.tests.test_graph.TestGraph.test_cuda_graph_topo_alloc_sequential_cuda_0 warp.tests.test_graph.TestGraph.test_cuda_graph_topo_alloc_fork_cuda_0 warp.tests.test_graph.TestGraph.test_cuda_graph_topo_alloc_free_serializes_dependent_streams_only_cuda_0`
- [x] `uv run -m unittest warp.tests.test_graph.TestGraph`
- [x] `uvx pre-commit run --files warp/tests/test_array.py warp/tests/test_graph.py`
- [x] Forced old-driver contamination repro for the graph topology and fill captures.

## Bug fix

The failure requires a reused test worker on a CUDA driver older than 12.3. The focused repro runs a negative codegen test first, forces `runtime.driver_version = (12, 2)`, then runs an affected CUDA graph capture test in the same process.

## New feature / enhancement

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated graph capture tests to use explicit module loading configuration across array and graph test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->