### PR TITLE
Document C++ and CUDA workflows

### DIFF
--- a/docs/deep_dive/allocators.rst
+++ b/docs/deep_dive/allocators.rst
@@ -246,7 +246,7 @@ Limitations
 Mempool-to-Mempool Copies Between GPUs During Graph Capture
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Copying data between different GPUs will fail during graph capture if the source and destination are allocated using mempool allocators and mempool access is not enabled between devices.  Note that this only applies to capturing mempool-to-mempool copies in a graph; copies done outside of graph capture are not affected.  Copies within the same mempool (i.e., same device) are also not affected.
+Copying data between different GPUs will fail during graph capture if the source and destination are allocated using mempool allocators and mempool access is not enabled between devices.  Note that this only applies to capturing mempool-to-mempool copies in a graph.  Copies done outside of graph capture are not affected.  Copies within the same mempool (i.e., same device) are also not affected.
 
 There are two workarounds.  If mempool access is supported, you can simply enable mempool access between the devices prior to graph capture, as shown in :ref:`mempool_access`.
 
@@ -398,11 +398,11 @@ PyTorch's cache, implement a small custom allocator that calls
 PyTorch tracks the device and stream for pointers returned by
 ``caching_allocator_alloc()``, so ``caching_allocator_delete()`` only needs the
 pointer. The ``_active_allocations`` dictionary above is for validation and
-debugging; applications can customize this tracking for their own accounting,
+debugging. Applications can customize this tracking for their own accounting,
 thread-safety, or distributed runtime needs.
 
-RMM Integration
-~~~~~~~~~~~~~~~
+RAPIDS Memory Manager (RMM) Integration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `RAPIDS Memory Manager (RMM) <https://github.com/rapidsai/rmm>`_ provides high-performance
 pooled allocators for CUDA. Warp includes a built-in adapter, :class:`~warp.utils.AllocatorRmm`, that

--- a/docs/deep_dive/codegen.rst
+++ b/docs/deep_dive/codegen.rst
@@ -97,6 +97,11 @@ Warp generates C++/CUDA source code for CPU/GPU and stores the .cpp/.cu source f
 The kernel cache folder path is printed during the :ref:`Warp initialization <warp-initialization>` and
 can be retrieved after Warp has been initialized from the ``warp.config.kernel_cache_dir`` :ref:`configuration setting <global-settings>`.
 
+When needed, users can intentionally insert small C++/CUDA snippets into
+generated modules with :func:`@wp.func_native <warp.func_native>`. See
+:ref:`Native Snippets in Warp Kernels <native_functions>` for the public
+native-function API.
+
 In addition to Warp's kernel cache, the NVIDIA CUDA driver maintains a separate
 compute cache that stores JIT-compiled GPU binaries (e.g., native code produced
 from PTX). This driver-level cache is not managed by Warp and is not affected by
@@ -1215,6 +1220,8 @@ Output:
     17
 
 Kernel ``k1`` uses the latest definition of function ``f``, while kernel ``k2`` uses the definition of ``f`` when the kernel was declared.
+
+.. _ahead_of_time_compilation_workflows:
 
 Ahead-of-Time Compilation Workflows
 -----------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -181,6 +181,7 @@ warp/examples/tile
     user_guide/tiles
     user_guide/interoperability
     user_guide/configuration
+    user_guide/cpp_cuda_workflows
     user_guide/debugging
     user_guide/limitations
     user_guide/contribution_guide

--- a/docs/user_guide/basics.rst
+++ b/docs/user_guide/basics.rst
@@ -316,8 +316,9 @@ determine the tile argument type:
 
 See :ref:`Generic Functions` for details on using ``typing.Any`` in user function signatures.
 
-See :doc:`differentiability` for details on how to define custom gradient functions,
-custom replay functions, and custom native functions.
+See :doc:`differentiability` for details on custom gradient and replay
+functions. See :doc:`cpp_cuda_workflows` for native C++/CUDA snippets and
+other non-Python integration workflows.
 
 User Structs
 --------------

--- a/docs/user_guide/cpp_cuda_workflows.rst
+++ b/docs/user_guide/cpp_cuda_workflows.rst
@@ -1,0 +1,330 @@
+C++ and CUDA Workflows
+======================
+
+.. currentmodule:: warp
+
+Warp is primarily authored from Python, but several workflows expose generated
+C++/CUDA code or replay captured Warp work from a native host application. This
+page collects the public entry points for those non-Python integration paths and
+links to the detailed workflow documentation and examples.
+
+Use this page when you need to:
+
+- insert native C++/CUDA snippets into generated Warp kernels.
+- ahead-of-time compile Warp kernels into source, PTX, or CUBIN files.
+- load generated Warp binaries or source from a CUDA C++ application.
+- serialize captured Warp work and replay it from C++ without a Python runtime.
+
+.. _native_functions:
+
+Native Snippets in Warp Kernels
+-------------------------------
+
+Use :func:`@wp.func_native <warp.func_native>` to insert native C++/CUDA code
+into generated Warp modules. Native functions are useful when Warp does not
+provide a built-in operation, CUDA intrinsic, synchronization pattern, or
+low-level expression that your kernel needs.
+
+Pure C++ snippets, meaning snippets without CUDA-only constructs, can be used
+by CPU kernels. The same snippet can also be used by CUDA kernels if the code is
+valid device code. CUDA-specific constructs, such as ``__shared__`` memory,
+``__syncthreads()``, and CUDA atomics, require CUDA kernels.
+
+The decorator takes native source code as a string. The decorated Python
+function is a typed stub: its arguments define the names and types available to
+the snippet, and its body should be ``...`` because Warp replaces the body with
+the native snippet during code generation.
+
+The thread index should be computed by the caller and passed explicitly. Native
+snippets are inserted into generated C++/CUDA, so they cannot call
+:func:`wp.tid() <warp.tid>` directly.
+
+.. code-block:: python
+
+    import numpy as np
+    import warp as wp
+
+    snippet = "out[tid] = x[tid] + 1.0f;"
+
+
+    @wp.func_native(snippet)
+    def increment(x: wp.array[wp.float32], out: wp.array[wp.float32], tid: int):
+        ...
+
+
+    @wp.kernel
+    def increment_kernel(x: wp.array[wp.float32], out: wp.array[wp.float32]):
+        tid = wp.tid()
+        increment(x, out, tid)
+
+
+    device = "cpu"
+    x = wp.array(np.arange(4, dtype=np.float32), dtype=wp.float32, device=device)
+    out = wp.zeros_like(x)
+    wp.launch(increment_kernel, dim=x.shape, inputs=[x], outputs=[out], device=device)
+
+CUDA Shared Memory
+~~~~~~~~~~~~~~~~~~
+
+Native snippets can use CUDA features that Warp does not expose directly. The
+following example performs a reduction within a single 128-thread block using
+shared memory. It assumes the launch uses exactly one block. Generalizing this
+pattern to multiple blocks requires using a per-block thread index and storing
+one result per block.
+
+.. code-block:: python
+
+    import numpy as np
+    import warp as wp
+
+    snippet = """
+        __shared__ int sum[128];
+
+        sum[tid] = arr[tid];
+        __syncthreads();
+
+        for (int stride = 64; stride > 0; stride >>= 1) {
+            if (tid < stride) {
+                sum[tid] += sum[tid + stride];
+            }
+            __syncthreads();
+        }
+
+        if (tid == 0) {
+            out[0] = sum[0];
+        }
+        """
+
+
+    @wp.func_native(snippet)
+    def reduce(arr: wp.array[int], out: wp.array[int], tid: int):
+        ...
+
+
+    @wp.kernel
+    def reduce_kernel(arr: wp.array[int], out: wp.array[int]):
+        tid = wp.tid()
+        reduce(arr, out, tid)
+
+
+    arr = wp.array(np.arange(128, dtype=np.int32), dtype=wp.int32, device="cuda")
+    out = wp.zeros(1, dtype=wp.int32, device="cuda")
+    wp.launch(reduce_kernel, dim=128, inputs=[arr], outputs=[out], block_dim=128, device="cuda")
+
+Inline PTX
+~~~~~~~~~~
+
+Native snippets can also use `inline Parallel Thread Execution (PTX) assembly
+<https://docs.nvidia.com/cuda/inline-ptx-assembly/index.html>`_ inside CUDA
+code. Inline PTX is useful when you need a GPU instruction that is not exposed
+directly through Warp or CUDA C++.
+
+The following example computes the sum of four byte-wise absolute differences
+between two packed 8-bit values. The `PTX vabsdiff4 instruction
+<https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#simd-video-instructions-vadd4-vsub4-vavrg4-vabsdiff4-vmin4-vmax4>`_
+performs four byte-wise absolute differences and, with the ``.add`` modifier,
+accumulates them into one 32-bit result.
+
+.. testcode::
+    :skipif: wp.get_cuda_device_count() == 0
+
+    import numpy as np
+    import warp as wp
+
+    snippet = r"""
+        unsigned int result;
+        unsigned int zero = 0;
+        asm("vabsdiff4.u32.u32.u32.add %0, %1, %2, %3;"
+            : "=r"(result)
+            : "r"(a), "r"(b), "r"(zero));
+        return result;
+        """
+
+
+    @wp.func_native(snippet)
+    def absdiff4_sum_u8(a: wp.uint32, b: wp.uint32) -> wp.uint32:
+        ...
+
+
+    @wp.kernel
+    def absdiff4_kernel(
+        a: wp.array[wp.uint32],
+        b: wp.array[wp.uint32],
+        out: wp.array[wp.uint32],
+    ):
+        tid = wp.tid()
+        out[tid] = absdiff4_sum_u8(a[tid], b[tid])
+
+
+    def pack4(values):
+        return np.uint32(values[0] | (values[1] << 8) | (values[2] << 16) | (values[3] << 24))
+
+
+    a_host = np.array([pack4([10, 20, 30, 40]), pack4([0, 128, 255, 13])], dtype=np.uint32)
+    b_host = np.array([pack4([13, 18, 41, 35]), pack4([255, 120, 0, 15])], dtype=np.uint32)
+
+    a = wp.array(a_host, dtype=wp.uint32, device="cuda")
+    b = wp.array(b_host, dtype=wp.uint32, device="cuda")
+    out = wp.zeros_like(a)
+    wp.launch(absdiff4_kernel, dim=a.shape, inputs=[a, b], outputs=[out], device="cuda")
+
+    # [3 + 2 + 11 + 5, 255 + 8 + 255 + 2]
+    print(out.numpy().tolist())
+    np.testing.assert_array_equal(out.numpy(), np.array([21, 520], dtype=np.uint32))
+
+.. testoutput::
+    :skipif: wp.get_cuda_device_count() == 0
+
+    [21, 520]
+
+The ``"r"`` constraints bind the operands to 32-bit integer registers, which
+matches the ``.u32`` instruction operands. The final PTX operand is an
+accumulator and is supplied as a zero-initialized register in this example. If
+the assembly reads or writes memory through pointers, add the appropriate
+``"memory"`` clobber as described in NVIDIA's inline PTX documentation.
+
+Returning Values
+~~~~~~~~~~~~~~~~
+
+A native snippet can return a value when the Python stub declares a return type.
+Warp supports scalar, vector, matrix, quaternion, array, and fixed-array return
+types. Struct return values are not supported.
+
+.. code-block:: python
+
+    snippet = """
+        float sq = x * x;
+        return sq;
+        """
+
+
+    @wp.func_native(snippet)
+    def square(x: wp.float32) -> wp.float32:
+        ...
+
+Differentiable Native Functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a native function participates in a tape-recorded computation, provide an
+``adj_snippet`` that accumulates adjoints for the native operation. Adjoint
+variables use the ``adj_`` prefix, and return-value adjoints are named
+``adj_ret``.
+
+.. code-block:: python
+
+    snippet = "out[tid] = 2.0f * x[tid] + y[tid];"
+    adj_snippet = """
+        adj_x[tid] += 2.0f * adj_out[tid];
+        adj_y[tid] += adj_out[tid];
+        """
+
+
+    @wp.func_native(snippet=snippet, adj_snippet=adj_snippet)
+    def axpy(
+        x: wp.array[wp.float32],
+        y: wp.array[wp.float32],
+        out: wp.array[wp.float32],
+        tid: int,
+    ):
+        ...
+
+During the backward pass, Warp runs a forward replay phase. By default, native
+functions replay the original ``snippet``. If the forward snippet has side
+effects that should not be repeated, such as mutating a counter with an atomic
+operation, provide ``replay_snippet``. An empty string is a valid no-op replay
+snippet.
+
+.. code-block:: python
+
+    snippet = """
+        int next_index = atomicAdd(counter, 1);
+        thread_values[tid] = next_index;
+        """
+    replay_snippet = ""
+
+
+    @wp.func_native(snippet, replay_snippet=replay_snippet)
+    def record_index(counter: wp.array[int], thread_values: wp.array[int], tid: int):
+        ...
+
+Native Function Limitations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Native snippets are inserted into generated C++/CUDA and are not parsed as
+  Warp code.
+- The snippet can refer to variables named after the typed Python stub
+  arguments.
+- CUDA-specific snippets cannot run on CPU devices.
+- Type hints must accurately describe the stub arguments and return type.
+- Struct return values are unsupported.
+- Users are responsible for native-code correctness, synchronization, memory
+  safety, and portability.
+
+Ahead-of-Time C++/CUDA Workflows
+--------------------------------
+
+Warp can compile kernels ahead of time and write the generated CUDA source,
+metadata, PTX, or CUBIN files to disk. This is useful when a Python build step
+authors and validates kernels, but a native CUDA C++ application owns runtime
+execution.
+
+The full AOT workflow is documented in
+:ref:`ahead_of_time_compilation_workflows`. The C++ examples under
+``warp/examples/cpp/`` show two deployment patterns:
+
+- `00_cubin_launch <https://github.com/NVIDIA/warp/tree/main/warp/examples/cpp/00_cubin_launch>`_
+  compiles a Warp kernel to a CUBIN, loads that module with the CUDA Driver API,
+  and launches the generated kernel with ``cuLaunchKernel()``.
+- `01_source_include <https://github.com/NVIDIA/warp/tree/main/warp/examples/cpp/01_source_include>`_
+  includes the generated ``.cu`` source in a CUDA C++ translation unit and
+  launches the generated forward and backward kernels directly.
+
+Both examples use ``warp/native/aot.h`` for Warp's generated type definitions,
+CUDA setup helpers, and error-checking macros. The generated code also depends
+on the native type headers such as ``builtin.h`` that ship in ``warp/native/``.
+
+API Capture Replay from C++
+---------------------------
+
+API Capture (APIC) can serialize a captured Warp graph to a ``.wrp`` file plus a
+companion module directory. The saved graph can later be loaded from Python or
+from a standalone C++ program that links against the Warp native library.
+
+See :ref:`apic_save_load` for the C API surface, serialization format notes, and
+current limitations. The C++ examples cover both device families:
+
+- `02_apic_visualization <https://github.com/NVIDIA/warp/tree/main/warp/examples/cpp/02_apic_visualization>`_
+  captures a CUDA graph in Python, loads it from C++, updates named inputs, and
+  replays the frame with ``cudaGraphLaunch()``.
+- `03_apic_visualization_cpu <https://github.com/NVIDIA/warp/tree/main/warp/examples/cpp/03_apic_visualization_cpu>`_
+  captures and replays on the CPU device. The C++ viewer does not link against
+  CUDA. It loads recorded CPU kernel objects and replays the graph with
+  ``wp_apic_cpu_replay_graph()``.
+
+Native Library Headers
+----------------------
+
+The C++ integration examples intentionally use a small native surface:
+
+- ``warp/native/aot.h`` exposes utilities for generated AOT kernels and includes
+  Warp's generated type support.
+- ``warp/native/warp.h`` declares the core Warp C API exported by the native
+  library.
+- ``warp/native/apic.h`` declares the APIC graph loading and replay API used by
+  ``.wrp`` graph consumers.
+
+Other files in ``warp/native/`` implement Warp's runtime and kernel support
+library. They are useful when inspecting generated code, but the examples above
+are the recommended starting points for native host integration.
+
+Related Topics
+--------------
+
+- :doc:`basics` covers regular :func:`@wp.func <warp.func>` functions called
+  from kernels.
+- :doc:`differentiability` covers custom gradients, custom replay functions,
+  tapes, and native-function adjoints.
+- :doc:`runtime` covers runtime kernel creation, CUDA graph capture, and APIC
+  save/load.
+- :doc:`../deep_dive/codegen` covers generated C++/CUDA source and AOT
+  compilation.

--- a/docs/user_guide/debugging.rst
+++ b/docs/user_guide/debugging.rst
@@ -78,7 +78,7 @@ non-differentiable.
 
     Reading or setting either deprecated flag emits a one-time
     ``DeprecationWarning``. During the deprecation window the flag is still
-    honored alongside ``log_level``, so existing code keeps working; remove the
+    honored alongside ``log_level``, so existing code keeps working. Remove the
     flag once your code sets ``log_level`` directly.
 
     ``wp.config.verbose_warnings`` is not deprecated. It is an orthogonal
@@ -167,7 +167,7 @@ Debug Mode Compilation
 In debug mode, Warp kernels will perform the following additional checks:
 
 * Raise an assertion if there is an array access outside the defined shape.
-* Warn if :func:`wp.tid() <warp._src.lang.tid>` will return an overflowed value on large grids.
+* Warn if :func:`wp.tid() <warp.tid>` will return an overflowed value on large grids.
 * (GPU-only) Warn if the CUDA grid dimensions have been capped due to an overflowed number of blocks.
 * (GPU-only) Generate line-number information for device code.
 

--- a/docs/user_guide/differentiability.rst
+++ b/docs/user_guide/differentiability.rst
@@ -652,80 +652,28 @@ for the input array:
 Custom Native Functions
 #######################
 
-Users may insert native C++/CUDA code in Warp kernels using :func:`@wp.func_native <warp.func_native>` decorated functions.
-These accept native code as strings that get compiled after code generation, and are called within :func:`@wp.kernel <warp.kernel>` functions.
-For example:
+Native functions created with :func:`@wp.func_native <warp.func_native>` insert
+C++/CUDA snippets into generated Warp modules. The general feature is documented
+in :ref:`Native Snippets in Warp Kernels <native_functions>`; this section only
+covers how native snippets interact with tape replay and backward passes.
+
+When a native function participates in a tape-recorded computation, Warp needs
+an adjoint implementation for the native operation. Provide it with the
+``adj_snippet`` argument:
 
 .. testcode::
     :skipif: wp.get_cuda_device_count() == 0
 
     snippet = """
-        __shared__ int sum[128];
-
-        sum[tid] = arr[tid];
-        __syncthreads();
-
-        for (int stride = 64; stride > 0; stride >>= 1) {
-            if (tid < stride) {
-                sum[tid] += sum[tid + stride];
-            }
-            __syncthreads();
-        }
-
-        if (tid == 0) {
-            out[0] = sum[0];
-        }
-        """
-
-    @wp.func_native(snippet)
-    def reduce(arr: wp.array[int], out: wp.array[int], tid: int): ...
-
-
-    @wp.kernel
-    def reduce_kernel(arr: wp.array[int], out: wp.array[int]):
-        tid = wp.tid()
-        reduce(arr, out, tid)
-
-
-    N = 128
-    x = wp.array(np.arange(N, dtype=int), dtype=int)
-    out = wp.zeros(1, dtype=int)
-
-    wp.launch(kernel=reduce_kernel, dim=N, inputs=[x, out])
-
-    print(out)
-
-.. testoutput::
-    :skipif: wp.get_cuda_device_count() == 0
-
-    [8128]
-
-Notice the use of shared memory here: The Warp library does not expose shared memory as a feature, but the CUDA compiler will
-readily accept the above snippet. This means CUDA features not exposed in Warp are still accessible in Warp scripts.
-Warp kernels meant for the CPU won't be able to leverage CUDA features of course, but this same mechanism supports pure C++ snippets as well.
-
-Please bear in mind the following: the thread index in your snippet should be computed in a :func:`@wp.kernel <warp.kernel>` and passed to your snippet,
-as in the above example. This means your :func:`@wp.func_native <warp.func_native>` function signature should include the variables used in your snippet, 
-as well as a thread index of type ``int``. The function body itself should be stubbed with ``...`` (the snippet will be inserted during compilation).
-
-Should you wish to record your native function on the tape and then subsequently rewind the tape, you must include an adjoint snippet
-alongside your snippet as an additional input to the decorator, as in the following example:
-
-.. testcode::
-    :skipif: wp.get_cuda_device_count() == 0
-
-    snippet = """
-    out[tid] = a * x[tid] + y[tid];
+    out[tid] = 2.0f * x[tid] + y[tid];
     """
     adj_snippet = """
-    adj_a += x[tid] * adj_out[tid];
-    adj_x[tid] += a * adj_out[tid];
+    adj_x[tid] += 2.0f * adj_out[tid];
     adj_y[tid] += adj_out[tid];
     """
 
-    @wp.func_native(snippet, adj_snippet)
-    def saxpy(
-        a: float,
+    @wp.func_native(snippet=snippet, adj_snippet=adj_snippet)
+    def axpy(
         x: wp.array[float],
         y: wp.array[float],
         out: wp.array[float],
@@ -734,28 +682,23 @@ alongside your snippet as an additional input to the decorator, as in the follow
         ...
 
     @wp.kernel
-    def saxpy_kernel(
-        a: float,
+    def axpy_kernel(
         x: wp.array[float],
         y: wp.array[float],
-        out: wp.array[float]
+        out: wp.array[float],
     ):
         tid = wp.tid()
-        saxpy(a, x, y, out, tid)
+        axpy(x, y, out, tid)
 
-    N = 128
-    a = 2.0
+    N = 8
     x = wp.array(np.arange(N, dtype=np.float32), dtype=wp.float32, requires_grad=True)
     y = wp.zeros_like(x)
-    out = wp.array(np.arange(N, dtype=np.float32), dtype=wp.float32)
-    adj_out = wp.array(np.ones(N, dtype=np.float32), dtype=wp.float32)
+    out = wp.zeros_like(x)
 
-    tape = wp.Tape()
+    with wp.Tape() as tape:
+        wp.launch(kernel=axpy_kernel, dim=N, inputs=[x, y], outputs=[out])
 
-    with tape:
-        wp.launch(kernel=saxpy_kernel, dim=N, inputs=[a, x, y], outputs=[out])
-
-    tape.backward(grads={out: adj_out})
+    tape.backward(grads={out: wp.ones_like(out)})
 
     print(f"x.grad = {x.grad}")
     print(f"y.grad = {y.grad}")
@@ -763,111 +706,19 @@ alongside your snippet as an additional input to the decorator, as in the follow
 .. testoutput::
     :skipif: wp.get_cuda_device_count() == 0
 
-    x.grad = [2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2.
-     2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2.
-     2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2.
-     2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2.
-     2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2. 2.
-     2. 2. 2. 2. 2. 2. 2. 2.]
-    y.grad = [1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.
-     1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.
-     1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.
-     1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.
-     1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1. 1.
-     1. 1. 1. 1. 1. 1. 1. 1.]
+    x.grad = [2. 2. 2. 2. 2. 2. 2. 2.]
+    y.grad = [1. 1. 1. 1. 1. 1. 1. 1.]
 
-You may also include a custom replay snippet to be executed as part of the adjoint (see `Custom Gradient Functions`_ for a full explanation).
-Consider the following example:
+During the backward pass, Warp runs a forward replay phase. By default, native
+functions replay the original ``snippet``. If replaying the native snippet would
+repeat an unsafe side effect, provide ``replay_snippet``.
+For example, a native snippet that writes cached indices using an atomic counter
+can use an empty replay snippet so the cached forward values are reused instead
+of overwritten during the backward pass.
 
-.. testcode::
-    :skipif: wp.get_cuda_device_count() == 0
-
-    num_threads = 8
-    counter = wp.zeros(1, dtype=wp.int32)
-    thread_values = wp.zeros(num_threads, dtype=wp.int32)
-    inputs = wp.array(np.arange(num_threads, dtype=np.float32), requires_grad=True)
-    outputs = wp.zeros_like(inputs)
-
-    snippet = """
-        int next_index = atomicAdd(counter, 1);
-        thread_values[tid] = next_index;
-        """
-    replay_snippet = ""
-
-
-    @wp.func_native(snippet, replay_snippet=replay_snippet)
-    def reversible_increment(counter: wp.array[int], thread_values: wp.array[int], tid: int):
-        ...
-
-
-    @wp.kernel
-    def run_atomic_add(
-        input: wp.array[float],
-        counter: wp.array[int],
-        thread_values: wp.array[int],
-        output: wp.array[float],
-    ):
-        tid = wp.tid()
-        reversible_increment(counter, thread_values, tid)
-        idx = thread_values[tid]
-        output[idx] = input[idx] ** 2.0
-
-
-    with wp.Tape() as tape:
-        wp.launch(run_atomic_add, dim=num_threads, inputs=[inputs, counter, thread_values], outputs=[outputs])
-
-    tape.backward(grads={outputs: wp.ones(num_threads, dtype=wp.float32)})
-
-    print(f"inputs.grad = {np.round(inputs.grad.numpy(), 5)}")
-
-.. testoutput::
-    :skipif: wp.get_cuda_device_count() == 0
-
-    inputs.grad = [ 0.  2.  4.  6.  8. 10. 12. 14.]
-
-By default, ``snippet`` would be called in the backward pass, but in this case, we have defined a custom replay snippet that is called instead.
-``replay_snippet`` is a no-op, which is all that we require, since ``thread_values`` are cached in the forward pass.
-If we did not have a ``replay_snippet`` defined, ``thread_values`` would be overwritten with counter values that exceed the input array size in the backward pass.
-
-A native snippet may also include a return statement. If this is the case, you must specify the return type in the native function definition, as in the following example:
-
-.. testcode::
-
-    snippet = """
-        float sq = x * x;
-        return sq;
-        """
-    adj_snippet = """
-        adj_x += 2.f * x * adj_ret;
-        """
-
-
-    @wp.func_native(snippet, adj_snippet)
-    def square(x: float) -> float:
-        ...
-
-
-    @wp.kernel
-    def square_kernel(input: wp.array[Any], output: wp.array[Any]):
-        tid = wp.tid()
-        x = input[tid]
-        output[tid] = square(x)
-
-
-    N = 5
-    x = wp.array(np.arange(N, dtype=float), dtype=float, requires_grad=True)
-    y = wp.zeros_like(x)
-
-    with wp.Tape() as tape:
-        wp.launch(kernel=square_kernel, dim=N, inputs=[x, y])
-
-    tape.backward(grads={y: wp.ones(N, dtype=float)})
-
-    print(f"x.grad = {x.grad}")
-
-.. testoutput::
-
-    x.grad = [0. 2. 4. 6. 8.]
+See :ref:`Native Snippets in Warp Kernels <native_functions>` for the full
+native-function syntax, CPU/CUDA behavior, return values, replay snippets, and
+limitations.
 
 ``grad()``
 #############

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -999,8 +999,97 @@ def func(
 
 
 def func_native(snippet: str, adj_snippet: str | None = None, replay_snippet: str | None = None):
-    """
-    Decorator to register native code snippet, @func_native
+    """Register a Warp function implemented by a native C++/CUDA snippet.
+
+    ``@wp.func_native`` is an escape hatch for operations that are easier to
+    express in native code than in Warp's kernel language, such as CUDA
+    intrinsics, shared-memory synchronization patterns, or small C++ helper
+    expressions. The decorated Python function is a typed stub: its argument
+    names become the variable names available inside the snippet, and its body
+    should be ``...``.
+
+    Args:
+        snippet: Native C++/CUDA code inserted into the generated forward
+            function body.
+        adj_snippet: Optional native code inserted into the generated adjoint
+            function body. Use ``adj_``-prefixed argument names, and ``adj_ret``
+            for the adjoint of a return value.
+        replay_snippet: Optional native code used when Warp replays the forward
+            function while executing the generated backward pass. Use this when
+            replaying ``snippet`` would repeat an unsafe side effect, such as
+            incrementing an atomic counter.
+
+    Returns:
+        A decorator that registers the typed stub as a Warp function.
+
+    Note:
+        Compute thread indices in the calling kernel or function and pass them
+        explicitly; snippets cannot call :func:`wp.tid() <warp.tid>`.
+        Pure C++ snippets can be used by CPU kernels, while CUDA-specific
+        constructs require CUDA kernels. If the snippet returns a value, the
+        Python stub must declare the return type. Struct return values are not
+        supported.
+
+    Example:
+        Insert a native element-wise operation:
+
+        .. code-block:: python
+
+            snippet = "out[tid] = x[tid] + 1.0f;"
+
+
+            @wp.func_native(snippet)
+            def increment(
+                x: wp.array[wp.float32],
+                out: wp.array[wp.float32],
+                tid: int,
+            ): ...
+
+
+            @wp.kernel
+            def kernel(x: wp.array[wp.float32], out: wp.array[wp.float32]):
+                tid = wp.tid()
+                increment(x, out, tid)
+
+        Use CUDA shared memory:
+
+        This pattern assumes the kernel is launched with ``block_dim=128``.
+
+        .. code-block:: python
+
+            snippet = '''
+                int local_tid = threadIdx.x;
+                __shared__ int values[128];
+                values[local_tid] = arr[tid];
+                __syncthreads();
+                out[tid] = values[127 - local_tid];
+                '''
+
+
+            @wp.func_native(snippet)
+            def reverse_block(arr: wp.array[int], out: wp.array[int], tid: int): ...
+
+        Provide an adjoint snippet for differentiability:
+
+        .. code-block:: python
+
+            snippet = "out[tid] = 2.0f * x[tid] + y[tid];"
+            adj_snippet = '''
+                adj_x[tid] += 2.0f * adj_out[tid];
+                adj_y[tid] += adj_out[tid];
+                '''
+
+
+            @wp.func_native(snippet=snippet, adj_snippet=adj_snippet)
+            def axpy(
+                x: wp.array[wp.float32],
+                y: wp.array[wp.float32],
+                out: wp.array[wp.float32],
+                tid: int,
+            ): ...
+
+    See Also:
+        :ref:`Native Snippets in Warp Kernels <native_functions>`
     """
 
     frame = inspect.currentframe()
@@ -1310,7 +1399,7 @@ def kernel(
 
 
         @wp.kernel(module_options={"fast_math": True}, module="unique")
-        def my_kernel_fast(a: wp.array(dtype=float), b: wp.array(dtype=float)):
+        def my_kernel_fast(a: wp.array[float], b: wp.array[float]):
             # fast_math is a module-level option, so module="unique" is required
             tid = wp.tid()
             b[tid] = a[tid] + 1.0


### PR DESCRIPTION
## Description

Add a new `C++ and CUDA Workflows` user guide page that centralizes Warp's non-Python integration paths. The page covers native snippets with `wp.func_native`, including CUDA shared memory, inline PTX, return values, differentiable snippets, replay snippets, and current limitations. It also collects ahead-of-time compilation guidance, CUDA-driverless Docker build notes, native C++ launch examples, and standalone API Capture replay from C++ for CUDA and CPU graphs.

Move the C++/CUDA workflow material out of the Codegen and Runtime pages so those pages stay focused on their primary topics and link into the new workflow hub. The Differentiability page now keeps the autodiff-specific native snippet guidance and links to the full native-snippet reference. Basics, Codegen, Runtime, Allocators, and Debugging get smaller cross-reference, doctest, and wording updates to match the new organization.

Expand the generated API docs for `wp.func_native` with argument descriptions, return behavior, CPU/CUDA constraints, replay-snippet guidance, and safer examples.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `git diff --check upstream/main...HEAD`
- `uvx pre-commit run --files docs/index.rst docs/user_guide/cpp_cuda_workflows.rst docs/user_guide/basics.rst docs/user_guide/differentiability.rst docs/user_guide/runtime.rst docs/deep_dive/allocators.rst docs/user_guide/debugging.rst docs/deep_dive/codegen.rst warp/_src/context.py`
- `WARP_CACHE_ROOT=/tmp/warp-cache-warp-worktree-3-docs WARP_CACHE_PATH=/tmp/warp-cache-warp-worktree-3-docs uv run --extra docs build_docs.py 2>&1 | tee /tmp/build_docs.log`
- `rg -n "WARNING|undefined label|unknown document|Title underline too short|Inline emphasis" /tmp/build_docs.log`

## New feature / enhancement

This is a documentation discoverability enhancement for existing C++/CUDA and native-host Warp workflows.
