### PR TITLE
Reject reassigning wp.grad()-bound locals (GH-1487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,9 @@
   ``f`` is such a local now compile and call correctly instead of failing during codegen.
   Rebinding a function-valued local to a different function or to a non-function value raises a clear error
   ([GH-1423](https://github.com/NVIDIA/warp/issues/1423)).
+- Raise a clear `wp.WarpCodegenError` when a kernel-local variable bound to `wp.grad()` is reassigned to a
+  non-grad value, instead of failing with an internal `AttributeError`
+  ([GH-1487](https://github.com/NVIDIA/warp/issues/1487)).
 
 ### Documentation
 

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -3816,6 +3816,15 @@ class Adjoint:
         # For simple name targets (x += expr), evaluate the RHS once and
         # apply the operation directly to avoid double-evaluation.
         if isinstance(lhs, ast.Name):
+            # a local previously bound to wp.grad() is a function handle, not a value. Augmented
+            # assignment would otherwise read `.type` on the stored GradWrapper below and fail with
+            # the same opaque AttributeError that plain assignment used to, so reject it here with
+            # the matching clear error.
+            if isinstance(adj.symbols.get(lhs.id), warp._src.context.GradWrapper):
+                raise WarpCodegenError(
+                    f"Error, local variable '{lhs.id}' is bound to wp.grad() and cannot be reassigned to a non-grad value."
+                )
+
             rhs = adj.eval(node.value)
             target = adj.eval(lhs)
 

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -3350,6 +3350,14 @@ class Adjoint:
                         "must refer to a function throughout the kernel."
                     )
 
+                # a local previously bound to wp.grad() is a function handle, not a value. The same
+                # generic type check below would otherwise read `.type` on the GradWrapper and fail
+                # with an opaque AttributeError, so reject the reassignment with a clear error.
+                if isinstance(adj.symbols[name], warp._src.context.GradWrapper):
+                    raise WarpCodegenError(
+                        f"Error, local variable '{name}' is bound to wp.grad() and cannot be reassigned to a non-grad value."
+                    )
+
                 if not types_equal(strip_reference(rhs.type), adj.symbols[name].type):
                     raise WarpCodegenTypeError(
                         f"Error, assigning to existing symbol {name} ({adj.symbols[name].type}) with different type ({rhs.type})"

--- a/warp/tests/test_func.py
+++ b/warp/tests/test_func.py
@@ -370,6 +370,24 @@ def test_grad_in_func_grad(test, device):
     assert_np_equal(x.grad.numpy(), expected_grad, tol=1e-5)
 
 
+def test_grad_reassign_error(test, device):
+    # Reassigning a kernel-local bound to wp.grad() to a non-grad value is invalid
+    # kernel code. Warp should reject it with a clear codegen error rather than an
+    # internal AttributeError. See GH-1487.
+    @wp.kernel(module="unique", enable_backward=False)
+    def grad_reassign_kernel(out: wp.array(dtype=float)):
+        g = wp.grad(square)
+        g = 1.0
+        out[0] = g
+
+    out = wp.zeros(1, dtype=float, device=device)
+    with test.assertRaisesRegex(
+        wp.WarpCodegenError,
+        r"local variable 'g' is bound to wp.grad\(\) and cannot be reassigned to a non-grad value",
+    ):
+        wp.launch(grad_reassign_kernel, dim=1, outputs=[out], device=device)
+
+
 class TestFunc(unittest.TestCase):
     def test_user_func_export(self):
         # tests calling overloaded user-defined functions from Python
@@ -642,6 +660,7 @@ add_kernel_test(
 )
 add_function_test(TestFunc, func=test_grad, name="test_grad", devices=devices)
 add_function_test(TestFunc, func=test_grad_in_func_grad, name="test_grad_in_func_grad", devices=devices)
+add_function_test(TestFunc, func=test_grad_reassign_error, name="test_grad_reassign_error", devices=devices)
 
 
 if __name__ == "__main__":

--- a/warp/tests/test_func.py
+++ b/warp/tests/test_func.py
@@ -388,6 +388,24 @@ def test_grad_reassign_error(test, device):
         wp.launch(grad_reassign_kernel, dim=1, outputs=[out], device=device)
 
 
+def test_grad_aug_reassign_error(test, device):
+    # Augmented assignment (e.g. `g += 1.0`) of a kernel-local bound to wp.grad() is just
+    # as invalid as plain reassignment and must raise the same clear codegen error rather
+    # than the internal AttributeError that emit_AugAssign would otherwise hit. See GH-1487.
+    @wp.kernel(module="unique", enable_backward=False)
+    def grad_aug_reassign_kernel(out: wp.array(dtype=float)):
+        g = wp.grad(square)
+        g += 1.0
+        out[0] = g
+
+    out = wp.zeros(1, dtype=float, device=device)
+    with test.assertRaisesRegex(
+        wp.WarpCodegenError,
+        r"local variable 'g' is bound to wp.grad\(\) and cannot be reassigned to a non-grad value",
+    ):
+        wp.launch(grad_aug_reassign_kernel, dim=1, outputs=[out], device=device)
+
+
 class TestFunc(unittest.TestCase):
     def test_user_func_export(self):
         # tests calling overloaded user-defined functions from Python
@@ -661,6 +679,7 @@ add_kernel_test(
 add_function_test(TestFunc, func=test_grad, name="test_grad", devices=devices)
 add_function_test(TestFunc, func=test_grad_in_func_grad, name="test_grad_in_func_grad", devices=devices)
 add_function_test(TestFunc, func=test_grad_reassign_error, name="test_grad_reassign_error", devices=devices)
+add_function_test(TestFunc, func=test_grad_aug_reassign_error, name="test_grad_aug_reassign_error", devices=devices)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Reassigning a kernel-local variable that was bound to `wp.grad()` to a non-grad value previously failed with an internal `AttributeError` (`'GradWrapper' object has no attribute 'type'`) instead of a user-facing Warp codegen error.

Root cause: when `g = wp.grad(square)` is parsed, the local `g` is stored in the symbol table as a raw `GradWrapper`, which is a function handle rather than a value. When `g` is later reassigned to a value such as `g = 1.0`, the assignment falls through to the generic symbol type check, which reads `.type` on the previously stored object. `GradWrapper` has no `.type` attribute, so codegen aborts with an opaque `AttributeError`.

This mirrors the function-valued local case that already lives in the same `assign()` path. That code guards the type check by detecting a previously bound `Function` and raising a clear error before `.type` is read. This change adds the missing sibling guard for `GradWrapper` right next to it, so a grad-bound local that is reassigned to a non-grad value now raises a clear `WarpCodegenError`. Valid patterns are unaffected: calling a grad handle (`g = wp.grad(square)` then `g(x)`) and rebinding one grad handle to another grad handle both still work.

Fixes #1487.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

Added `test_grad_reassign_error` to `warp/tests/test_func.py`, registered via `add_function_test` so it runs across available devices. It asserts that the reassignment raises `wp.WarpCodegenError` with the expected message. Verified on the CPU device:

- `uv run --extra dev warp/tests/test_func.py` passes all 23 tests, including `test_grad_reassign_error_cpu`.
- `uv run --extra dev warp/tests/test_codegen.py` and `warp/tests/test_grad.py` pass with no regressions.

The test fails before this change (the kernel build raises the internal `AttributeError`) and passes after.

## Bug fix

```python
import warp as wp


@wp.func
def square(x: float):
    return x * x


@wp.kernel(enable_backward=False)
def k(out: wp.array(dtype=float)):
    g = wp.grad(square)
    g = 1.0
    out[0] = g


out = wp.zeros(1, dtype=float)
wp.launch(k, dim=1, outputs=[out])
```

Without this PR the launch fails with `AttributeError: 'GradWrapper' object has no attribute 'type'`. With this PR it raises a clear `WarpCodegenError` explaining that a local bound to `wp.grad()` cannot be reassigned to a non-grad value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer error when a kernel-local variable bound to a gradient is reassigned to a non-gradient value—replaces prior opaque failures with a specific, actionable message.

* **Tests**
  * Added tests to verify that reassignment and augmented reassignment of gradient-bound locals correctly raise the new error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->