### PR TITLE
Harden Windows MSVC env setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         id: cache-build
         with:
           path: warp/bin/
-          key: build-${{ matrix.artifact-name }}-${{ matrix.cuda-version }}-${{ hashFiles('build_lib.py', 'warp/build_dll.py', 'build_llvm.py', 'warp/native/**/*.cpp', 'warp/native/**/*.cu', 'warp/native/**/*.h', 'deps/libmathdx-deps.packman.xml') }}
+          key: build-${{ matrix.artifact-name }}-${{ matrix.cuda-version }}-${{ hashFiles('VERSION.md', 'build_lib.py', 'build_llvm.py', 'warp/__init__.py', 'warp/config.py', 'warp/_src/build.py', 'warp/_src/build_dll.py', 'warp/_src/builtins.py', 'warp/_src/codegen.py', 'warp/_src/context.py', 'warp/_src/generated_files.py', 'warp/_src/logger.py', 'warp/_src/math.py', 'warp/_src/texture.py', 'warp/_src/types.py', 'warp/_src/utils.py', 'warp/native/**/*.cpp', 'warp/native/**/*.cu', 'warp/native/**/*.cuh', 'warp/native/**/*.h', 'warp/native/libdevice/*.bc', 'warp/native/warp.map', 'deps/libmathdx-deps.packman.xml') }}
       
       - name: Install CTK (with non-CUDA packages)
         if: steps.cache-build.outputs.cache-hit != 'true' && matrix.cuda-sub-packages != '' && matrix.cuda-non-cuda-packages != ''

--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -23,6 +23,40 @@ verbose_cmd = True  # print command lines before executing them
 
 MIN_CTK_VERSION = (12, 0)
 
+_VCVARS_ENV_MARKER = "__WARP_VCVARS_ENV_BEGIN__"
+
+
+def _parse_vcvars_environment(output: str) -> dict[str, str]:
+    """Parse environment variables from ``vcvars64.bat && set`` output.
+
+    Scans the command output for ``_VCVARS_ENV_MARKER`` and only begins parsing
+    after it, so any banner text emitted by ``vcvars64.bat`` is ignored. Each
+    subsequent line is split on the first ``=`` into a ``KEY=VALUE`` pair; lines
+    without a separator or with an empty key are skipped.
+
+    Args:
+        output: Decoded output of ``vcvars64.bat && echo MARKER && set``.
+
+    Returns:
+        Mapping of environment variable names to values found after the marker.
+        Empty if the marker is absent or no valid entries follow it.
+    """
+    env = {}
+    parse_env = False
+
+    for line in output.splitlines():
+        if not parse_env:
+            parse_env = line.strip() == _VCVARS_ENV_MARKER
+            continue
+
+        key, sep, value = line.partition("=")
+        if not sep or not key:
+            continue
+
+        env[key] = value
+
+    return env
+
 
 def machine_architecture() -> str:
     """Return a canonical machine architecture string.
@@ -37,14 +71,14 @@ def machine_architecture() -> str:
     raise RuntimeError(f"Unrecognized machine architecture {machine}")
 
 
-def run_cmd(cmd):
+def run_cmd(cmd, print_success_output=True):
     if verbose_cmd:
         print(cmd)
 
     try:
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
         # Print output even on success to show warnings
-        if output:
+        if print_success_output and output:
             decoded_output = output.decode()
             if decoded_output.strip():  # Only print if not just whitespace
                 # In parallel builds, associate output with its command for clarity
@@ -115,24 +149,28 @@ def find_host_compiler() -> str:
 
         vswhere_path = r"%ProgramFiles(x86)%/Microsoft Visual Studio/Installer/vswhere.exe"
         vswhere_path = os.path.expandvars(vswhere_path)
-        if not os.path.exists(vswhere_path):
+        if not os.path.isfile(vswhere_path):
             return ""  # Signal to caller that VS not found
 
         vs_path = run_cmd(f'"{vswhere_path}" -latest -property installationPath').decode().rstrip()
         vsvars_path = os.path.join(vs_path, "VC\\Auxiliary\\Build\\vcvars64.bat")
 
-        if not os.path.exists(vsvars_path):
+        if not os.path.isfile(vsvars_path):
             return ""  # Signal to caller that VS environment script not found
 
-        output = run_cmd(f'"{vsvars_path}" && set').decode()
+        output = run_cmd(f'"{vsvars_path}" && echo {_VCVARS_ENV_MARKER} && set', print_success_output=False).decode()
 
-        for line in output.splitlines():
-            pair = line.split("=", 1)
-            if len(pair) >= 2:
-                os.environ[pair[0]] = pair[1]
+        os.environ.update(_parse_vcvars_environment(output))
 
         cl_path = shutil.which("cl.exe")
-        cl_version = os.environ["VCToolsVersion"].split(".")
+        if not cl_path:
+            return ""  # Signal to caller that cl.exe was not found after vcvars configuration
+
+        vc_tools_version = os.environ.get("VCToolsVersion")
+        if not vc_tools_version:
+            return ""  # Signal to caller that VS environment script did not configure MSVC
+
+        cl_version = vc_tools_version.split(".")
 
         # ensure at least VS2019 version, see list of MSVC versions here https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B
         cl_required_major = 14


### PR DESCRIPTION
## Description

This PR hardens the Windows source-build path that auto-discovers MSVC.
`find_host_compiler()` now imports only environment lines printed by the
final `set` command after `vcvars64.bat` has completed. This keeps normal
Visual Studio environment setup behavior while ignoring banner or error
output emitted before the environment dump.

The parser now accepts any non-empty environment key after the marker so
valid Windows names such as `ProgramFiles(x86)` are preserved. The
`vcvars64.bat && set` capture also suppresses successful command-output
logging, avoiding accidental exposure of the full process environment in CI
logs.

It also fixes the GitHub Actions `warp/bin/` cache key. The previous key
hashed a stale `warp/build_dll.py` path, so changes to the actual build
helper did not invalidate cached native build artifacts. The key now covers
the relevant Python build inputs, generated-header sources, and native inputs
used by `build_lib.py`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- One-off local `unittest` via `uv run python -` covering:
  - preserving Windows env names such as `ProgramFiles(x86)`
  - ignoring output before the vcvars environment marker
  - skipping malformed environment lines
  - suppressing the captured `set` output from successful command logs
- `uvx pre-commit run --files warp/_src/build_dll.py .github/workflows/ci.yml`
- `git diff --check`

## Bug fix

This is Windows source-build hardening, not a runtime Warp behavior bug. The
affected path is `build_lib.py` MSVC auto-discovery on Windows when the shell
is not already configured with a usable `cl.exe`.

Without this PR, any output line containing `=` from `vcvars64.bat && set`
was copied into `os.environ`, including output emitted before the final
environment dump. The captured environment dump was also printed on success,
which could expose unrelated process environment values in CI logs.

## New feature / enhancement

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened CI caching to include additional build outputs and source files, improving cache reliability and build performance.

* **Bug Fixes**
  * Improved Windows toolchain setup to parse and apply only validated environment entries from the compiler setup output, reducing environment pollution and improving compiler detection.
  * Command execution now can suppress successful-command output for cleaner logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->