### PR TITLE
Add optional CMake native build backend

### DIFF
--- a/.github/workflows/build-warp-builder-images.yml
+++ b/.github/workflows/build-warp-builder-images.yml
@@ -204,6 +204,12 @@ jobs:
               echo "uv Version:"
               uv --version
               echo ""
+              echo "CMake Version:"
+              cmake --version
+              echo ""
+              echo "Ninja Version:"
+              ninja --version
+              echo ""
               echo "Architecture:"
               uname -m
               echo ""
@@ -214,6 +220,16 @@ jobs:
               uv run build_lib.py --llvm-path /opt/llvm
               echo ""
               echo "=== Build Complete ==="
+              ls -lh warp/bin/
+              echo ""
+              echo "=== Building Warp with CMake ==="
+              rm -rf warp/bin _build/cmake-image
+              uv sync --no-install-project
+              export WARP_CACHE_ROOT="/tmp/warp-cache-cmake-image-${{ github.run_id }}-${{ matrix.cuda_version }}-${{ matrix.arch }}"
+              export WARP_CACHE_PATH="${WARP_CACHE_ROOT}"
+              cmake -S . -B _build/cmake-image -G Ninja -DWARP_LLVM_PATH=/opt/llvm
+              cmake --build _build/cmake-image --parallel
+              uv run python -c "import warp; info = warp.print_diagnostics(); assert not info[\"warp_native\"].startswith(\"unknown\"); assert not info[\"warp_clang\"].startswith(\"unknown\")"
               ls -lh warp/bin/
               echo ""
               echo "=== Building Python Wheel ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,131 @@ jobs:
           retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
       
 
+  build-warp-cmake:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2025
+            platform: windows
+            cuda-version: "13.0.2"
+            cuda-sub-packages: '["cudart", "crt", "nvcc", "nvrtc_dev", "nvjitlink", "nvvm", "nvptxcompiler"]'
+            cuda-non-cuda-packages: ''
+            warp-cache-root-suffix: '\warp-cache-cmake'
+          - os: ubuntu-24.04
+            platform: ubuntu-x86_64
+            cuda-version: "13.0.2"
+            cuda-sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
+            cuda-non-cuda-packages: '["libnvjitlink-dev"]'
+            warp-cache-root-suffix: /warp-cache-cmake
+          - os: ubuntu-24.04-arm
+            platform: ubuntu-aarch64
+            cuda-version: "13.0.2"
+            cuda-sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
+            cuda-non-cuda-packages: '["libnvjitlink-dev"]'
+            warp-cache-root-suffix: /warp-cache-cmake
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: "0.11.16"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install CTK (with non-CUDA packages)
+        if: matrix.cuda-sub-packages != '' && matrix.cuda-non-cuda-packages != ''
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
+        with:
+          cuda: ${{ matrix.cuda-version }}
+          sub-packages: ${{ matrix.cuda-sub-packages }}
+          non-cuda-sub-packages: ${{ matrix.cuda-non-cuda-packages }}
+          method: 'network'
+
+      - name: Install CTK (without non-CUDA packages)
+        if: matrix.cuda-sub-packages != '' && matrix.cuda-non-cuda-packages == ''
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
+        with:
+          cuda: ${{ matrix.cuda-version }}
+          sub-packages: ${{ matrix.cuda-sub-packages }}
+          method: 'network'
+
+      - name: Print build tool versions
+        run: |
+          cmake --version
+          ninja --version
+
+      - name: Prepare Python environment for CMake codegen
+        run: uv sync --no-install-project
+
+      - name: Set up MSVC developer environment
+        if: matrix.platform == 'windows'
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsPath = & $vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $vsDevCmd = Join-Path $vsPath "Common7\Tools\VsDevCmd.bat"
+          if (!(Test-Path $vsDevCmd)) {
+            throw "VsDevCmd.bat was not found"
+          }
+
+          $before = @{}
+          Get-ChildItem Env: | ForEach-Object { $before[$_.Name] = $_.Value }
+          cmd /c "`"$vsDevCmd`" -arch=x64 -host_arch=x64 > nul && set" |
+            ForEach-Object {
+              $name, $value = $_ -split '=', 2
+              if ($name -and $before[$name] -ne $value) {
+                "$name=$value" >> $env:GITHUB_ENV
+              }
+            }
+
+      - name: Build Warp with CMake
+        if: matrix.platform != 'windows'
+        env:
+          WARP_CACHE_ROOT: ${{ runner.temp }}${{ matrix.warp-cache-root-suffix }}
+          WARP_CACHE_PATH: ${{ runner.temp }}${{ matrix.warp-cache-root-suffix }}
+        run: |
+          cuda_path="${CUDA_HOME:-${CUDA_PATH:-}}"
+          if [ -z "$cuda_path" ]; then
+            echo "CUDA_HOME or CUDA_PATH must be set" >&2
+            exit 1
+          fi
+          cmake -S . -B _build/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DWARP_CUDA_PATH:PATH="$cuda_path"
+          cmake --build _build/cmake --parallel
+
+      - name: Build Warp with CMake
+        if: matrix.platform == 'windows'
+        env:
+          WARP_CACHE_ROOT: ${{ runner.temp }}${{ matrix.warp-cache-root-suffix }}
+          WARP_CACHE_PATH: ${{ runner.temp }}${{ matrix.warp-cache-root-suffix }}
+        run: |
+          if (!$env:CUDA_PATH) {
+            throw "CUDA_PATH must be set"
+          }
+          cmake -S . -B _build/cmake -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_COMPILER=cl `
+            -DCMAKE_CXX_COMPILER=cl `
+            "-DWARP_CUDA_PATH:PATH=$env:CUDA_PATH"
+          cmake --build _build/cmake --parallel
+
+      - name: Verify Warp diagnostics
+        env:
+          WARP_CACHE_ROOT: ${{ runner.temp }}${{ matrix.warp-cache-root-suffix }}
+          WARP_CACHE_PATH: ${{ runner.temp }}${{ matrix.warp-cache-root-suffix }}
+        run: |
+          uv run python -c "import warp; info = warp.print_diagnostics(); assert not info['warp_native'].startswith('unknown'); assert not info['warp_clang'].startswith('unknown')"
+
+
   test-warp-cpu:
     if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
 - Add `--use-dynamic-cuda` build option to link against shared CUDA libraries instead of embedding
   them statically; the corresponding shared libraries must be present at runtime
   ([GH-1334](https://github.com/NVIDIA/warp/issues/1334)).
+- Add an optional CMake source-build path for `warp` and `warp-clang`
+  with Packman-managed dependencies and support for parallel and incremental
+  developer builds ([GH-1495](https://github.com/NVIDIA/warp/issues/1495)).
 - Add pluggable logging infrastructure: implement the `wp.Logger` protocol and pass it to `wp.set_logger()`,
   or scope it temporarily with `wp.ScopedLogger`. `wp.config.log_level` controls the global verbosity threshold
   and can be scoped temporarily with `wp.ScopedLogLevel`; all Python-side diagnostic output now routes through

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,434 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.24)
+
+if(POLICY CMP0091)
+    cmake_policy(SET CMP0091 NEW)
+endif()
+
+if(APPLE)
+    set(_warp_enable_cuda_default OFF)
+    set(CMAKE_OSX_ARCHITECTURES "arm64" CACHE STRING "Apple Silicon only" FORCE)
+    if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "macOS deployment target" FORCE)
+    endif()
+else()
+    set(_warp_enable_cuda_default ON)
+endif()
+
+option(WARP_ENABLE_CUDA "Build Warp with CUDA support" ${_warp_enable_cuda_default})
+if(APPLE AND WARP_ENABLE_CUDA)
+    message(FATAL_ERROR "CUDA builds are not supported on macOS")
+endif()
+
+option(WARP_BUILD_CLANG "Build warp-clang" ON)
+option(WARP_VERIFY_FP "Enable floating point verification" OFF)
+option(WARP_FAST_MATH "Enable fast math compiler options" OFF)
+set(WARP_LIBMATHDX_PATH "" CACHE PATH "")
+set(WARP_LLVM_PATH "" CACHE PATH "")
+if(WARP_ENABLE_CUDA)
+    option(WARP_USE_LIBMATHDX "Build Warp with NVIDIA libmathdx support" ON)
+    option(WARP_USE_DYNAMIC_CUDA "Link CUDA runtime and compiler libraries dynamically" OFF)
+    set(WARP_CUDA_PATH "" CACHE PATH "")
+else()
+    set(WARP_USE_LIBMATHDX OFF)
+    set(WARP_USE_DYNAMIC_CUDA OFF)
+    set(WARP_CUDA_PATH "")
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
+include(WarpDependencies)
+
+if(WARP_ENABLE_CUDA)
+    warp_configure_cuda_root()
+    warp_set_default_cuda_architectures()
+    project(warp LANGUAGES CXX CUDA)
+else()
+    project(warp LANGUAGES CXX)
+endif()
+
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+endif()
+if(CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "CMAKE_CONFIGURATION_TYPES: ${CMAKE_CONFIGURATION_TYPES}")
+else()
+    message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(WARP_ENABLE_CUDA)
+    set(CMAKE_CUDA_STANDARD 17)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    set(CMAKE_CUDA_EXTENSIONS OFF)
+
+    find_package(CUDAToolkit 12.0 REQUIRED)
+    message(STATUS "CMAKE_CUDA_ARCHITECTURES: ${CMAKE_CUDA_ARCHITECTURES}")
+endif()
+
+warp_find_python()
+warp_add_generated_headers_target()
+warp_find_libmathdx()
+warp_find_llvm()
+
+set(WARP_NATIVE_DIR "${PROJECT_SOURCE_DIR}/warp/native")
+set(WARP_BIN_DIR "${PROJECT_SOURCE_DIR}/warp/bin")
+
+function(warp_set_shared_target_output target output_name)
+    set_target_properties(
+        "${target}"
+        PROPERTIES
+            OUTPUT_NAME "${output_name}"
+            ARCHIVE_OUTPUT_DIRECTORY "${WARP_BIN_DIR}"
+            LIBRARY_OUTPUT_DIRECTORY "${WARP_BIN_DIR}"
+            RUNTIME_OUTPUT_DIRECTORY "${WARP_BIN_DIR}"
+    )
+
+    if(NOT APPLE)
+        set_target_properties("${target}" PROPERTIES PREFIX "")
+    endif()
+
+    foreach(config DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+        set_target_properties(
+            "${target}"
+            PROPERTIES
+                ARCHIVE_OUTPUT_DIRECTORY_${config} "${WARP_BIN_DIR}"
+                LIBRARY_OUTPUT_DIRECTORY_${config} "${WARP_BIN_DIR}"
+                RUNTIME_OUTPUT_DIRECTORY_${config} "${WARP_BIN_DIR}"
+        )
+    endforeach()
+endfunction()
+
+function(warp_add_common_cxx_options target)
+    target_compile_options(
+        "${target}"
+        PRIVATE
+            "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/nologo>"
+            "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/GR->"
+            "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/EHsc>"
+            "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/wd4624>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-Werror>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-Wuninitialized>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-fno-rtti>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-fvisibility=hidden>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-fvisibility-inlines-hidden>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<CONFIG:Debug>>:-Og>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<CONFIG:Debug>>:-g>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<NOT:$<CONFIG:Debug>>>:-O3>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>,$<BOOL:${WARP_FAST_MATH}>>:/fp:fast>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<BOOL:${WARP_FAST_MATH}>>:-ffast-math>"
+    )
+endfunction()
+
+function(warp_add_linux_link_options target)
+    target_link_libraries("${target}" PRIVATE pthread dl rt)
+    target_link_options(
+        "${target}"
+        PRIVATE
+            -static-libstdc++
+            -static-libgcc
+            "LINKER:--version-script,${WARP_NATIVE_DIR}/warp.map"
+            "LINKER:-z,lazy"
+            "LINKER:--exclude-libs,ALL"
+            "LINKER:-rpath,$ORIGIN"
+    )
+endfunction()
+
+function(warp_find_optional_cuda_library out_var)
+    cmake_parse_arguments(ARG "" "" "NAMES" ${ARGN})
+
+    set(_cuda_library_hints)
+    foreach(_dir
+            "${CUDAToolkit_LIBRARY_DIR}"
+            "${CUDAToolkit_LIBRARY_ROOT}"
+            "${CUDAToolkit_TARGET_DIR}/lib64"
+            "${CUDAToolkit_TARGET_DIR}/lib"
+            "${CUDAToolkit_ROOT}/lib64"
+            "${CUDAToolkit_ROOT}/lib"
+            "${CUDAToolkit_ROOT}/lib/x64"
+    )
+        if(_dir)
+            list(APPEND _cuda_library_hints "${_dir}")
+        endif()
+    endforeach()
+
+    unset(_warp_cuda_library CACHE)
+    find_library(_warp_cuda_library NAMES ${ARG_NAMES} HINTS ${_cuda_library_hints})
+    set("${out_var}" "${_warp_cuda_library}" PARENT_SCOPE)
+    unset(_warp_cuda_library CACHE)
+endfunction()
+
+function(warp_find_required_cuda_library out_var)
+    cmake_parse_arguments(ARG "" "" "NAMES" ${ARGN})
+
+    warp_find_optional_cuda_library("${out_var}" NAMES ${ARG_NAMES})
+    if(NOT "${${out_var}}")
+        string(REPLACE ";" ", " _cuda_library_names "${ARG_NAMES}")
+        message(FATAL_ERROR "Required CUDA library ${_cuda_library_names} was not found by CUDAToolkit")
+    endif()
+
+    set("${out_var}" "${${out_var}}" PARENT_SCOPE)
+endfunction()
+
+function(warp_require_cuda_target target)
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "Required CUDA target ${target} was not found by CUDAToolkit")
+    endif()
+endfunction()
+
+function(warp_link_nvptxcompiler target)
+    if(WARP_USE_DYNAMIC_CUDA)
+        if(TARGET CUDA::nvptxcompiler)
+            target_link_libraries("${target}" PRIVATE CUDA::nvptxcompiler)
+        else()
+            warp_find_required_cuda_library(WARP_NVPTXCOMPILER_LIBRARY NAMES nvptxcompiler)
+            target_link_libraries("${target}" PRIVATE "${WARP_NVPTXCOMPILER_LIBRARY}")
+        endif()
+    else()
+        if(TARGET CUDA::nvptxcompiler_static)
+            target_link_libraries("${target}" PRIVATE CUDA::nvptxcompiler_static)
+        else()
+            warp_find_required_cuda_library(WARP_NVPTXCOMPILER_STATIC_LIBRARY NAMES nvptxcompiler_static)
+            target_link_libraries("${target}" PRIVATE "${WARP_NVPTXCOMPILER_STATIC_LIBRARY}")
+        endif()
+    endif()
+endfunction()
+
+set(WARP_CPP_SOURCES
+    warp/native/warp.cpp
+    warp/native/bvh.cpp
+    warp/native/scan.cpp
+    warp/native/apic.cpp
+    warp/native/alloc_tracker.cpp
+    warp/native/crt.cpp
+    warp/native/error.cpp
+    warp/native/cuda_util.cpp
+    warp/native/mesh.cpp
+    warp/native/hashgrid.cpp
+    warp/native/reduce.cpp
+    warp/native/runlength_encode.cpp
+    warp/native/sort.cpp
+    warp/native/sparse.cpp
+    warp/native/volume.cpp
+    warp/native/texture.cpp
+    warp/native/mathdx.cpp
+    warp/native/coloring.cpp
+    warp/native/fastcall.cpp
+)
+
+set(WARP_SOURCES ${WARP_CPP_SOURCES})
+
+if(WARP_ENABLE_CUDA)
+    list(
+        APPEND WARP_SOURCES
+        warp/native/bvh.cu
+        warp/native/mesh.cu
+        warp/native/sort.cu
+        warp/native/hashgrid.cu
+        warp/native/reduce.cu
+        warp/native/runlength_encode.cu
+        warp/native/scan.cu
+        warp/native/sparse.cu
+        warp/native/volume.cu
+        warp/native/volume_builder.cu
+        warp/native/warp.cu
+    )
+endif()
+
+add_library(warp SHARED ${WARP_SOURCES})
+add_dependencies(warp warp_generated_headers)
+warp_set_shared_target_output(warp warp)
+warp_add_common_cxx_options(warp)
+set_target_properties(
+    warp
+    PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        MSVC_RUNTIME_LIBRARY "MultiThreaded"
+)
+target_include_directories(warp PRIVATE "${WARP_NATIVE_DIR}" ${WARP_PYTHON_INCLUDE_DIRS})
+target_compile_features(warp PRIVATE cxx_std_17)
+
+if(WARP_ENABLE_CUDA)
+    target_compile_features(warp PRIVATE cuda_std_17)
+    set_target_properties(
+        warp
+        PROPERTIES CUDA_RUNTIME_LIBRARY "$<IF:$<BOOL:${WARP_USE_DYNAMIC_CUDA}>,Shared,Static>"
+    )
+endif()
+
+if(WARP_ENABLE_CUDA AND WARP_LIBMATHDX_LIBRARY)
+    set(WARP_ENABLE_MATHDX_VALUE 1)
+else()
+    set(WARP_ENABLE_MATHDX_VALUE 0)
+endif()
+
+# CMake builds are intended for local development. Use build_lib.py for release
+# builds that need the full CUDA compatibility policy.
+set(WARP_ENABLE_CUDA_COMPATIBILITY_VALUE 0)
+
+target_compile_definitions(
+    warp
+    PRIVATE
+        WP_ENABLE_CUDA=$<IF:$<BOOL:${WARP_ENABLE_CUDA}>,1,0>
+        WP_ENABLE_MATHDX=${WARP_ENABLE_MATHDX_VALUE}
+        WP_ENABLE_CUDA_COMPATIBILITY=${WARP_ENABLE_CUDA_COMPATIBILITY_VALUE}
+        WP_ENABLE_DEBUG=$<IF:$<CONFIG:Debug>,1,0>
+        "$<$<CXX_COMPILER_ID:MSVC>:NDEBUG>"
+        "$<$<CXX_COMPILER_ID:MSVC>:_ITERATOR_DEBUG_LEVEL=0>"
+        "$<$<AND:$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<CONFIG:Debug>>:_DEBUG>"
+        "$<$<BOOL:${WARP_VERIFY_FP}>:WP_VERIFY_FP>"
+        "$<$<BOOL:${WARP_FAST_MATH}>:WP_FAST_MATH>"
+        "$<$<PLATFORM_ID:Linux,Darwin>:_GLIBCXX_USE_CXX11_ABI=0>"
+)
+set_source_files_properties(warp/native/fastcall.cpp PROPERTIES COMPILE_DEFINITIONS Py_LIMITED_API=0x030a0000)
+
+if(WARP_ENABLE_CUDA)
+    target_compile_options(
+        warp
+        PRIVATE
+            "$<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>"
+            "$<$<COMPILE_LANGUAGE:CUDA>:-diag-suppress=221>"
+            # Intentional: -t0 lets nvcc use all CPUs; use -t1 to constrain threading.
+            "$<$<COMPILE_LANGUAGE:CUDA>:-t0>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-g>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-G>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-O0>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:-lineinfo>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<NOT:$<CONFIG:Debug>>>:-O3>"
+            "$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<BOOL:${WARP_FAST_MATH}>>:--use_fast_math>"
+    )
+
+    if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "13.0")
+        foreach(_cuda_include_dir IN LISTS CUDAToolkit_INCLUDE_DIRS)
+            if(EXISTS "${_cuda_include_dir}/cccl")
+                target_include_directories(warp PRIVATE "${_cuda_include_dir}/cccl")
+            endif()
+        endforeach()
+    endif()
+
+    # CUDA imported targets differ across Toolkit versions and static/dynamic
+    # modes. Prefer official CMake targets, then fall back to direct library
+    # lookup for components that older CMake/CUDA combinations do not expose.
+    if(WARP_USE_DYNAMIC_CUDA)
+        warp_require_cuda_target(CUDA::cudart)
+        warp_require_cuda_target(CUDA::nvrtc)
+        target_link_libraries(warp PRIVATE CUDA::cudart CUDA::nvrtc)
+        warp_link_nvptxcompiler(warp)
+        if(TARGET CUDA::nvJitLink)
+            target_link_libraries(warp PRIVATE CUDA::nvJitLink)
+        else()
+            warp_find_optional_cuda_library(WARP_NVJITLINK_LIBRARY NAMES nvJitLink)
+            if(WARP_NVJITLINK_LIBRARY)
+                target_link_libraries(warp PRIVATE "${WARP_NVJITLINK_LIBRARY}")
+            endif()
+        endif()
+    else()
+        warp_require_cuda_target(CUDA::cudart_static)
+        warp_require_cuda_target(CUDA::nvrtc_static)
+        target_link_libraries(warp PRIVATE CUDA::cudart_static CUDA::nvrtc_static)
+        warp_link_nvptxcompiler(warp)
+        if(TARGET CUDA::nvrtc_builtins_static)
+            target_link_libraries(warp PRIVATE CUDA::nvrtc_builtins_static)
+        elseif(TARGET CUDA::nvrtc-builtins_static)
+            target_link_libraries(warp PRIVATE CUDA::nvrtc-builtins_static)
+        else()
+            warp_find_optional_cuda_library(WARP_NVRTC_BUILTINS_LIBRARY NAMES nvrtc-builtins_static nvrtc_builtins_static)
+            if(WARP_NVRTC_BUILTINS_LIBRARY)
+                target_link_libraries(warp PRIVATE "${WARP_NVRTC_BUILTINS_LIBRARY}")
+            endif()
+        endif()
+        if(TARGET CUDA::nvJitLink_static)
+            target_link_libraries(warp PRIVATE CUDA::nvJitLink_static)
+        elseif(TARGET CUDA::nvJitLink)
+            target_link_libraries(warp PRIVATE CUDA::nvJitLink)
+        else()
+            warp_find_optional_cuda_library(WARP_NVJITLINK_LIBRARY NAMES nvJitLink_static nvJitLink)
+            if(WARP_NVJITLINK_LIBRARY)
+                target_link_libraries(warp PRIVATE "${WARP_NVJITLINK_LIBRARY}")
+            endif()
+        endif()
+    endif()
+
+    if(WARP_LIBMATHDX_LIBRARY)
+        target_include_directories(warp PRIVATE "${WARP_LIBMATHDX_INCLUDE_DIR}")
+        target_link_libraries(warp PRIVATE "${WARP_LIBMATHDX_LIBRARY}")
+    endif()
+endif()
+
+if(WIN32)
+    target_link_libraries(warp PRIVATE ws2_32 user32 delayimp "${WARP_PYTHON3_LIBRARY}")
+    target_link_options(warp PRIVATE /DELAYLOAD:python3.dll)
+elseif(APPLE)
+    target_link_options(warp PRIVATE "LINKER:-undefined,dynamic_lookup" "LINKER:-rpath,@loader_path")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    warp_add_linux_link_options(warp)
+endif()
+
+if(WARP_BUILD_CLANG)
+    add_library(
+        warp-clang
+        SHARED
+        warp/native/clang/clang.cpp
+        warp/native/crt.cpp
+    )
+    add_dependencies(warp-clang warp_generated_headers)
+    warp_set_shared_target_output(warp-clang warp-clang)
+    warp_add_common_cxx_options(warp-clang)
+    set_target_properties(
+        warp-clang
+        PROPERTIES
+            POSITION_INDEPENDENT_CODE ON
+            MSVC_RUNTIME_LIBRARY "MultiThreaded"
+    )
+    target_compile_features(warp-clang PRIVATE cxx_std_17)
+    target_include_directories(warp-clang PRIVATE "${WARP_NATIVE_DIR}" "${WARP_LLVM_INCLUDE_DIR}")
+    # Match the GCC ABI version used by Warp's LLVM archives.
+    target_compile_options(
+        warp-clang
+        PRIVATE "$<$<AND:$<PLATFORM_ID:Linux>,$<COMPILE_LANG_AND_ID:CXX,GNU>>:-fabi-version=13>"
+    )
+    target_compile_definitions(
+        warp-clang
+        PRIVATE
+            WP_ENABLE_CUDA=0
+            WP_ENABLE_MATHDX=0
+            WP_ENABLE_CUDA_COMPATIBILITY=0
+            WP_ENABLE_DEBUG=$<IF:$<CONFIG:Debug>,1,0>
+            "$<$<CXX_COMPILER_ID:MSVC>:NDEBUG>"
+            "$<$<CXX_COMPILER_ID:MSVC>:_ITERATOR_DEBUG_LEVEL=0>"
+            "$<$<AND:$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<CONFIG:Debug>>:_DEBUG>"
+            "$<$<BOOL:${WARP_FAST_MATH}>:WP_FAST_MATH>"
+            "$<$<PLATFORM_ID:Linux,Darwin>:_GLIBCXX_USE_CXX11_ABI=0>"
+    )
+
+    if(WIN32)
+        target_link_libraries(
+            warp-clang
+            PRIVATE
+                ${WARP_LLVM_LIBRARIES}
+                Version
+                Ws2_32
+                ntdll
+                delayimp
+                "${WARP_PYTHON3_LIBRARY}"
+        )
+        target_link_options(warp-clang PRIVATE /DELAYLOAD:python3.dll)
+    elseif(APPLE)
+        # Repeat LLVM static archives to resolve circular dependencies on macOS.
+        target_link_libraries(warp-clang PRIVATE ${WARP_LLVM_LIBRARIES} ${WARP_LLVM_LIBRARIES} pthread dl)
+        target_link_options(warp-clang PRIVATE "LINKER:-undefined,dynamic_lookup")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        target_link_libraries(
+            warp-clang
+            PRIVATE
+                -Wl,--start-group
+                ${WARP_LLVM_LIBRARIES}
+                -Wl,--end-group
+        )
+        warp_add_linux_link_options(warp-clang)
+    endif()
+endif()

--- a/docker/warp-builder/Dockerfile
+++ b/docker/warp-builder/Dockerfile
@@ -55,17 +55,48 @@ RUN CUDA_MAJOR=$(echo ${CUDA_VERSION} | cut -d. -f1) && \
     --component $component || exit 1; \
     done
 
+# Install pinned CMake from official Kitware binary tarballs.
+FROM base AS cmake-installer
+
+ARG CMAKE_VERSION=4.3.3
+ARG TARGETARCH
+
+RUN if [ "$TARGETARCH" = "sbsa" ]; then \
+    CMAKE_ARCH="aarch64"; \
+    elif [ "$TARGETARCH" = "x86_64" ]; then \
+    CMAKE_ARCH="x86_64"; \
+    elif [ "$TARGETARCH" = "aarch64" ]; then \
+    CMAKE_ARCH="aarch64"; \
+    else \
+    echo "Unsupported architecture: $TARGETARCH" && exit 1; \
+    fi && \
+    if [ "$CMAKE_ARCH" = "x86_64" ]; then \
+    CMAKE_SHA256="927b2368a946c37269c3a66225ab00544e756459cdd0b5d0da438694fb9ff802"; \
+    elif [ "$CMAKE_ARCH" = "aarch64" ]; then \
+    CMAKE_SHA256="9ea38356dbd3e32e51029a3e09a0f2f8e117ef4fbcaad7a21ffb36409bbd5cb4"; \
+    fi && \
+    CMAKE_FILE="cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz" && \
+    wget -nv --https-only --max-redirect=1 "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_FILE}" && \
+    echo "${CMAKE_SHA256}  ${CMAKE_FILE}" | sha256sum -c - && \
+    mkdir -p /opt/cmake && \
+    tar -xzf "${CMAKE_FILE}" --strip-components=1 -C /opt/cmake && \
+    rm "${CMAKE_FILE}" && \
+    /opt/cmake/bin/cmake --version
+
 # Build LLVM from source
 FROM base AS llvm-builder
 WORKDIR /tmp/llvm-build
 
 ARG TARGETARCH
 
+COPY --from=cmake-installer /opt/cmake /opt/cmake
+ENV PATH=/opt/cmake/bin:${PATH}
+
 # Install build tools needed for LLVM (not needed in final image)
 RUN yum install -y \
+    curl \
     git \
     unzip \
-    cmake \
     && yum clean all
 
 # Install modern Ninja from GitHub releases (yum's ninja-build is too old for LLVM 21.1.0)
@@ -74,16 +105,21 @@ ARG NINJA_VERSION=1.13.2
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
     NINJA_FILE="ninja-linux.zip"; \
+    NINJA_SHA256="5749cbc4e668273514150a80e387a957f933c6ed3f5f11e03fb30955e2bbead6"; \
     elif [ "$ARCH" = "aarch64" ]; then \
     NINJA_FILE="ninja-linux-aarch64.zip"; \
+    NINJA_SHA256="fd2cacc8050a7f12a16a2e48f9e06fca5c14fc4c2bee2babb67b58be17a607fc"; \
     else \
     echo "Unsupported architecture: $ARCH" && exit 1; \
     fi && \
-    wget --max-redirect=1 https://github.com/ninja-build/ninja/releases/download/v${NINJA_VERSION}/${NINJA_FILE} && \
-    unzip ${NINJA_FILE} && \
+    curl -fL --proto '=https' --proto-redir '=https' --max-redirs 1 \
+    -o "${NINJA_FILE}" \
+    "https://github.com/ninja-build/ninja/releases/download/v${NINJA_VERSION}/${NINJA_FILE}" && \
+    echo "${NINJA_SHA256}  ${NINJA_FILE}" | sha256sum -c - && \
+    unzip "${NINJA_FILE}" && \
     mv ninja /usr/local/bin/ && \
     chmod +x /usr/local/bin/ninja && \
-    rm ${NINJA_FILE} && \
+    rm "${NINJA_FILE}" && \
     ninja --version
 
 # Clone LLVM 21.1.0 (same version as build_llvm.py)
@@ -286,8 +322,14 @@ ARG TARGETARCH
 # parse_redist.py creates /opt/cuda/linux-${TARGETARCH}/ structure (e.g., linux-x86_64, linux-aarch64)
 COPY --from=cuda-installer /opt/cuda/linux-${TARGETARCH} /usr/local/cuda
 
+# Copy the pinned CMake binary distribution from Kitware.
+COPY --from=cmake-installer /opt/cmake /opt/cmake
+
 # Copy LLVM installation from builder stage
 COPY --from=llvm-builder /opt/llvm /opt/llvm
+
+# Copy the pinned modern Ninja downloaded in the LLVM builder stage.
+COPY --from=llvm-builder /usr/local/bin/ninja /usr/local/bin/ninja
 
 # Copy uv from official image
 COPY --from=uv /uv /uvx /bin/
@@ -305,13 +347,15 @@ RUN mkdir -p /usr/local/cuda/licenses && \
     echo "See: https://docs.nvidia.com/cuda/eula/" >> /usr/local/cuda/licenses/README.txt
 
 # Set environment variables
-ENV PATH=/usr/local/cuda/bin:/opt/llvm/bin:${PATH}
+ENV PATH=/opt/cmake/bin:/usr/local/cuda/bin:/opt/llvm/bin:${PATH}
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/lib:/opt/llvm/lib:${LD_LIBRARY_PATH}
 ENV CUDA_HOME=/usr/local/cuda
 ENV CUDA_PATH=/usr/local/cuda
 
-# Verify CUDA, LLVM, and uv installation
+# Verify CUDA, CMake, Ninja, LLVM, and uv installation
 RUN nvcc --version && \
+    cmake --version && \
+    ninja --version && \
     uv --version && \
     echo "Build environment ready with LLVM!" && \
     echo "LLVM libraries:" && \

--- a/docs/user_guide/installation.rst
+++ b/docs/user_guide/installation.rst
@@ -187,6 +187,94 @@ After building, the Warp package should be installed using:
 The ``-e`` option is optional but ensures that subsequent modifications to the
 library will be reflected in the Python package.
 
+CMake build
+~~~~~~~~~~~
+
+Developers who have CMake installed can use the alternate CMake build path.
+This builds the native Warp libraries in place, like ``build_lib.py``, while
+letting CMake and the selected generator handle parallel and incremental
+rebuilds.
+The commands shown below require CMake 3.24 or newer and Ninja. CMake also uses
+a Python 3.10+ environment with NumPy installed to regenerate derived native
+headers. By default, CMake may fetch LLVM and ``libmathdx`` through Packman
+unless explicit paths are provided or the corresponding features are disabled
+(``-DWARP_BUILD_CLANG=OFF`` for LLVM, ``-DWARP_USE_LIBMATHDX=OFF`` for
+``libmathdx``, or ``-DWARP_ENABLE_CUDA=OFF`` for a CPU-only build).
+
+From the repository root, the recommended path uses
+`uv <https://docs.astral.sh/uv/>`__ to prepare the Python environment before
+configuring and building:
+
+.. code-block:: console
+
+    $ uv sync --no-install-project
+    $ cmake -S . -B _build/cmake -G Ninja
+    $ cmake --build _build/cmake --parallel
+
+Without ``uv``, use a Python environment you manage and install NumPy before
+running the CMake commands:
+
+.. code-block:: console
+
+    $ python -m pip install numpy
+    $ cmake -S . -B _build/cmake -G Ninja
+    $ cmake --build _build/cmake --parallel
+
+Upon success, the CMake build writes the native libraries to ``warp/bin/``.
+The default CMake build enables CUDA on Linux and Windows, disables CUDA on
+macOS, and builds both ``warp`` and ``warp-clang``. Pass
+``-DWARP_ENABLE_CUDA=OFF`` for a CPU-only CMake build. CUDA builds default to a
+single PTX target for fast local builds; use ``CMAKE_CUDA_ARCHITECTURES`` to
+select different GPU architectures. Use ``build_lib.py`` for release builds
+that need Warp's full GPU architecture coverage.
+
+To use a specific CUDA Toolkit:
+
+.. code-block:: console
+
+    $ cmake -S . -B _build/cmake -G Ninja -DWARP_CUDA_PATH=/usr/local/cuda
+    $ cmake --build _build/cmake --parallel
+
+To link against shared CUDA libraries in the CMake build:
+
+.. code-block:: console
+
+    $ cmake -S . -B _build/cmake -G Ninja -DWARP_USE_DYNAMIC_CUDA=ON
+    $ cmake --build _build/cmake --parallel
+
+The corresponding shared CUDA libraries, including ``libnvptxcompiler``, must
+be available at runtime when using this option.
+
+To use an existing LLVM installation for ``warp-clang``:
+
+.. code-block:: console
+
+    $ cmake -S . -B _build/cmake -G Ninja -DWARP_LLVM_PATH=/opt/llvm
+    $ cmake --build _build/cmake --parallel
+
+To use an existing ``libmathdx`` installation:
+
+.. code-block:: console
+
+    $ cmake -S . -B _build/cmake -G Ninja -DWARP_LIBMATHDX_PATH=/path/to/libmathdx
+    $ cmake --build _build/cmake --parallel
+
+To build for specific CUDA architectures:
+
+.. code-block:: console
+
+    $ cmake -S . -B _build/cmake -G Ninja -DCMAKE_CUDA_ARCHITECTURES="86;89"
+    $ cmake --build _build/cmake --parallel
+
+After building, verify that the libraries can be loaded:
+
+.. code-block:: console
+
+    $ uv run python -c "import warp; warp.print_diagnostics()"
+
+The CMake path is a native library build path only. It does not replace the
+Python package build backend used for wheels.
+
 .. _conda:
 
 Conda Environments

--- a/tools/build/generate_exports_header.py
+++ b/tools/build/generate_exports_header.py
@@ -1,0 +1,36 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "numpy",
+# ]
+# ///
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate warp/native/exports.h")
+    parser.add_argument("repo_root", help="Path to the Warp repository root")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve()
+    if not (repo_root / "warp" / "_src" / "generated_files.py").is_file():
+        parser.error(f"{repo_root} does not look like a Warp repository root")
+
+    sys.path.insert(0, str(repo_root))
+
+    from warp._src.generated_files import generate_exports_header_file  # noqa: PLC0415
+
+    generate_exports_header_file(str(repo_root))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/cmake/WarpDependencies.cmake
+++ b/tools/cmake/WarpDependencies.cmake
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+include_guard(GLOBAL)
+
+function(warp_get_host_arch out_var)
+    string(TOLOWER "${CMAKE_HOST_SYSTEM_PROCESSOR}" _processor)
+    if(_processor MATCHES "^(x86_64|amd64)$")
+        set(_arch "x86_64")
+    elseif(_processor MATCHES "^(aarch64|arm64)$")
+        set(_arch "aarch64")
+    else()
+        message(FATAL_ERROR "Unsupported host architecture: ${CMAKE_HOST_SYSTEM_PROCESSOR}")
+    endif()
+    set(${out_var} "${_arch}" PARENT_SCOPE)
+endfunction()
+
+function(warp_get_packman_command out_var)
+    if(WIN32)
+        set(_packman "${PROJECT_SOURCE_DIR}/tools/packman/packman.cmd")
+    else()
+        set(_packman "${PROJECT_SOURCE_DIR}/tools/packman/packman")
+    endif()
+
+    if(NOT EXISTS "${_packman}")
+        message(FATAL_ERROR "Packman was not found at ${_packman}")
+    endif()
+
+    set(${out_var} "${_packman}" PARENT_SCOPE)
+endfunction()
+
+function(warp_get_packman_platform out_var)
+    warp_get_host_arch(_arch)
+    if(WIN32)
+        set(_platform "windows-${_arch}")
+    elseif(APPLE)
+        set(_platform "darwin-${_arch}")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        set(_platform "linux-${_arch}")
+    else()
+        message(FATAL_ERROR "Unsupported Packman platform: ${CMAKE_SYSTEM_NAME}")
+    endif()
+    set(${out_var} "${_platform}" PARENT_SCOPE)
+endfunction()
+
+function(warp_get_packman_python out_var)
+    if(NOT WARP_PYTHON_EXECUTABLE)
+        message(FATAL_ERROR "warp_find_python() must be called before fetching Packman dependencies")
+    endif()
+    set(${out_var} "${WARP_PYTHON_EXECUTABLE}" PARENT_SCOPE)
+endfunction()
+
+function(warp_configure_cuda_root)
+    if(WARP_CUDA_PATH)
+        set(CUDAToolkit_ROOT "${WARP_CUDA_PATH}" CACHE PATH "CUDA Toolkit root" FORCE)
+        if(EXISTS "${WARP_CUDA_PATH}/bin/nvcc${CMAKE_EXECUTABLE_SUFFIX}")
+            set(CMAKE_CUDA_COMPILER "${WARP_CUDA_PATH}/bin/nvcc${CMAKE_EXECUTABLE_SUFFIX}" CACHE FILEPATH "CUDA compiler" FORCE)
+        endif()
+        return()
+    endif()
+
+    if((DEFINED CUDAToolkit_ROOT AND NOT CUDAToolkit_ROOT STREQUAL "")
+       OR (DEFINED CMAKE_CUDA_COMPILER AND NOT CMAKE_CUDA_COMPILER STREQUAL ""))
+        return()
+    endif()
+
+    if(DEFINED ENV{WARP_CUDA_PATH})
+        set(_cuda_root "$ENV{WARP_CUDA_PATH}")
+    elseif(DEFINED ENV{CUDA_HOME})
+        set(_cuda_root "$ENV{CUDA_HOME}")
+    elseif(DEFINED ENV{CUDA_PATH})
+        set(_cuda_root "$ENV{CUDA_PATH}")
+    else()
+        set(_cuda_root "")
+    endif()
+
+    if(_cuda_root)
+        set(CUDAToolkit_ROOT "${_cuda_root}" CACHE PATH "CUDA Toolkit root" FORCE)
+        if((NOT DEFINED CMAKE_CUDA_COMPILER OR CMAKE_CUDA_COMPILER STREQUAL "")
+           AND EXISTS "${_cuda_root}/bin/nvcc${CMAKE_EXECUTABLE_SUFFIX}")
+            set(CMAKE_CUDA_COMPILER "${_cuda_root}/bin/nvcc${CMAKE_EXECUTABLE_SUFFIX}" CACHE FILEPATH "CUDA compiler" FORCE)
+        endif()
+    endif()
+endfunction()
+
+function(warp_set_default_cuda_architectures)
+    if((DEFINED CMAKE_CUDA_ARCHITECTURES AND NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "")
+       OR (DEFINED CACHE{CMAKE_CUDA_ARCHITECTURES} AND NOT "$CACHE{CMAKE_CUDA_ARCHITECTURES}" STREQUAL "")
+       OR (DEFINED ENV{CUDAARCHS} AND NOT "$ENV{CUDAARCHS}" STREQUAL ""))
+        return()
+    endif()
+
+    set(CMAKE_CUDA_ARCHITECTURES "75-virtual" CACHE STRING "CUDA architectures" FORCE)
+endfunction()
+
+function(warp_find_python)
+    find_package(Python3 3.10 COMPONENTS Interpreter Development.Module REQUIRED)
+    set(WARP_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}" PARENT_SCOPE)
+    set(WARP_PYTHON_INCLUDE_DIRS "${Python3_INCLUDE_DIRS}" PARENT_SCOPE)
+
+    if(WIN32)
+        execute_process(
+            COMMAND "${Python3_EXECUTABLE}" -c "import sysconfig; print(sysconfig.get_config_var('base') or sysconfig.get_config_var('installed_base') or '')"
+            OUTPUT_VARIABLE _python_base
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+        unset(_warp_python3_library CACHE)
+        find_library(
+            _warp_python3_library
+            NAMES python3
+            PATHS "${_python_base}/libs" "${Python3_LIBRARY_DIRS}"
+            NO_DEFAULT_PATH
+        )
+        if(NOT _warp_python3_library OR NOT EXISTS "${_warp_python3_library}")
+            message(FATAL_ERROR "Could not find python3.lib for Python stable ABI linking")
+        endif()
+        set(WARP_PYTHON3_LIBRARY "${_warp_python3_library}" PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(warp_get_python_script_command out_var script_path)
+    if(NOT WARP_PYTHON_EXECUTABLE)
+        message(FATAL_ERROR "warp_find_python() must be called before generating headers")
+    endif()
+
+    find_program(WARP_UV_EXECUTABLE uv)
+    if(WARP_UV_EXECUTABLE)
+        set(_command "${WARP_UV_EXECUTABLE};run;--no-project;--script;${script_path}")
+    else()
+        set(_command "${WARP_PYTHON_EXECUTABLE};${script_path}")
+    endif()
+
+    set("${out_var}" "${_command}" PARENT_SCOPE)
+endfunction()
+
+function(warp_add_generated_headers_target)
+    set(_exports_header "${PROJECT_SOURCE_DIR}/warp/native/exports.h")
+    set(_exports_header_script "${PROJECT_SOURCE_DIR}/tools/build/generate_exports_header.py")
+    warp_get_python_script_command(_exports_header_command "${_exports_header_script}")
+
+    add_custom_command(
+        OUTPUT "${_exports_header}"
+        COMMAND ${_exports_header_command} "${PROJECT_SOURCE_DIR}"
+        DEPENDS
+            "${_exports_header_script}"
+            "${PROJECT_SOURCE_DIR}/warp/_src/generated_files.py"
+            "${PROJECT_SOURCE_DIR}/warp/_src/context.py"
+            "${PROJECT_SOURCE_DIR}/warp/_src/builtins.py"
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+        COMMENT "Generating warp/native/exports.h"
+        VERBATIM
+    )
+
+    add_custom_target(warp_generated_headers DEPENDS "${_exports_header}")
+endfunction()
+
+function(warp_find_libmathdx)
+    if(NOT WARP_ENABLE_CUDA OR NOT WARP_USE_LIBMATHDX)
+        set(WARP_LIBMATHDX_INCLUDE_DIR "" PARENT_SCOPE)
+        set(WARP_LIBMATHDX_LIBRARY "" PARENT_SCOPE)
+        return()
+    endif()
+
+    if(NOT CUDAToolkit_VERSION)
+        message(FATAL_ERROR "CUDAToolkit_VERSION is required to find libmathdx")
+    endif()
+
+    if(WARP_LIBMATHDX_PATH)
+        set(_mathdx_root "${WARP_LIBMATHDX_PATH}")
+    elseif(DEFINED ENV{LIBMATHDX_HOME})
+        set(_mathdx_root "$ENV{LIBMATHDX_HOME}")
+    else()
+        warp_get_packman_python(_packman_python)
+        warp_get_packman_command(_packman)
+        warp_get_packman_platform(_platform)
+        string(REGEX MATCH "^[0-9]+" _cuda_major "${CUDAToolkit_VERSION}")
+        execute_process(
+            COMMAND "${CMAKE_COMMAND}" -E env "PM_PYTHON_EXT=${_packman_python}"
+                    "${_packman}" pull --verbose --platform "${_platform}" --include-tag "cu${_cuda_major}"
+                    "${PROJECT_SOURCE_DIR}/deps/libmathdx-deps.packman.xml"
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+        set(_mathdx_root "${PROJECT_SOURCE_DIR}/_build/target-deps/libmathdx")
+    endif()
+
+    if(WIN32)
+        set(_mathdx_lib_dir "${_mathdx_root}/lib/x64")
+    else()
+        set(_mathdx_lib_dir "${_mathdx_root}/lib")
+    endif()
+
+    if(WARP_USE_DYNAMIC_CUDA)
+        set(_mathdx_names mathdx)
+    else()
+        set(_mathdx_names mathdx_static mathdx)
+    endif()
+
+    unset(_warp_libmathdx_library CACHE)
+    find_library(_warp_libmathdx_library NAMES ${_mathdx_names} PATHS "${_mathdx_lib_dir}" NO_DEFAULT_PATH)
+    if(NOT EXISTS "${_mathdx_root}/include")
+        warp_invalid_libmathdx_path("libmathdx include directory was not found at ${_mathdx_root}/include")
+    endif()
+    if(NOT _warp_libmathdx_library)
+        warp_invalid_libmathdx_path("libmathdx library was not found under ${_mathdx_lib_dir}")
+    endif()
+
+    set(WARP_LIBMATHDX_INCLUDE_DIR "${_mathdx_root}/include" PARENT_SCOPE)
+    set(WARP_LIBMATHDX_LIBRARY "${_warp_libmathdx_library}" PARENT_SCOPE)
+endfunction()
+
+# Explicit dependency paths are cached by CMake. Clear invalid cache entries so
+# a rerun without the option can fall back to Packman instead of failing forever.
+function(warp_invalid_libmathdx_path message)
+    if(WARP_LIBMATHDX_PATH AND DEFINED CACHE{WARP_LIBMATHDX_PATH})
+        unset(WARP_LIBMATHDX_PATH CACHE)
+        message(FATAL_ERROR
+            "${message}. The invalid WARP_LIBMATHDX_PATH cache entry was cleared; "
+            "rerun configure without -DWARP_LIBMATHDX_PATH to use Packman discovery, "
+            "set LIBMATHDX_HOME, or pass -DWARP_USE_LIBMATHDX=OFF."
+        )
+    endif()
+
+    message(FATAL_ERROR "${message}")
+endfunction()
+
+# Keep invalid explicit LLVM paths recoverable for the same reason as libmathdx.
+function(warp_invalid_llvm_path message)
+    if(WARP_LLVM_PATH AND DEFINED CACHE{WARP_LLVM_PATH})
+        unset(WARP_LLVM_PATH CACHE)
+        message(FATAL_ERROR
+            "${message}. The invalid WARP_LLVM_PATH cache entry was cleared; "
+            "rerun configure without -DWARP_LLVM_PATH to use Packman discovery."
+        )
+    endif()
+
+    message(FATAL_ERROR "${message}")
+endfunction()
+
+function(warp_find_llvm)
+    if(NOT WARP_BUILD_CLANG)
+        set(WARP_LLVM_INCLUDE_DIR "" PARENT_SCOPE)
+        set(WARP_LLVM_LIBRARIES "" PARENT_SCOPE)
+        set(WARP_LLVM_LIBRARY_DIR "" PARENT_SCOPE)
+        return()
+    endif()
+
+    warp_get_host_arch(_arch)
+
+    if(WARP_LLVM_PATH)
+        set(_llvm_root "${WARP_LLVM_PATH}")
+    else()
+        warp_get_packman_python(_packman_python)
+        warp_get_packman_command(_packman)
+        if(WIN32)
+            set(_llvm_package "15.0.7-windows-x86_64-ptx-vs142")
+        elseif(APPLE)
+            set(_llvm_package "15.0.7-darwin-aarch64-macos11")
+        elseif(_arch STREQUAL "aarch64")
+            set(_llvm_package "15.0.7-linux-aarch64-gcc7.5")
+        else()
+            set(_llvm_package "18.1.3-linux-x86_64-gcc9.4")
+        endif()
+        set(_llvm_root "${PROJECT_SOURCE_DIR}/_build/host-deps/llvm-project/release-${_arch}")
+        execute_process(
+            COMMAND "${CMAKE_COMMAND}" -E env "PM_PYTHON_EXT=${_packman_python}"
+                    "${_packman}" install -l "${_llvm_root}" clang+llvm-warp "${_llvm_package}"
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+    endif()
+
+    if(NOT EXISTS "${_llvm_root}/include")
+        warp_invalid_llvm_path("LLVM include directory was not found at ${_llvm_root}/include")
+    endif()
+    if(NOT EXISTS "${_llvm_root}/lib")
+        warp_invalid_llvm_path("LLVM library directory was not found at ${_llvm_root}/lib")
+    endif()
+
+    if(WIN32)
+        file(GLOB _llvm_libs CONFIGURE_DEPENDS "${_llvm_root}/lib/*.lib")
+    else()
+        file(GLOB _llvm_libs CONFIGURE_DEPENDS "${_llvm_root}/lib/*.a")
+    endif()
+    if(NOT _llvm_libs)
+        warp_invalid_llvm_path("No LLVM static libraries were found under ${_llvm_root}/lib")
+    endif()
+
+    # Consumers still need platform system libraries expected by LLVM. Linux
+    # consumers should use link grouping for these static archives, while Darwin
+    # consumers may need to duplicate LLVM archives to resolve circular symbols.
+    set(WARP_LLVM_INCLUDE_DIR "${_llvm_root}/include" PARENT_SCOPE)
+    set(WARP_LLVM_LIBRARIES "${_llvm_libs}" PARENT_SCOPE)
+    set(WARP_LLVM_LIBRARY_DIR "${_llvm_root}/lib" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
## Description

Add an optional CMake-based native build path that coexists with `build_lib.py` and builds both `warp` and `warp-clang` into `warp/bin`. The backend is intended for developers and CI jobs that want CMake/Ninja parallelism and incremental rebuilds while preserving the existing Python build script as the default source-build path.

This also documents the CMake workflow, adds a changelog entry, updates the warp-builder image recipe to include CMake/Ninja, and adds GitHub CI coverage for Linux x86_64, Linux aarch64, and Windows.

Closes #1495.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `git diff --check`
- `uvx pre-commit run --files .github/workflows/build-warp-builder-images.yml .github/workflows/ci.yml CHANGELOG.md CMakeLists.txt docker/warp-builder/Dockerfile docs/user_guide/installation.rst tools/cmake/WarpDependencies.cmake`
- `cmake --build _build/cmake --parallel`
- `WARP_CACHE_ROOT=/tmp/warp-cache-warp-worktree-3-pr-cmake WARP_CACHE_PATH=/tmp/warp-cache-warp-worktree-3-pr-cmake uv run python -c "import warp; info = warp.print_diagnostics(); assert info['warp_native'] != 'unknown'; assert info['warp_clang'] != 'unknown'"`
- `WARP_CACHE_ROOT=/tmp/warp-cache-warp-worktree-3-pr-docs WARP_CACHE_PATH=/tmp/warp-cache-warp-worktree-3-pr-docs uv run --extra docs build_docs.py --no-html --doctest`

## New feature / enhancement

```bash
cmake -S . -B _build/cmake -G Ninja
cmake --build _build/cmake --parallel
uv run python -c "import warp; warp.print_diagnostics()"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an alternative CMake-based native build for Warp with configurable CUDA, clang, and libmathdx support for parallel/incremental developer builds and new build options.

* **Documentation**
  * Added CMake build instructions, configuration options, and a post-build verification command to the installation guide; noted CMake requirements.

* **Chores**
  * CI and builder images updated to support CMake/Ninja builds, include pinned CMake/Ninja in images, and emit richer build/version diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/warp/pull/1496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->