### PR TITLE
Fix Tape scope end handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,9 @@
 - Fix CUDA BVH refit out-of-bounds access for single-node and packed-root
   trees ([GH-860](https://github.com/NVIDIA/warp/issues/860),
   [GH-1506](https://github.com/NVIDIA/warp/issues/1506)).
+- Fix `Tape.record_scope_end()` to raise a clear error for unmatched
+  scope ends and preserve nested non-empty tape visualization scopes
+  ([GH-1515](https://github.com/NVIDIA/warp/issues/1515)).
 
 ### Documentation
 

--- a/warp/_src/tape.py
+++ b/warp/_src/tape.py
@@ -194,7 +194,17 @@ class Tape:
         Args:
             remove_scope_if_empty (bool): If True, the scope will be removed if no kernel launches were recorded within it.
         """
-        if remove_scope_if_empty and self.scopes[-1][0] == len(self.launches):
+        open_scope_count = 0
+        for _, scope_name, _ in self.scopes:
+            if scope_name is None:
+                open_scope_count -= 1
+            else:
+                open_scope_count += 1
+
+        if open_scope_count == 0:
+            raise RuntimeError("Warp: Error, ended tape scope, but scope not present")
+
+        if remove_scope_if_empty and self.scopes[-1][1] is not None and self.scopes[-1][0] == len(self.launches):
             self.scopes = self.scopes[:-1]
         else:
             self.scopes.append((len(self.launches), None, None))

--- a/warp/tests/test_tape.py
+++ b/warp/tests/test_tape.py
@@ -303,6 +303,54 @@ def test_tape_visualize_subscript(test, device):
     test.assertIn("array: dtype=", dot_code)
 
 
+def test_tape_scope_end_without_matching_begin(test):
+    tape = wp.Tape()
+
+    with test.assertRaisesRegex(RuntimeError, "ended tape scope, but scope not present"):
+        tape.record_scope_end()
+
+
+def test_tape_scope_end_twice_raises(test):
+    tape = wp.Tape()
+
+    tape.record_scope_begin("scope")
+    tape.record_scope_end()
+
+    with test.assertRaisesRegex(RuntimeError, "ended tape scope, but scope not present"):
+        tape.record_scope_end()
+
+
+def test_tape_nested_nonempty_scope_markers(test):
+    tape = wp.Tape()
+
+    tape.record_scope_begin("outer")
+    tape.record_scope_begin("inner")
+    tape.launches.append(object())
+    tape.record_scope_end()
+    tape.record_scope_end()
+
+    test.assertEqual(
+        tape.scopes,
+        [
+            (0, "outer", {}),
+            (0, "inner", {}),
+            (1, None, None),
+            (1, None, None),
+        ],
+    )
+
+
+def test_tape_empty_nested_scope_markers_removed(test):
+    tape = wp.Tape()
+
+    tape.record_scope_begin("outer")
+    tape.record_scope_begin("inner")
+    tape.record_scope_end()
+    tape.record_scope_end()
+
+    test.assertEqual(tape.scopes, [])
+
+
 devices = get_test_devices()
 
 
@@ -312,6 +360,18 @@ class TestTape(unittest.TestCase):
             with wp.Tape():
                 with wp.Tape():
                     pass
+
+    def test_tape_scope_end_without_matching_begin(self):
+        test_tape_scope_end_without_matching_begin(self)
+
+    def test_tape_scope_end_twice_raises(self):
+        test_tape_scope_end_twice_raises(self)
+
+    def test_tape_nested_nonempty_scope_markers(self):
+        test_tape_nested_nonempty_scope_markers(self)
+
+    def test_tape_empty_nested_scope_markers_removed(self):
+        test_tape_empty_nested_scope_markers_removed(self)
 
 
 add_function_test(TestTape, "test_tape_mul_constant", test_tape_mul_constant, devices=devices)


### PR DESCRIPTION
## Description

Fixes `Tape.record_scope_end()` scope bookkeeping for unmatched and nested
scope-end calls. Previously, calling `record_scope_end()` without a matching
open scope leaked an `IndexError` from `self.scopes[-1]`. The empty-scope
cleanup path also removed the wrong marker when closing an outer non-empty
scope immediately after an inner scope.

The method now derives open-scope depth before ending a scope, raises a clear
Warp `RuntimeError` when no scope is open, and only removes empty scopes when
the last marker is an opening marker at the current launch count.

Closes #1515.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

```bash
WARP_CACHE_PATH=/tmp/warp-cache-ershi-tape-scope-validation-pr \
WARP_CACHE_ROOT=/tmp/warp-cache-ershi-tape-scope-validation-pr \
uv run warp/tests/test_tape.py

uvx pre-commit run --files CHANGELOG.md warp/_src/tape.py warp/tests/test_tape.py
```

## Bug fix

```python
import warp as wp

tape = wp.Tape()
tape.record_scope_end()
```

Without this change, the call raises `IndexError: list index out of range`.
With this change, it raises a clear Warp `RuntimeError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scope-tracking now raises a clear error when scope-end markers are unmatched while preserving nested non-empty scope visualization.

* **Tests**
  * Added tests that validate error behavior for unmatched scope ends and correct handling/removal of nested scope markers.

* **Documentation**
  * Updated the unreleased changelog entry to document the scope-end error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->