### PR TITLE
Fix indexedarray adjoint

### DIFF
--- a/changelog/1479.fixed.md
+++ b/changelog/1479.fixed.md
@@ -1,0 +1,4 @@
+Fix gradient propagation through 1-D `wp.indexedarray` kernel inputs. `wp.Tape` previously raised `AttributeError`
+(indexed arrays had no `grad`), a manual adjoint launch passing the base array's gradient segfaulted on CPU, and CUDA
+silently produced zero gradients. The adjoint now follows the gather indirection and accumulates into the base array's
+gradient. Gradients of multi-dimensional indexed arrays are not yet supported and raise `NotImplementedError`.

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -8120,7 +8120,11 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
             # - in forward passes, array types have to match
             # - in backward passes, indexed array gradients are regular arrays
             if adjoint:
-                array_matches = isinstance(value, warp.array)
+                # adjoint may be a regular array (gradient of the base storage) or the
+                # same array class as the forward arg (e.g. an indexedarray over base.grad)
+                array_matches = isinstance(value, warp.array) or (
+                    type(value) is warp._src.types.concrete_array_type(arg_type)
+                )
             else:
                 array_matches = type(value) is warp._src.types.concrete_array_type(arg_type)
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -10392,14 +10392,18 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
             # check for array type
             # - in forward passes, array types have to match
             # - in backward passes, indexed array gradients are regular arrays
+            concrete_type = warp._src.types.concrete_array_type(arg_type)
             if adjoint:
-                # adjoint may be a regular array (gradient of the base storage) or the
-                # same array class as the forward arg (e.g. an indexedarray over base.grad)
-                array_matches = isinstance(value, warp.array) or (
-                    type(value) is warp._src.types.concrete_array_type(arg_type)
+                # gradients are passed with the same array class as the forward argument;
+                # array and indexedarray parameters also accept a plain array (for an
+                # indexedarray this is the gradient of the base storage). Fabric arrays
+                # have no plain-array gradient representation, so they require an exact
+                # class match.
+                array_matches = type(value) is concrete_type or (
+                    isinstance(value, warp.array) and concrete_type in (warp.array, warp.indexedarray)
                 )
             else:
-                array_matches = type(value) is warp._src.types.concrete_array_type(arg_type)
+                array_matches = type(value) is concrete_type
 
             if not array_matches:
                 # if a regular Warp array is required, try converting from __cuda_array_interface__ or __array_interface__
@@ -10465,6 +10469,13 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
             # wrapped in an indexedarray_t with no indices; the adjoint kernel
             # accumulates at indices already remapped through the forward argument.
             if adjoint and warp._src.types.matches_array_class(arg_type, warp.indexedarray):
+                # match indexedarray.grad: without dedicated multi-dimensional adjoints
+                # the adjoint kernel would match the no-op generic adj_address and
+                # silently produce zero gradients
+                if arg_type.ndim > 1:
+                    raise NotImplementedError(
+                        "Gradient propagation through indexed arrays is only supported for 1-D indexed arrays"
+                    )
                 if isinstance(value, warp.array):
                     return warp._src.types.indexedarray_t(value, [None] * value.ndim, value.shape)
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -10393,7 +10393,11 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
             # - in forward passes, array types have to match
             # - in backward passes, indexed array gradients are regular arrays
             if adjoint:
-                array_matches = isinstance(value, warp.array)
+                # adjoint may be a regular array (gradient of the base storage) or the
+                # same array class as the forward arg (e.g. an indexedarray over base.grad)
+                array_matches = isinstance(value, warp.array) or (
+                    type(value) is warp._src.types.concrete_array_type(arg_type)
+                )
             else:
                 array_matches = type(value) is warp._src.types.concrete_array_type(arg_type)
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -10458,6 +10458,16 @@ def pack_arg(kernel, arg_type, arg_name, value, device, adjoint=False):
             if warp.config.launch_array_access_mode != warp.config.LaunchArrayAccessMode.RELAXED:
                 _validate_launch_array_access(kernel, arg_name, value, device)
 
+            # the packed ctype class must match the kernel's declared parameter type:
+            # the CPU launch builds the adjoint argument struct from the packed value
+            # types, and the CUDA launch copies sizeof(declared type) bytes per parameter.
+            # A plain array passed as the gradient of an indexed array is therefore
+            # wrapped in an indexedarray_t with no indices; the adjoint kernel
+            # accumulates at indices already remapped through the forward argument.
+            if adjoint and warp._src.types.matches_array_class(arg_type, warp.indexedarray):
+                if isinstance(value, warp.array):
+                    return warp._src.types.indexedarray_t(value, [None] * value.ndim, value.shape)
+
             return value.__ctype__()
 
     # Handle Texture1D, Texture2D and Texture3D types (when used as type annotations)

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -4924,6 +4924,13 @@ class indexedarray(noncontiguous_array_base[DType, NDim]):
     def __ctype__(self):
         return indexedarray_t(self.data, self.indices, self.shape)
 
+    # gradient of an indexed view is an indexed view into the base array's grad (same indices)
+    @property
+    def grad(self):
+        if self.data is None or self.data.grad is None:
+            return None
+        return indexedarray(self.data.grad, self.indices[: self.ndim], ndim=self.ndim)
+
     @property
     def vars(self):
         # member attributes available during code-gen (e.g.: d = arr.shape[0])

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -5349,6 +5349,13 @@ class indexedarray(noncontiguous_array_base[DType, NDim]):
     def __ctype__(self):
         return indexedarray_t(self.data, self.indices, self.shape)
 
+    # gradient of an indexed view is an indexed view into the base array's grad (same indices)
+    @property
+    def grad(self):
+        if self.data is None or self.data.grad is None:
+            return None
+        return indexedarray(self.data.grad, self.indices[: self.ndim], ndim=self.ndim)
+
     @property
     def vars(self):
         # member attributes available during code-gen (e.g.: d = arr.shape[0])

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -5354,6 +5354,10 @@ class indexedarray(noncontiguous_array_base[DType, NDim]):
     def grad(self):
         if self.data is None or self.data.grad is None:
             return None
+        if self.ndim > 1:
+            raise NotImplementedError(
+                "Gradient propagation through indexed arrays is only supported for 1-D indexed arrays"
+            )
         return indexedarray(self.data.grad, self.indices[: self.ndim], ndim=self.ndim)
 
     @property

--- a/warp/native/array.h
+++ b/warp/native/array.h
@@ -1312,6 +1312,38 @@ adj_address(const array_t<T>& buf, int i, const array_t<T>& adj_buf, int adj_i, 
     else if (buf.grad)
         adj_atomic_add(&index_grad(buf, i), adj_output);
 }
+// indexedarray adjoint: resolve the index indirection, then accumulate into the
+// adjoint indexedarray's storage (adj_buf.arr) or the base array's embedded grad
+template <typename T>
+inline CUDA_CALLABLE void
+adj_address(const indexedarray_t<T>& buf, int i, const indexedarray_t<T>& adj_buf, int adj_i, const T& adj_output)
+{
+    if (i < 0)
+        i += buf.shape[0];
+    if (buf.indices[0])
+        i = buf.indices[0][i];
+
+    if (adj_buf.arr.data)
+        adj_atomic_add(&index(adj_buf.arr, i), adj_output);
+    else if (buf.arr.grad)
+        adj_atomic_add(&index_grad(buf.arr, i), adj_output);
+}
+// indexedarray with a regular-array adjoint (as passed by the CUDA codegen): resolve the
+// index indirection, then accumulate into the base grad or the base array's embedded grad
+template <typename T>
+inline CUDA_CALLABLE void
+adj_address(const indexedarray_t<T>& buf, int i, const array_t<T>& adj_buf, int adj_i, const T& adj_output)
+{
+    if (i < 0)
+        i += buf.shape[0];
+    if (buf.indices[0])
+        i = buf.indices[0][i];
+
+    if (adj_buf.data)
+        adj_atomic_add(&index(adj_buf, i), adj_output);
+    else if (buf.arr.grad)
+        adj_atomic_add(&index_grad(buf.arr, i), adj_output);
+}
 template <typename T>
 inline CUDA_CALLABLE void
 adj_address(const array_t<T>& buf, int i, int j, const array_t<T>& adj_buf, int adj_i, int adj_j, const T& adj_output)

--- a/warp/native/array.h
+++ b/warp/native/array.h
@@ -1343,8 +1343,10 @@ adj_address(const indexedarray_t<T>& buf, int i, const indexedarray_t<T>& adj_bu
     else if (buf.arr.grad)
         adj_atomic_add(&index_grad(buf.arr, i), adj_output);
 }
-// indexedarray with a regular-array adjoint (as passed by the CUDA codegen): resolve the
-// index indirection, then accumulate into the base grad or the base array's embedded grad
+// indexedarray with a regular-array adjoint: the CUDA codegen declares the adjoint of an
+// indexedarray parameter as a plain array_t (the base array's gradient), while the CPU
+// codegen reuses the forward parameter type (see the overload above). Resolve the index
+// indirection, then accumulate into the adjoint array or the base array's embedded grad
 template <typename T>
 inline CUDA_CALLABLE void
 adj_address(const indexedarray_t<T>& buf, int i, const array_t<T>& adj_buf, int adj_i, const T& adj_output)

--- a/warp/native/array.h
+++ b/warp/native/array.h
@@ -1327,6 +1327,38 @@ adj_address(const array_t<T>& buf, int i, const array_t<T>& adj_buf, int adj_i, 
     else if (buf.grad)
         adj_atomic_add(&index_grad(buf, i), adj_output);
 }
+// indexedarray adjoint: resolve the index indirection, then accumulate into the
+// adjoint indexedarray's storage (adj_buf.arr) or the base array's embedded grad
+template <typename T>
+inline CUDA_CALLABLE void
+adj_address(const indexedarray_t<T>& buf, int i, const indexedarray_t<T>& adj_buf, int adj_i, const T& adj_output)
+{
+    if (i < 0)
+        i += buf.shape[0];
+    if (buf.indices[0])
+        i = buf.indices[0][i];
+
+    if (adj_buf.arr.data)
+        adj_atomic_add(&index(adj_buf.arr, i), adj_output);
+    else if (buf.arr.grad)
+        adj_atomic_add(&index_grad(buf.arr, i), adj_output);
+}
+// indexedarray with a regular-array adjoint (as passed by the CUDA codegen): resolve the
+// index indirection, then accumulate into the base grad or the base array's embedded grad
+template <typename T>
+inline CUDA_CALLABLE void
+adj_address(const indexedarray_t<T>& buf, int i, const array_t<T>& adj_buf, int adj_i, const T& adj_output)
+{
+    if (i < 0)
+        i += buf.shape[0];
+    if (buf.indices[0])
+        i = buf.indices[0][i];
+
+    if (adj_buf.data)
+        adj_atomic_add(&index(adj_buf, i), adj_output);
+    else if (buf.arr.grad)
+        adj_atomic_add(&index_grad(buf.arr, i), adj_output);
+}
 template <typename T>
 inline CUDA_CALLABLE void
 adj_address(const array_t<T>& buf, int i, int j, const array_t<T>& adj_buf, int adj_i, int adj_j, const T& adj_output)

--- a/warp/tests/test_indexedarray.py
+++ b/warp/tests/test_indexedarray.py
@@ -1246,6 +1246,43 @@ def test_indexedarray_fill_struct(test, device):
     assert_np_equal(a4.numpy(), np.zeros(a4.shape, dtype=nptype))
 
 
+@wp.kernel
+def kernel_indexedarray_grad_1d(
+    samples: wp.indexedarray(dtype=float),
+    weights: wp.array(dtype=float),
+    total: wp.array(dtype=float),
+):
+    i = wp.tid()
+    wp.atomic_add(total, 0, samples[i] * weights[i])
+
+
+def test_indexedarray_grad_1d(test, device):
+    # gradients must flow back through a differentiable indexedarray input (GH-1479):
+    # the adjoint follows the gather indirection and accumulates into the base array's grad
+    base = wp.array(np.linspace(1.0, 6.0, 6, dtype=np.float32), dtype=float, device=device, requires_grad=True)
+    weights_np = np.array([0.25, 0.5, 1.0], dtype=np.float32)
+    weights = wp.array(weights_np, dtype=float, device=device)
+    indices = wp.array([1, 3, 5], dtype=int, device=device)
+    samples = wp.indexedarray1d(base, [indices])
+    total = wp.zeros(1, dtype=float, device=device, requires_grad=True)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(
+            kernel_indexedarray_grad_1d, dim=samples.size, inputs=[samples, weights], outputs=[total], device=device
+        )
+
+    # forward: sum of base[i] * weight over the gathered indices
+    assert_np_equal(total.numpy(), np.array([8.5], dtype=np.float32), tol=1e-6)
+
+    tape.backward(loss=total)
+
+    # d(total)/d(base[j]) is the matching weight at each gathered index, zero elsewhere
+    expected = np.zeros(6, dtype=np.float32)
+    expected[[1, 3, 5]] = weights_np
+    assert_np_equal(base.grad.numpy(), expected, tol=1e-6)
+
+
 devices = get_test_devices()
 
 
@@ -1254,6 +1291,7 @@ class TestIndexedArray(unittest.TestCase):
 
 
 add_function_test(TestIndexedArray, "test_indexedarray_1d", test_indexedarray_1d, devices=devices)
+add_function_test(TestIndexedArray, "test_indexedarray_grad_1d", test_indexedarray_grad_1d, devices=devices)
 add_function_test(TestIndexedArray, "test_indexedarray_2d", test_indexedarray_2d, devices=devices)
 add_function_test(TestIndexedArray, "test_indexedarray_3d", test_indexedarray_3d, devices=devices)
 add_function_test(TestIndexedArray, "test_indexedarray_4d", test_indexedarray_4d, devices=devices)

--- a/warp/tests/test_indexedarray.py
+++ b/warp/tests/test_indexedarray.py
@@ -1283,6 +1283,109 @@ def test_indexedarray_grad_1d(test, device):
     assert_np_equal(base.grad.numpy(), expected, tol=1e-6)
 
 
+def test_indexedarray_grad_1d_manual_adjoint(test, device):
+    # a manual adjoint launch accepts either the base array's gradient (a plain array,
+    # the original GH-1479 repro that segfaulted on CPU) or the indexed gradient view
+    for adj_samples_kind in ("base", "indexed"):
+        base = wp.array(np.linspace(1.0, 6.0, 6, dtype=np.float32), dtype=float, device=device, requires_grad=True)
+        weights_np = np.array([0.25, 0.5, 1.0], dtype=np.float32)
+        weights = wp.array(weights_np, dtype=float, device=device)
+        indices = wp.array([1, 3, 5], dtype=int, device=device)
+        samples = wp.indexedarray1d(base, [indices])
+        total = wp.zeros(1, dtype=float, device=device, requires_grad=True)
+
+        wp.launch(
+            kernel_indexedarray_grad_1d, dim=samples.size, inputs=[samples, weights], outputs=[total], device=device
+        )
+
+        total.grad.fill_(1.0)
+        adj_samples = base.grad if adj_samples_kind == "base" else samples.grad
+        wp.launch(
+            kernel_indexedarray_grad_1d,
+            dim=samples.size,
+            inputs=[samples, weights],
+            outputs=[total],
+            adj_inputs=[adj_samples, None],
+            adj_outputs=[total.grad],
+            adjoint=True,
+            device=device,
+        )
+
+        expected = np.zeros(6, dtype=np.float32)
+        expected[[1, 3, 5]] = weights_np
+        assert_np_equal(base.grad.numpy(), expected, tol=1e-6)
+
+
+def test_indexedarray_grad_1d_tape_zero(test, device):
+    # tape.zero() must clear the gradient reached through the indexed view so that
+    # a second backward pass does not accumulate on top of stale gradients
+    base = wp.array(np.linspace(1.0, 6.0, 6, dtype=np.float32), dtype=float, device=device, requires_grad=True)
+    weights_np = np.array([0.25, 0.5, 1.0], dtype=np.float32)
+    weights = wp.array(weights_np, dtype=float, device=device)
+    indices = wp.array([1, 3, 5], dtype=int, device=device)
+    samples = wp.indexedarray1d(base, [indices])
+    total = wp.zeros(1, dtype=float, device=device, requires_grad=True)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(
+            kernel_indexedarray_grad_1d, dim=samples.size, inputs=[samples, weights], outputs=[total], device=device
+        )
+
+    expected = np.zeros(6, dtype=np.float32)
+    expected[[1, 3, 5]] = weights_np
+
+    tape.backward(loss=total)
+    assert_np_equal(base.grad.numpy(), expected, tol=1e-6)
+
+    tape.zero()
+    assert_np_equal(base.grad.numpy(), np.zeros(6, dtype=np.float32))
+
+    tape.backward(loss=total)
+    assert_np_equal(base.grad.numpy(), expected, tol=1e-6)
+
+
+@wp.kernel
+def kernel_indexedarray_grad_1d_negative(
+    samples: wp.indexedarray(dtype=float),
+    weights: wp.array(dtype=float),
+    total: wp.array(dtype=float),
+):
+    i = wp.tid()
+    # negative view coordinates wrap around before the gather remap
+    wp.atomic_add(total, 0, samples[i - 3] * weights[i])
+
+
+def test_indexedarray_grad_1d_negative_indices(test, device):
+    # the adjoint must apply the same negative-coordinate wrap-around as the forward
+    # read before remapping through the index array
+    base = wp.array(np.linspace(1.0, 6.0, 6, dtype=np.float32), dtype=float, device=device, requires_grad=True)
+    weights_np = np.array([0.25, 0.5, 1.0], dtype=np.float32)
+    weights = wp.array(weights_np, dtype=float, device=device)
+    indices = wp.array([1, 3, 5], dtype=int, device=device)
+    samples = wp.indexedarray1d(base, [indices])
+    total = wp.zeros(1, dtype=float, device=device, requires_grad=True)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(
+            kernel_indexedarray_grad_1d_negative,
+            dim=samples.size,
+            inputs=[samples, weights],
+            outputs=[total],
+            device=device,
+        )
+
+    # samples[i - 3] wraps to samples[i], so the result matches the non-negative kernel
+    assert_np_equal(total.numpy(), np.array([8.5], dtype=np.float32), tol=1e-6)
+
+    tape.backward(loss=total)
+
+    expected = np.zeros(6, dtype=np.float32)
+    expected[[1, 3, 5]] = weights_np
+    assert_np_equal(base.grad.numpy(), expected, tol=1e-6)
+
+
 devices = get_test_devices()
 
 
@@ -1292,6 +1395,21 @@ class TestIndexedArray(unittest.TestCase):
 
 add_function_test(TestIndexedArray, "test_indexedarray_1d", test_indexedarray_1d, devices=devices)
 add_function_test(TestIndexedArray, "test_indexedarray_grad_1d", test_indexedarray_grad_1d, devices=devices)
+add_function_test(
+    TestIndexedArray,
+    "test_indexedarray_grad_1d_manual_adjoint",
+    test_indexedarray_grad_1d_manual_adjoint,
+    devices=devices,
+)
+add_function_test(
+    TestIndexedArray, "test_indexedarray_grad_1d_tape_zero", test_indexedarray_grad_1d_tape_zero, devices=devices
+)
+add_function_test(
+    TestIndexedArray,
+    "test_indexedarray_grad_1d_negative_indices",
+    test_indexedarray_grad_1d_negative_indices,
+    devices=devices,
+)
 add_function_test(TestIndexedArray, "test_indexedarray_2d", test_indexedarray_2d, devices=devices)
 add_function_test(TestIndexedArray, "test_indexedarray_3d", test_indexedarray_3d, devices=devices)
 add_function_test(TestIndexedArray, "test_indexedarray_4d", test_indexedarray_4d, devices=devices)

--- a/warp/tests/test_indexedarray.py
+++ b/warp/tests/test_indexedarray.py
@@ -1386,6 +1386,43 @@ def test_indexedarray_grad_1d_negative_indices(test, device):
     assert_np_equal(base.grad.numpy(), expected, tol=1e-6)
 
 
+@wp.kernel
+def kernel_indexedarray_grad_2d(samples: wp.indexedarray2d(dtype=float), total: wp.array(dtype=float)):
+    i, j = wp.tid()
+    wp.atomic_add(total, 0, samples[i, j])
+
+
+def test_indexedarray_grad_2d_not_implemented(test, device):
+    # gradients of multi-dimensional indexed arrays are not implemented: without
+    # dedicated adjoints the backward kernel would match the no-op generic
+    # adj_address and silently produce zero gradients, so both the tape and the
+    # manual adjoint launch must raise instead
+    base = wp.array(np.arange(16, dtype=np.float32).reshape(4, 4), dtype=float, device=device, requires_grad=True)
+    rows = wp.array([1, 3], dtype=int, device=device)
+    samples = wp.indexedarray2d(base, [rows, None])
+    total = wp.zeros(1, dtype=float, device=device, requires_grad=True)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(kernel_indexedarray_grad_2d, dim=samples.shape, inputs=[samples], outputs=[total], device=device)
+
+    with test.assertRaisesRegex(NotImplementedError, "only supported for 1-D indexed arrays"):
+        tape.backward(loss=total)
+
+    total.grad.fill_(1.0)
+    with test.assertRaisesRegex(NotImplementedError, "only supported for 1-D indexed arrays"):
+        wp.launch(
+            kernel_indexedarray_grad_2d,
+            dim=samples.shape,
+            inputs=[samples],
+            outputs=[total],
+            adj_inputs=[base.grad],
+            adj_outputs=[total.grad],
+            adjoint=True,
+            device=device,
+        )
+
+
 devices = get_test_devices()
 
 
@@ -1408,6 +1445,12 @@ add_function_test(
     TestIndexedArray,
     "test_indexedarray_grad_1d_negative_indices",
     test_indexedarray_grad_1d_negative_indices,
+    devices=devices,
+)
+add_function_test(
+    TestIndexedArray,
+    "test_indexedarray_grad_2d_not_implemented",
+    test_indexedarray_grad_2d_not_implemented,
     devices=devices,
 )
 add_function_test(TestIndexedArray, "test_indexedarray_2d", test_indexedarray_2d, devices=devices)


### PR DESCRIPTION
## Description

wp.indexedarray inputs were not differentiable: wp.Tape raised AttributeError (no .grad), a manual adjoint launch segfaulted on CPU, and CUDA silently produced zero gradients.

This adds gradient support for 1-D indexed-array inputs: the adjoint follows the gather indirection and accumulates into the base array's gradient.
 - indexedarray.grad returns an indexed view over the base array's gradient (consumed by wp.Tape).
- pack_arg packs a plain-array adjoint of an indexedarray parameter as an indexedarray_t with no indices, so the packed ctype layout always matches the kernel's declared parameter type. The CPU launch builds the adjoint argument struct from the packed value types, which is what previously segfaulted.
- Two adj_address overloads cover the codegen asymmetry: CUDA declares indexedarray adjoints as plain array_t, CPU reuses the forward parameter type.
- Multi-dimensional indexed arrays raise NotImplementedError from .grad; support will land in a follow-up PR.

Closes #1479


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Test plan

New tests in warp/tests/test_indexedarray.py, run on CPU and CUDA: Tape backward, manual adjoint launch with both the base gradient (the original repro) and the indexed gradient view, tape.zero() across two backward passes, and negative view coordinates.

```bash
uv run warp/tests/test_indexedarray.py
uv run warp/tests/test_indexedarray.py -k grad_1d
```

Verified gradients are correct on CPU and CUDA via both `wp.Tape` and a manual
adjoint launch (expected `[0, 0.25, 0, 0.5, 0, 1.0]`).

## Bug fix

```python
import warp as wp
import numpy as np

@wp.kernel
def weighted_sample_sum(samples: wp.indexedarray[float], weights: wp.array[float], total: wp.array[float]):
    i = wp.tid()
    wp.atomic_add(total, 0, samples[i] * weights[i])

base = wp.array(np.linspace(1, 6, 6, dtype=np.float32), dtype=float, requires_grad=True)
weights = wp.array([0.25, 0.5, 1.0], dtype=float)
samples = wp.indexedarray1d(base, [wp.array([1, 3, 5], dtype=wp.int32)])
total = wp.zeros(1, dtype=float, requires_grad=True)

tape = wp.Tape()
with tape:
    wp.launch(weighted_sample_sum, dim=samples.size, inputs=[samples, weights], outputs=[total])
tape.backward(loss=total)
print(base.grad.numpy())   # without this PR: AttributeError / zeros / segfault
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic differentiation for one-dimensional indexed arrays, including gradient access and propagation through indirect and negative indexing.
  * Gradients can now accumulate correctly into either indexed views or their underlying arrays.

* **Bug Fixes**
  * Fixed missing, zero, or invalid gradients when using indexed arrays during backward passes on CPU and CUDA.
  * Added a clear notification for unsupported multidimensional indexed-array gradients.

* **Tests**
  * Added coverage for automatic differentiation, manual adjoints, gradient resets, and negative indices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->