### PR TITLE
Pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-warp-builder-images.yml
+++ b/.github/workflows/build-warp-builder-images.yml
@@ -56,7 +56,9 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
@@ -159,7 +161,9 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef

--- a/.github/workflows/build-warp-cpp-test-env-image.yml
+++ b/.github/workflows/build-warp-cpp-test-env-image.yml
@@ -27,7 +27,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,21 +75,22 @@ jobs:
             cuda-non-cuda-packages: ''
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           lfs: true
       
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
       
       - name: Set up Python
         run: uv python install
       
       - name: Cache build artifacts
         if: matrix.platform != 'macos'
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         id: cache-build
         with:
           path: warp/bin/
@@ -117,7 +118,7 @@ jobs:
         run: uv run build_lib.py
       
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ matrix.artifact-name }}
           path: warp/bin/
@@ -148,20 +149,21 @@ jobs:
             artifact-name: build-artifact-macos
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           lfs: true
       
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
       
       - name: Set up Python
         run: uv python install
       
       - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ matrix.artifact-name }}
           path: warp/bin/
@@ -185,20 +187,21 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           lfs: true
       
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
       
       - name: Set up Python
         run: uv python install
       
       - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
@@ -232,7 +235,9 @@ jobs:
       docs_relevant: ${{ steps.filter-docs.outputs.any_changed || 'true' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Fetch main for diff base
         run: git fetch --depth=1 origin main
@@ -316,20 +321,21 @@ jobs:
           git lfs install
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           lfs: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
 
       - name: Set up Python
         run: uv python install
 
       - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ${{ matrix.artifact-name }}
           path: warp/bin/
@@ -404,20 +410,21 @@ jobs:
           git lfs install
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           lfs: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
 
       - name: Set up Python
         run: uv python install
 
       - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
@@ -473,20 +480,21 @@ jobs:
         run: nvidia-smi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           lfs: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
 
       - name: Set up Python
         run: uv python install
 
       - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: build-artifact-windows-cuda13
           path: warp/bin/
@@ -563,8 +571,9 @@ jobs:
           git lfs install
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           lfs: true
 
       - name: Mark workspace as a safe git directory
@@ -577,13 +586,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
 
       - name: Set up Python
         run: uv python install
 
       - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
@@ -601,15 +610,17 @@ jobs:
       artifact-url: ${{ steps.build-docs-output.outputs.artifact-url }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
       - name: Set up Python
         run: uv python install
       - name: Download Warp binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
@@ -617,7 +628,7 @@ jobs:
         run: |
           uv run --extra docs build_docs.py
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         id: build-docs-output
         with:
           name: build-docs-output
@@ -635,9 +646,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Download build_docs.py output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: build-docs-output
           path: .
@@ -656,7 +669,7 @@ jobs:
       contents: read
     steps:
       - name: Download Warp build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
@@ -697,11 +710,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
       - name: Set up Python
         run: uv python install
       - name: Run pyright on stub file

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,15 @@ jobs:
         language: [python]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -15,9 +15,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Create Draft Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,10 +35,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       
       - name: Cache cppcheck build directory
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: _build/.cppcheck
           key: cppcheck-${{ github.run_id }}
@@ -96,7 +98,7 @@ jobs:
       
       - name: Upload cppcheck report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: cppcheck-report
           path: cppcheck-report.xml

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -33,7 +33,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           lfs: true
           # deploy_doc.py uses historical vX.Y.N tags to decide which
@@ -90,7 +90,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
         with:
-          version: "0.11.3"
+          version: "0.11.16"
       - name: Set up Python
         run: uv python install
       - name: Build Warp without CUDA Support
@@ -103,7 +103,7 @@ jobs:
           DOC_VERSION=${{ steps.dv.outputs.version }} uv run --extra docs build_docs.py
       - name: Upload artifacts
         if: steps.dv.outputs.metadata_only != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: html-docs
           path: docs/_build/html/


### PR DESCRIPTION
## Description

Pin non-NVIDIA GitHub Actions to immutable commit hashes and keep
human-readable version comments next to the pinned refs. Keep the
NVIDIA-owned runner helper on its existing ref.

This also updates the uv installer input to use uv 0.11.16 while
preserving the existing setup-uv action pin, and moves the image
workflow checkout steps to the current v6.0.2 checkout hash.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `git diff --check -- .github/workflows/...`
- Parsed all 7 workflow YAML files with PyYAML.
- `uvx pre-commit run --files .github/workflows/build-warp-builder-images.yml .github/workflows/build-warp-cpp-test-env-image.yml .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/draft-release.yml .github/workflows/pr.yml .github/workflows/sphinx.yml`
- Open this PR to exercise the GitHub Actions pins in upstream CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to pin action revisions for improved consistency and reproducibility.
  * Standardized checkout behavior (explicit non-persisted credentials) across jobs.
  * Upgraded tooling versions used by workflows.
  * Applied changes across build, test, docs, analysis, and release pipelines to enhance CI/CD stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->