### PR TITLE
Fix struct array grad keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,9 @@
 - Fix CUDA BVH refit out-of-bounds access for single-node and packed-root
   trees ([GH-860](https://github.com/NVIDIA/warp/issues/860),
   [GH-1506](https://github.com/NVIDIA/warp/issues/1506)).
+- Fix stale gradient keepalive references when replacing a `@wp.struct`
+  plain-array field with `None` or a non-gradient array
+  ([GH-1520](https://github.com/NVIDIA/warp/issues/1520)).
 
 ### Documentation
 

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -345,11 +345,15 @@ def _make_struct_field_setter(cls, field: str, var_type: type):
             )
             setattr(inst._ctype, field, value.__ctype__())
 
-            # workaround to prevent gradient buffers being garbage collected
-            # since users can do struct.array.requires_grad = False the gradient array
-            # would be collected while the struct ctype still holds a reference to it
-            if value.requires_grad:
-                cls.__setattr__(inst, "_" + field + "_grad", value.grad)
+        # workaround to prevent gradient buffers being garbage collected
+        # since users can do struct.array.requires_grad = False the gradient array
+        # would be collected while the struct ctype still holds a reference to it
+        grad_attr = "_" + field + "_grad"
+        if value is not None and value.requires_grad:
+            cls.__setattr__(inst, grad_attr, value.grad)
+        else:
+            # clear any previous keepalive
+            cls.__setattr__(inst, grad_attr, None)
 
         cls.__setattr__(inst, field, value)
 

--- a/warp/tests/test_struct.py
+++ b/warp/tests/test_struct.py
@@ -3,6 +3,7 @@
 
 import gc  # Added for garbage collection tests
 import unittest
+import weakref
 from typing import Any
 
 import numpy as np
@@ -784,6 +785,32 @@ def test_struct_array_gc_requires_grad_toggle(test, device):
     tape.backward(loss=loss_wp)
 
 
+def test_struct_array_gc_replacement_clears_grad_keepalive(test, device):
+    """
+    Tests that replacing a grad-tracked array in a struct releases the old
+    gradient keepalive when the new field value cannot reference that gradient.
+    """
+    wp.init()
+
+    for replacement in ("none", "non_grad_array"):
+        with test.subTest(replacement=replacement):
+            s = StructWithArray()
+            old_array = wp.array([1.0, 2.0, 3.0], dtype=float, device=device, requires_grad=True)
+            old_grad_ref = weakref.ref(old_array.grad)
+            s.data = old_array
+            del old_array
+
+            if replacement == "none":
+                s.data = None
+            else:
+                s.data = wp.array([4.0, 5.0, 6.0], dtype=float, device=device)
+
+            gc.collect()
+
+            test.assertIsNone(getattr(s, "_data_grad", None))
+            test.assertIsNone(old_grad_ref())
+
+
 class TestStruct(unittest.TestCase):
     # check structs default initialized in Python correctly
     def test_struct_default_attributes_python(self):
@@ -922,6 +949,12 @@ add_kernel_test(
 add_function_test(TestStruct, "test_struct_array_hash", test_struct_array_hash, devices=None)
 add_function_test(
     TestStruct, "test_struct_array_gc_requires_grad_toggle", test_struct_array_gc_requires_grad_toggle, devices=devices
+)
+add_function_test(
+    TestStruct,
+    "test_struct_array_gc_replacement_clears_grad_keepalive",
+    test_struct_array_gc_replacement_clears_grad_keepalive,
+    devices=devices,
 )
 add_function_test(
     TestStruct, "test_struct_array_gc_direct_assignment", test_struct_array_gc_direct_assignment, devices=devices


### PR DESCRIPTION
## Description

Fix stale `_field_grad` keepalive references when replacing a `@wp.struct` plain-array field with `None` or a non-gradient array.

Plain array fields already keep their gradient arrays alive when assigned a `requires_grad=True` array. That is needed for the `struct.field.requires_grad = False` toggle case because the setter does not run and the struct C field can still hold the old gradient pointer. Replacement assignment is different: the setter runs and rewrites the struct C field, so keeping the previous gradient array only retains stale memory.

This change clears the keepalive whenever the replacement value cannot reference a gradient array, matching the indexed-array field behavior while preserving the toggle case.

Closes #1520.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `WARP_CACHE_PATH=/tmp/warp-cache-1520-publish-cpu-$$ WARP_CACHE_ROOT=/tmp/warp-cache-1520-publish-cpu-$$ uv run warp/tests/test_struct.py TestStruct.test_struct_array_gc_replacement_clears_grad_keepalive_cpu TestStruct.test_struct_array_gc_requires_grad_toggle_cpu TestStruct.test_struct_array_gc_direct_assignment_cpu`
- `WARP_CACHE_PATH=/tmp/warp-cache-1520-publish-cuda-$$ WARP_CACHE_ROOT=/tmp/warp-cache-1520-publish-cuda-$$ uv run warp/tests/test_struct.py TestStruct.test_struct_array_gc_replacement_clears_grad_keepalive_cuda_0 TestStruct.test_struct_array_gc_replacement_clears_grad_keepalive_cuda_1`
- `uvx pre-commit run --files CHANGELOG.md warp/_src/codegen.py warp/tests/test_struct.py`

## Bug fix

```python
import gc
import weakref

import warp as wp


@wp.struct
class StructWithArray:
    data: wp.array(dtype=float)


wp.init()

for replacement in ("none", "non_grad_array"):
    s = StructWithArray()
    old_array = wp.array([1.0, 2.0, 3.0], dtype=float, device="cpu", requires_grad=True)
    old_grad_ref = weakref.ref(old_array.grad)

    s.data = old_array
    del old_array

    if replacement == "none":
        s.data = None
    else:
        s.data = wp.array([4.0, 5.0, 6.0], dtype=float, device="cpu")

    gc.collect()

    assert getattr(s, "_data_grad", None) is None
    assert old_grad_ref() is None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale gradient keepalive references when struct array fields are replaced with `None` or non-gradient arrays (GH-1520).

* **Tests**
  * Added garbage collection regression test to ensure proper cleanup when replacing gradient-tracked arrays in structs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->