### PR TITLE
Validate allocator device preconditions

### DIFF
--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -3495,7 +3495,8 @@ def _set_alloc_tag_if_tracking(ptr):
 
 class CpuDefaultAllocator:
     def __init__(self, device):
-        assert device.is_cpu
+        if not device.is_cpu:
+            raise ValueError(f"CpuDefaultAllocator requires a CPU device, got '{device}'")
 
     def allocate(self, size_in_bytes):
         ptr = runtime.core.wp_alloc_host(size_in_bytes, None)
@@ -3510,7 +3511,8 @@ class CpuDefaultAllocator:
 
 class CpuPinnedAllocator:
     def __init__(self, device):
-        assert device.is_cpu
+        if not device.is_cpu:
+            raise ValueError(f"CpuPinnedAllocator requires a CPU device, got '{device}'")
         self.device = device
 
     def allocate(self, size_in_bytes):
@@ -3526,7 +3528,8 @@ class CpuPinnedAllocator:
 
 class CudaDefaultAllocator:
     def __init__(self, device):
-        assert device.is_cuda
+        if not device.is_cuda:
+            raise ValueError(f"CudaDefaultAllocator requires a CUDA device, got '{device}'")
         self.device = device
 
     def allocate(self, size_in_bytes):
@@ -3558,8 +3561,10 @@ class CudaDefaultAllocator:
 
 class CudaMempoolAllocator:
     def __init__(self, device):
-        assert device.is_cuda
-        assert device.is_mempool_supported
+        if not device.is_cuda:
+            raise ValueError(f"CudaMempoolAllocator requires a CUDA device, got '{device}'")
+        if not device.is_mempool_supported:
+            raise RuntimeError(f"CudaMempoolAllocator requires memory pool support on CUDA device '{device}'")
         self.device = device
 
     def allocate(self, size_in_bytes):

--- a/warp/tests/test_allocator.py
+++ b/warp/tests/test_allocator.py
@@ -7,7 +7,13 @@ from unittest import mock
 import numpy as np
 
 import warp as wp
-from warp._src.context import Allocator
+from warp._src.context import (
+    Allocator,
+    CpuDefaultAllocator,
+    CpuPinnedAllocator,
+    CudaDefaultAllocator,
+    CudaMempoolAllocator,
+)
 from warp.tests.unittest_utils import add_function_test, get_cuda_test_devices
 
 wp.init()
@@ -64,6 +70,19 @@ class FailAllocator:
 
     def deallocate(self, ptr, size_in_bytes):
         pass
+
+
+class FakeDevice:
+    """Minimal device shape for allocator constructor validation."""
+
+    def __init__(self, alias, *, is_cpu=False, is_cuda=False, is_mempool_supported=False):
+        self.alias = alias
+        self.is_cpu = is_cpu
+        self.is_cuda = is_cuda
+        self.is_mempool_supported = is_mempool_supported
+
+    def __str__(self):
+        return self.alias
 
 
 class TorchCachingAllocatorForWarp:
@@ -159,6 +178,53 @@ def test_protocol_conformance_cuda(test, device):
 add_function_test(
     TestAllocatorProtocol, "test_protocol_conformance_cuda", test_protocol_conformance_cuda, devices=cuda_test_devices
 )
+
+
+# -- Built-in allocator validation -----------------------------------------
+
+
+class TestAllocatorValidation(unittest.TestCase):
+    def test_cpu_allocators_require_cpu_device(self):
+        """CPU allocators reject non-CPU devices."""
+        cuda_device = FakeDevice("cuda:fake", is_cuda=True, is_mempool_supported=True)
+
+        for allocator_type in (CpuDefaultAllocator, CpuPinnedAllocator):
+            with self.subTest(allocator_type=allocator_type.__name__):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    rf"{allocator_type.__name__} requires a CPU device, got 'cuda:fake'",
+                ):
+                    allocator_type(cuda_device)
+
+    def test_cuda_default_allocator_requires_cuda_device(self):
+        """The CUDA default allocator rejects non-CUDA devices."""
+        cpu_device = FakeDevice("cpu", is_cpu=True)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"CudaDefaultAllocator requires a CUDA device, got 'cpu'",
+        ):
+            CudaDefaultAllocator(cpu_device)
+
+    def test_cuda_mempool_allocator_requires_cuda_device(self):
+        """The CUDA mempool allocator rejects non-CUDA devices."""
+        cpu_device = FakeDevice("cpu", is_cpu=True)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"CudaMempoolAllocator requires a CUDA device, got 'cpu'",
+        ):
+            CudaMempoolAllocator(cpu_device)
+
+    def test_cuda_mempool_allocator_requires_mempool_support(self):
+        """The CUDA mempool allocator rejects devices without memory pool support."""
+        cuda_device = FakeDevice("cuda:no-mempool", is_cuda=True, is_mempool_supported=False)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"CudaMempoolAllocator requires memory pool support on CUDA device 'cuda:no-mempool'",
+        ):
+            CudaMempoolAllocator(cuda_device)
 
 
 # -- Custom allocator -------------------------------------------------------

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -130,6 +130,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.test_allocation_tracker import TestAllocTracker
     from warp.tests.test_allocator import (
         TestAllocatorProtocol,
+        TestAllocatorValidation,
         TestCustomAllocator,
         TestRmmAllocator,
         TestTorchAllocator,
@@ -253,6 +254,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestAdam,
         TestAllocTracker,
         TestAllocatorProtocol,
+        TestAllocatorValidation,
         TestApic,
         TestApicMesh,
         TestArithmetic,


### PR DESCRIPTION
## Description

This PR replaces assert-only precondition checks in the built-in allocator constructors with explicit Python exceptions. Optimized Python strips assert statements, so invalid CPU, CUDA, or CUDA mempool allocator construction could previously bypass the guard and fail later in lower-level allocation paths.

Wrong device types now raise `ValueError` with the allocator name and device, while CUDA devices without memory pool support raise `RuntimeError` at `CudaMempoolAllocator` construction time.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

```bash
uvx pre-commit run --files warp/_src/context.py warp/tests/test_allocator.py warp/tests/unittest_suites.py
env WARP_CACHE_PATH=/tmp/warp-cache-warp-shi-eric-fix-allocator-guards WARP_CACHE_ROOT=/tmp/warp-cache-warp-shi-eric-fix-allocator-guards uv run warp/tests/test_allocator.py TestAllocatorValidation -v
env PYTHONOPTIMIZE=1 WARP_CACHE_PATH=/tmp/warp-cache-warp-shi-eric-fix-allocator-guards WARP_CACHE_ROOT=/tmp/warp-cache-warp-shi-eric-fix-allocator-guards uv run warp/tests/test_allocator.py TestAllocatorValidation -v
```

## Bug fix

Without this PR, the constructor checks below are removed when Python runs with optimization enabled:

```python
from warp._src.context import CudaDefaultAllocator


class FakeDevice:
    is_cpu = True
    is_cuda = False
    is_mempool_supported = False

    def __str__(self):
        return "cpu"


CudaDefaultAllocator(FakeDevice())
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Allocator classes now properly validate device compatibility at construction time, raising clear error messages instead of assertions when incorrect device types are used.

* **Tests**
  * Added comprehensive validation tests for allocator device compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->