### PR TITLE
Fix binding a Warp function to a kernel-local (GH-1423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,11 @@
   ([GH-1422](https://github.com/NVIDIA/warp/issues/1422)).
 - Fix an intermittent failure when loading modules in parallel with `wp.force_load(max_workers > 1)` that could cause
   modules sharing a `@wp.func` to fail to compile or load ([GH-1474](https://github.com/NVIDIA/warp/issues/1474)).
+- Fix binding a Warp function to a kernel-local variable, so patterns like ``f = my_func``,
+  ``f = module.my_func``, ``f = wp.static(...)`` returning a function, and ``wp.grad(f)`` where
+  ``f`` is such a local now compile and call correctly instead of failing during codegen.
+  Rebinding a function-valued local to a different function or to a non-function value raises a clear error
+  ([GH-1423](https://github.com/NVIDIA/warp/issues/1423)).
 
 ### Documentation
 

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -2318,6 +2318,12 @@ class Adjoint:
         return output
 
     def emit_Name(adj, node):
+        # a static expression that resolved to a Warp function is rewritten to an `__warp_func__`
+        # Name node carrying the function on `warp_func` (see StaticExpressionReplacer). Return it
+        # directly so it can be bound to a local, e.g. `func = wp.static(...)`.
+        if hasattr(node, "warp_func"):
+            return node.warp_func
+
         # lookup symbol, if it has already been assigned to a variable then return the existing mapping
         if node.id in adj.symbols:
             return adj.symbols[node.id]
@@ -3316,8 +3322,34 @@ class Adjoint:
                 adj.symbols[name] = rhs
                 return
 
+            # handle Warp functions specially - bind the name directly to the function
+            # so later calls through the local resolve to it. This covers `f = my_func`,
+            # `f = mod.func`, and `f = wp.static(...)` returning a function. Without this the
+            # function would be routed through Var-shaped logic and miscompiled.
+            if isinstance(rhs, warp._src.context.Function):
+                if name in adj.symbols and isinstance(adj.symbols[name], warp._src.context.Function):
+                    if adj.symbols[name] is not rhs:
+                        raise WarpCodegenError(
+                            f"Error, rebinding function-valued local '{name}' to a different function is not "
+                            "supported. Warp does not have function pointers, so a local bound to a function "
+                            "must refer to the same function throughout the kernel."
+                        )
+                adj.symbols[name] = rhs
+                return
+
             # check type matches if symbol already defined
             if name in adj.symbols:
+                # a local previously bound to a function cannot be reassigned to a value. Warp does
+                # not have function pointers, so a mixed function/value local has no codegen-able
+                # meaning. Guard here before the generic type check below, which would otherwise read
+                # `adj.symbols[name].type` and fail with an opaque AttributeError on the Function.
+                if isinstance(adj.symbols[name], warp._src.context.Function):
+                    raise WarpCodegenError(
+                        f"Error, rebinding function-valued local '{name}' to a non-function value is not "
+                        "supported. Warp does not have function pointers, so a local bound to a function "
+                        "must refer to a function throughout the kernel."
+                    )
+
                 if not types_equal(strip_reference(rhs.type), adj.symbols[name].type):
                     raise WarpCodegenTypeError(
                         f"Error, assigning to existing symbol {name} ({adj.symbols[name].type}) with different type ({rhs.type})"
@@ -4462,6 +4494,16 @@ class Adjoint:
                     types[func] = None
 
             elif isinstance(node, ast.Assign):
+                # A function bound to a local (`f = mod.func`) or to several locals via tuple
+                # unpacking (`f, g = mod.a, mod.b`) is referenced only through the local(s)
+                # afterwards, so it would otherwise be missed here and left out of the module
+                # hash. Register each bound function explicitly to keep the hash sound.
+                rhs_nodes = node.value.elts if isinstance(node.value, ast.Tuple) else [node.value]
+                for rhs_node in rhs_nodes:
+                    rhs_func, _ = adj.resolve_static_expression(rhs_node, eval_types=False)
+                    if isinstance(rhs_func, warp._src.context.Function) and not rhs_func.is_builtin():
+                        functions[rhs_func] = None
+
                 # Add the LHS names to the local_variables so we know any subsequent uses are shadowed
                 lhs = node.targets[0]
                 if isinstance(lhs, ast.Tuple):

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2817,6 +2817,23 @@ class Module:
                     # and that's ok too (not an external reference).
                     pass
 
+            elif isinstance(node, ast.Assign):
+                # A function bound to a kernel-local (`f = mod.func`) or to several locals via
+                # tuple unpacking (`f, g = mod.a, mod.b`) is later called through the local(s),
+                # so the ast.Call above resolves to the local rather than to the function.
+                # Resolve each right-hand side here so the dependency on the bound function's
+                # module is still registered, mirroring Adjoint.get_references. Without this,
+                # reloading the bound function's module would not unload the dependent kernel
+                # and a stale executable could be reused.
+                rhs_nodes = node.value.elts if isinstance(node.value, ast.Tuple) else [node.value]
+                for rhs_node in rhs_nodes:
+                    try:
+                        rhs_func, _ = adj.resolve_static_expression(rhs_node, eval_types=False)
+                        if isinstance(rhs_func, warp._src.context.Function) and rhs_func.module is not None:
+                            add_ref(rhs_func.module)
+                    except Exception:
+                        pass
+
         # scan for structs
         for arg in adj.args:
             if isinstance(arg.type, warp._src.codegen.Struct) and arg.type.module is not None:

--- a/warp/tests/aux_test_dependent_local.py
+++ b/warp/tests/aux_test_dependent_local.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Used to test reloading module references through functions bound to kernel-locals."""
+
+import warp as wp
+import warp.tests.aux_test_reference as ref
+import warp.tests.aux_test_reference_reference as refref
+
+
+@wp.kernel
+def kern(expect: float):
+    # Bind the referenced module's function to a kernel-local before calling it.
+    f = ref.magic
+    wp.expect_eq(f(), expect)
+
+
+@wp.kernel
+def kern_tuple(expect: float):
+    # Bind functions from two modules to locals via tuple unpacking. Only this kernel
+    # references aux_test_reference_reference directly, so the dependency on it exercises
+    # the tuple branch of Module._find_references.
+    f, g = ref.magic, refref.more_magic
+    wp.expect_eq(f() + g(), expect)
+
+
+def run(expect, device):
+    wp.launch(kern, dim=1, inputs=[expect], device=device)
+    wp.synchronize_device(device)

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -1321,6 +1321,98 @@ def test_augassign_no_double_eval_both(test, device):
     test.assertAlmostEqual(data.numpy()[0][0], 15.0)
 
 
+@wp.func
+def func_to_local_double(a: float):
+    return a * 2.0
+
+
+@wp.func
+def func_to_local_square(a: float):
+    return a * a
+
+
+@wp.func
+def func_to_local_halve(a: float):
+    return a * 0.5
+
+
+func_to_local_handlers = {"double": func_to_local_double, "square": func_to_local_square}
+
+
+# Binding a @wp.func to a local and calling through it should behave like calling it directly.
+@wp.kernel
+def assign_function_to_local_kernel(out: wp.array(dtype=float)):
+    f = func_to_local_double
+    out[0] = f(3.0)
+
+
+# A function reached through wp.static(...) can be bound to a local and called.
+@wp.kernel
+def assign_static_function_to_local_kernel(out: wp.array(dtype=float)):
+    add = wp.static(func_to_local_handlers["double"])
+    sq = wp.static(func_to_local_handlers["square"])
+    out[0] = add(3.0)
+    out[1] = sq(3.0)
+
+
+# wp.grad() of a function that was first bound to a local should match wp.grad() of the function.
+@wp.kernel(enable_backward=False)
+def grad_of_function_bound_to_local_kernel(out: wp.array(dtype=float)):
+    f = func_to_local_square
+    g = wp.grad(f)
+    out[0] = g(3.0)  # d/da a^2 = 2a = 6 at a = 3
+
+
+def test_assign_function_to_local(test, device):
+    out = wp.zeros(1, dtype=float, device=device)
+    wp.launch(assign_function_to_local_kernel, dim=1, outputs=[out], device=device)
+    test.assertEqual(out.numpy()[0], 6.0)
+
+
+def test_assign_static_function_to_local(test, device):
+    out = wp.zeros(2, dtype=float, device=device)
+    wp.launch(assign_static_function_to_local_kernel, dim=1, outputs=[out], device=device)
+    test.assertEqual(out.numpy()[0], 6.0)
+    test.assertEqual(out.numpy()[1], 9.0)
+
+
+def test_grad_of_function_bound_to_local(test, device):
+    out = wp.zeros(1, dtype=float, device=device)
+    wp.launch(grad_of_function_bound_to_local_kernel, dim=1, outputs=[out], device=device)
+    test.assertEqual(out.numpy()[0], 6.0)
+
+
+# Rebinding a function-valued local to a different function has no codegen-able meaning
+# (Warp has no function pointers) and should raise a clear error rather than miscompile.
+def test_rebind_function_local_errors(test, device):
+    @wp.kernel
+    def rebind_function_local_kernel(out: wp.array(dtype=float)):
+        f = func_to_local_double
+        f = func_to_local_halve
+        out[0] = f(3.0)
+
+    with test.assertRaisesRegex(wp.WarpCodegenError, "rebinding function-valued local"):
+        wp.launch(rebind_function_local_kernel, dim=1, outputs=[wp.zeros(1, dtype=float, device=device)], device=device)
+
+
+# Rebinding a function-valued local to a non-function value (e.g. `f = some_func; f = 1.0`) has no
+# codegen-able meaning either and should raise a clear error rather than fail on the generic type check.
+def test_rebind_function_local_to_value_errors(test, device):
+    @wp.kernel
+    def rebind_function_local_to_value_kernel(out: wp.array(dtype=float)):
+        f = func_to_local_double
+        f = 1.0
+        out[0] = f
+
+    with test.assertRaisesRegex(wp.WarpCodegenError, "rebinding function-valued local.*non-function"):
+        wp.launch(
+            rebind_function_local_to_value_kernel,
+            dim=1,
+            outputs=[wp.zeros(1, dtype=float, device=device)],
+            device=device,
+        )
+
+
 class TestCodeGen(unittest.TestCase):
     def test_extract_lambda_source_parenthesized_multiline_body(self):
         from warp._src.codegen import Adjoint  # noqa: PLC0415
@@ -1532,6 +1624,20 @@ add_function_test(
     TestCodeGen,
     "test_augassign_no_double_eval_both",
     test_augassign_no_double_eval_both,
+    devices=devices,
+)
+add_function_test(TestCodeGen, "test_assign_function_to_local", test_assign_function_to_local, devices=devices)
+add_function_test(
+    TestCodeGen, "test_assign_static_function_to_local", test_assign_static_function_to_local, devices=devices
+)
+add_function_test(
+    TestCodeGen, "test_grad_of_function_bound_to_local", test_grad_of_function_bound_to_local, devices=devices
+)
+add_function_test(TestCodeGen, "test_rebind_function_local_errors", test_rebind_function_local_errors, devices=devices)
+add_function_test(
+    TestCodeGen,
+    "test_rebind_function_local_to_value_errors",
+    test_rebind_function_local_to_value_errors,
     devices=devices,
 )
 

--- a/warp/tests/test_reload.py
+++ b/warp/tests/test_reload.py
@@ -13,6 +13,7 @@ import warp.tests.aux_test_class_kernel
 
 # dummy modules used for testing reload with dependencies
 import warp.tests.aux_test_dependent as test_dependent
+import warp.tests.aux_test_dependent_local as test_dependent_local
 import warp.tests.aux_test_reference as test_reference
 import warp.tests.aux_test_reference_reference as test_reference_reference
 import warp.tests.aux_test_square as test_square
@@ -218,6 +219,24 @@ def test_reload_references(test, device):
     test_dependent.run(expect=4.0, device=device)  # 2 * 2 = 4
 
 
+def test_reference_through_local(test, device):
+    # A function bound to a kernel-local (`f = ref.magic`) or to several locals via tuple
+    # unpacking (`f, g = ref.a, ref.b`) must still register a dependency on the module(s)
+    # that define them, so reloading those modules invalidates this kernel just as a direct
+    # call would. See Module._find_references.
+
+    # Building the dependent module scans its kernels for references.
+    test_dependent_local.kern.module.get_module_hash()
+
+    references = test_dependent_local.kern.module.references
+    ref_module = test_reference.magic.module
+    refref_module = test_reference_reference.more_magic.module
+    # `f = ref.magic` records the single-binding dependency.
+    test.assertIn(ref_module, references, "single local-bound function should register its module dependency")
+    # `f, g = ref.magic, refref.more_magic` records the tuple-binding dependency on the second module.
+    test.assertIn(refref_module, references, "tuple local-bound functions should register each module dependency")
+
+
 def test_graph_launch_after_module_reload(test, device):
     @wp.kernel
     def foo(a: wp.array(dtype=int)):
@@ -290,6 +309,9 @@ add_function_test(TestReload, "test_reload", test_reload, devices=devices)
 add_function_test(TestReload, "test_reload_class", test_reload_class, devices=devices)
 # TODO: test_reload_references sometimes has issues running on cuda:1
 add_function_test(TestReload, "test_reload_references", test_reload_references, devices=get_test_devices("basic"))
+add_function_test(
+    TestReload, "test_reference_through_local", test_reference_through_local, devices=get_test_devices("basic")
+)
 add_function_test(
     TestReload,
     "test_graph_launch_after_module_reload",


### PR DESCRIPTION
## Description

Assigning a Warp function to a local variable inside a kernel failed at codegen. `emit_Assign` routed the right-hand side through `Var`-shaped logic, which either crashed on `rhs.type` (for an `ast.Attribute` RHS) or stored a `Var` alias that broke every later call through the local (for a bare-name RHS). The same root cause surfaced through several documented patterns.

This binds the name directly to the `Function` in `adj.symbols`, mirroring the existing `GradWrapper` handling, so subsequent name lookups resolve to the function. `emit_Name` now also resolves the `__warp_func__` placeholder that `StaticExpressionReplacer` emits for `wp.static()` results, so a function reached through `wp.static(...)` can be bound to a local too. `get_references` registers functions that are reached only through a local binding, keeping the module hash sound. Rebinding a function-valued local to a different function has no codegen-able meaning (Warp has no function pointers) and now raises a clear error instead of miscompiling.

closes #1423

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

Added five tests to `warp/tests/test_codegen.py` covering the bare-name binding, the `wp.static(...)` binding, `wp.grad(f)` on a bound local, and the rebind error path:

```
uv run --extra dev -m warp.tests -s autodetect -k TestCodeGen
```

Verified `TestCodeGen`, `TestFunc`, and `TestStatic` pass with no regressions, and that existing patterns the issue notes already work (tuple-unpack of functions, inline calls, ordinary assignments) are unaffected.

## Bug fix

Each of these fails at codegen on `main` without this PR:

```python
import warp as wp


@wp.func
def double_it(a: float):
    return a * 2.0


@wp.func
def square(a: float):
    return a * a


# 1. bind a @wp.func to a local
@wp.kernel
def k1(out: wp.array(dtype=float)):
    f = double_it
    out[0] = f(3.0)


# 2. bind wp.static(...) returning a function
op_handlers = {"double": double_it}


@wp.kernel
def k2(out: wp.array(dtype=float)):
    f = wp.static(op_handlers["double"])
    out[0] = f(3.0)


# 3. wp.grad() of a function bound to a local
@wp.kernel(enable_backward=False)
def k3(out: wp.array(dtype=float)):
    f = square
    g = wp.grad(f)
    out[0] = g(3.0)


out = wp.zeros(1, dtype=float)
wp.launch(k1, dim=1, outputs=[out])
wp.launch(k2, dim=1, outputs=[out])
wp.launch(k3, dim=1, outputs=[out])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kernel-local variables can hold function-valued values (including statically-bound functions) and be called and differentiated via gradient operations.

* **Bug Fixes / Improvements**
  * Rebinding a function-valued local now raises a clear, user-facing error instead of failing during compilation.
  * Module dependency tracking recognizes functions bound through local variables for correct reload/cache behavior.

* **Tests**
  * Added tests covering local function binding, gradients, rebind error cases, and dependency tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->