### PR TITLE
Fix block_dim dispatch state handling (GH-564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,16 @@
 
 ### Fixed
 
+- Fix `Module.load` cross-device `block_dim` leak. A CPU launch on a module
+  (which silently overrides `block_dim` to 1) would mutate the module's
+  shared `options["block_dim"]`, so a subsequent `wp.load_module` or
+  `wp.ScopedCapture(force_module_load=True)` on CUDA would compile only the
+  `block_dim=1` variant on CUDA — leaving the captured CUDA launch's
+  `block_dim=256` variant uncompiled until replay time. On CUDA driver
+  versions older than 12.3 (where in-capture `cuModuleLoadDataEx` is
+  forbidden) this surfaced as `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED`; on
+  newer drivers it silently re-compiled inside the capture
+  ([GH-564](https://github.com/NVIDIA/warp/issues/564)).
 - Fix APIC backward replay so it consumes output gradients exactly like live
   `wp.Tape().backward()`: the array descriptor reconstructed at replay now
   carries the original `grad` pointer and array flags (including

--- a/warp/_src/apic/capture.py
+++ b/warp/_src/apic/capture.py
@@ -470,8 +470,8 @@ class APICapture:
         if module_hash not in self.collected_modules:
             # Compute the binary path in the kernel cache (same logic as Module.load)
             module = kernel.module
-            output_name = module._get_compile_output_name(self.device)
-            module_id = module.get_module_identifier()
+            output_name = module._get_compile_output_name(self.device, block_dim=module_exec.block_dim)
+            module_id = module.get_module_identifier(block_dim=module_exec.block_dim)
             module_dir = os.path.join(warp.config.kernel_cache_dir, module_id)
             binary_path = os.path.join(module_dir, output_name)
 
@@ -503,5 +503,5 @@ class APICapture:
                 "backward_name": backward_name,
                 "forward_smem_bytes": hooks.forward_smem_bytes,
                 "backward_smem_bytes": hooks.backward_smem_bytes,
-                "block_dim": kernel.options.get("block_dim", 256),
+                "block_dim": module_exec.block_dim,
             }

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2447,12 +2447,13 @@ class ModuleExec:
         instance.handle = None
         return instance
 
-    def __init__(self, handle, module_hash, device, meta):
+    def __init__(self, handle, module_hash, device, meta, block_dim: int):
         self.handle = handle
         self.module_hash = module_hash
         self.device = device
         self.kernel_hooks = {}
         self.meta = meta
+        self.block_dim = block_dim
 
     # release the loaded module
     def __del__(self):
@@ -3329,13 +3330,13 @@ class Module:
                     != 0
                 ):
                     raise Exception(f"Failed to load CPU module '{self.name}'")
-                module_exec = ModuleExec(module_handle, module_hash, device, meta)
+                module_exec = ModuleExec(module_handle, module_hash, device, meta, active_block_dim)
                 self.execs[(None, active_block_dim)] = module_exec
 
             elif device.is_cuda:
                 cuda_module = warp._src.build.load_cuda(binary_path, device)
                 if cuda_module is not None:
-                    module_exec = ModuleExec(cuda_module, module_hash, device, meta)
+                    module_exec = ModuleExec(cuda_module, module_hash, device, meta, active_block_dim)
                     self.execs[(device.context, active_block_dim)] = module_exec
                 else:
                     module_load_timer.extra_msg = " (error)"

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2634,14 +2634,20 @@ class Module:
         self.references = set()  # modules whose content we depend on
         self.dependents = set()  # modules that depend on our content
 
-    def resolve_options(self, config) -> dict:
+    def resolve_options(self, config, block_dim: int | None = None) -> dict:
         """Return a fully-resolved copy of the module options.
 
         Resolves ``None`` sentinels by falling back to ``config`` values and
         hardcoded defaults. Also includes global config flags that affect
         compilation, so downstream consumers never need to read config directly.
+
+        When ``block_dim`` is supplied, it overrides ``self.options["block_dim"]``
+        in the returned dict. This lets ``Module.load`` resolve a per-load
+        ``block_dim`` variant without mutating the module-level default.
         """
         options = dict(self.options)
+        if block_dim is not None:
+            options["block_dim"] = block_dim
 
         # Resolve None-means-inherit options
         if options["mode"] is None:
@@ -2864,7 +2870,7 @@ class Module:
                     self.has_unresolved_static_expressions = False
 
                 if block_dim not in self.hashers:
-                    options = self.resolve_options(warp.config)
+                    options = self.resolve_options(warp.config, block_dim=block_dim)
                     self.hashers[block_dim] = ModuleHasher(self._get_live_kernels(), options)
                     self.resolved_options[block_dim] = options
 
@@ -2899,6 +2905,7 @@ class Module:
         output_arch: int | None = None,
         arch_suffix: str = "",
         use_ptx: bool | None = None,
+        block_dim: int | None = None,
     ) -> str:
         """Get the filename to use for the compiled module binary.
 
@@ -2912,7 +2919,7 @@ class Module:
         produce distinct ``.o`` filenames without affecting the shared
         module directory (and thus CUDA caches).
         """
-        module_name_short = self.get_module_identifier()
+        module_name_short = self.get_module_identifier(block_dim=block_dim)
 
         if device and device.is_cpu:
             resolved_flags = _resolve_cpu_compiler_flags(
@@ -2957,12 +2964,12 @@ class Module:
 
         return output_name
 
-    def _get_meta_name(self) -> str:
+    def _get_meta_name(self, block_dim: int | None = None) -> str:
         """Get the filename to use for the module metadata file.
 
         This is only the filename. It should be used to form a path.
         """
-        return f"{self.get_module_identifier()}.meta"
+        return f"{self.get_module_identifier(block_dim=block_dim)}.meta"
 
     def _compile(
         self,
@@ -3003,6 +3010,13 @@ class Module:
 
         options = options | {"output_arch": output_arch}
 
+        # ``options`` is the resolved dict for the active block_dim variant
+        # (set by ``Module.load`` via ``resolve_options(block_dim=...)``). Use
+        # it for every cache-path lookup below so the .meta filename and
+        # module dir line up with the variant being compiled -- not the
+        # module-level default in ``self.options["block_dim"]``.
+        active_block_dim = options["block_dim"]
+
         # Resolve the arch suffix once for both the output filename and the build call
         if not is_cpu:
             init()
@@ -3016,10 +3030,12 @@ class Module:
             arch_suffix = ""
 
         if output_name is None:
-            output_name = self._get_compile_output_name(device, output_arch, arch_suffix, use_ptx)
+            output_name = self._get_compile_output_name(
+                device, output_arch, arch_suffix, use_ptx, block_dim=active_block_dim
+            )
 
         # Resolve output directory early so we can check for cached binaries
-        module_name_short = self.get_module_identifier()
+        module_name_short = self.get_module_identifier(block_dim=active_block_dim)
 
         if output_dir is None:
             output_dir = os.path.join(warp.config.kernel_cache_dir, f"{module_name_short}")
@@ -3032,11 +3048,11 @@ class Module:
             warp.config.cache_kernels
             and not options.get("verify_autograd_array_access", False)
             and os.path.exists(os.path.join(output_dir, output_name))
-            and os.path.exists(os.path.join(output_dir, self._get_meta_name()))
+            and os.path.exists(os.path.join(output_dir, self._get_meta_name(block_dim=active_block_dim)))
         ):
             return False
 
-        meta_path = os.path.join(output_dir, self._get_meta_name())
+        meta_path = os.path.join(output_dir, self._get_meta_name(block_dim=active_block_dim))
 
         build_dir = os.path.normpath(output_dir) + f"_p{os.getpid()}_t{threading.get_ident()}"
 
@@ -3150,7 +3166,7 @@ class Module:
         # ------------------------------------------------------------
         # write meta data (already produced under ``_codegen_lock``)
 
-        output_meta_path = os.path.join(build_dir, self._get_meta_name())
+        output_meta_path = os.path.join(build_dir, self._get_meta_name(block_dim=active_block_dim))
 
         with open(output_meta_path, "w") as meta_file:
             json.dump(meta, meta_file)
@@ -3211,11 +3227,16 @@ class Module:
     ) -> ModuleExec | None:
         device = runtime.get_device(device)
 
-        # update module options if launching with a new block dim
-        if block_dim is not None:
-            self.options["block_dim"] = block_dim
-
-        active_block_dim = self.options["block_dim"]
+        # Resolve the active block_dim without mutating self.options.
+        # Module.options["block_dim"] is the documented per-module default
+        # (settable via wp.set_module_options); it must not be silently
+        # retargeted by every individual load, because the same field is
+        # read by force_load, wp.load_module, get_kernel_hooks, and the
+        # unique-module hash salt -- letting a CPU launch (which overrides
+        # block_dim to 1 in launch()) leak into the next CUDA pre-load via
+        # this field is the cause of GH-564 / CUDA 12.2 stream-capture
+        # failures in test_apic.py.
+        active_block_dim = block_dim if block_dim is not None else self.options["block_dim"]
 
         # check if executable module is already loaded and not stale
         exec = self.execs.get((device.context, active_block_dim))
@@ -3271,11 +3292,11 @@ class Module:
                 else:
                     module_load_timer.extra_msg = " (cached)"
             else:
-                output_name = self._get_compile_output_name(device)
+                output_name = self._get_compile_output_name(device, block_dim=active_block_dim)
                 output_arch = self._get_compile_arch(device)
 
                 module_dir = os.path.join(warp.config.kernel_cache_dir, module_name_short)
-                meta_path = os.path.join(module_dir, self._get_meta_name())
+                meta_path = os.path.join(module_dir, self._get_meta_name(block_dim=active_block_dim))
                 binary_path = os.path.join(module_dir, output_name)
 
                 try:

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -624,6 +624,40 @@ def test_capture_replay_with_tile_kernel_no_stack_overflow(test, device):
     np.testing.assert_allclose(out.numpy(), np.zeros(n, dtype=np.float32))
 
 
+def test_save_load_tiled_nondefault_block_dim(test, device):
+    """APIC save must copy the binary for the captured block_dim variant."""
+    n = 32
+    block_dim = 64
+    out = wp.zeros(n, dtype=float, device=device)
+
+    # Compile the default variant first so capture_save would have a plausible
+    # but wrong binary to copy if it ignored the captured module executable's
+    # block_dim.
+    wp.load_module(device=device)
+    wp.load_module(module=_tile_using_kernel.module, device=device, block_dim=block_dim)
+
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        wp.launch_tiled(_tile_using_kernel, dim=n, inputs=[out], block_dim=block_dim, device=device)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "tiled_block_dim")
+        wp.capture_save(capture.graph, path, outputs={"out": out})
+
+        module_infos = list(capture.graph._apic_capture.collected_modules.values())
+        test.assertEqual(len(module_infos), 1)
+        module_info = module_infos[0]
+        test.assertIn(module_info["module_hash"][:7], module_info["binary_filename"])
+        test.assertTrue(os.path.exists(os.path.join(path + "_modules", module_info["binary_filename"])))
+
+        loaded = wp.capture_load(path, device=device)
+        wp.capture_launch(loaded)
+        wp.synchronize_device(device)
+
+        result = wp.zeros(n, dtype=float, device=device)
+        loaded.get_param("out", result)
+        np.testing.assert_allclose(result.numpy(), np.zeros(n, dtype=np.float32))
+
+
 @wp.kernel
 def _vec3_after_int_kernel(
     pre: int,
@@ -1260,6 +1294,12 @@ add_function_test(
     "test_capture_replay_with_tile_kernel_no_stack_overflow",
     test_capture_replay_with_tile_kernel_no_stack_overflow,
     devices=[d for d in devices if d.is_cpu],
+)
+add_function_test(
+    TestApic,
+    "test_save_load_tiled_nondefault_block_dim",
+    test_save_load_tiled_nondefault_block_dim,
+    devices=get_cuda_test_devices(),
 )
 add_function_test(
     TestApic,

--- a/warp/tests/test_block_dim_dispatch.py
+++ b/warp/tests/test_block_dim_dispatch.py
@@ -99,6 +99,72 @@ def test_block_dim_record_cmd_cpu(test, device):
     test.assertEqual(values_cpu[1], 0, "CPU: Second branch should not execute")
 
 
+def test_load_module_no_cross_device_block_dim_leak(test, device):
+    """wp.load_module(device='cuda:0') after a CPU launch must compile the
+    CUDA-default block_dim variant (256), not the stale block_dim=1 left
+    over from the CPU launch's silent override. Regression for GH-564 and
+    for the CUDA 12.2 stream-capture failure chain in test_apic.py.
+    """
+
+    @wp.kernel(module="unique")
+    def k(out: wp.array(dtype=wp.int32)):
+        wp.atomic_add(out, 0, 1)
+
+    module = k.module
+    cpu_device = wp.get_device("cpu")
+    cuda_device = wp.get_device(device)
+
+    # CPU launch first -- without the fix this also leaves
+    # module.options["block_dim"] = 1.
+    result_cpu = wp.zeros(1, dtype=wp.int32, device="cpu")
+    wp.launch(k, dim=1, inputs=[result_cpu], device="cpu")
+    test.assertIn((cpu_device.context, 1), module.execs)
+
+    # wp.load_module(device='cuda:0') without explicit block_dim must
+    # compile the CUDA-default variant, not the leaked CPU value.
+    wp.load_module(module=module, device=cuda_device)
+    test.assertIn(
+        (cuda_device.context, 256),
+        module.execs,
+        "wp.load_module should compile the CUDA default block_dim=256 variant",
+    )
+    test.assertNotIn(
+        (cuda_device.context, 1),
+        module.execs,
+        "wp.load_module must not have compiled a block_dim=1 variant on CUDA",
+    )
+
+
+def test_load_module_tiled_block_dim(test, device):
+    """A tiled launch with block_dim != 256 must compile the variant for
+    the launch's block_dim, with the source template's WP_TILE_BLOCK_DIM
+    matching. Verifies that Module.resolve_options() honours the per-load
+    block_dim, not a stale module-level default.
+    """
+
+    @wp.kernel(module="unique")
+    def k(out: wp.array(dtype=float)):
+        t = wp.tile_zeros(shape=64, dtype=float)
+        out[wp.tid()] = t[0]
+
+    module = k.module
+    cuda_device = wp.get_device(device)
+
+    out = wp.zeros(64, dtype=float, device=device)
+    wp.launch_tiled(k, dim=64, inputs=[out], block_dim=64, device=device)
+
+    test.assertIn(
+        (cuda_device.context, 64),
+        module.execs,
+        "tiled launch should produce a block_dim=64 variant",
+    )
+
+    # The resolved options for the block_dim=64 variant must carry
+    # block_dim=64, not the module-level default. (Source-gen reads this
+    # value to substitute WP_TILE_BLOCK_DIM in the .cu template.)
+    test.assertEqual(module.resolved_options[64]["block_dim"], 64)
+
+
 devices = get_test_devices()
 
 # Only test on CUDA devices (CPU would pass trivially)
@@ -115,6 +181,20 @@ add_function_test(
     TestBlockDimDispatch,
     "test_block_dim_record_cmd_cpu",
     test_block_dim_record_cmd_cpu,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_load_module_no_cross_device_block_dim_leak",
+    test_load_module_no_cross_device_block_dim_leak,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_load_module_tiled_block_dim",
+    test_load_module_tiled_block_dim,
     devices=cuda_devices,
 )
 


### PR DESCRIPTION
## Description

Fix block dimension dispatch state handling for `Module.load()` and APIC capture. The branch keeps per-execution `block_dim` from leaking across devices and threads, and preserves the active `block_dim` when APIC records module execution and backward launches.

References #564.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

This draft PR is being opened to trigger the GitHub workflows. Local validation was not run during this PR-opening step.

## Bug fix

Without this change, cached module execution could observe stale or cross-device `block_dim` state, and APIC capture could miss the active `block_dim` for recorded module execution/backward launches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a cross-device block_dim leak where CPU launches could mutate module settings, causing subsequent CUDA module loads to compile incorrect kernel variants.

* **Improvements**
  * Enhanced module compilation caching to properly track block_dim variants separately per device and launch context, ensuring correct kernel compilation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->