### PR TITLE
Report Clang CUDA compile errors (NVIDIAGH-1325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,9 @@
   ``f`` is such a local now compile and call correctly instead of failing during codegen.
   Rebinding a function-valued local to a different function or to a non-function value raises a clear error
   ([GH-1423](https://github.com/NVIDIA/warp/issues/1423)).
+- Report Clang CUDA compilation failures immediately instead of raising a
+  downstream CUDA module load error
+  ([GH-1325](https://github.com/NVIDIA/warp/issues/1325)).
 
 ### Documentation
 

--- a/warp/_src/build.py
+++ b/warp/_src/build.py
@@ -52,8 +52,7 @@ def build_cuda(
     output_path = output_path.encode("utf-8")
 
     if llvm_cuda:
-        warp._src.context.runtime.llvm.wp_compile_cuda(src, cu_path_bytes, inc_path, output_path, False)
-
+        err = warp._src.context.runtime.llvm.wp_compile_cuda(src, cu_path_bytes, inc_path, output_path, False)
     else:
         if ltoirs is None:
             ltoirs = []
@@ -96,8 +95,8 @@ def build_cuda(
             arr_link_sizes,
             arr_link_input_types,
         )
-        if err != 0:
-            raise Exception(f"CUDA kernel build failed with error code {err}")
+    if err != 0:
+        raise Exception(f"CUDA kernel build failed with error code {err}")
 
 
 # load PTX or CUBIN as a CUDA runtime module (input type determined by input_path extension)

--- a/warp/tests/cuda/test_clang_cuda.py
+++ b/warp/tests/cuda/test_clang_cuda.py
@@ -56,7 +56,7 @@ def conditional_kernel(
 def bad_func(x: float) -> float: ...
 
 
-@wp.kernel
+@wp.kernel(module="unique")
 def invalid_native_func_kernel(a: wp.array(dtype=float)):
     i = wp.tid()
     a[i] = bad_func(1.0)
@@ -142,7 +142,7 @@ def test_bf16_arithmetic(test, device):
 def test_invalid_native_func_compile_error(test, device):
     a = wp.zeros(10, dtype=float, device=device)
 
-    with test.assertRaisesRegex(Exception, "CUDA kernel build failed with error code -1"):
+    with test.assertRaisesRegex(Exception, "CUDA kernel build failed with error code"):
         wp.launch(invalid_native_func_kernel, dim=10, inputs=[a], device=device)
 
 

--- a/warp/tests/cuda/test_clang_cuda.py
+++ b/warp/tests/cuda/test_clang_cuda.py
@@ -50,6 +50,18 @@ def conditional_kernel(
         b[i] = -a[i]
 
 
+@wp.func_native("""
+        INVALID SOURCE;
+""")
+def bad_func(x: float) -> float: ...
+
+
+@wp.kernel
+def invalid_native_func_kernel(a: wp.array(dtype=float)):
+    i = wp.tid()
+    a[i] = bad_func(1.0)
+
+
 def test_trivial_kernel(test, device):
     n = 10
     a = wp.array(np.arange(n, dtype=np.float32), device=device)
@@ -127,6 +139,13 @@ def test_bf16_arithmetic(test, device):
     np.testing.assert_allclose(out.numpy(), a_np + b_np, rtol=1e-2)
 
 
+def test_invalid_native_func_compile_error(test, device):
+    a = wp.zeros(10, dtype=float, device=device)
+
+    with test.assertRaisesRegex(Exception, "CUDA kernel build failed with error code -1"):
+        wp.launch(invalid_native_func_kernel, dim=10, inputs=[a], device=device)
+
+
 class TestClangCUDA(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -146,7 +165,9 @@ add_function_test(TestClangCUDA, "test_conditional_kernel", test_conditional_ker
 bf16_devices = [d for d in devices if d.arch >= 80]
 add_function_test(TestClangCUDA, "test_bf16_round_trip", test_bf16_round_trip, devices=bf16_devices)
 add_function_test(TestClangCUDA, "test_bf16_arithmetic", test_bf16_arithmetic, devices=bf16_devices)
-
+add_function_test(
+    TestClangCUDA, "test_invalid_native_func_compile_error", test_invalid_native_func_compile_error, devices=devices
+)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

A failed Clang CUDA compilation now raises an exception immediately instead of silently continuing and causing a downstream module-load exception that doesn't indicate the root cause. Closes #1325.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

Added `test_invalid_native_func_compile_error` in `warp/tests/cuda/test_clang_cuda.py`.

Ran:

```bash
uv run warp/tests/cuda/test_clang_cuda.py -k invalid_native_func_compile_error
```

Result: test collected and skipped locally because no suitable CUDA device was available.

## Bug fix

**Repro from #1325:**

```python
import sys
import warp as wp

mode = sys.argv[1] if len(sys.argv) > 1 else "nvrtc"
wp.config.llvm_cuda = (mode == "clang")

@wp.func_native("""
    INVALID SOURCE;
""")
def bad_func(x: float) -> float: ...

@wp.kernel
def test_kernel(a: wp.array(dtype=float)):
    i = wp.tid()
    a[i] = bad_func(1.0)

a = wp.zeros(10, dtype=float, device="cuda:0")
wp.launch(test_kernel, dim=10, inputs=[a], device="cuda:0")
```

**NVRTC (uv run repro.py nvrtc):**

```
Exception: CUDA kernel build failed with error code 6
```

**Clang CUDA (uv run repro.py clang):**

```
Exception: Failed to load CUDA module '__main__'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clang CUDA compilation failures are now reported immediately at compile time instead of appearing later as downstream errors.
  * Improved error handling ensures CUDA kernel compilation failures are consistently detected across all compilation paths.

* **Tests**
  * Added a test that verifies invalid native/CUDA compilation errors are raised as expected.

* **Documentation**
  * Updated changelog with the above fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->