### PR TITLE
Fix LTO cache key collisions (GH-1511)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,8 @@
 - Fix `Tape.record_scope_end()` to raise a clear error for unmatched
   scope ends and preserve nested non-empty tape visualization scopes
   ([GH-1515](https://github.com/NVIDIA/warp/issues/1515)).
+- Fix LTO cache collisions and stale FFT metadata handling by using longer cache keys and rebuilding invalid metadata
+  ([GH-1511](https://github.com/NVIDIA/warp/issues/1511)).
 
 ### Documentation
 

--- a/warp/_src/build.py
+++ b/warp/_src/build.py
@@ -23,6 +23,8 @@ nvJitLink_input_type = {"cubin": 1, "ptx": 2, "ltoir": 3, "fatbin": 4, "object":
 
 warp_home = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 
+LTO_CACHE_KEY_LENGTH = 16
+
 
 # builds cuda source to PTX or CUBIN using NVRTC (output type determined by output_path extension)
 def build_cuda(
@@ -295,13 +297,23 @@ def get_cached_lto(path):
 
 
 def get_cached_lto_meta(path, symbol):
-    if os.path.exists(path):
+    if not os.path.exists(path):
+        return None
+
+    try:
         with open(path) as f:
             keys = json.load(f)
-        value = keys[symbol]
-        return value
-    else:
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
         return None
+
+    if not isinstance(keys, dict):
+        return None
+
+    value = keys.get(symbol)
+    if not isinstance(value, int):
+        return None
+
+    return value
 
 
 def _build_lto_base(lto_symbol, compile_func, builder, extra_files=None):
@@ -328,9 +340,9 @@ def _build_lto_base(lto_symbol, compile_func, builder, extra_files=None):
         extra_files = {}
 
     # Hash symbol and set up paths
-    h = hash_symbol(lto_symbol)
+    h = hash_symbol(lto_symbol)[:LTO_CACHE_KEY_LENGTH]
     lto_dir = get_lto_cache_dir()
-    lto_name = f"{h[:7]}.lto"
+    lto_name = f"{h}.lto"
     lto_path = os.path.join(lto_dir, lto_name)
 
     # Set up paths for extra files
@@ -338,11 +350,13 @@ def _build_lto_base(lto_symbol, compile_func, builder, extra_files=None):
     temp_file_paths = {}
 
     for ext, _ in extra_files.items():
-        name = f"{h[:7]}{ext}"
+        name = f"{h}{ext}"
         file_paths[ext] = os.path.join(lto_dir, name)
 
-    # Check if already built but not cached
+    # Check the persistent LTO cache before compiling.
     lto_code_data = get_cached_lto(lto_path)
+    cached_extra_files = {}
+    invalid_extra_files = set()
     if lto_code_data is not None:
         # Get the cached data for the extra files and early return
         all_files_cached = True
@@ -350,9 +364,10 @@ def _build_lto_base(lto_symbol, compile_func, builder, extra_files=None):
             if getter and os.path.exists(file_paths[ext]):
                 cached_data = getter(file_paths[ext])
                 if cached_data is None:
+                    invalid_extra_files.add(ext)
                     all_files_cached = False
                     break
-                extra_files[ext] = cached_data
+                cached_extra_files[ext] = cached_data
             elif getter:  # If there's a getter but file doesn't exist
                 all_files_cached = False
                 break
@@ -361,7 +376,11 @@ def _build_lto_base(lto_symbol, compile_func, builder, extra_files=None):
             if not extra_files:
                 return (True, lto_code_data)
             else:
-                return (True, lto_code_data, *[extra_files[ext] for ext in extra_files.keys()])
+                return (
+                    True,
+                    lto_code_data,
+                    *[cached_extra_files.get(ext) for ext in extra_files.keys()],
+                )
 
     # Create process-dependent temporary build directory
     build_dir = f"{lto_dir}_p{os.getpid()}_t{threading.get_ident()}"
@@ -389,8 +408,15 @@ def _build_lto_base(lto_symbol, compile_func, builder, extra_files=None):
 
         # If build_dir couldn't be moved by a rename, move the outputs one-by-one to lto_dir
         if os.path.exists(lto_dir):
+            replace_lto = bool(invalid_extra_files)
             for ext, path in file_paths.items():
-                if not os.path.exists(path):
+                if (replace_lto and ext == ".lto") or ext in invalid_extra_files:
+                    try:
+                        # Replace inconsistent cache outputs so future processes hit a coherent entry.
+                        os.replace(temp_file_paths[ext], path)
+                    except OSError:
+                        pass
+                elif not os.path.exists(path):
                     try:
                         # copy output file to the destination lto dir
                         os.rename(temp_file_paths[ext], path)

--- a/warp/tests/test_kernel_cache.py
+++ b/warp/tests/test_kernel_cache.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 import tempfile
 import unittest
@@ -59,6 +60,122 @@ class TestKernelCache(unittest.TestCase):
         """The default cache path (no env var, no explicit path) includes the version."""
         warp._src.build.init_kernel_cache()
         self.assertIn(warp.config.version, warp.config.kernel_cache_dir)
+
+    def test_lto_cache_does_not_reuse_legacy_prefix_collision(self):
+        """LTO cache keys distinguish hashes that share the legacy 7-char prefix."""
+        symbol_a = "synthetic_lto_symbol_a"
+        symbol_b = "synthetic_lto_symbol_b"
+        short_prefix = "abcdef0"
+        synthetic_hashes = {
+            symbol_a: f"{short_prefix}{'1' * 57}",
+            symbol_b: f"{short_prefix}{'2' * 57}",
+        }
+        self.assertEqual(synthetic_hashes[symbol_a][:7], synthetic_hashes[symbol_b][:7])
+        self.assertNotEqual(
+            synthetic_hashes[symbol_a][: warp._src.build.LTO_CACHE_KEY_LENGTH],
+            synthetic_hashes[symbol_b][: warp._src.build.LTO_CACHE_KEY_LENGTH],
+        )
+
+        def compile_lto(symbol):
+            def compile_func(temp_paths):
+                lto_data = symbol.encode("utf-8")
+                with open(temp_paths[".lto"], "wb") as f:
+                    f.write(lto_data)
+                return True, {".lto": lto_data}
+
+            return compile_func
+
+        with tempfile.TemporaryDirectory() as tmp:
+            warp.config.kernel_cache_dir = tmp
+
+            with patch("warp._src.build.hash_symbol", side_effect=lambda symbol: synthetic_hashes[symbol]):
+                result_a, lto_data_a = warp._src.build._build_lto_base(symbol_a, compile_lto(symbol_a), builder=None)
+                result_b, lto_data_b = warp._src.build._build_lto_base(symbol_b, compile_lto(symbol_b), builder=None)
+
+        self.assertTrue(result_a)
+        self.assertTrue(result_b)
+        self.assertEqual(lto_data_a, symbol_a.encode("utf-8"))
+        self.assertEqual(lto_data_b, symbol_b.encode("utf-8"))
+
+    def test_lto_meta_missing_symbol_is_cache_miss(self):
+        """A metadata sidecar without the requested symbol is a cache miss."""
+        with tempfile.TemporaryDirectory() as tmp:
+            meta_path = os.path.join(tmp, "cached.meta")
+            with open(meta_path, "w") as f:
+                json.dump({"other_symbol": 128}, f)
+
+            self.assertIsNone(warp._src.build.get_cached_lto_meta(meta_path, "requested_symbol"))
+
+    def test_lto_meta_invalid_json_is_cache_miss(self):
+        """A corrupt metadata sidecar is a cache miss."""
+        with tempfile.TemporaryDirectory() as tmp:
+            meta_path = os.path.join(tmp, "cached.meta")
+            with open(meta_path, "w") as f:
+                f.write("{")
+
+            self.assertIsNone(warp._src.build.get_cached_lto_meta(meta_path, "requested_symbol"))
+
+    def test_lto_meta_invalid_encoding_is_cache_miss(self):
+        """A metadata sidecar with invalid text encoding is a cache miss."""
+        with tempfile.TemporaryDirectory() as tmp:
+            meta_path = os.path.join(tmp, "cached.meta")
+            with open(meta_path, "wb") as f:
+                f.write(b"\xff")
+
+            self.assertIsNone(warp._src.build.get_cached_lto_meta(meta_path, "requested_symbol"))
+
+    def test_lto_meta_non_integer_value_is_cache_miss(self):
+        """A metadata sidecar with a non-integer value is a cache miss."""
+        with tempfile.TemporaryDirectory() as tmp:
+            meta_path = os.path.join(tmp, "cached.meta")
+            with open(meta_path, "w") as f:
+                json.dump({"requested_symbol": "oops"}, f)
+
+            self.assertIsNone(warp._src.build.get_cached_lto_meta(meta_path, "requested_symbol"))
+
+    def test_lto_rebuild_replaces_invalid_meta_sidecar(self):
+        """A rebuilt LTO cache entry heals an invalid metadata sidecar."""
+        lto_symbol = "fft_64_4_70_forward_5"
+        shared_memory_bytes = 256
+        h = warp._src.build.hash_symbol(lto_symbol)[: warp._src.build.LTO_CACHE_KEY_LENGTH]
+
+        def compile_lto(temp_paths):
+            lto_data = b"rebuilt"
+            with open(temp_paths[".lto"], "wb") as f:
+                f.write(lto_data)
+            with open(temp_paths[".meta"], "w") as f:
+                json.dump({lto_symbol: shared_memory_bytes}, f)
+            return True, {".lto": lto_data, ".meta": shared_memory_bytes}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            warp.config.kernel_cache_dir = tmp
+            lto_dir = warp._src.build.get_lto_cache_dir()
+            os.makedirs(lto_dir)
+
+            lto_path = os.path.join(lto_dir, f"{h}.lto")
+            meta_path = os.path.join(lto_dir, f"{h}.meta")
+            with open(lto_path, "wb") as f:
+                f.write(b"cached")
+            with open(meta_path, "w") as f:
+                json.dump({"other_symbol": 128}, f)
+
+            result, lto_data, cached_shared_memory_bytes = warp._src.build._build_lto_base(
+                lto_symbol,
+                compile_lto,
+                builder=None,
+                extra_files={".meta": lambda path: warp._src.build.get_cached_lto_meta(path, lto_symbol)},
+            )
+
+            with open(meta_path) as f:
+                healed_meta = json.load(f)
+            with open(lto_path, "rb") as f:
+                healed_lto_data = f.read()
+
+        self.assertTrue(result)
+        self.assertEqual(lto_data, b"rebuilt")
+        self.assertEqual(cached_shared_memory_bytes, shared_memory_bytes)
+        self.assertEqual(healed_meta, {lto_symbol: shared_memory_bytes})
+        self.assertEqual(healed_lto_data, b"rebuilt")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Closes #1511.

This fixes LTO cache artifacts that could collide because cache filenames used only the first seven hex characters of the LTO symbol hash. It also hardens FFT metadata sidecar handling so missing, invalid, or stale metadata is treated as a cache miss and invalid sidecars are replaced after a successful rebuild.

The cache key stays short enough for generated filenames while making accidental collisions much less likely. Replacing invalid metadata after rebuild prevents each new process from recompiling against the same stale sidecar.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `cache=$(mktemp -d /tmp/warp-cache-kernel-cache-amend.XXXXXX); WARP_CACHE_PATH="$cache" WARP_CACHE_ROOT="$cache" uv run warp/tests/test_kernel_cache.py`
- `cache=$(mktemp -d /tmp/warp-cache-precommit-amend.XXXXXX); WARP_CACHE_PATH="$cache" WARP_CACHE_ROOT="$cache" uvx pre-commit run --files CHANGELOG.md warp/_src/build.py warp/tests/test_kernel_cache.py`

## Bug fix

The original failure can be reproduced with two distinct LTO symbols that share the same seven-character SHA-256 prefix:

```text
fft_264_6_70_forward_5   -> d42bb65
fft_3605_35_70_forward_5 -> d42bb65
```

With the old cache key, both symbols could target the same `.lto` and `.meta` filenames. If the existing FFT `.meta` sidecar was corrupt or did not contain the requested symbol, Warp either raised during metadata lookup or rebuilt while leaving the bad sidecar in place for future processes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LTO cache reliability by preventing key collisions, detecting and healing invalid or missing cache metadata, and ensuring rebuilt artifacts replace corrupted sidecars for consistent reuse.

* **Documentation**
  * Updated changelog to document the cache fixes.

* **Tests**
  * Added tests for hash-collision scenarios, multiple cache-miss cases (invalid/missing/ill‑formed metadata), encoding issues, and automatic cache healing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->