### PR TITLE
Fix byte fill graph capture (GH-1525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,9 @@
   scope ends and preserve nested non-empty tape visualization scopes
   ([GH-1515](https://github.com/NVIDIA/warp/issues/1515)).
 
+- Fix CUDA graph capture for contiguous `wp.bool`, `wp.int8`, and `wp.uint8`
+  `array.fill_()` calls ([GH-1525](https://github.com/NVIDIA/warp/issues/1525)).
+
 ### Documentation
 
 - Remove stale tutorial notebooks from the repository. The maintained tutorials remain linked from the

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -1357,7 +1357,7 @@ void wp_memtile_device(void* context, void* dst, const void* src, size_t srcsize
         int16_t value = *reinterpret_cast<const int16_t*>(src);
         wp_launch_device(WP_CURRENT_CONTEXT, memtile_value_kernel, n, (p, value, n));
     } else if (srcsize == 1) {
-        check_cuda(cudaMemset(dst, *reinterpret_cast<const int8_t*>(src), n));
+        wp_memset_device(context, dst, *reinterpret_cast<const int8_t*>(src), n, WP_CURRENT_STREAM);
     } else if (!launch_memtile_kernel_by_value(dst, src, srcsize, n)) {
         // generic fallback for values too large to pass through kernel args
         void* value_devptr = NULL;  // fill value in device memory

--- a/warp/tests/cuda/test_array_fill_capture.py
+++ b/warp/tests/cuda/test_array_fill_capture.py
@@ -108,6 +108,30 @@ def test_contiguous_vec3_fill_forked_stream_capture(test, device):
         np.testing.assert_array_equal(arr.numpy(), expected)
 
 
+def test_contiguous_byte_fill_capture(test, device):
+    """Contiguous 1-byte fills through ``device.memtile`` must be capturable."""
+    cases = (
+        (wp.bool, True, np.bool_),
+        (wp.int8, -3, np.int8),
+        (wp.uint8, 7, np.uint8),
+    )
+
+    with wp.ScopedDevice(device):
+        for dtype, value, np_type in cases:
+            wp.synchronize_device()
+
+            arr = wp.zeros(8, dtype=dtype, device=device)
+            test.assertTrue(arr.is_contiguous)
+
+            with wp.ScopedCapture(device=device, force_module_load=False) as capture:
+                arr.fill_(value)
+
+            wp.capture_launch(capture.graph)
+            wp.synchronize_device(device)
+
+            np.testing.assert_array_equal(arr.numpy(), np.full(arr.shape, value, dtype=np_type))
+
+
 def test_array_fill_oversized_value_fallback(test, device):
     """Fill values larger than the largest inline bucket use the ``_devptr`` fallback path correctly.
 
@@ -160,6 +184,13 @@ add_function_test(
     TestArrayFillCapture,
     "test_contiguous_vec3_fill_forked_stream_capture",
     test_contiguous_vec3_fill_forked_stream_capture,
+    devices=devices,
+    check_output=False,
+)
+add_function_test(
+    TestArrayFillCapture,
+    "test_contiguous_byte_fill_capture",
+    test_contiguous_byte_fill_capture,
     devices=devices,
     check_output=False,
 )


### PR DESCRIPTION
## Description

Closes #1525.

This PR fixes CUDA graph capture for contiguous one-byte `array.fill_()` calls. The `wp_memtile_device()` fast path for `srcsize == 1` used synchronous `cudaMemset`, which can make the legacy stream depend on the capturing stream and invalidate CUDA graph capture. The branch now routes that path through Warp's current-stream memset helper.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Test plan

- `uv run build_lib.py`
- `uv run python -m unittest warp.tests.cuda.test_array_fill_capture`
- `uvx pre-commit run --files CHANGELOG.md warp/native/warp.cu warp/tests/cuda/test_array_fill_capture.py`

## Bug fix

Without this PR, the `wp.bool` case fails during `capture_end()` with CUDA error 906 from `wp_memtile_device`.

```python
import warp as wp

x = wp.zeros(10, dtype=wp.bool, device="cuda")

with wp.ScopedCapture(device="cuda") as capture:
    x.fill_(True)

wp.capture_launch(capture.graph)
wp.synchronize_device("cuda")
print(x.numpy())
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CUDA graph capture compatibility with `wp.array.fill_()` for contiguous bool, int8, and uint8 arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->