### PR TITLE
Validate struct array field assignments

### DIFF
--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -339,10 +339,13 @@ def _make_struct_field_setter(cls, field: str, var_type: type):
             setattr(inst._ctype, field, array_t())
         else:
             # wp.array
-            assert isinstance(value, array)
-            assert types_equal(value.dtype, var_type.dtype), (
-                f"assign to struct member variable {field} failed, expected type {type_repr(var_type.dtype)}, got type {type_repr(value.dtype)}"
-            )
+            if not isinstance(value, array):
+                raise TypeError(f"Struct field '{field}' expects a Warp array, got {type(value).__name__}")
+            if not types_equal(value.dtype, var_type.dtype):
+                raise TypeError(
+                    f"Assign to struct member variable {field} failed, expected type {type_repr(var_type.dtype)}, "
+                    f"got type {type_repr(value.dtype)}"
+                )
             setattr(inst._ctype, field, value.__ctype__())
 
             # workaround to prevent gradient buffers being garbage collected
@@ -357,10 +360,13 @@ def _make_struct_field_setter(cls, field: str, var_type: type):
         if value is None:
             setattr(inst._ctype, field, var_type.__ctype__())
         else:
-            assert isinstance(value, indexedarray)
-            assert types_equal(value.dtype, var_type.dtype), (
-                f"assign to struct member variable {field} failed, expected type {type_repr(var_type.dtype)}, got type {type_repr(value.dtype)}"
-            )
+            if not isinstance(value, indexedarray):
+                raise TypeError(f"Struct field '{field}' expects a Warp indexed array, got {type(value).__name__}")
+            if not types_equal(value.dtype, var_type.dtype):
+                raise TypeError(
+                    f"Assign to struct member variable {field} failed, expected type {type_repr(var_type.dtype)}, "
+                    f"got type {type_repr(value.dtype)}"
+                )
             setattr(inst._ctype, field, value.__ctype__())
 
         # workaround to prevent gradient buffers being garbage collected

--- a/warp/tests/test_struct.py
+++ b/warp/tests/test_struct.py
@@ -839,6 +839,40 @@ class TestStruct(unittest.TestCase):
         self.assertIsInstance(s.i32, int)
         self.assertIsInstance(s.f64, float)
 
+    def test_struct_array_field_assignment_validation(self):
+        @wp.struct
+        class ArrayFieldStruct:
+            values: wp.array(dtype=wp.int32)
+
+        @wp.struct
+        class IndexedArrayFieldStruct:
+            values: wp.indexedarray(dtype=wp.int32)
+
+        wrong_dtype_array = wp.array([1.0], dtype=wp.float32)
+        indices = wp.array([0], dtype=wp.int32)
+        wrong_dtype_indexedarray = wp.indexedarray1d(wrong_dtype_array, [indices])
+
+        cases = (
+            (ArrayFieldStruct, "array", wrong_dtype_array, r"expects a Warp array, got list"),
+            (
+                IndexedArrayFieldStruct,
+                "indexedarray",
+                wrong_dtype_indexedarray,
+                r"expects a Warp indexed array, got list",
+            ),
+        )
+
+        for struct_type, case_name, wrong_dtype, non_array_error in cases:
+            with self.subTest(case_name=case_name, error="non_array"):
+                s = struct_type()
+                with self.assertRaisesRegex(TypeError, non_array_error):
+                    s.values = [1, 2, 3]
+
+            with self.subTest(case_name=case_name, error="wrong_dtype"):
+                s = struct_type()
+                with self.assertRaisesRegex(TypeError, r"expected type int32, got type float32"):
+                    s.values = wrong_dtype
+
     def test_nested_vec_assignment(self):
         v = VecStruct()
         v.value[0] = 1.0


### PR DESCRIPTION
## Description

Struct array field setters validated assigned values with `assert`.
Optimized Python removes those checks, so invalid values could reach ctype
storage or surface as misleading attribute errors.

This PR replaces those assert-only checks with explicit `TypeError` validation
for `wp.array` and `wp.indexedarray` fields on `@wp.struct` classes.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `uv run --extra dev -m unittest warp.tests.test_struct.TestStruct.test_struct_array_field_assignment_validation`
- `uv run --extra dev python -O -m unittest warp.tests.test_struct.TestStruct.test_struct_array_field_assignment_validation`

## Bug fix

Without this PR, running the setter path under optimized Python can bypass the
array and dtype checks:

```python
import warp as wp


@wp.struct
class S:
    values: wp.array(dtype=wp.int32)


s = S()
s.values = wp.array([1.0], dtype=wp.float32)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced struct field validation for array-based assignments. Now provides explicit error messages when assigning incompatible types or mismatched data types to array or indexed array fields, replacing less informative assertion failures.

* **Tests**
  * Added comprehensive test coverage for struct array field assignment validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->