### PR TITLE
Harden line directive filenames

### DIFF
--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -31,6 +31,28 @@ _wp_module_name_ = "warp.codegen"
 options = {}
 
 
+def _escape_line_directive_filename(filename: str) -> str:
+    """Return ``filename`` escaped for the quoted filename field of a C/CUDA ``#line`` directive."""
+
+    escaped = []
+    for c in filename.replace("\\", "/"):
+        if c == '"':
+            escaped.append('\\"')
+        elif c == "\n":
+            escaped.append("\\n")
+        elif c == "\r":
+            escaped.append("\\r")
+        elif c == "\t":
+            escaped.append("\\t")
+        elif ord(c) < 32 or ord(c) == 127:
+            # Use fixed-width octal so following filename characters cannot be consumed by the escape.
+            escaped.append(f"\\{ord(c):03o}")
+        else:
+            escaped.append(c)
+
+    return "".join(escaped)
+
+
 def get_node_name_safe(node):
     """Safely get a string representation of an AST node for error messages.
 
@@ -1446,9 +1468,8 @@ class Adjoint:
             is_comment = statement.strip().startswith("//")
             if not is_comment:
                 line = relative_lineno + adj.fun_lineno
-                # Convert backslashes to forward slashes for CUDA compatibility
-                normalized_path = adj.filename.replace("\\", "/")
-                return f'#line {line} "{normalized_path}"'
+                escaped_path = _escape_line_directive_filename(adj.filename)
+                return f'#line {line} "{escaped_path}"'
         return None
 
     def add_forward(adj, statement: str, replay: str | None = None, skip_replay: builtins.bool = False) -> None:

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ast
+import linecache
 import sys
 import unittest
 
@@ -1414,6 +1415,39 @@ def test_rebind_function_local_to_value_errors(test, device):
 
 
 class TestCodeGen(unittest.TestCase):
+    def _make_adjoint_with_filename(self, filename):
+        source = "def kernel_fn(x: int):\n    y = x + 1\n    return y\n"
+        linecache.cache[filename] = (len(source), None, source.splitlines(True), filename)
+        namespace = {}
+        try:
+            exec(compile(source, filename, "exec"), namespace)
+            adj = wp._src.codegen.Adjoint(namespace["kernel_fn"])
+            adj.builder_options = {"lineinfo": True, "line_directives": True, "mode": "release"}
+            return adj
+        finally:
+            linecache.cache.pop(filename, None)
+
+    def test_line_directive_escapes_filename(self):
+        filename = '/tmp/warp_poc"\n\r\t\x00\x1f\x7fint injected_from_filename;\n//.py'
+        adj = self._make_adjoint_with_filename("/tmp/warp_poc.py")
+        adj.filename = filename
+
+        directive = adj.get_line_directive("int x;", 0)
+
+        self.assertEqual(
+            directive,
+            '#line 1 "/tmp/warp_poc\\"\\n\\r\\t\\000\\037\\177int injected_from_filename;\\n//.py"',
+        )
+        self.assertEqual(directive.count("\n"), 0)
+
+    def test_line_directive_preserves_normalized_path(self):
+        filename = "C:\\warp\\kernels\\example.py"
+        adj = self._make_adjoint_with_filename(filename)
+
+        directive = adj.get_line_directive("int x;", 0)
+
+        self.assertEqual(directive, '#line 1 "C:/warp/kernels/example.py"')
+
     def test_extract_lambda_source_parenthesized_multiline_body(self):
         from warp._src.codegen import Adjoint  # noqa: PLC0415
 


### PR DESCRIPTION
## Description

Escape source filenames before inserting them into generated C/CUDA `#line` directives. Previously Warp only normalized backslashes before interpolating the filename into a quoted preprocessor token, so quotes or control characters in a filename could break out of the directive and add generated source text.

This keeps the existing backslash-to-forward-slash normalization, preserves the existing `lineinfo` / debug-mode / `line_directives` emission gates, and adds focused coverage for quotes, LF, CR, tab, NUL, other control characters, DEL, and Windows-style paths.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `WARP_CACHE_PATH=/tmp/warp-cache-line-directive-commit WARP_CACHE_ROOT=/tmp/warp-cache-line-directive-commit uv run warp/tests/test_codegen.py TestCodeGen.test_line_directive_escapes_filename TestCodeGen.test_line_directive_preserves_normalized_path`
- `WARP_CACHE_PATH=/tmp/warp-cache-line-directive-final WARP_CACHE_ROOT=/tmp/warp-cache-line-directive-final uv run warp/tests/test_codegen.py`
- `uvx pre-commit run --files warp/_src/codegen.py warp/tests/test_codegen.py`

## Bug fix

Without this PR, a filename containing a quote and newline can terminate the `#line` filename token and inject additional generated source lines:

```python
import linecache

import warp as wp
from warp._src.codegen import Adjoint

filename = '/tmp/warp_poc"\nint injected_from_filename;\n//.py'
source = "def kernel_fn(x: int):\n    y = x + 1\n    return y\n"
linecache.cache[filename] = (len(source), None, source.splitlines(True), filename)

namespace = {}
exec(compile(source, filename, "exec"), namespace)
adj = Adjoint(namespace["kernel_fn"])
adj.builder_options = {"lineinfo": True, "line_directives": True, "mode": "release"}

print(adj.get_line_directive("int x;", 0))
```

Before this PR, the printed directive contains physical newlines from the filename. With this PR, those characters are escaped inside the quoted filename token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of code generation by enhancing filename handling in compiler directives to properly escape special characters (quotes, newlines, tabs, control characters) and normalize Windows-style paths, preventing potential compilation issues.

* **Tests**
  * Added tests for filename escaping and path normalization in code generation directives to ensure edge cases are properly handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->