### PR TITLE
Reject non-None kernel return annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@
   ([GH-1466](https://github.com/NVIDIA/warp/issues/1466)).
 - Fix tile byte-offset overflow for arrays larger than 2 GiB
   ([GH-1422](https://github.com/NVIDIA/warp/issues/1422)).
+- Raise an error when a kernel is defined with a non-`None` return annotation ([GH-1471](https://github.com/NVIDIA/warp/issues/1471)).
 
 ### Documentation
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2288,6 +2288,12 @@ class ModuleBuilder:
         if kernel.adj.return_var is not None:
             raise WarpCodegenTypeError(f"'{kernel.key}': Error, kernels can't have return values")
 
+        if kernel.adj.arg_types.get("return") is not None:
+            raise WarpCodegenTypeError(
+                f"'{kernel.key}': Error, kernels can't have return values; "
+                "write results to output arguments and either omit the return annotation or use '-> None'"
+            )
+
     def build_function(self, func):
         if func in self.functions:
             return

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -565,13 +565,16 @@ def test_error_kernel_return_value(test, device):
     with test.assertRaisesRegex(wp.WarpCodegenTypeError, r".*Error, kernels can't have return values"):
         wp.launch(f3, dim=1, inputs=[3.0], device=device)
 
-    # TODO: specifying a return type without returning a value is benign, but should be reported to avoid confusion
-    # @wp.kernel
-    # def f4(x: float) -> float:
-    #     return
+    @wp.kernel(module="unique")
+    def f4(x: float) -> float:
+        return
 
-    # with test.assertRaisesRegex(wp.WarpCodegenTypeError, r".*Error, kernels can't have return values"):
-    #     wp.launch(f4, dim=1, inputs=[3.0], device=device)
+    with test.assertRaisesRegex(
+        wp.WarpCodegenTypeError,
+        r".*Error, kernels can't have return values; "
+        r"write results to output arguments and either omit the return annotation or use '-> None'",
+    ):
+        wp.launch(f4, dim=1, inputs=[3.0], device=device)
 
 
 def test_error_mutating_constant_in_dynamic_loop(test, device):


### PR DESCRIPTION
## Description

Raises an error when a kernel has a non-`None` return annotation. Closes #1471.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

Tested on CPU with:

```bash
uv run warp/tests/test_codegen.py TestCodeGen.test_error_kernel_return_value_cpu
```

## Bug fix

Previously, the `float` return annotation was silently ignored by Warp:

```python
import warp as wp

@wp.kernel
def annotated_kernel(x: float) -> float:
    return

wp.launch(annotated_kernel, dim=1, inputs=[1.0], device="cpu")
```

This PR makes that code raise:

```text
WarpCodegenTypeError: 'annotated_kernel': Error, kernels can't have return values; write results to output arguments and either omit the return annotation or use '-> None'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kernels with non-None return type annotations now raise a clear error, with guidance to write results to output arguments or use a None return.

* **Documentation**
  * Changelog updated with an Unreleased entry describing the behavior change.

* **Tests**
  * Tests updated to cover and assert the new error behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->