### PR TITLE
Add PyTorch allocator tests and docs

### DIFF
--- a/docs/deep_dive/allocators.rst
+++ b/docs/deep_dive/allocators.rst
@@ -332,6 +332,75 @@ during CUDA graph capture.
 
 See ``warp/examples/core/example_custom_allocator.py`` for a complete example.
 
+.. _pytorch-cuda-caching-allocator:
+
+PyTorch CUDA Caching Allocator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PyTorch exposes low-level CUDA caching allocator functions that can be used by
+other frameworks. If an application wants Warp CUDA arrays to be allocated from
+PyTorch's cache, implement a small custom allocator that calls
+``torch.cuda.caching_allocator_alloc()`` and releases pointers with
+``torch.cuda.caching_allocator_delete()``:
+
+.. code:: python
+
+    import torch
+    import warp as wp
+
+
+    class TorchCachingAllocator:
+        """Route Warp CUDA array allocations through PyTorch."""
+
+        def __init__(self):
+            self._active_allocations = {}
+
+        @staticmethod
+        def _current_warp_device_and_stream():
+            device = wp.get_cuda_device()
+            stream = device.stream.cuda_stream
+            return device.ordinal, int(stream) if stream is not None else 0
+
+        def allocate(self, size_in_bytes: int) -> int:
+            if size_in_bytes == 0:
+                return 0
+
+            device, stream = self._current_warp_device_and_stream()
+            ptr = torch.cuda.caching_allocator_alloc(size_in_bytes, device=device, stream=stream)
+            ptr = int(ptr)
+            self._active_allocations[ptr] = size_in_bytes
+            return ptr
+
+        def deallocate(self, ptr: int, size_in_bytes: int) -> None:
+            if ptr == 0:
+                return
+
+            allocated_size = self._active_allocations.get(ptr)
+            if allocated_size is None:
+                raise RuntimeError(f"Unrecognized allocation pointer {ptr:#x}")
+            if allocated_size != size_in_bytes:
+                raise RuntimeError(
+                    f"Allocation size mismatch for pointer {ptr:#x}: "
+                    f"allocated {allocated_size}, deallocating {size_in_bytes}"
+                )
+
+            del self._active_allocations[ptr]
+            torch.cuda.caching_allocator_delete(ptr)
+
+
+    allocator = TorchCachingAllocator()
+    wp.set_cuda_allocator(allocator)
+    try:
+        a = wp.zeros(1000, dtype=wp.float32, device="cuda:0")
+    finally:
+        wp.set_cuda_allocator(None)
+
+PyTorch tracks the device and stream for pointers returned by
+``caching_allocator_alloc()``, so ``caching_allocator_delete()`` only needs the
+pointer. The ``_active_allocations`` dictionary above is for validation and
+debugging; applications can customize this tracking for their own accounting,
+thread-safety, or distributed runtime needs.
+
 RMM Integration
 ~~~~~~~~~~~~~~~
 

--- a/docs/user_guide/interoperability_pytorch.rst
+++ b/docs/user_guide/interoperability_pytorch.rst
@@ -35,6 +35,11 @@ Warp also provides helper functions for mapping devices and dtypes between Warp 
     warp_dtype = wp.dtype_from_torch(t.dtype)
     warp_device = wp.device_from_torch(t.device)
 
+By default, Warp arrays allocated with functions such as :func:`wp.zeros() <warp.zeros>`
+use Warp's CUDA allocator. If an application needs those allocations to come
+from PyTorch's CUDA caching allocator, see
+:ref:`pytorch-cuda-caching-allocator` for a minimal custom allocator example.
+
 Stream Conversion
 -----------------
 

--- a/warp/tests/test_allocator.py
+++ b/warp/tests/test_allocator.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from unittest import mock
 
 import numpy as np
 
@@ -13,12 +14,29 @@ wp.init()
 
 cuda_test_devices = get_cuda_test_devices(mode="basic")
 
+# RMM imports NVIDIA's top-level ``cuda`` package. Keep this probe after
+# ``unittest_utils`` normalizes direct-test ``sys.path`` so ``warp/tests/cuda``
+# does not shadow the installed CUDA package when this file is run by path.
 try:
     import rmm
 
     rmm_available = True
 except ImportError:
     rmm_available = False
+
+_TORCH_CUDA_PROBE_EXCEPTIONS = (RuntimeError, OSError, ValueError)
+
+
+def _try_import_torch():
+    try:
+        import torch  # noqa: PLC0415
+    except (ImportError, OSError):
+        return None, False
+
+    return torch, True
+
+
+torch, torch_available = _try_import_torch()
 
 
 class CountingAllocator:
@@ -46,6 +64,79 @@ class FailAllocator:
 
     def deallocate(self, ptr, size_in_bytes):
         pass
+
+
+class TorchCachingAllocatorForWarp:
+    """Test allocator that routes CUDA allocations through PyTorch's cache."""
+
+    def __init__(self):
+        self._active_allocations: dict[int, int] = {}
+        self.alloc_count = 0
+        self.dealloc_count = 0
+
+    @staticmethod
+    def _get_warp_device_and_stream() -> tuple[int, int]:
+        from warp._src.context import runtime  # noqa: PLC0415
+
+        device = runtime.get_current_cuda_device()
+        stream = device.stream.cuda_stream
+        return device.ordinal, int(stream) if stream is not None else 0
+
+    def allocate(self, size_in_bytes: int) -> int:
+        if size_in_bytes == 0:
+            return 0
+
+        device, stream = self._get_warp_device_and_stream()
+        ptr = torch.cuda.caching_allocator_alloc(size_in_bytes, device=device, stream=stream)
+        if not ptr:
+            raise RuntimeError(f"Failed to allocate {size_in_bytes} bytes on CUDA device {device} using PyTorch")
+
+        ptr = int(ptr)
+        self.alloc_count += 1
+        self._active_allocations[ptr] = size_in_bytes
+        return ptr
+
+    def deallocate(self, ptr: int, size_in_bytes: int) -> None:
+        if ptr == 0:
+            return
+
+        allocated_size = self._active_allocations.get(ptr)
+        if allocated_size is None:
+            raise RuntimeError(
+                f"{type(self).__name__}.deallocate called with unrecognized pointer {ptr:#x} (size={size_in_bytes})"
+            )
+        if allocated_size != size_in_bytes:
+            raise RuntimeError(
+                f"{type(self).__name__}.deallocate size mismatch for pointer {ptr:#x}: "
+                f"allocated {allocated_size}, deallocating {size_in_bytes}"
+            )
+        del self._active_allocations[ptr]
+        self.dealloc_count += 1
+
+        torch.cuda.caching_allocator_delete(ptr)
+
+    def __repr__(self):
+        return f"{type(self).__name__}(active_allocations={len(self._active_allocations)})"
+
+
+def _get_torch_cuda_allocator_test_devices():
+    if not torch_available:
+        return []
+    if not torch.cuda.is_available():
+        return []
+    if not hasattr(torch.cuda, "caching_allocator_alloc") or not hasattr(torch.cuda, "caching_allocator_delete"):
+        return []
+
+    devices = []
+    for device in cuda_test_devices:
+        try:
+            torch.empty(1, device=wp.device_to_torch(device))
+        except _TORCH_CUDA_PROBE_EXCEPTIONS as e:
+            print(f"Skipping PyTorch allocator test on device '{device}' due to exception: {e}")
+        else:
+            devices.append(device)
+
+    return devices
 
 
 # -- Protocol conformance ---------------------------------------------------
@@ -339,6 +430,88 @@ if rmm_available:
         test_rmm_allocator_double_free,
     ]:
         add_function_test(TestRmmAllocator, fn.__name__, fn, devices=cuda_test_devices)
+
+
+# -- PyTorch allocator ------------------------------------------------------
+
+
+class TestTorchAllocator(unittest.TestCase):
+    def test_torch_import_probe_handles_os_error(self):
+        """Torch DLL load failures make Torch allocator tests unavailable."""
+
+        real_import = __import__
+
+        def import_with_torch_os_error(name, *args, **kwargs):
+            if name == "torch":
+                raise OSError("DLL initialization failed")
+
+            return real_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=import_with_torch_os_error):
+            imported_torch, is_available = _try_import_torch()
+
+        self.assertIsNone(imported_torch)
+        self.assertFalse(is_available)
+
+    def test_torch_import_probe_propagates_unexpected_errors(self):
+        """Unexpected Torch import failures still fail test collection."""
+
+        real_import = __import__
+
+        def import_with_torch_runtime_error(name, *args, **kwargs):
+            if name == "torch":
+                raise RuntimeError("unexpected import failure")
+
+            return real_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=import_with_torch_runtime_error):
+            with self.assertRaisesRegex(RuntimeError, "unexpected import failure"):
+                _try_import_torch()
+
+
+def test_torch_caching_allocator(test, device):
+    """Warp arrays can allocate from PyTorch's CUDA caching allocator."""
+    device = wp.get_device(device)
+    allocator = TorchCachingAllocatorForWarp()
+    baseline_allocated = torch.cuda.memory_allocated(device.ordinal)
+    a = None
+    t = None
+
+    wp.set_cuda_allocator(allocator)
+    try:
+        a = wp.empty(128, dtype=wp.float32, device=device)
+        test.assertEqual(allocator.alloc_count, 1)
+        test.assertIn(a.ptr, allocator._active_allocations)
+        test.assertEqual(allocator._active_allocations[a.ptr], a.capacity)
+        test.assertGreaterEqual(torch.cuda.memory_allocated(device.ordinal) - baseline_allocated, a.capacity)
+
+        a.fill_(5.0)
+        wp.synchronize_device(device)
+
+        t = wp.to_torch(a)
+        test.assertEqual(t.data_ptr(), a.ptr)
+        np.testing.assert_allclose(t.cpu().numpy(), 5.0)
+
+        ptr = a.ptr
+        t = None
+        a = None
+        torch.cuda.synchronize(device.ordinal)
+
+        test.assertEqual(allocator.dealloc_count, 1)
+        test.assertNotIn(ptr, allocator._active_allocations)
+        test.assertEqual(torch.cuda.memory_allocated(device.ordinal), baseline_allocated)
+    finally:
+        t = None
+        a = None
+        wp.set_cuda_allocator(None)
+
+
+add_function_test(
+    TestTorchAllocator,
+    "test_torch_caching_allocator",
+    test_torch_caching_allocator,
+    devices=_get_torch_cuda_allocator_test_devices(),
+)
 
 
 if __name__ == "__main__":

--- a/warp/tests/test_import.py
+++ b/warp/tests/test_import.py
@@ -1,10 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import sys
 import unittest
 
 import warp as wp
 import warp.tests.test_func as test_func
+import warp.tests.unittest_utils as unittest_utils
 from warp.tests.unittest_utils import *
 
 
@@ -22,7 +25,20 @@ devices = get_test_devices()
 
 
 class TestImport(unittest.TestCase):
-    pass
+    def test_normalize_direct_test_sys_path(self):
+        """Direct test execution should not shadow top-level packages."""
+        tests_root = os.path.dirname(os.path.abspath(unittest_utils.__file__))
+        repo_root = os.path.dirname(os.path.dirname(tests_root))
+        original_sys_path = sys.path[:]
+        try:
+            sys.path[:] = [tests_root, *[p for p in sys.path if os.path.abspath(p or os.getcwd()) != tests_root]]
+            unittest_utils._normalize_direct_test_sys_path()
+
+            self.assertNotEqual(os.path.abspath(sys.path[0] or os.getcwd()), tests_root)
+            self.assertIn(repo_root, sys.path)
+            self.assertNotIn(tests_root, [os.path.abspath(p or os.getcwd()) for p in sys.path])
+        finally:
+            sys.path[:] = original_sys_path
 
 
 add_kernel_test(TestImport, kernel=test_import_func, name="test_import_func", dim=1, devices=devices)

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -128,7 +128,12 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.matrix.test_mat_lite import TestMatLite
     from warp.tests.test_adam import TestAdam
     from warp.tests.test_allocation_tracker import TestAllocTracker
-    from warp.tests.test_allocator import TestAllocatorProtocol, TestCustomAllocator, TestRmmAllocator
+    from warp.tests.test_allocator import (
+        TestAllocatorProtocol,
+        TestCustomAllocator,
+        TestRmmAllocator,
+        TestTorchAllocator,
+    )
     from warp.tests.test_apic import TestApic
     from warp.tests.test_apic_mesh import TestApicMesh
     from warp.tests.test_arithmetic import TestArithmetic
@@ -393,6 +398,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestTileStack,
         TestTileView,
         TestTorch,
+        TestTorchAllocator,
         TestTransientModule,
         TestTriangleClosestPoint,
         TestTypes,

--- a/warp/tests/unittest_utils.py
+++ b/warp/tests/unittest_utils.py
@@ -13,9 +13,31 @@ import time
 import unittest
 import xml.etree.ElementTree as ET
 
-import numpy as np
 
-import warp as wp
+def _normalize_direct_test_sys_path():
+    """Keep direct test execution from shadowing installed top-level packages.
+
+    Running a test file by path makes Python place that file's directory first
+    on ``sys.path``. For files under ``warp/tests``, that can make test
+    packages such as ``warp/tests/cuda`` shadow unrelated installed packages
+    with the same top-level name. Keep the repository root importable while
+    removing the tests package root from import precedence.
+    """
+    tests_root = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.dirname(os.path.dirname(tests_root))
+    normalized_sys_path = {os.path.abspath(path or os.getcwd()) for path in sys.path}
+
+    if repo_root not in normalized_sys_path:
+        sys.path.insert(0, repo_root)
+
+    sys.path[:] = [path for path in sys.path if os.path.abspath(path or os.getcwd()) != tests_root]
+
+
+_normalize_direct_test_sys_path()
+
+import numpy as np  # noqa: E402
+
+import warp as wp  # noqa: E402
 
 pxr = importlib.util.find_spec("pxr")
 USD_AVAILABLE = pxr is not None


### PR DESCRIPTION
## Description

Add coverage for using PyTorch's CUDA caching allocator as a Warp custom CUDA allocator, alongside the existing RMM allocator coverage. The test allocator uses PyTorch's low-level `torch.cuda.caching_allocator_alloc()` and `torch.cuda.caching_allocator_delete()` hooks while preserving Warp's active CUDA device and stream.

This also fixes direct execution of `warp/tests/test_allocator.py`: running a test file by path puts `warp/tests` first on `sys.path`, which allowed `warp/tests/cuda/` to shadow NVIDIA's top-level `cuda` package during RMM import probing. `unittest_utils` now normalizes that direct-test path, and `test_import.py` covers the behavior.

The docs now include a minimal PyTorch CUDA caching allocator example in the allocator deep dive, with a cross-link from the PyTorch interoperability guide so PyTorch users can find it.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

```bash
uvx pre-commit run --files warp/tests/test_allocator.py warp/tests/test_import.py warp/tests/unittest_suites.py warp/tests/unittest_utils.py
WARP_CACHE_PATH=/tmp/warp-cache-wt2-commit-allocator WARP_CACHE_ROOT=/tmp/warp-cache-wt2-commit-allocator uv run --with rmm-cu13 --with cuda-python --extra torch-cu13 warp/tests/test_allocator.py
WARP_CACHE_PATH=/tmp/warp-cache-wt2-commit-import WARP_CACHE_ROOT=/tmp/warp-cache-wt2-commit-import uv run warp/tests/test_import.py
uvx pre-commit run --files docs/deep_dive/allocators.rst docs/user_guide/interoperability_pytorch.rst
uv run --extra docs build_docs.py 2>&1 | tee /tmp/build_docs.log
```

## Bug fix

Running `warp/tests/test_allocator.py` directly used to put `warp/tests` ahead of installed packages on `sys.path`. Because that directory contains `warp/tests/cuda/`, RMM's import of NVIDIA's `cuda` package could resolve to the test package instead of the installed CUDA bindings.

```bash
uv run --with rmm-cu13 --with cuda-python --extra torch-cu13 warp/tests/test_allocator.py
```

## New feature / enhancement

Applications can now copy the documented allocator pattern when they want Warp CUDA arrays to allocate from PyTorch's CUDA caching allocator.

```python
allocator = TorchCachingAllocator()
wp.set_cuda_allocator(allocator)
try:
    a = wp.zeros(1000, dtype=wp.float32, device="cuda:0")
finally:
    wp.set_cuda_allocator(None)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for routing Warp CUDA allocations through PyTorch’s CUDA caching allocator, with a minimal example and guidance; clarified which allocator Warp helpers use by default.

* **Tests**
  * Added interoperability tests for the PyTorch CUDA-caching-backed allocator, validating allocation tracking and cleanup.
  * Made tests resilient to optional CUDA dependency/import failures, improved test import/path normalization, and included the new tests in the default suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->