### PR TITLE
Fix APIC tests under CUDA driver < 12.3

### DIFF
--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -9460,6 +9460,63 @@ def load_module(
     force_load(device=device, modules=modules, block_dim=block_dim, max_workers=max_workers)
 
 
+def _force_load_cuda_graph_capture_modules(device: Device):
+    modules = list(user_modules.values())
+    if not modules:
+        return
+
+    restore_context = is_cuda_driver_initialized()
+    if restore_context:
+        saved_context = runtime.core.wp_cuda_context_get_current()
+
+    original_block_dims = {module: module.options["block_dim"] for module in modules}
+    original_cuda_execs = {
+        module: module.execs.get((device.context, block_dim)) is not None
+        for module, block_dim in original_block_dims.items()
+    }
+    original_cpu_execs = {
+        module: module.execs.get((None, block_dim)) is not None for module, block_dim in original_block_dims.items()
+    }
+    try:
+        # Capture preloading is best-effort because long-lived test and
+        # application processes can retain unrelated modules that are expected
+        # to fail compilation. A captured kernel that is not loadable will still
+        # fail when launched, but unrelated modules must not block capture.
+        for module in modules:
+            try:
+                module.load(device)
+            except Exception:
+                pass
+
+        # Default CUDA launches use block_dim=256. A preceding CPU launch may
+        # have left a module's active block_dim at 1, so force-loading only the
+        # active variant is not enough for graph capture on drivers that forbid
+        # module loading during capture. Limit this repair to modules that were
+        # stale from CPU execution; explicit non-default CUDA block dimensions
+        # may be required by tile kernels and must not be recompiled at the
+        # default block size.
+        default_cuda_block_dim = 256
+        default_modules = [
+            module
+            for module, block_dim in original_block_dims.items()
+            if block_dim == 1
+            and original_cpu_execs[module]
+            and not original_cuda_execs[module]
+            and module.execs.get((device.context, block_dim)) is not None
+        ]
+        for module in default_modules:
+            try:
+                module.load(device, block_dim=default_cuda_block_dim)
+            except Exception:
+                pass
+    finally:
+        for module, block_dim in original_block_dims.items():
+            module.options["block_dim"] = block_dim
+
+        if restore_context:
+            runtime.core.wp_cuda_context_set_current(saved_context)
+
+
 def _resolve_module(module: Module | types.ModuleType | str) -> Module:
     """Resolve a module from a string, Module, or types.ModuleType.
 
@@ -9917,7 +9974,7 @@ def capture_begin(
                 raise RuntimeError("Graph capture already in progress on this stream")
 
             if force_module_load:
-                force_load(device)
+                _force_load_cuda_graph_capture_modules(device)
 
         if not runtime.core.wp_cuda_graph_begin_capture(
             device.context, stream.cuda_stream, int(external), int(CaptureMode(capture_mode))

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -9470,10 +9470,6 @@ def _force_load_cuda_graph_capture_modules(device: Device):
         saved_context = runtime.core.wp_cuda_context_get_current()
 
     original_block_dims = {module: module.options["block_dim"] for module in modules}
-    original_cuda_execs = {
-        module: module.execs.get((device.context, block_dim)) is not None
-        for module, block_dim in original_block_dims.items()
-    }
     original_cpu_execs = {
         module: module.execs.get((None, block_dim)) is not None for module, block_dim in original_block_dims.items()
     }
@@ -9484,14 +9480,12 @@ def _force_load_cuda_graph_capture_modules(device: Device):
         # module loading during capture. Load the default CUDA variant first so
         # a failed stale block_dim=1 load cannot prevent the variant needed by a
         # captured default launch from being preloaded. Limit this repair to
-        # modules that were stale from CPU execution; explicit non-default CUDA
-        # block dimensions may be required by tile kernels and must not be
-        # recompiled at the default block size.
+        # modules that were stale from CPU execution; an explicit stale CUDA
+        # block_dim=1 preload does not cover later default block_dim=256
+        # launches.
         default_cuda_block_dim = 256
         default_modules = [
-            module
-            for module, block_dim in original_block_dims.items()
-            if block_dim == 1 and original_cpu_execs[module] and not original_cuda_execs[module]
+            module for module, block_dim in original_block_dims.items() if block_dim == 1 and original_cpu_execs[module]
         ]
         for module in default_modules:
             try:

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -9478,35 +9478,34 @@ def _force_load_cuda_graph_capture_modules(device: Device):
         module: module.execs.get((None, block_dim)) is not None for module, block_dim in original_block_dims.items()
     }
     try:
-        # Capture preloading is best-effort because long-lived test and
-        # application processes can retain unrelated modules that are expected
-        # to fail compilation. A captured kernel that is not loadable will still
-        # fail when launched, but unrelated modules must not block capture.
-        for module in modules:
-            try:
-                module.load(device)
-            except Exception:
-                pass
-
         # Default CUDA launches use block_dim=256. A preceding CPU launch may
         # have left a module's active block_dim at 1, so force-loading only the
         # active variant is not enough for graph capture on drivers that forbid
-        # module loading during capture. Limit this repair to modules that were
-        # stale from CPU execution; explicit non-default CUDA block dimensions
-        # may be required by tile kernels and must not be recompiled at the
-        # default block size.
+        # module loading during capture. Load the default CUDA variant first so
+        # a failed stale block_dim=1 load cannot prevent the variant needed by a
+        # captured default launch from being preloaded. Limit this repair to
+        # modules that were stale from CPU execution; explicit non-default CUDA
+        # block dimensions may be required by tile kernels and must not be
+        # recompiled at the default block size.
         default_cuda_block_dim = 256
         default_modules = [
             module
             for module, block_dim in original_block_dims.items()
-            if block_dim == 1
-            and original_cpu_execs[module]
-            and not original_cuda_execs[module]
-            and module.execs.get((device.context, block_dim)) is not None
+            if block_dim == 1 and original_cpu_execs[module] and not original_cuda_execs[module]
         ]
         for module in default_modules:
             try:
                 module.load(device, block_dim=default_cuda_block_dim)
+            except Exception:
+                pass
+
+        # Capture preloading is best-effort because long-lived test and
+        # application processes can retain unrelated modules that are expected
+        # to fail compilation. A captured kernel that is not loadable will still
+        # fail when launched, but unrelated modules must not block capture.
+        for module, block_dim in original_block_dims.items():
+            try:
+                module.load(device, block_dim=block_dim)
             except Exception:
                 pass
     finally:

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -44,7 +44,7 @@ def test_save_apic_false_error(test, device):
     b = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=False, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=False) as capture:
         wp.launch(scale_kernel, dim=n, inputs=[a, b, 2.0], device=device)
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -59,7 +59,7 @@ def test_save_single_kernel(test, device):
     b = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(scale_kernel, dim=n, inputs=[a, b, 3.0], device=device)
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -78,7 +78,7 @@ def test_save_load_round_trip(test, device):
     b = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(scale_kernel, dim=n, inputs=[a, b, 2.0], device=device)
 
     # Launch the original graph first to verify it works
@@ -113,7 +113,7 @@ def test_bindings_param_update(test, device):
     b = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(scale_kernel, dim=n, inputs=[a, b, 5.0], device=device)
 
     # Launch original graph to populate memory before saving
@@ -153,7 +153,7 @@ def test_save_load_multiple_kernels(test, device):
     d = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(add_kernel, dim=n, inputs=[a, b, c], device=device)
         wp.launch(scale_kernel, dim=n, inputs=[c, d, 10.0], device=device)
 
@@ -182,7 +182,7 @@ def test_save_load_memcpy(test, device):
     dst = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.copy(dst, src)
 
     wp.capture_launch(capture.graph)
@@ -208,7 +208,7 @@ def test_save_load_memset(test, device):
     arr = wp.array(np.arange(n, dtype=np.float32), device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         arr.zero_()
 
     wp.capture_launch(capture.graph)
@@ -267,7 +267,7 @@ def test_complex_pipeline(test, device):
     g = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(add_kernel, dim=n, inputs=[a, b, c], device=device)  # c = 5
         wp.copy(d, c)  # d = 5
         wp.launch(scale_kernel, dim=n, inputs=[d, e, 2.0], device=device)  # e = 10
@@ -305,7 +305,7 @@ def test_internal_allocation(test, device):
     output_data = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         tmp = wp.zeros(n, dtype=float, device=device)
         wp.launch(scale_kernel, dim=n, inputs=[input_data, tmp, 2.0], device=device)
         wp.launch(add_kernel, dim=n, inputs=[tmp, input_data, output_data], device=device)
@@ -340,7 +340,7 @@ def test_multiple_internal_allocations(test, device):
     output_data = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         t1 = wp.zeros(n, dtype=float, device=device)
         t2 = wp.zeros(n, dtype=float, device=device)
         t3 = wp.zeros(n, dtype=float, device=device)
@@ -378,7 +378,7 @@ def test_graph_execution_unchanged(test, device):
     output_data = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(scale_kernel, dim=n, inputs=[input_data, output_data, 0.5], device=device)
 
     for _ in range(3):
@@ -398,7 +398,7 @@ def test_save_load_with_param_update(test, device):
     d = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(add_kernel, dim=n, inputs=[a, b, c], device=device)
         wp.launch(scale_kernel, dim=n, inputs=[c, d, 2.0], device=device)
 
@@ -436,7 +436,7 @@ def test_save_load_memcpy_and_kernel(test, device):
     dst = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.copy(tmp, src)
         wp.launch(scale_kernel, dim=n, inputs=[tmp, dst, 2.0], device=device)
 
@@ -467,7 +467,7 @@ def test_save_load_fill(test, device):
     arr = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         arr.fill_(42.0)
 
     wp.capture_launch(capture.graph)
@@ -493,7 +493,7 @@ def test_save_load_alloc_only(test, device):
     src = wp.array(np.arange(n, dtype=np.float32) + 1.0, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         # Allocate inside capture and copy data into it
         dst = wp.zeros(n, dtype=float, device=device)
         wp.copy(dst, src)
@@ -578,7 +578,7 @@ def test_capture_2d_launch_minimal(test, device):
     out_count = wp.zeros(1, dtype=int, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(
             two_d_strided_kernel,
             dim=[256, 128],
@@ -614,7 +614,7 @@ def test_capture_replay_with_tile_kernel_no_stack_overflow(test, device):
     out = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch_tiled(_tile_using_kernel, dim=n, inputs=[out], block_dim=64, device=device)
 
     # Multiple launches verify there's no slow leak / cumulative stack use.
@@ -650,7 +650,7 @@ def test_capture_replay_vec3_scalar_alignment(test, device):
     v = wp.vec3(1.0, 2.0, 3.0)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(_vec3_after_int_kernel, dim=n, inputs=[10, v, 100, 0.5, arr_in, arr_out], device=device)
 
     # Live execution sets the expected pattern; arr_out was zeroed before
@@ -675,7 +675,7 @@ def test_capture_with_empty_array_input(test, device):
     test.assertTrue(empty.ptr is None, f"expected None, got {empty.ptr!r}")
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(touch_first_if_nonempty_kernel, dim=n_out, inputs=[empty, out], device=device)
 
     wp.capture_launch(capture.graph)
@@ -758,7 +758,7 @@ def test_capture_with_large_scalar_param(test, device):
     expected = np.full(n, float(sum(range(24))), dtype=np.float32)  # 0+1+...+23 = 276
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(big_struct_sum_kernel, dim=n, inputs=[s, out], device=device)
 
     wp.capture_launch(capture.graph)
@@ -801,7 +801,7 @@ def test_capture_backward_consumes_y_grad_cpu(test, device):
     y = wp.zeros(n, dtype=float, device=device, requires_grad=True)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         tape = wp.Tape()
         with tape:
             wp.launch(assign_kernel, dim=n, inputs=[x, y], device=device)
@@ -829,7 +829,7 @@ def test_capture_backward_retain_grad_cpu(test, device):
     y.retain_grad = True
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         tape = wp.Tape()
         with tape:
             wp.launch(assign_kernel, dim=n, inputs=[x, y], device=device)
@@ -853,7 +853,7 @@ def test_capture_backward_kernel_cpu(test, device):
     loss = wp.zeros(1, dtype=float, device=device, requires_grad=True)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         tape = wp.Tape()
         with tape:
             wp.launch(square_loss_kernel, dim=n, inputs=[x, loss], device=device)
@@ -899,7 +899,7 @@ def test_capture_struct_with_array_cpu(test, device):
     p.radius = 0.5
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(step_particles_struct_kernel, dim=n, inputs=[p, 0.5], device=device)
 
     wp.capture_launch(capture.graph)
@@ -939,7 +939,7 @@ def test_capture_indexedarray_cpu(test, device):
     iarr = wp.indexedarray1d(base, [indices])
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(write_indexed_kernel, dim=iarr.size, inputs=[iarr, 42.0], device=device)
 
     wp.capture_launch(capture.graph)
@@ -996,7 +996,7 @@ def test_capture_indexedarray_adjoint_pack_cpu(test, device):
     total.grad.fill_(1.0)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(
             weighted_sample_sum_kernel,
             dim=samples.size,
@@ -1037,7 +1037,7 @@ def test_capture_if_cpu(test, device):
         wp.launch(write_value_kernel, dim=n, inputs=[out, 22.0], device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.capture_if(cond, on_true=on_true, on_false=on_false)
 
     # Replay with cond=1 -> on_true branch -> out filled with 11.0
@@ -1063,7 +1063,7 @@ def test_capture_while_cpu(test, device):
         wp.launch(decrement_counter_kernel, dim=1, inputs=[counter], device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.capture_while(counter, while_body=body)
 
     counter.assign([5])
@@ -1097,11 +1097,11 @@ def test_capture_with_array_scan(test, device):
 
     if wp.get_device(device).is_cpu:
         with test.assertRaises(NotImplementedError):
-            with wp.ScopedCapture(device=device, apic=True, force_module_load=False):
+            with wp.ScopedCapture(device=device, apic=True):
                 wp.utils.array_scan(src, dst_in, inclusive=True)
         return
 
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.utils.array_scan(src, dst_in, inclusive=True)
         wp.utils.array_scan(src, dst_ex, inclusive=False)
 
@@ -1121,7 +1121,7 @@ def test_end_recording_null_state_preserves_active(test, device):
     b = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(scale_kernel, dim=n, inputs=[a, b, 2.0], device=device)
         # While capture is active, an external caller (e.g. error-cleanup path
         # in another component) calls wp_apic_end_recording(NULL).
@@ -1151,7 +1151,7 @@ def test_get_param_ptr(test, device):
     b = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
-    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+    with wp.ScopedCapture(device=device, apic=True) as capture:
         wp.launch(scale_kernel, dim=n, inputs=[a, b, 2.0], device=device)
 
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -1169,7 +1169,7 @@ def test_get_param_ptr(test, device):
         test.assertIsNone(loaded.get_param_ptr("nonexistent"))
 
     # Non-loaded graph: should raise RuntimeError mentioning loaded APIC graphs.
-    with wp.ScopedCapture(device=device, force_module_load=False) as plain_capture:
+    with wp.ScopedCapture(device=device) as plain_capture:
         wp.launch(scale_kernel, dim=n, inputs=[a, b, 1.0], device=device)
 
     with test.assertRaisesRegex(RuntimeError, "loaded APIC"):

--- a/warp/tests/test_block_dim_dispatch.py
+++ b/warp/tests/test_block_dim_dispatch.py
@@ -185,6 +185,42 @@ def test_force_module_load_preloads_default_before_stale_cuda_block_dim(test, de
     )
 
 
+def test_force_module_load_preloads_default_after_stale_cuda_load(test, device):
+    """A stale CUDA block_dim=1 exec still needs default CUDA preloading."""
+
+    @wp.kernel(module="unique")
+    def simple_kernel(result: wp.array(dtype=wp.int32)):
+        result[0] = 1
+
+    module = simple_kernel.module
+
+    result_cpu = wp.zeros(1, dtype=wp.int32, device="cpu")
+    wp.launch(simple_kernel, dim=1, inputs=[result_cpu], device="cpu")
+    test.assertIn((wp.get_device("cpu").context, 1), module.execs)
+
+    wp.load_module(module=module, device=device, block_dim=1)
+    test.assertIn((device.context, 1), module.execs)
+    test.assertNotIn((device.context, 256), module.execs)
+
+    user_modules = warp_context.user_modules
+    saved_user_modules = dict(user_modules)
+    try:
+        user_modules.clear()
+        user_modules[module.name] = module
+
+        with wp.ScopedCapture(device=device, force_module_load=True):
+            pass
+    finally:
+        user_modules.clear()
+        user_modules.update(saved_user_modules)
+
+    test.assertIn(
+        (device.context, 256),
+        module.execs,
+        "force_module_load should preload default CUDA block_dim even when stale block_dim=1 already exists",
+    )
+
+
 def test_force_module_load_preserves_explicit_cuda_block_dim(test, device):
     """Force-loading before capture must not compile unused default variants."""
 
@@ -291,6 +327,13 @@ add_function_test(
     TestBlockDimDispatch,
     "test_force_module_load_preloads_default_before_stale_cuda_block_dim",
     test_force_module_load_preloads_default_before_stale_cuda_block_dim,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_force_module_load_preloads_default_after_stale_cuda_load",
+    test_force_module_load_preloads_default_after_stale_cuda_load,
     devices=cuda_devices,
 )
 

--- a/warp/tests/test_block_dim_dispatch.py
+++ b/warp/tests/test_block_dim_dispatch.py
@@ -17,6 +17,7 @@ The bug manifests when:
 import unittest
 
 import warp as wp
+from warp._src import context as warp_context
 from warp.tests.unittest_utils import *
 
 
@@ -99,6 +100,120 @@ def test_block_dim_record_cmd_cpu(test, device):
     test.assertEqual(values_cpu[1], 0, "CPU: Second branch should not execute")
 
 
+def test_force_module_load_preloads_default_cuda_block_dim_after_cpu(test, device):
+    """Force-loading before CUDA graph capture must cover default CUDA launches.
+
+    CPU launches compile modules with block_dim=1. If that stale module option
+    is the only CUDA variant preloaded before capture, a default CUDA launch
+    (block_dim=256) still lazy-loads inside capture, which fails on CUDA drivers
+    before 12.3.
+    """
+
+    @wp.kernel(module="unique")
+    def simple_kernel(result: wp.array(dtype=wp.int32)):
+        result[0] = 1
+
+    module = simple_kernel.module
+
+    result_cpu = wp.zeros(1, dtype=wp.int32, device="cpu")
+    wp.launch(simple_kernel, dim=1, inputs=[result_cpu], device="cpu")
+    test.assertIn((wp.get_device("cpu").context, 1), module.execs)
+
+    user_modules = warp_context.user_modules
+    saved_user_modules = dict(user_modules)
+    try:
+        user_modules.clear()
+        user_modules[module.name] = module
+
+        with wp.ScopedCapture(device=device, force_module_load=True):
+            pass
+    finally:
+        user_modules.clear()
+        user_modules.update(saved_user_modules)
+
+    test.assertIn(
+        (device.context, 256),
+        module.execs,
+        "force_module_load should preload the default CUDA launch block_dim",
+    )
+
+
+def test_force_module_load_preserves_explicit_cuda_block_dim(test, device):
+    """Force-loading before capture must not compile unused default variants."""
+
+    tile_threads = 32
+
+    @wp.kernel(module="unique")
+    def tile_kernel(y: wp.array2d(dtype=float)):
+        local = wp.vec3(1.0, 2.0, 3.0)
+        f = wp.tile(local)
+        b = wp.tile_zeros(shape=(3, 1), dtype=float)
+        z = f + wp.tile_broadcast(b, shape=(3, tile_threads))
+        wp.tile_store(y, z)
+
+    module = tile_kernel.module
+    wp.load_module(module=module, device=device, block_dim=tile_threads)
+    test.assertIn((device.context, tile_threads), module.execs)
+
+    user_modules = warp_context.user_modules
+    saved_user_modules = dict(user_modules)
+    try:
+        user_modules.clear()
+        user_modules[module.name] = module
+
+        with wp.ScopedCapture(device=device, force_module_load=True):
+            pass
+    finally:
+        user_modules.clear()
+        user_modules.update(saved_user_modules)
+
+    test.assertNotIn(
+        (device.context, 256),
+        module.execs,
+        "force_module_load should not preload default block_dim for explicit CUDA block_dim modules",
+    )
+
+
+def test_force_module_load_ignores_unrelated_invalid_modules(test, device):
+    """Unrelated invalid modules must not block capture preloading."""
+
+    @wp.kernel(module="unique")
+    def good_kernel(result: wp.array(dtype=wp.int32)):
+        result[0] = 1
+
+    tile_threads = 32
+
+    @wp.kernel(module="unique")
+    def invalid_tile_kernel(y: wp.array2d(dtype=float)):
+        local = wp.vec3(1.0, 2.0, 3.0)
+        f = wp.tile(local)
+        b = wp.tile_zeros(shape=(3, 1), dtype=float)
+        z = f + wp.tile_broadcast(b, shape=(3, tile_threads))
+        wp.tile_store(y, z)
+
+    good_module = good_kernel.module
+    invalid_module = invalid_tile_kernel.module
+
+    result_cpu = wp.zeros(1, dtype=wp.int32, device="cpu")
+    wp.launch(good_kernel, dim=1, inputs=[result_cpu], device="cpu")
+    test.assertIn((wp.get_device("cpu").context, 1), good_module.execs)
+
+    user_modules = warp_context.user_modules
+    saved_user_modules = dict(user_modules)
+    try:
+        user_modules.clear()
+        user_modules[good_module.name] = good_module
+        user_modules[invalid_module.name] = invalid_module
+
+        with wp.ScopedCapture(device=device, force_module_load=True):
+            pass
+    finally:
+        user_modules.clear()
+        user_modules.update(saved_user_modules)
+
+    test.assertIn((device.context, 256), good_module.execs)
+
+
 devices = get_test_devices()
 
 # Only test on CUDA devices (CPU would pass trivially)
@@ -115,6 +230,27 @@ add_function_test(
     TestBlockDimDispatch,
     "test_block_dim_record_cmd_cpu",
     test_block_dim_record_cmd_cpu,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_force_module_load_preloads_default_cuda_block_dim_after_cpu",
+    test_force_module_load_preloads_default_cuda_block_dim_after_cpu,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_force_module_load_preserves_explicit_cuda_block_dim",
+    test_force_module_load_preserves_explicit_cuda_block_dim,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_force_module_load_ignores_unrelated_invalid_modules",
+    test_force_module_load_ignores_unrelated_invalid_modules,
     devices=cuda_devices,
 )
 

--- a/warp/tests/test_block_dim_dispatch.py
+++ b/warp/tests/test_block_dim_dispatch.py
@@ -138,6 +138,53 @@ def test_force_module_load_preloads_default_cuda_block_dim_after_cpu(test, devic
     )
 
 
+def test_force_module_load_preloads_default_before_stale_cuda_block_dim(test, device):
+    """Default CUDA preloading must not depend on stale block_dim=1 loading."""
+
+    @wp.kernel(module="unique")
+    def simple_kernel(result: wp.array(dtype=wp.int32)):
+        result[0] = 1
+
+    module = simple_kernel.module
+
+    result_cpu = wp.zeros(1, dtype=wp.int32, device="cpu")
+    wp.launch(simple_kernel, dim=1, inputs=[result_cpu], device="cpu")
+    test.assertIn((wp.get_device("cpu").context, 1), module.execs)
+
+    original_load = module.load
+    load_calls = []
+
+    def fail_stale_cuda_load(load_device, block_dim=None, *args, **kwargs):
+        load_device = warp_context.runtime.get_device(load_device)
+        load_calls.append(block_dim)
+
+        if load_device.context == device.context and block_dim in (None, 1):
+            raise RuntimeError("simulated stale CUDA block_dim load failure")
+
+        return original_load(load_device, *args, block_dim=block_dim, **kwargs)
+
+    user_modules = warp_context.user_modules
+    saved_user_modules = dict(user_modules)
+    try:
+        user_modules.clear()
+        user_modules[module.name] = module
+        module.load = fail_stale_cuda_load
+
+        with wp.ScopedCapture(device=device, force_module_load=True):
+            pass
+    finally:
+        module.load = original_load
+        user_modules.clear()
+        user_modules.update(saved_user_modules)
+
+    test.assertIn(256, load_calls)
+    test.assertIn(
+        (device.context, 256),
+        module.execs,
+        "force_module_load should not require stale CUDA block_dim=1 to load first",
+    )
+
+
 def test_force_module_load_preserves_explicit_cuda_block_dim(test, device):
     """Force-loading before capture must not compile unused default variants."""
 
@@ -237,6 +284,13 @@ add_function_test(
     TestBlockDimDispatch,
     "test_force_module_load_preloads_default_cuda_block_dim_after_cpu",
     test_force_module_load_preloads_default_cuda_block_dim_after_cpu,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_force_module_load_preloads_default_before_stale_cuda_block_dim",
+    test_force_module_load_preloads_default_before_stale_cuda_block_dim,
     devices=cuda_devices,
 )
 


### PR DESCRIPTION
## Description

Fix APIC test failures on CUDA drivers earlier than 12.3 by letting `wp.ScopedCapture(...)` use its version-aware `force_module_load` default instead of passing `False` explicitly in `warp/tests/test_apic.py`.

References #1431.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Test plan

- [ ] GitHub CI for this PR.

Local tests were not run by me; this PR was opened to verify the fix against GitHub CI.

## Bug fix

On CUDA drivers earlier than 12.3, affected APIC graph capture tests can fail when a CUDA module is lazily loaded inside `wp.ScopedCapture(...)`, because `cuModuleLoadDataEx` returns `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED` during stream capture.

Reproduce without this PR on a CUDA driver earlier than 12.3:

```bash
uv run warp/tests/test_apic.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA graph capture reliability on drivers that restrict module loading during capture by preloading the correct kernel variants, ensuring captures succeed and use the intended block dimensions.
* **Tests**
  * Added/updated tests to validate module preloading and capture behavior on CUDA devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->