### PR TITLE
Clarify block_dim docs and refactor dispatch tests [GH-564]

### DIFF
--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2863,9 +2863,10 @@ class Module:
         return self.hashers[block_dim].get_hash()
 
     def get_module_hash(self, block_dim: int | None = None) -> bytes:
-        """Get the hash of the module for the current block_dim.
+        """Get the hash of the module for a block_dim variant.
 
-        If a hash has not been computed for the current block_dim, it will be computed and cached.
+        If ``block_dim`` is ``None``, use the module-level default. If the
+        variant hash has not been computed yet, compute and cache it.
         """
         if block_dim is None:
             block_dim = self.options["block_dim"]
@@ -3247,13 +3248,9 @@ class Module:
 
         # Resolve the active block_dim without mutating self.options.
         # Module.options["block_dim"] is the documented per-module default
-        # (settable via wp.set_module_options); it must not be silently
-        # retargeted by every individual load, because the same field is
-        # read by force_load, wp.load_module, get_kernel_hooks, and the
-        # unique-module hash salt -- letting a CPU launch (which overrides
-        # block_dim to 1 in launch()) leak into the next CUDA pre-load via
-        # this field is the cause of GH-564 / CUDA 12.2 stream-capture
-        # failures in test_apic.py.
+        # (settable via wp.set_module_options); per-load variants flow
+        # through active_block_dim and are stored on ModuleExec, so a CPU
+        # launch's block_dim=1 override cannot retarget later CUDA preloads.
         active_block_dim = block_dim if block_dim is not None else self.options["block_dim"]
 
         # check if executable module is already loaded and not stale

--- a/warp/tests/test_block_dim_dispatch.py
+++ b/warp/tests/test_block_dim_dispatch.py
@@ -1,17 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Test that kernel dispatch uses correct block_dim for each device.
+"""Test block_dim variant selection across devices and explicit loads.
 
-This test reproduces a bug where shared mutable state (Module.options["block_dim"])
-can cause a module compiled for one block dimension to be incorrectly used for
-execution with a different block dimension.
+These tests cover regressions where per-launch block_dim choices, such as
+CPU's forced block_dim=1 or a tiled launch's explicit block_dim, must stay
+scoped to the loaded executable variant instead of retargeting the
+module-level default used by later loads.
 
-The bug manifests when:
-1. A kernel is launched on CPU (which sets block_dim=1)
-2. The same kernel is later launched on CUDA (which should use block_dim=256)
-3. If Module.load() is called without explicit block_dim, it uses the stale value
-4. This causes out-of-bounds shared memory access in tile infrastructure
+The covered flows include:
+1. A CPU launch loads a block_dim=1 variant.
+2. A later CUDA launch or load uses the CUDA-default block_dim=256 variant.
+3. Explicit non-default tiled loads and captures keep their requested variant.
 """
 
 import unittest
@@ -19,9 +19,37 @@ import unittest
 import warp as wp
 from warp.tests.unittest_utils import *
 
+# Kernels are declared once at module scope so the @wp.kernel decorator (and its
+# module hashing) runs a single time at import, not on every device-parameterized
+# test invocation. Each kernel uses module="unique" because these tests assert on
+# a module's per-(context, block_dim) execs, including negative assertNotIn checks
+# (see test_load_module_no_cross_device_block_dim_leak and
+# test_force_load_preserves_loaded_block_dim). A single shared module would not
+# work: test_block_dim_cpu_then_cuda deliberately compiles the CUDA default
+# block_dim=256 variant, which would then appear in the shared execs and break the
+# force_load test's assertNotIn((ctx, 256)). module="unique" gives each distinct
+# kernel its own module; identical kernels are deduplicated by hash, so the two
+# conditional-atomic tests share one module and the two tile tests share another.
+
+
+@wp.kernel(module="unique")
+def conditional_atomic(x: float, result: wp.array[wp.int32]):
+    wp.atomic_add(result, 0, 1) if x > 0.0 else wp.atomic_add(result, 1, 1)
+
+
+@wp.kernel(module="unique")
+def single_atomic(out: wp.array[wp.int32]):
+    wp.atomic_add(out, 0, 1)
+
+
+@wp.kernel(module="unique")
+def tile_zeros_64(out: wp.array[float]):
+    t = wp.tile_zeros(shape=64, dtype=float)
+    out[wp.tid()] = t[0]
+
 
 def test_block_dim_cpu_then_cuda(test, device):
-    """Test that CUDA execution uses correct block_dim after CPU execution.
+    """Verify CUDA execution uses the correct block_dim after CPU execution.
 
     This test verifies that the kernel dispatch mechanism loads separate
     module executables for CPU (block_dim=1) and CUDA (block_dim=256),
@@ -31,16 +59,12 @@ def test_block_dim_cpu_then_cuda(test, device):
     for the different (device.context, block_dim) pairs.
     """
 
-    @wp.kernel(module="unique")
-    def simple_conditional(x: float, result: wp.array(dtype=wp.int32)):
-        wp.atomic_add(result, 0, 1) if x > 0.0 else wp.atomic_add(result, 1, 1)
-
-    module = simple_conditional.module
+    module = conditional_atomic.module
     cpu_device = wp.get_device("cpu")
 
     # First, launch on CPU (should load module with block_dim=1)
     result_cpu = wp.zeros(2, dtype=wp.int32, device="cpu")
-    wp.launch(simple_conditional, dim=1, inputs=[1.0, result_cpu], device="cpu")
+    wp.launch(conditional_atomic, dim=1, inputs=[1.0, result_cpu], device="cpu")
 
     # Verify CPU module exec was loaded with block_dim=1
     cpu_exec_key = (cpu_device.context, 1)
@@ -48,7 +72,7 @@ def test_block_dim_cpu_then_cuda(test, device):
 
     # Now launch on CUDA (should load separate module with block_dim=256)
     result_cuda = wp.zeros(2, dtype=wp.int32, device=device)
-    wp.launch(simple_conditional, dim=1, inputs=[1.0, result_cuda], device=device)
+    wp.launch(conditional_atomic, dim=1, inputs=[1.0, result_cuda], device=device)
 
     # Verify CUDA module exec was loaded with block_dim=256
     cuda_exec_key = (device.context, 256)
@@ -69,26 +93,22 @@ class TestBlockDimDispatch(unittest.TestCase):
 
 
 def test_block_dim_record_cmd_cpu(test, device):
-    """Test that CPU command recording uses correct block_dim after CUDA launch.
+    """Verify CPU command recording uses the correct block_dim after CUDA launch.
 
-    This test specifically checks the CPU record_cmd path to ensure it passes
-    block_dim to Launch.__init__ correctly, even when module.options["block_dim"]
-    has been set to 256 by a previous CUDA launch.
+    This test specifically checks that the CPU record_cmd path carries the
+    launch-normalized block_dim=1 into Launch.__init__ after a previous CUDA
+    launch loaded the CUDA-default variant.
     """
 
-    @wp.kernel(module="unique")
-    def simple_conditional(x: float, result: wp.array(dtype=wp.int32)):
-        wp.atomic_add(result, 0, 1) if x > 0.0 else wp.atomic_add(result, 1, 1)
-
-    # First, launch on CUDA (sets module.options["block_dim"] = 256)
+    # First, launch on CUDA to load the CUDA-default block_dim=256 variant.
     result_cuda = wp.zeros(2, dtype=wp.int32, device=device)
-    wp.launch(simple_conditional, dim=1, inputs=[1.0, result_cuda], device=device)
+    wp.launch(conditional_atomic, dim=1, inputs=[1.0, result_cuda], device=device)
     test.assertEqual(result_cuda.numpy()[0], 1)
 
-    # Now record a command on CPU - this should use block_dim=1, not the stale value of 256
-    # Without the fix, the record_cmd path would use block_dim=256 and fail
+    # Now record a command on CPU. The launch path should normalize the
+    # recorded block_dim to 1 instead of carrying the prior CUDA launch's 256.
     result_cpu = wp.zeros(2, dtype=wp.int32, device="cpu")
-    cmd = wp.launch(simple_conditional, dim=1, inputs=[1.0, result_cpu], device="cpu", record_cmd=True)
+    cmd = wp.launch(conditional_atomic, dim=1, inputs=[1.0, result_cpu], device="cpu", record_cmd=True)
 
     # Execute the recorded command
     cmd.launch()
@@ -100,103 +120,98 @@ def test_block_dim_record_cmd_cpu(test, device):
 
 
 def test_load_module_no_cross_device_block_dim_leak(test, device):
-    """wp.load_module(device='cuda:0') after a CPU launch must compile the
-    CUDA-default block_dim variant (256), not the stale block_dim=1 left
-    over from the CPU launch's silent override. Regression for GH-564 and
-    for the CUDA 12.2 stream-capture failure chain in test_apic.py.
+    """Verify wp.load_module on CUDA ignores a prior CPU launch's block_dim variant.
+
+    The CPU fallback for the tile API loads modules with a forced block_dim=1.
+    If that value leaks into the module-level default, a later GPU load picks up
+    the nonsense block_dim=1 instead of the intended threads-per-block, forcing an
+    unnecessary recompilation when the GPU kernel is actually launched. This test
+    pins the fix: after a CPU launch loads a block_dim=1 variant,
+    wp.load_module(device='cuda:0') without an explicit block_dim must compile the
+    CUDA-default block_dim=256 variant and must not produce a block_dim=1 variant
+    on CUDA.
     """
 
-    @wp.kernel(module="unique")
-    def k(out: wp.array(dtype=wp.int32)):
-        wp.atomic_add(out, 0, 1)
-
-    module = k.module
+    module = single_atomic.module
     cpu_device = wp.get_device("cpu")
-    cuda_device = wp.get_device(device)
 
-    # CPU launch first -- without the fix this also leaves
-    # module.options["block_dim"] = 1.
+    # CPU launch first. The CPU path loads a block_dim=1 variant.
     result_cpu = wp.zeros(1, dtype=wp.int32, device="cpu")
-    wp.launch(k, dim=1, inputs=[result_cpu], device="cpu")
+    wp.launch(single_atomic, dim=1, inputs=[result_cpu], device="cpu")
     test.assertIn((cpu_device.context, 1), module.execs)
 
     # wp.load_module(device='cuda:0') without explicit block_dim must
-    # compile the CUDA-default variant, not the leaked CPU value.
-    wp.load_module(module=module, device=cuda_device)
+    # compile the CUDA-default variant, not reuse the CPU variant.
+    wp.load_module(module=module, device=device)
     test.assertIn(
-        (cuda_device.context, 256),
+        (device.context, 256),
         module.execs,
         "wp.load_module should compile the CUDA default block_dim=256 variant",
     )
     test.assertNotIn(
-        (cuda_device.context, 1),
+        (device.context, 1),
         module.execs,
         "wp.load_module must not have compiled a block_dim=1 variant on CUDA",
     )
 
 
 def test_load_module_tiled_block_dim(test, device):
-    """A tiled launch with block_dim != 256 must compile the variant for
+    """Verify a tiled launch compiles the variant for its own block_dim.
+
+    A tiled launch with block_dim != 256 must compile the variant for
     the launch's block_dim, with the source template's WP_TILE_BLOCK_DIM
     matching. Verifies that Module.resolve_options() honours the per-load
-    block_dim, not a stale module-level default.
+    block_dim, not the module-level default when they differ.
     """
 
-    @wp.kernel(module="unique")
-    def k(out: wp.array(dtype=float)):
-        t = wp.tile_zeros(shape=64, dtype=float)
-        out[wp.tid()] = t[0]
-
-    module = k.module
-    cuda_device = wp.get_device(device)
+    module = tile_zeros_64.module
 
     out = wp.zeros(64, dtype=float, device=device)
-    wp.launch_tiled(k, dim=64, inputs=[out], block_dim=64, device=device)
+    wp.launch_tiled(tile_zeros_64, dim=64, inputs=[out], block_dim=64, device=device)
 
     test.assertIn(
-        (cuda_device.context, 64),
+        (device.context, 64),
         module.execs,
         "tiled launch should produce a block_dim=64 variant",
     )
 
     # The resolved options for the block_dim=64 variant must carry
-    # block_dim=64, not the module-level default. (Source-gen reads this
-    # value to substitute WP_TILE_BLOCK_DIM in the .cu template.)
+    # block_dim=64, not the module-level default. Source-gen reads this
+    # value to substitute WP_TILE_BLOCK_DIM in the .cu template.
     test.assertEqual(module.resolved_options[64]["block_dim"], 64)
+
+    wp.synchronize_device(device)
 
 
 def test_force_load_preserves_loaded_block_dim(test, device):
-    """force_load(device) with no explicit block_dim must reuse the variant
+    """Verify force_load reuses an already-loaded block_dim variant.
+
+    force_load(device) with no explicit block_dim must reuse the variant
     already loaded on the device, not compile a fresh module-level-default
     (256) variant. capture_begin() routes through force_load() on driver
     < 12.3, so a spurious default-block_dim compile there breaks graph
     capture for kernels whose tile shapes are tied to a specific block_dim
-    (e.g. examples/tile/example_tile_mlp.py). Regression for the GH-564
-    mutation removal.
+    (e.g. examples/tile/example_tile_mlp.py).
     """
 
-    @wp.kernel(module="unique")
-    def k(out: wp.array(dtype=float)):
-        t = wp.tile_zeros(shape=64, dtype=float)
-        out[wp.tid()] = t[0]
-
-    module = k.module
-    cuda_device = wp.get_device(device)
+    module = tile_zeros_64.module
 
     out = wp.zeros(64, dtype=float, device=device)
-    wp.launch_tiled(k, dim=64, inputs=[out], block_dim=64, device=device)
-    test.assertIn((cuda_device.context, 64), module.execs)
+    wp.launch_tiled(tile_zeros_64, dim=64, inputs=[out], block_dim=64, device=device)
+    test.assertIn((device.context, 64), module.execs)
 
     # force_load without an explicit block_dim must reuse the loaded 64
     # variant and must not compile the module-level default (256).
-    wp.force_load(device=cuda_device, modules=[module])
-    test.assertIn((cuda_device.context, 64), module.execs)
+    wp.force_load(device=device, modules=[module])
+    test.assertIn((device.context, 64), module.execs)
     test.assertNotIn(
-        (cuda_device.context, 256),
+        (device.context, 256),
         module.execs,
         "force_load must not compile the default block_dim=256 variant when a "
         "non-default variant is already loaded on the device",
     )
+
+    wp.synchronize_device(device)
 
 
 devices = get_test_devices()


### PR DESCRIPTION
## Description

Follow-up clarifying that `Module.options["block_dim"]` is the module-level default after the GH-564 fix (per-load block_dim variants flow through the active block_dim and `ModuleExec`), together with a cleanup of the block_dim dispatch tests.

- **warp/_src/context.py**: Update `get_module_hash()` and `Module.load()` comments/docstrings to describe block_dim variants instead of an active mutable option.
- **warp/tests/test_block_dim_dispatch.py**: Make docstrings self-contained, hoist the kernels to module scope so the `@wp.kernel` decorator and its hashing run once instead of on every device-parameterized invocation, and adopt subscript-style `wp.array[...]` annotations. `module="unique"` is kept because the tests assert on per-module `execs`, and a single shared module would cross-contaminate the negative `assertNotIn` checks.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

```bash
uv run warp/tests/test_block_dim_dispatch.py
```

All 10 tests (5 tests across 2 CUDA devices) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified block-dimension hashing and caching semantics in module docs.

* **Tests**
  * Refactored block-dimension dispatch tests for better reuse and clarity.
  * Added assertions ensuring per-device block-dimension variants are isolated, recording/recorded commands normalize to the correct CPU variant, tiled load resolution is per-load, and force-load reuses already-loaded variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->