### PR TITLE
Fix Module.load cross-device block_dim leak [GH-564]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,13 @@
 
 ### Fixed
 
+- Fix a bug where launching a kernel on CPU and then calling `wp.load_module`
+  or using `wp.ScopedCapture(force_module_load=True)` on CUDA would fail to
+  pre-compile the correct kernel variant for CUDA. On CUDA driver versions
+  older than 12.3 this caused a `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED` error
+  at graph-capture time; on newer drivers the missing variant was silently
+  recompiled inside the capture window
+  ([GH-564](https://github.com/NVIDIA/warp/issues/564)).
 - Fix APIC backward replay so it consumes output gradients exactly like live
   `wp.Tape().backward()`: the array descriptor reconstructed at replay now
   carries the original `grad` pointer and array flags (including

--- a/warp/_src/apic/capture.py
+++ b/warp/_src/apic/capture.py
@@ -470,8 +470,8 @@ class APICapture:
         if module_hash not in self.collected_modules:
             # Compute the binary path in the kernel cache (same logic as Module.load)
             module = kernel.module
-            output_name = module._get_compile_output_name(self.device)
-            module_id = module.get_module_identifier()
+            output_name = module._get_compile_output_name(self.device, block_dim=module_exec.block_dim)
+            module_id = module.get_module_identifier(block_dim=module_exec.block_dim)
             module_dir = os.path.join(warp.config.kernel_cache_dir, module_id)
             binary_path = os.path.join(module_dir, output_name)
 
@@ -503,5 +503,5 @@ class APICapture:
                 "backward_name": backward_name,
                 "forward_smem_bytes": hooks.forward_smem_bytes,
                 "backward_smem_bytes": hooks.backward_smem_bytes,
-                "block_dim": kernel.options.get("block_dim", 256),
+                "block_dim": module_exec.block_dim,
             }

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -9335,16 +9335,29 @@ def force_load(
         else:
             max_workers = warp.config.load_module_max_workers
 
+    def _load_block_dims(m: Module, d: Device) -> list[int | None]:
+        # With no explicit block_dim, preload the variants already loaded on
+        # this device rather than the module-level default, so we don't
+        # compile a default-block_dim variant the caller never requested.
+        # Reading m.execs keeps this device-scoped (a CPU block_dim never
+        # leaks into a CUDA preload).
+        if block_dim is not None:
+            return [block_dim]
+        loaded = [bd for (ctx, bd) in m.execs if ctx == d.context]
+        return loaded or [None]
+
     if max_workers <= 1 or (len(devices) * len(modules)) == 1:
         # serial loading; avoid the overhead of using a thread pool
         for d in devices:
             for m in modules:
-                m.load(d, block_dim=block_dim)
+                for bd in _load_block_dims(m, d):
+                    m.load(d, block_dim=bd)
     else:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             for d in devices:
                 for m in modules:
-                    executor.submit(m.load, d, block_dim=block_dim)
+                    for bd in _load_block_dims(m, d):
+                        executor.submit(m.load, d, block_dim=bd)
 
     if is_cuda_available():
         # restore original context to avoid side effects

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2634,14 +2634,20 @@ class Module:
         self.references = set()  # modules whose content we depend on
         self.dependents = set()  # modules that depend on our content
 
-    def resolve_options(self, config) -> dict:
+    def resolve_options(self, config, block_dim: int | None = None) -> dict:
         """Return a fully-resolved copy of the module options.
 
         Resolves ``None`` sentinels by falling back to ``config`` values and
         hardcoded defaults. Also includes global config flags that affect
         compilation, so downstream consumers never need to read config directly.
+
+        When ``block_dim`` is supplied, it overrides ``self.options["block_dim"]``
+        in the returned dict. This lets ``Module.load`` resolve a per-load
+        ``block_dim`` variant without mutating the module-level default.
         """
         options = dict(self.options)
+        if block_dim is not None:
+            options["block_dim"] = block_dim
 
         # Resolve None-means-inherit options
         if options["mode"] is None:
@@ -2881,7 +2887,7 @@ class Module:
                     self.has_unresolved_static_expressions = False
 
                 if block_dim not in self.hashers:
-                    options = self.resolve_options(warp.config)
+                    options = self.resolve_options(warp.config, block_dim=block_dim)
                     self.hashers[block_dim] = ModuleHasher(self._get_live_kernels(), options)
                     self.resolved_options[block_dim] = options
 
@@ -2916,6 +2922,7 @@ class Module:
         output_arch: int | None = None,
         arch_suffix: str = "",
         use_ptx: bool | None = None,
+        block_dim: int | None = None,
     ) -> str:
         """Get the filename to use for the compiled module binary.
 
@@ -2929,7 +2936,7 @@ class Module:
         produce distinct ``.o`` filenames without affecting the shared
         module directory (and thus CUDA caches).
         """
-        module_name_short = self.get_module_identifier()
+        module_name_short = self.get_module_identifier(block_dim=block_dim)
 
         if device and device.is_cpu:
             resolved_flags = _resolve_cpu_compiler_flags(
@@ -2974,12 +2981,12 @@ class Module:
 
         return output_name
 
-    def _get_meta_name(self) -> str:
+    def _get_meta_name(self, block_dim: int | None = None) -> str:
         """Get the filename to use for the module metadata file.
 
         This is only the filename. It should be used to form a path.
         """
-        return f"{self.get_module_identifier()}.meta"
+        return f"{self.get_module_identifier(block_dim=block_dim)}.meta"
 
     def _compile(
         self,
@@ -3020,6 +3027,13 @@ class Module:
 
         options = options | {"output_arch": output_arch}
 
+        # ``options`` is the resolved dict for the active block_dim variant
+        # (set by ``Module.load`` via ``resolve_options(block_dim=...)``). Use
+        # it for every cache-path lookup below so the .meta filename and
+        # module dir line up with the variant being compiled -- not the
+        # module-level default in ``self.options["block_dim"]``.
+        active_block_dim = options["block_dim"]
+
         # Resolve the arch suffix once for both the output filename and the build call
         if not is_cpu:
             init()
@@ -3033,10 +3047,12 @@ class Module:
             arch_suffix = ""
 
         if output_name is None:
-            output_name = self._get_compile_output_name(device, output_arch, arch_suffix, use_ptx)
+            output_name = self._get_compile_output_name(
+                device, output_arch, arch_suffix, use_ptx, block_dim=active_block_dim
+            )
 
         # Resolve output directory early so we can check for cached binaries
-        module_name_short = self.get_module_identifier()
+        module_name_short = self.get_module_identifier(block_dim=active_block_dim)
 
         if output_dir is None:
             output_dir = os.path.join(warp.config.kernel_cache_dir, f"{module_name_short}")
@@ -3049,11 +3065,11 @@ class Module:
             warp.config.cache_kernels
             and not options.get("verify_autograd_array_access", False)
             and os.path.exists(os.path.join(output_dir, output_name))
-            and os.path.exists(os.path.join(output_dir, self._get_meta_name()))
+            and os.path.exists(os.path.join(output_dir, self._get_meta_name(block_dim=active_block_dim)))
         ):
             return False
 
-        meta_path = os.path.join(output_dir, self._get_meta_name())
+        meta_path = os.path.join(output_dir, self._get_meta_name(block_dim=active_block_dim))
 
         build_dir = os.path.normpath(output_dir) + f"_p{os.getpid()}_t{threading.get_ident()}"
 
@@ -3167,7 +3183,7 @@ class Module:
         # ------------------------------------------------------------
         # write meta data (already produced under ``_codegen_lock``)
 
-        output_meta_path = os.path.join(build_dir, self._get_meta_name())
+        output_meta_path = os.path.join(build_dir, self._get_meta_name(block_dim=active_block_dim))
 
         with open(output_meta_path, "w") as meta_file:
             json.dump(meta, meta_file)
@@ -3228,11 +3244,16 @@ class Module:
     ) -> ModuleExec | None:
         device = runtime.get_device(device)
 
-        # update module options if launching with a new block dim
-        if block_dim is not None:
-            self.options["block_dim"] = block_dim
-
-        active_block_dim = self.options["block_dim"]
+        # Resolve the active block_dim without mutating self.options.
+        # Module.options["block_dim"] is the documented per-module default
+        # (settable via wp.set_module_options); it must not be silently
+        # retargeted by every individual load, because the same field is
+        # read by force_load, wp.load_module, get_kernel_hooks, and the
+        # unique-module hash salt -- letting a CPU launch (which overrides
+        # block_dim to 1 in launch()) leak into the next CUDA pre-load via
+        # this field is the cause of GH-564 / CUDA 12.2 stream-capture
+        # failures in test_apic.py.
+        active_block_dim = block_dim if block_dim is not None else self.options["block_dim"]
 
         # check if executable module is already loaded and not stale
         exec = self.execs.get((device.context, active_block_dim))
@@ -3288,11 +3309,11 @@ class Module:
                 else:
                     module_load_timer.extra_msg = " (cached)"
             else:
-                output_name = self._get_compile_output_name(device)
+                output_name = self._get_compile_output_name(device, block_dim=active_block_dim)
                 output_arch = self._get_compile_arch(device)
 
                 module_dir = os.path.join(warp.config.kernel_cache_dir, module_name_short)
-                meta_path = os.path.join(module_dir, self._get_meta_name())
+                meta_path = os.path.join(module_dir, self._get_meta_name(block_dim=active_block_dim))
                 binary_path = os.path.join(module_dir, output_name)
 
                 try:

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2586,7 +2586,7 @@ class Module:
         # executable modules currently loaded
         self.execs = {}  # ((device.context, blockdim): ModuleExec)
 
-        # set of device contexts where the build has failed
+        # set of (device context, block_dim) variants where the build has failed
         self.failed_builds = set()
 
         # hash data, including the module hash. Module may store multiple hashes (one per block_dim used)
@@ -3175,9 +3175,9 @@ class Module:
                 _check_and_raise_long_path_error(e)
 
             if is_cpu:
-                self.failed_builds.add(None)
+                self.failed_builds.add((None, active_block_dim))
             elif device:
-                self.failed_builds.add(device.context)
+                self.failed_builds.add((device.context, active_block_dim))
 
             raise (e)
 
@@ -3269,7 +3269,7 @@ class Module:
                 log_debug(f"[Module.load] Module hash changed, recompiling: {self.name} ({old_str} -> {new_str})")
 
         # quietly avoid repeated build attempts to reduce error spew
-        if device.context in self.failed_builds:
+        if (device.context, active_block_dim) in self.failed_builds:
             return None
 
         module_hash = self.get_module_hash(active_block_dim)
@@ -9326,7 +9326,7 @@ def force_load(
         devices = [get_device(device)]
 
     if modules is None:
-        modules = user_modules.values()
+        modules = list(user_modules.values())
 
     if max_workers is None:
         if warp.config.load_module_max_workers is None:
@@ -9335,29 +9335,33 @@ def force_load(
         else:
             max_workers = warp.config.load_module_max_workers
 
+    # Copy each module's loaded variant keys before the loads below mutate
+    # m.execs (the parallel path writes it concurrently).
+    loaded_variants = {m: tuple(m.execs) for m in modules}
+
     def _load_block_dims(m: Module, d: Device) -> list[int | None]:
         # With no explicit block_dim, preload the variants already loaded on
         # this device rather than the module-level default, so we don't
         # compile a default-block_dim variant the caller never requested.
-        # Reading m.execs keeps this device-scoped (a CPU block_dim never
+        # Filtering by context keeps this device-scoped (a CPU block_dim never
         # leaks into a CUDA preload).
         if block_dim is not None:
             return [block_dim]
-        loaded = [bd for (ctx, bd) in m.execs if ctx == d.context]
+        loaded = [dim for (ctx, dim) in loaded_variants[m] if ctx == d.context]
         return loaded or [None]
 
     if max_workers <= 1 or (len(devices) * len(modules)) == 1:
         # serial loading; avoid the overhead of using a thread pool
         for d in devices:
             for m in modules:
-                for bd in _load_block_dims(m, d):
-                    m.load(d, block_dim=bd)
+                for dim in _load_block_dims(m, d):
+                    m.load(d, block_dim=dim)
     else:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             for d in devices:
                 for m in modules:
-                    for bd in _load_block_dims(m, d):
-                        executor.submit(m.load, d, block_dim=bd)
+                    for dim in _load_block_dims(m, d):
+                        executor.submit(m.load, d, block_dim=dim)
 
     if is_cuda_available():
         # restore original context to avoid side effects

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2447,12 +2447,13 @@ class ModuleExec:
         instance.handle = None
         return instance
 
-    def __init__(self, handle, module_hash, device, meta):
+    def __init__(self, handle, module_hash, device, meta, block_dim: int):
         self.handle = handle
         self.module_hash = module_hash
         self.device = device
         self.kernel_hooks = {}
         self.meta = meta
+        self.block_dim = block_dim
 
     # release the loaded module
     def __del__(self):
@@ -3346,13 +3347,13 @@ class Module:
                     != 0
                 ):
                     raise Exception(f"Failed to load CPU module '{self.name}'")
-                module_exec = ModuleExec(module_handle, module_hash, device, meta)
+                module_exec = ModuleExec(module_handle, module_hash, device, meta, active_block_dim)
                 self.execs[(None, active_block_dim)] = module_exec
 
             elif device.is_cuda:
                 cuda_module = warp._src.build.load_cuda(binary_path, device)
                 if cuda_module is not None:
-                    module_exec = ModuleExec(cuda_module, module_hash, device, meta)
+                    module_exec = ModuleExec(cuda_module, module_hash, device, meta, active_block_dim)
                     self.execs[(device.context, active_block_dim)] = module_exec
                 else:
                     module_load_timer.extra_msg = " (error)"

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -624,6 +624,40 @@ def test_capture_replay_with_tile_kernel_no_stack_overflow(test, device):
     np.testing.assert_allclose(out.numpy(), np.zeros(n, dtype=np.float32))
 
 
+def test_save_load_tiled_nondefault_block_dim(test, device):
+    """APIC save must copy the binary for the captured block_dim variant."""
+    n = 32
+    block_dim = 64
+    out = wp.zeros(n, dtype=float, device=device)
+
+    # Compile the default variant first so capture_save would have a plausible
+    # but wrong binary to copy if it ignored the captured module executable's
+    # block_dim.
+    wp.load_module(device=device)
+    wp.load_module(module=_tile_using_kernel.module, device=device, block_dim=block_dim)
+
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        wp.launch_tiled(_tile_using_kernel, dim=n, inputs=[out], block_dim=block_dim, device=device)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "tiled_block_dim")
+        wp.capture_save(capture.graph, path, outputs={"out": out})
+
+        module_infos = list(capture.graph._apic_capture.collected_modules.values())
+        test.assertEqual(len(module_infos), 1)
+        module_info = module_infos[0]
+        test.assertIn(module_info["module_hash"][:7], module_info["binary_filename"])
+        test.assertTrue(os.path.exists(os.path.join(path + "_modules", module_info["binary_filename"])))
+
+        loaded = wp.capture_load(path, device=device)
+        wp.capture_launch(loaded)
+        wp.synchronize_device(device)
+
+        result = wp.zeros(n, dtype=float, device=device)
+        loaded.get_param("out", result)
+        np.testing.assert_allclose(result.numpy(), np.zeros(n, dtype=np.float32))
+
+
 @wp.kernel
 def _vec3_after_int_kernel(
     pre: int,
@@ -1260,6 +1294,12 @@ add_function_test(
     "test_capture_replay_with_tile_kernel_no_stack_overflow",
     test_capture_replay_with_tile_kernel_no_stack_overflow,
     devices=[d for d in devices if d.is_cpu],
+)
+add_function_test(
+    TestApic,
+    "test_save_load_tiled_nondefault_block_dim",
+    test_save_load_tiled_nondefault_block_dim,
+    devices=get_cuda_test_devices(),
 )
 add_function_test(
     TestApic,

--- a/warp/tests/test_block_dim_dispatch.py
+++ b/warp/tests/test_block_dim_dispatch.py
@@ -165,6 +165,40 @@ def test_load_module_tiled_block_dim(test, device):
     test.assertEqual(module.resolved_options[64]["block_dim"], 64)
 
 
+def test_force_load_preserves_loaded_block_dim(test, device):
+    """force_load(device) with no explicit block_dim must reuse the variant
+    already loaded on the device, not compile a fresh module-level-default
+    (256) variant. capture_begin() routes through force_load() on driver
+    < 12.3, so a spurious default-block_dim compile there breaks graph
+    capture for kernels whose tile shapes are tied to a specific block_dim
+    (e.g. examples/tile/example_tile_mlp.py). Regression for the GH-564
+    mutation removal.
+    """
+
+    @wp.kernel(module="unique")
+    def k(out: wp.array(dtype=float)):
+        t = wp.tile_zeros(shape=64, dtype=float)
+        out[wp.tid()] = t[0]
+
+    module = k.module
+    cuda_device = wp.get_device(device)
+
+    out = wp.zeros(64, dtype=float, device=device)
+    wp.launch_tiled(k, dim=64, inputs=[out], block_dim=64, device=device)
+    test.assertIn((cuda_device.context, 64), module.execs)
+
+    # force_load without an explicit block_dim must reuse the loaded 64
+    # variant and must not compile the module-level default (256).
+    wp.force_load(device=cuda_device, modules=[module])
+    test.assertIn((cuda_device.context, 64), module.execs)
+    test.assertNotIn(
+        (cuda_device.context, 256),
+        module.execs,
+        "force_load must not compile the default block_dim=256 variant when a "
+        "non-default variant is already loaded on the device",
+    )
+
+
 devices = get_test_devices()
 
 # Only test on CUDA devices (CPU would pass trivially)
@@ -195,6 +229,13 @@ add_function_test(
     TestBlockDimDispatch,
     "test_load_module_tiled_block_dim",
     test_load_module_tiled_block_dim,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_force_load_preserves_loaded_block_dim",
+    test_force_load_preserves_loaded_block_dim,
     devices=cuda_devices,
 )
 

--- a/warp/tests/test_block_dim_dispatch.py
+++ b/warp/tests/test_block_dim_dispatch.py
@@ -99,6 +99,72 @@ def test_block_dim_record_cmd_cpu(test, device):
     test.assertEqual(values_cpu[1], 0, "CPU: Second branch should not execute")
 
 
+def test_load_module_no_cross_device_block_dim_leak(test, device):
+    """wp.load_module(device='cuda:0') after a CPU launch must compile the
+    CUDA-default block_dim variant (256), not the stale block_dim=1 left
+    over from the CPU launch's silent override. Regression for GH-564 and
+    for the CUDA 12.2 stream-capture failure chain in test_apic.py.
+    """
+
+    @wp.kernel(module="unique")
+    def k(out: wp.array(dtype=wp.int32)):
+        wp.atomic_add(out, 0, 1)
+
+    module = k.module
+    cpu_device = wp.get_device("cpu")
+    cuda_device = wp.get_device(device)
+
+    # CPU launch first -- without the fix this also leaves
+    # module.options["block_dim"] = 1.
+    result_cpu = wp.zeros(1, dtype=wp.int32, device="cpu")
+    wp.launch(k, dim=1, inputs=[result_cpu], device="cpu")
+    test.assertIn((cpu_device.context, 1), module.execs)
+
+    # wp.load_module(device='cuda:0') without explicit block_dim must
+    # compile the CUDA-default variant, not the leaked CPU value.
+    wp.load_module(module=module, device=cuda_device)
+    test.assertIn(
+        (cuda_device.context, 256),
+        module.execs,
+        "wp.load_module should compile the CUDA default block_dim=256 variant",
+    )
+    test.assertNotIn(
+        (cuda_device.context, 1),
+        module.execs,
+        "wp.load_module must not have compiled a block_dim=1 variant on CUDA",
+    )
+
+
+def test_load_module_tiled_block_dim(test, device):
+    """A tiled launch with block_dim != 256 must compile the variant for
+    the launch's block_dim, with the source template's WP_TILE_BLOCK_DIM
+    matching. Verifies that Module.resolve_options() honours the per-load
+    block_dim, not a stale module-level default.
+    """
+
+    @wp.kernel(module="unique")
+    def k(out: wp.array(dtype=float)):
+        t = wp.tile_zeros(shape=64, dtype=float)
+        out[wp.tid()] = t[0]
+
+    module = k.module
+    cuda_device = wp.get_device(device)
+
+    out = wp.zeros(64, dtype=float, device=device)
+    wp.launch_tiled(k, dim=64, inputs=[out], block_dim=64, device=device)
+
+    test.assertIn(
+        (cuda_device.context, 64),
+        module.execs,
+        "tiled launch should produce a block_dim=64 variant",
+    )
+
+    # The resolved options for the block_dim=64 variant must carry
+    # block_dim=64, not the module-level default. (Source-gen reads this
+    # value to substitute WP_TILE_BLOCK_DIM in the .cu template.)
+    test.assertEqual(module.resolved_options[64]["block_dim"], 64)
+
+
 devices = get_test_devices()
 
 # Only test on CUDA devices (CPU would pass trivially)
@@ -115,6 +181,20 @@ add_function_test(
     TestBlockDimDispatch,
     "test_block_dim_record_cmd_cpu",
     test_block_dim_record_cmd_cpu,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_load_module_no_cross_device_block_dim_leak",
+    test_load_module_no_cross_device_block_dim_leak,
+    devices=cuda_devices,
+)
+
+add_function_test(
+    TestBlockDimDispatch,
+    "test_load_module_tiled_block_dim",
+    test_load_module_tiled_block_dim,
     devices=cuda_devices,
 )
 


### PR DESCRIPTION
## Description

`Module.load(device, block_dim=N)` mutates `self.options["block_dim"] = N` on every call, treating the field as the "currently active variant" tracker. But `Module.options["block_dim"]` is the documented per-module default (settable via `wp.set_module_options`) and is also read by several callers that have no idea which device or variant is active:

- `force_load(device)` / `wp.load_module(device=...)` calls `Module.load(device, block_dim=None)`, which falls back to `self.options["block_dim"]`.
- `ScopedCapture(force_module_load=True)` goes through the same path.
- `get_kernel_hooks(kernel, device)` reads `self.options["block_dim"]` directly to look up the cached `ModuleExec`.
- The unique-module hash salt in `register_kernel` reads `self.options["block_dim"]` as the default key into `Module.hashers`.

`wp.launch(..., device='cpu')` silently overrides `block_dim` to `1`. After a CPU launch, the module's `options["block_dim"]` is left at `1`, and the next CUDA pre-load (`wp.load_module`, `ScopedCapture`, etc.) compiles only the `block_dim=1` variant. The subsequent CUDA `wp.launch` defaults to `block_dim=256`, misses the per-device per-block_dim cache, and falls through to `cuModuleLoadDataEx`. Under CUDA driver < 12.3 that call is forbidden inside a stream-capture window and fails with `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED` (CUDA error 900):

```
Warp CUDA error 900: operation not permitted when stream is capturing
  (in function wp_cuda_load_module, warp/native/warp.cu:5115)
Warp CUDA error: Loading module failed
Exception: Failed to load CUDA module 'warp.tests.test_apic'
```

This is the same root cause as [GH-564](https://github.com/NVIDIA/warp/issues/564) ("Consider maintaining separate Module `block_dim` variables for CPU and GPU"), and the three CUDA stream-capture failures in `test_apic.py` on `linux-amd64-gpu-l4-earliest-1` (driver 12.2) are a direct symptom. On driver 12.3+ the in-capture `cuModuleLoadDataEx` silently re-compiles instead of erroring, so the bug is invisible locally on current drivers.

The first revision of the core fix also exposed the same stale-default assumption in APIC serialization: `capture_save()` recomputed module binary paths from `Module.options["block_dim"]` instead of the already-loaded executable's variant. That broke the C++ CPU APIC example job by looking for the wrong `.o` file (`block_dim=256` default instead of the CPU `block_dim=1` variant). This MR now carries the active `block_dim` on `ModuleExec` and uses it when APIC records module and kernel metadata.

Closes GH-564.

**Approach.** Drop the cross-device mutation. Treat `Module.options["block_dim"]` as the stable per-module default (matching its `wp.set_module_options` documentation) and thread the per-load `block_dim` through every helper that currently relies on the mutation to pick the active variant:

- `Module.resolve_options(config, block_dim=...)` overrides the per-load value in the returned dict, so `ModuleHasher` keys, `ModuleBuilder` (including the `WP_TILE_BLOCK_DIM` substitution in the `.cu` template), and downstream consumers all see the correct value.
- `Module.get_module_hash` propagates `block_dim` into `resolve_options`, so `Module.resolved_options[N]["block_dim"] == N` for every keyed variant.
- `Module._get_compile_output_name` and `Module._get_meta_name` accept `block_dim` and forward it to `get_module_identifier`, so the `.cubin` / `.ptx` / `.o` and `.meta` filenames are uniquely keyed per variant (no cache filename collisions between variants).
- `Module._compile` derives its own `active_block_dim` from the resolved `options` dict and uses it for every `get_module_identifier` / `_get_meta_name` call inside the compile path, so the build_dir and meta path it writes line up with the cache path `Module.load` reads.
- `Module.load` resolves `active_block_dim` from the per-load argument (falling back to the documented module default) and threads it into both helpers, with an inline comment documenting why the field must stay stable.
- `ModuleExec` records the active `block_dim` used to create the executable, so downstream code can ask "which variant is this?" without reading the stable module default.
- `APICapture._collect_metadata` uses `module_exec.block_dim` for both cache-path lookup and the `block_dim` serialized into the `.wrp` kernel metadata.

**Alternatives considered.**

- *Add warm-up `wp.launch` calls before each failing `ScopedCapture` in `test_apic.py`* (the previous revision of this MR, commit `402c5e824`). Works for the three failing tests but papers over the same defect for every other caller, every example, every downstream user --- in particular, any non-Warp test that touches a Warp module on both CPU and CUDA in a single process and then uses CUDA graph capture. Reverted in favour of the core fix.
- *Make `force_load` iterate every known `Module.hashers` variant.* Helps callers that already saw the right `block_dim` once, but `hashers` is populated lazily, so empty-cache cases still fail. Doesn't address `get_kernel_hooks` or the unique-module hash salt.
- *Hard-code `force_load(device, block_dim=256)` in `ScopedCapture`'s CUDA path.* Bakes a magic number into core code, still wrong for users who launch with a non-default `block_dim`.

The core fix is the smallest change that closes GH-564 without baking assumptions about Warp internals into either tests or `ScopedCapture`.

## Changes

- **[warp/_src/context.py](warp/_src/context.py)**: `resolve_options`, `get_module_hash`, `_get_compile_output_name`, `_get_meta_name`, `_compile`, and `Module.load` now thread a per-load `block_dim` through every cache-name and resolved-options lookup; `Module.load` no longer mutates `self.options["block_dim"]`.
- **[warp/_src/apic/capture.py](warp/_src/apic/capture.py)**: APIC module metadata now uses the active `ModuleExec.block_dim` when finding the binary to copy and when recording the replay launch block dimension.
- **[warp/tests/test_apic.py](warp/tests/test_apic.py)**: adds `test_save_load_tiled_nondefault_block_dim`, which captures, saves, loads, and replays a tiled CUDA launch with `block_dim=64`, verifying APIC copies the matching module variant.
- **[warp/tests/test_block_dim_dispatch.py](warp/tests/test_block_dim_dispatch.py)**: adds `test_load_module_no_cross_device_block_dim_leak` (direct GH-564 regression --- a CPU launch followed by `wp.load_module(device='cuda:0')` must compile the `(cuda_ctx, 256)` variant, not a leaked `(cuda_ctx, 1)`) and `test_load_module_tiled_block_dim` (a tiled launch with `block_dim=64` must produce a `(cuda_ctx, 64)` variant whose resolved options carry `block_dim=64`, which is what source-gen substitutes into `WP_TILE_BLOCK_DIM`).
- **[CHANGELOG.md](CHANGELOG.md)**: adds an `Unreleased / Fixed` entry for the cross-device `block_dim` leak.

The CHANGELOG entry is included because the bug affects user-visible graph-capture behaviour. The implementation still aligns `Module.options["block_dim"]` with its documented contract as a per-module default, not an active-variant tracker.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Test plan

```bash
# Direct GH-564 regressions plus the existing cross-device dispatch tests.
uv run warp/tests/test_block_dim_dispatch.py
# -> Ran 4 tests, OK

# APIC save/load regression for non-default block_dim variants.
uv run warp/tests/test_apic.py TestApic.test_save_load_tiled_nondefault_block_dim_cuda_0
# -> OK

# Original CUDA driver 12.2 failure shape, sanity-checked locally on driver 13.1.
uv run warp/tests/test_apic.py TestApic.test_capture_with_empty_array_input_cuda_0 TestApic.test_capture_with_large_scalar_param_cuda_0 TestApic.test_end_recording_null_state_preserves_active_cuda_0
# -> OK

# CPU APIC save/load smoke for the C++ example failure class.
uv run warp/tests/test_apic.py TestApic.test_save_load_round_trip_cpu
# -> OK

uvx pre-commit run --files warp/_src/context.py warp/_src/apic/capture.py warp/tests/test_apic.py
# -> all hooks pass
```

The headline gate is the next CI run on `linux-amd64-gpu-l4-earliest-1` (driver 12.2). Pre-fix, that job fails with three `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED` module-load errors in `test_apic.py`; with this MR it should pass on driver 12.2 as well as on current drivers.

The C++ APIC example job that failed after the first revision should also pass now: APIC save no longer recomputes module paths from the default `Module.options["block_dim"]`, so CPU capture finds the compiled `block_dim=1` `.o` variant.

## Bug fix

Without this MR applied, on any driver:

```python
import warp as wp

@wp.kernel(module="unique")
def k(out: wp.array(dtype=wp.int32)):
    wp.atomic_add(out, 0, 1)

# CPU launch silently overrides block_dim to 1 and mutates
# module.options["block_dim"] = 1.
out_cpu = wp.zeros(1, dtype=wp.int32, device="cpu")
wp.launch(k, dim=1, inputs=[out_cpu], device="cpu")

# Now wp.load_module on CUDA, with no explicit block_dim, reads the
# leaked block_dim=1 from module.options and compiles only that
# variant -- not the block_dim=256 variant a default CUDA launch
# actually needs.
wp.load_module(module=k.module, device="cuda:0")

assert (wp.get_device("cuda:0").context, 256) in k.module.execs  # FAILS pre-fix
```

On driver < 12.3, the same chain inside a `ScopedCapture` window then triggers `Exception: Failed to load CUDA module ...` from [`warp/_src/context.py`](warp/_src/context.py) because the lazy `cuModuleLoadDataEx` for the missing `block_dim=256` variant is forbidden during stream capture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CUDA capture/module-loading issues that could use the wrong block-dimension variant, preventing capture errors on older drivers and silent recompiles on newer drivers.
  * Eliminated cross-device/block-dimension state leaks so compilation, caching, capture, and replay respect per-load block-dimension variants.

* **Tests**
  * Added regression tests covering per-device/per-load block-dimension handling, capture/save/load of non-default block dims, and force-load behavior.

* **Documentation**
  * Updated changelog with the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->