### PR TITLE
Document Large Array Indexing

### DIFF
--- a/docs/user_guide/basics.rst
+++ b/docs/user_guide/basics.rst
@@ -117,6 +117,48 @@ We retrieve a 2D thread index inside the kernel by using multiple assignment whe
         # get thread index
         i, j = wp.tid()
 
+.. _large_launch_indexing:
+
+Large array indexing
+^^^^^^^^^^^^^^^^^^^^
+
+For multi-dimensional launches, Warp derives the coordinates from a linear
+thread order in row-major form, with the last dimension varying fastest. This
+matches the default contiguous Warp array layout, so adjacent threads that
+differ only in the last index access adjacent array elements. On CUDA devices,
+this is the preferred pattern for coalesced global memory access.
+
+This is also useful when a logical data set has more than :math:`2^{31}-1`
+elements. Because each array dimension must fit in a signed 32-bit integer,
+store the data across multiple dimensions, launch over the array shape, and
+construct a 64-bit linear index when the algorithm is naturally expressed in
+1D:
+
+.. code-block:: python
+
+    @wp.kernel
+    def process_large_array(values: wp.array2d[wp.float32], logical_size: wp.int64):
+        i, j = wp.tid()
+
+        linear = wp.int64(i) * wp.int64(values.shape[1]) + wp.int64(j)
+        if linear < logical_size:
+            values[i, j] = float(linear % wp.int64(1024))
+
+    rows = 1 << 20
+    cols = 1 << 12
+    logical_size = (1 << 32) - 123
+    values = wp.empty((rows, cols), dtype=wp.float32, device="cuda")
+    wp.launch(
+        process_large_array,
+        dim=values.shape,
+        inputs=[values, wp.int64(logical_size)],
+        device=values.device,
+    )
+
+Here, the array shape pads the allocation beyond ``logical_size``. The bounds
+check skips those padded elements while preserving coalesced access for the
+contiguous region.
+
 Arrays
 ------
 

--- a/docs/user_guide/limitations.rst
+++ b/docs/user_guide/limitations.rst
@@ -61,6 +61,9 @@ Arrays
 * Arrays can have a maximum of four dimensions.
 * Each dimension of a Warp array cannot be greater than the maximum value representable by a 32-bit signed integer,
   :math:`2^{31}-1`.
+* A one-dimensional Warp array cannot represent more than :math:`2^{31}-1` elements. Larger logical data sets
+  must be split across multiple dimensions. See :ref:`large-array launch indexing <large_launch_indexing>` for the
+  launch and indexing pattern.
 * There are currently no data types that support complex numbers.
 * ``wp.config.launch_array_access_mode = wp.config.LaunchArrayAccessMode.CHECKED``
   only fully verifies cross-device :class:`wp.array <warp.array>` arguments when

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -5418,6 +5418,8 @@ def tid() -> int | tuple[int, int] | tuple[int, int, int] | tuple[int, int, int,
     The indices correspond to the thread's position in the kernel launch grid.
     If fewer indices are requested than the launch dimensionality, only the
     leading indices are returned.
+    For multi-dimensional launches, the linear thread order is unraveled in
+    row-major order, with the last launch dimension varying fastest.
 
     This function may not be called from user-defined Warp functions."""
     ...

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -9433,6 +9433,8 @@ add_builtin(
     The indices correspond to the thread's position in the kernel launch grid.
     If fewer indices are requested than the launch dimensionality, only the
     leading indices are returned.
+    For multi-dimensional launches, the linear thread order is unraveled in
+    row-major order, with the last launch dimension varying fastest.
 
     This function may not be called from user-defined Warp functions.""",
     namespace="",
@@ -9457,6 +9459,8 @@ add_builtin(
     The indices correspond to the thread's position in the kernel launch grid.
     If fewer indices are requested than the launch dimensionality, only the
     leading indices are returned.
+    For multi-dimensional launches, the linear thread order is unraveled in
+    row-major order, with the last launch dimension varying fastest.
 
     This function may not be called from user-defined Warp functions.""",
     namespace="",
@@ -9481,6 +9485,8 @@ add_builtin(
     The indices correspond to the thread's position in the kernel launch grid.
     If fewer indices are requested than the launch dimensionality, only the
     leading indices are returned.
+    For multi-dimensional launches, the linear thread order is unraveled in
+    row-major order, with the last launch dimension varying fastest.
 
     This function may not be called from user-defined Warp functions.""",
     namespace="",
@@ -9505,6 +9511,8 @@ add_builtin(
     The indices correspond to the thread's position in the kernel launch grid.
     If fewer indices are requested than the launch dimensionality, only the
     leading indices are returned.
+    For multi-dimensional launches, the linear thread order is unraveled in
+    row-major order, with the last launch dimension varying fastest.
 
     This function may not be called from user-defined Warp functions.""",
     namespace="",


### PR DESCRIPTION
## Description

Clarifies Warp's large-array indexing guidance in the docs. The update documents that one-dimensional Warp arrays are limited by the signed 32-bit per-dimension bound, and shows how larger logical data sets can use multi-dimensional arrays with a 64-bit linear index.

The PR also documents the multi-dimensional `wp.tid()` coordinate order: Warp unravels linear launch order in row-major form, with the last launch dimension varying fastest. That makes the last array index the preferred direction for contiguous, coalesced CUDA global memory access.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- Ran a temporary standalone script using the docs kernel pattern with `wp.array2d[wp.float32]` on `cuda:0`.
- `uv run --extra docs build_docs.py 2>&1 | tee /tmp/build_docs.log`
- `uvx pre-commit run --files docs/user_guide/basics.rst docs/user_guide/limitations.rst warp/_src/builtins.py warp/__init__.pyi`

## New feature / enhancement

This is a documentation enhancement. It adds large logical array indexing guidance and clarifies row-major launch coordinate ordering for multi-dimensional launches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance showing how multi-dimensional launch coordinates map from a linear thread order (row-major; last dimension varies fastest).
  * Documented per-dimension signed 32-bit limits and the 1D array size limit (2^31−1), recommending splitting very large datasets across dimensions.
  * Added an example computing 64-bit linear indices with bounds checks to skip padded elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->