### PR TITLE
Suppress WER dumps in assert tests

### DIFF
--- a/warp/tests/test_assert.py
+++ b/warp/tests/test_assert.py
@@ -11,8 +11,20 @@ from warp.tests.unittest_utils import *
 
 def _run_in_subprocess(func_name: str, timeout: int = 60):
     """Run a module-level function in a subprocess, return (returncode, stdout, stderr)."""
+    setup_code = ""
+    if sys.platform == "win32":
+        # These tests intentionally abort subprocesses. Suppress Windows Error
+        # Reporting there so systems with LocalDumps enabled do not collect the
+        # expected aborts as false positive application crash dumps.
+        setup_code = (
+            "import ctypes;"
+            "SEM_FAILCRITICALERRORS=0x0001;"
+            "SEM_NOGPFAULTERRORBOX=0x0002;"
+            "ctypes.windll.kernel32.SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);"
+        )
+
     result = subprocess.run(
-        [sys.executable, "-c", f"import warp.tests.test_assert; warp.tests.test_assert.{func_name}()"],
+        [sys.executable, "-c", f"{setup_code}import warp.tests.test_assert; warp.tests.test_assert.{func_name}()"],
         check=False,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Description

This PR suppresses Windows Error Reporting in the subprocesses spawned by
`warp/tests/test_assert.py`. These tests intentionally trigger CPU assertion
failures in child `python.exe` processes and then verify the nonzero return code
and stderr output from the parent process.

On Windows machines with WER LocalDumps enabled for `python.exe`, those expected
child-process aborts are collected as `.dmp` files. QA infrastructure then picks
up the dumps as false positive application crashes even though the test itself
passes.

The change sets the Windows child-process error mode before invoking each
assert-triggering helper so WER does not collect those expected aborts. The
suppression is scoped to the spawned subprocess command used by this test file.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `uv run warp/tests/test_assert.py`
  - `Ran 11 tests in 20.217s` / `OK`
- `uvx pre-commit run --files warp/tests/test_assert.py`
  - all hooks passed
- Manual Windows LocalDumps A/B verification:
  - Created `C:\udump`.
  - Enabled WER LocalDumps for `python.exe` under
    `HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\python.exe`.
  - Set `DumpFolder=C:\udump`, `DumpCount=20`, and `DumpType=2`.
  - Cleared `C:\udump` and ran the fixed test file: the tests passed and
    `C:\udump` stayed empty.
  - Temporarily disabled the new child-process error-mode setup and reran the
    same test file: the tests still passed, but five `python.exe.*.dmp` files
    were written to `C:\udump`.
  - Restored the fix, cleared `C:\udump`, and reran the test file: the tests
    passed and `C:\udump` stayed empty again.

## Bug fix

Minimal Windows repro without this PR applied:

```powershell
New-Item -ItemType Directory -Force C:\udump | Out-Null
reg add "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\python.exe" /v DumpFolder /t REG_EXPAND_SZ /d "C:\udump" /f
reg add "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\python.exe" /v DumpCount /t REG_DWORD /d 20 /f
reg add "HKLM\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\python.exe" /v DumpType /t REG_DWORD /d 2 /f
uv run warp/tests/test_assert.py
Get-ChildItem C:\udump -Filter "python.exe.*.dmp"
```

Without this PR, the assertion tests pass but Windows writes dump files for the
expected child-process aborts. With this PR, the assertion behavior is still
verified and no WER dumps are collected for those expected aborts.

## New feature / enhancement

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Windows test assertion handling to prevent spurious error reporting artifacts from being generated during test execution. Tests on Windows now run cleanly without generating additional system error notifications when assertions fail as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->