### PR TITLE
Fix BVH refit root leaves (GH-1506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,9 @@
   ``f`` is such a local now compile and call correctly instead of failing during codegen.
   Rebinding a function-valued local to a different function or to a non-function value raises a clear error
   ([GH-1423](https://github.com/NVIDIA/warp/issues/1423)).
+- Fix CUDA BVH refit out-of-bounds access for single-node and packed-root
+  trees ([GH-860](https://github.com/NVIDIA/warp/issues/860),
+  [GH-1506](https://github.com/NVIDIA/warp/issues/1506)).
 
 ### Documentation
 

--- a/warp/native/bvh.cu
+++ b/warp/native/bvh.cu
@@ -71,8 +71,8 @@ __global__ void bvh_refit_kernel(
             BVHPackedNodeHalf& upper = node_uppers[index];
             // update the leaf node
 
-            // only need to compute bound when this is a valid leaf node
-            if (!node_lowers[parent].b) {
+            // Single-node trees store the root leaf without a parent.
+            if (parent == -1 || !node_lowers[parent].b) {
                 const int start = lower.i;
                 const int end = upper.i;
 
@@ -112,10 +112,9 @@ __global__ void bvh_refit_kernel(
                 {
                     // update the leaf node
                     int parent_parent = parents[parent];
-                    ;
 
                     // only need to compute bound when this is a valid leaf node
-                    if (!node_lowers[parent_parent].b) {
+                    if (parent_parent == -1 || !node_lowers[parent_parent].b) {
                         const int start = parent_lower.i;
                         const int end = parent_upper.i;
                         bounds3 bound;

--- a/warp/tests/geometry/test_bvh.py
+++ b/warp/tests/geometry/test_bvh.py
@@ -158,89 +158,95 @@ def test_bvh_ray_query_inside_and_outside_bounds(test, device):
         test.assertEqual(device_intersected.sum(), 1)
 
 
-def test_bvh_refit_single_leaf(test, device):
-    """Refit a single-node CUDA BVH after moving its only leaf.
+def test_bvh_refit_root_leaves(test, device):
+    """Refit CUDA BVHs whose root is represented as a leaf.
 
-    The old and new AABBs are one-unit boxes separated along x. Querying the
-    old box after refit should miss, while querying the new box should hit,
-    proving the root leaf bound was recomputed without reading a parent node.
+    Single-node trees store the root leaf without a parent. LBVH can also pack
+    the root into a leaf when ``leaf_size`` covers all primitives. The old and
+    new AABBs occupy disjoint x-ranges, so the old query should miss after
+    refit and the new query should hit the updated bounds.
     """
-    old_lower = wp.vec3(0.0, 0.0, 0.0)
-    old_upper = wp.vec3(1.0, 1.0, 1.0)
-    new_lower = wp.vec3(2.0, 0.0, 0.0)
-    new_upper = wp.vec3(3.0, 1.0, 1.0)
+    old_single_lower = wp.vec3(0.0, 0.0, 0.0)
+    old_single_upper = wp.vec3(1.0, 1.0, 1.0)
+    new_single_lower = wp.vec3(2.0, 0.0, 0.0)
+    new_single_upper = wp.vec3(3.0, 1.0, 1.0)
 
-    for constructor in ("sah", "median", "lbvh"):
-        lowers = wp.array([old_lower], dtype=wp.vec3, device=device)
-        uppers = wp.array([old_upper], dtype=wp.vec3, device=device)
-        bvh = wp.Bvh(lowers, uppers, constructor=constructor)
-
-        wp.copy(lowers, wp.array([new_lower], dtype=wp.vec3, device=device))
-        wp.copy(uppers, wp.array([new_upper], dtype=wp.vec3, device=device))
-        bvh.refit()
-
-        bounds_intersected = wp.zeros(shape=1, dtype=int, device=device)
-        wp.launch(
-            bvh_query_aabb,
-            dim=1,
-            inputs=[bvh.id, old_lower, old_upper, bounds_intersected],
-            device=device,
+    cases = [
+        (
+            f"single_leaf_{constructor}",
+            constructor,
+            1,
+            [old_single_lower],
+            [old_single_upper],
+            [new_single_lower],
+            [new_single_upper],
+            old_single_lower,
+            old_single_upper,
+            new_single_lower,
+            new_single_upper,
+            1,
         )
-        test.assertEqual(bounds_intersected.numpy()[0], 0, f"Expected miss at old bounds ({constructor})")
-
-        bounds_intersected.zero_()
-        wp.launch(
-            bvh_query_aabb,
-            dim=1,
-            inputs=[bvh.id, new_lower, new_upper, bounds_intersected],
-            device=device,
+        for constructor in ("sah", "median", "lbvh")
+    ]
+    cases.append(
+        (
+            "packed_root_lbvh",
+            "lbvh",
+            2,
+            [wp.vec3(0.0, 0.0, 0.0), wp.vec3(2.0, 0.0, 0.0)],
+            [wp.vec3(1.0, 1.0, 1.0), wp.vec3(3.0, 1.0, 1.0)],
+            [wp.vec3(4.0, 0.0, 0.0), wp.vec3(6.0, 0.0, 0.0)],
+            [wp.vec3(5.0, 1.0, 1.0), wp.vec3(7.0, 1.0, 1.0)],
+            wp.vec3(0.0, 0.0, 0.0),
+            wp.vec3(3.0, 1.0, 1.0),
+            wp.vec3(4.0, 0.0, 0.0),
+            wp.vec3(7.0, 1.0, 1.0),
+            2,
         )
-        test.assertEqual(bounds_intersected.numpy()[0], 1, f"Expected hit at refit bounds ({constructor})")
-
-
-def test_bvh_refit_packed_root(test, device):
-    """Refit an LBVH whose root is packed into a leaf.
-
-    The old and new AABBs occupy disjoint x-ranges, and each aggregate query
-    spans exactly one pair. With ``leaf_size=2`` the LBVH root is a packed
-    leaf, so the old query should miss after refit and the new query should
-    return both bounds without reading a parent-parent node.
-    """
-    old_lowers = [wp.vec3(0.0, 0.0, 0.0), wp.vec3(2.0, 0.0, 0.0)]
-    old_uppers = [wp.vec3(1.0, 1.0, 1.0), wp.vec3(3.0, 1.0, 1.0)]
-    new_lowers = [wp.vec3(4.0, 0.0, 0.0), wp.vec3(6.0, 0.0, 0.0)]
-    new_uppers = [wp.vec3(5.0, 1.0, 1.0), wp.vec3(7.0, 1.0, 1.0)]
-
-    old_query_lower = wp.vec3(0.0, 0.0, 0.0)
-    old_query_upper = wp.vec3(3.0, 1.0, 1.0)
-    new_query_lower = wp.vec3(4.0, 0.0, 0.0)
-    new_query_upper = wp.vec3(7.0, 1.0, 1.0)
-
-    lowers = wp.array(old_lowers, dtype=wp.vec3, device=device)
-    uppers = wp.array(old_uppers, dtype=wp.vec3, device=device)
-    bvh = wp.Bvh(lowers, uppers, constructor="lbvh", leaf_size=2)
-
-    wp.copy(lowers, wp.array(new_lowers, dtype=wp.vec3, device=device))
-    wp.copy(uppers, wp.array(new_uppers, dtype=wp.vec3, device=device))
-    bvh.refit()
-
-    bounds_intersected = wp.zeros(shape=2, dtype=int, device=device)
-    wp.launch(
-        bvh_query_aabb,
-        dim=1,
-        inputs=[bvh.id, old_query_lower, old_query_upper, bounds_intersected],
-        device=device,
     )
-    test.assertEqual(bounds_intersected.numpy().sum(), 0, "Expected miss at old bounds")
 
-    bounds_intersected.zero_()
-    wp.launch(
-        bvh_query_aabb,
-        dim=1,
-        inputs=[bvh.id, new_query_lower, new_query_upper, bounds_intersected],
-        device=device,
-    )
-    test.assertEqual(bounds_intersected.numpy().sum(), 2, "Expected hits at refit bounds")
+    for (
+        name,
+        constructor,
+        leaf_size,
+        old_lowers,
+        old_uppers,
+        new_lowers,
+        new_uppers,
+        old_query_lower,
+        old_query_upper,
+        new_query_lower,
+        new_query_upper,
+        expected_new_hits,
+    ) in cases:
+        with test.subTest(name=name):
+            lowers = wp.array(old_lowers, dtype=wp.vec3, device=device)
+            uppers = wp.array(old_uppers, dtype=wp.vec3, device=device)
+            bvh = wp.Bvh(lowers, uppers, constructor=constructor, leaf_size=leaf_size)
+
+            wp.copy(lowers, wp.array(new_lowers, dtype=wp.vec3, device=device))
+            wp.copy(uppers, wp.array(new_uppers, dtype=wp.vec3, device=device))
+            bvh.refit()
+
+            bounds_intersected = wp.zeros(shape=len(old_lowers), dtype=int, device=device)
+            wp.launch(
+                bvh_query_aabb,
+                dim=1,
+                inputs=[bvh.id, old_query_lower, old_query_upper, bounds_intersected],
+                device=device,
+            )
+            test.assertEqual(bounds_intersected.numpy().sum(), 0, f"Expected miss at old bounds ({name})")
+
+            bounds_intersected.zero_()
+            wp.launch(
+                bvh_query_aabb,
+                dim=1,
+                inputs=[bvh.id, new_query_lower, new_query_upper, bounds_intersected],
+                device=device,
+            )
+            test.assertEqual(
+                bounds_intersected.numpy().sum(), expected_new_hits, f"Expected hits at refit bounds ({name})"
+            )
 
 
 def get_random_aabbs(n, center, relative_shift, relative_size, rng):
@@ -820,8 +826,7 @@ add_function_test(
     test_bvh_ray_query_inside_and_outside_bounds,
     devices=devices,
 )
-add_function_test(TestBvh, "test_bvh_refit_single_leaf", test_bvh_refit_single_leaf, devices=cuda_devices)
-add_function_test(TestBvh, "test_bvh_refit_packed_root", test_bvh_refit_packed_root, devices=cuda_devices)
+add_function_test(TestBvh, "test_bvh_refit_root_leaves", test_bvh_refit_root_leaves, devices=cuda_devices)
 add_function_test(TestBvh, "test_tile_bvh_query_aabb", test_tile_bvh_query, devices=cuda_devices)
 add_function_test(TestBvh, "test_tile_bvh_query_ray", test_tile_bvh_query_ray, devices=cuda_devices)
 

--- a/warp/tests/geometry/test_bvh.py
+++ b/warp/tests/geometry/test_bvh.py
@@ -158,6 +158,91 @@ def test_bvh_ray_query_inside_and_outside_bounds(test, device):
         test.assertEqual(device_intersected.sum(), 1)
 
 
+def test_bvh_refit_single_leaf(test, device):
+    """Refit a single-node CUDA BVH after moving its only leaf.
+
+    The old and new AABBs are one-unit boxes separated along x. Querying the
+    old box after refit should miss, while querying the new box should hit,
+    proving the root leaf bound was recomputed without reading a parent node.
+    """
+    old_lower = wp.vec3(0.0, 0.0, 0.0)
+    old_upper = wp.vec3(1.0, 1.0, 1.0)
+    new_lower = wp.vec3(2.0, 0.0, 0.0)
+    new_upper = wp.vec3(3.0, 1.0, 1.0)
+
+    for constructor in ("sah", "median", "lbvh"):
+        lowers = wp.array([old_lower], dtype=wp.vec3, device=device)
+        uppers = wp.array([old_upper], dtype=wp.vec3, device=device)
+        bvh = wp.Bvh(lowers, uppers, constructor=constructor)
+
+        wp.copy(lowers, wp.array([new_lower], dtype=wp.vec3, device=device))
+        wp.copy(uppers, wp.array([new_upper], dtype=wp.vec3, device=device))
+        bvh.refit()
+
+        bounds_intersected = wp.zeros(shape=1, dtype=int, device=device)
+        wp.launch(
+            bvh_query_aabb,
+            dim=1,
+            inputs=[bvh.id, old_lower, old_upper, bounds_intersected],
+            device=device,
+        )
+        test.assertEqual(bounds_intersected.numpy()[0], 0, f"Expected miss at old bounds ({constructor})")
+
+        bounds_intersected.zero_()
+        wp.launch(
+            bvh_query_aabb,
+            dim=1,
+            inputs=[bvh.id, new_lower, new_upper, bounds_intersected],
+            device=device,
+        )
+        test.assertEqual(bounds_intersected.numpy()[0], 1, f"Expected hit at refit bounds ({constructor})")
+
+
+def test_bvh_refit_packed_root(test, device):
+    """Refit an LBVH whose root is packed into a leaf.
+
+    The old and new AABBs occupy disjoint x-ranges, and each aggregate query
+    spans exactly one pair. With ``leaf_size=2`` the LBVH root is a packed
+    leaf, so the old query should miss after refit and the new query should
+    return both bounds without reading a parent-parent node.
+    """
+    old_lowers = [wp.vec3(0.0, 0.0, 0.0), wp.vec3(2.0, 0.0, 0.0)]
+    old_uppers = [wp.vec3(1.0, 1.0, 1.0), wp.vec3(3.0, 1.0, 1.0)]
+    new_lowers = [wp.vec3(4.0, 0.0, 0.0), wp.vec3(6.0, 0.0, 0.0)]
+    new_uppers = [wp.vec3(5.0, 1.0, 1.0), wp.vec3(7.0, 1.0, 1.0)]
+
+    old_query_lower = wp.vec3(0.0, 0.0, 0.0)
+    old_query_upper = wp.vec3(3.0, 1.0, 1.0)
+    new_query_lower = wp.vec3(4.0, 0.0, 0.0)
+    new_query_upper = wp.vec3(7.0, 1.0, 1.0)
+
+    lowers = wp.array(old_lowers, dtype=wp.vec3, device=device)
+    uppers = wp.array(old_uppers, dtype=wp.vec3, device=device)
+    bvh = wp.Bvh(lowers, uppers, constructor="lbvh", leaf_size=2)
+
+    wp.copy(lowers, wp.array(new_lowers, dtype=wp.vec3, device=device))
+    wp.copy(uppers, wp.array(new_uppers, dtype=wp.vec3, device=device))
+    bvh.refit()
+
+    bounds_intersected = wp.zeros(shape=2, dtype=int, device=device)
+    wp.launch(
+        bvh_query_aabb,
+        dim=1,
+        inputs=[bvh.id, old_query_lower, old_query_upper, bounds_intersected],
+        device=device,
+    )
+    test.assertEqual(bounds_intersected.numpy().sum(), 0, "Expected miss at old bounds")
+
+    bounds_intersected.zero_()
+    wp.launch(
+        bvh_query_aabb,
+        dim=1,
+        inputs=[bvh.id, new_query_lower, new_query_upper, bounds_intersected],
+        device=device,
+    )
+    test.assertEqual(bounds_intersected.numpy().sum(), 2, "Expected hits at refit bounds")
+
+
 def get_random_aabbs(n, center, relative_shift, relative_size, rng):
     centers = rng.uniform(-0.5, 0.5, size=n * 3).reshape(n, 3) * relative_shift + center
     diffs = 0.5 * rng.random(n * 3).reshape(n, 3) * relative_size
@@ -735,6 +820,8 @@ add_function_test(
     test_bvh_ray_query_inside_and_outside_bounds,
     devices=devices,
 )
+add_function_test(TestBvh, "test_bvh_refit_single_leaf", test_bvh_refit_single_leaf, devices=cuda_devices)
+add_function_test(TestBvh, "test_bvh_refit_packed_root", test_bvh_refit_packed_root, devices=cuda_devices)
 add_function_test(TestBvh, "test_tile_bvh_query_aabb", test_tile_bvh_query, devices=cuda_devices)
 add_function_test(TestBvh, "test_tile_bvh_query_ray", test_tile_bvh_query_ray, devices=cuda_devices)
 


### PR DESCRIPTION
## Description

Closes #1506.

Fix CUDA `wp.Bvh.refit()` for root-leaf cases. The device refit kernel now treats `parent == -1` and `parent_parent == -1` as valid leaf/root cases before reading parent node metadata, avoiding out-of-bounds reads for single-node BVHs and packed LBVH roots.

The bug was specific to the plain BVH CUDA refit path. The solid-angle mesh refit path already had equivalent guards.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `uv run build_lib.py --quick`
- `WARP_CACHE_PATH=/tmp/warp-cache-fix-bvh-refit-single-node-final WARP_CACHE_ROOT=/tmp/warp-cache-fix-bvh-refit-single-node-final uv run --extra dev -m warp.tests -s autodetect -k TestBvh.test_bvh_refit_single_leaf -k TestBvh.test_bvh_refit_packed_root`
- `WARP_CACHE_PATH=/tmp/warp-cache-fix-bvh-refit-single-node-bvhfile WARP_CACHE_ROOT=/tmp/warp-cache-fix-bvh-refit-single-node-bvhfile uv run --extra dev -m warp.tests -s autodetect -k TestBvh`
- `uvx pre-commit run --files CHANGELOG.md warp/native/bvh.cu warp/tests/geometry/test_bvh.py`

## Bug fix

The out-of-bounds read is most directly observed with CUDA memory checking tools. In normal execution it may not surface as a deterministic Python exception because the invalid read can land in accessible allocator padding.

```python
import warp as wp

lowers = wp.array([wp.vec3(0.0, 0.0, 0.0)], dtype=wp.vec3, device="cuda")
uppers = wp.array([wp.vec3(1.0, 1.0, 1.0)], dtype=wp.vec3, device="cuda")
bvh = wp.Bvh(lowers, uppers, constructor="lbvh")
bvh.refit()
```

## New feature / enhancement

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an out-of-bounds memory access in CUDA BVH refit affecting single-node and packed-root tree refits, improving stability on CUDA devices.

* **Tests**
  * Added a consolidated regression test validating BVH refit updates bounds and restores query results for single-leaf and packed-root scenarios.

* **Documentation**
  * Updated changelog to note the BVH refit fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->