### PR TITLE
Surface CUDA launch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
   instead of an internal `AttributeError` ([GH-1487](https://github.com/NVIDIA/warp/issues/1487)).
 - Fix stale gradient keepalive references when replacing a `@wp.struct` plain-array field with `None` or a
   non-gradient array ([GH-1520](https://github.com/NVIDIA/warp/issues/1520)).
+- Fix CUDA kernel launch failures to raise a Python `RuntimeError` instead of only logging native CUDA stderr and
+  continuing with stale outputs or gradients ([GH-1535](https://github.com/NVIDIA/warp/issues/1535)).
 
 ### Documentation
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -8580,6 +8580,11 @@ def invoke(kernel, hooks, params: Sequence[Any], adjoint: bool):
         hooks.backward(ctypes.byref(params[0]), ctypes.byref(args), ctypes.byref(adj_args))
 
 
+def _raise_cuda_launch_error(kernel: Kernel, device: Device) -> None:
+    """Raise a RuntimeError for the current CUDA launch failure."""
+    raise RuntimeError(f"Error launching kernel: {kernel.key} on device {device}: {runtime.get_error_string()}")
+
+
 class Launch:
     """Represent all data required for a kernel launch so that launches can be replayed quickly.
 
@@ -8786,7 +8791,7 @@ class Launch:
                     graph._retain_module_exec(self.module_exec)
 
             if self.adjoint:
-                runtime.core.wp_cuda_launch_kernel(
+                if runtime.core.wp_cuda_launch_kernel(
                     self.device.context,
                     self.hooks.backward,
                     self.bounds.size,
@@ -8796,9 +8801,10 @@ class Launch:
                     self.params_addr,
                     stream.cuda_stream,
                     None,  # apic_info: replayed launches don't re-record
-                )
+                ):
+                    _raise_cuda_launch_error(self.kernel, self.device)
             else:
-                runtime.core.wp_cuda_launch_kernel(
+                if runtime.core.wp_cuda_launch_kernel(
                     self.device.context,
                     self.hooks.forward,
                     self.bounds.size,
@@ -8808,7 +8814,8 @@ class Launch:
                     self.params_addr,
                     stream.cuda_stream,
                     None,  # apic_info: replayed launches don't re-record
-                )
+                ):
+                    _raise_cuda_launch_error(self.kernel, self.device)
 
 
 def _canonicalize_dim(dim: int | Sequence[int]) -> tuple[int, ...]:
@@ -9127,7 +9134,7 @@ def launch(
                             "Backward kernel launches are not supported during APIC graph capture. "
                             "Use wp.Tape outside of capture scope instead."
                         )
-                    runtime.core.wp_cuda_launch_kernel(
+                    if runtime.core.wp_cuda_launch_kernel(
                         device.context,
                         hooks.backward,
                         bounds.size,
@@ -9137,7 +9144,8 @@ def launch(
                         kernel_params,
                         stream.cuda_stream,
                         None,
-                    )
+                    ):
+                        _raise_cuda_launch_error(kernel, device)
 
             else:
                 if hooks.forward is None:
@@ -9170,7 +9178,7 @@ def launch(
                             False,
                         )
                         apic_info_ptr = ctypes.byref(apic_info)
-                    runtime.core.wp_cuda_launch_kernel(
+                    if runtime.core.wp_cuda_launch_kernel(
                         device.context,
                         hooks.forward,
                         bounds.size,
@@ -9180,7 +9188,8 @@ def launch(
                         kernel_params,
                         stream.cuda_stream,
                         apic_info_ptr,
-                    )
+                    ):
+                        _raise_cuda_launch_error(kernel, device)
 
             try:
                 runtime.verify_cuda_device(device)

--- a/warp/_src/jax/ffi.py
+++ b/warp/_src/jax/ffi.py
@@ -451,7 +451,7 @@ class FfiKernel:
                 assert hooks.forward, "Failed to find kernel entry point"
 
                 # launch the kernel
-                wp._src.context.runtime.core.wp_cuda_launch_kernel(
+                if wp._src.context.runtime.core.wp_cuda_launch_kernel(
                     device.context,
                     hooks.forward,
                     launch_bounds.size,
@@ -461,7 +461,11 @@ class FfiKernel:
                     kernel_params,
                     stream,
                     None,  # apic_info
-                )
+                ):
+                    raise RuntimeError(
+                        f"Error launching kernel: {self.kernel.key} on device {device}: "
+                        f"{wp._src.context.runtime.get_error_string()}"
+                    )
 
         except Exception as e:
             print(traceback.format_exc())

--- a/warp/native/apic.cu
+++ b/warp/native/apic.cu
@@ -372,13 +372,17 @@ static bool apic_rebuild_cuda_graph(APICGraph* graph, CUstream stream)
             // Replay via the same wp_cuda_launch_kernel that captured this op.
             // apic_info=nullptr is safe: g_apic_state is null during replay, so
             // the recording branch in wp_cuda_launch_kernel is a no-op.
-            wp_cuda_launch_kernel(
+            size_t launch_result = wp_cuda_launch_kernel(
                 graph->cuda_context, kernel, rec->dim, rec->max_blocks, rec->block_dim, rec->smem_bytes, args.data(),
                 stream, /*apic_info=*/nullptr
             );
 
             for (uint8_t* p : arg_storage)
                 delete[] p;
+            if (launch_result) {
+                success = false;
+                break;
+            }
             break;
         }
 

--- a/warp/tests/test_launch.py
+++ b/warp/tests/test_launch.py
@@ -48,6 +48,11 @@ def square_kernel(input: wp.array(dtype=float), output: wp.array(dtype=float)):
     output[i] = input[i] * input[i]
 
 
+@wp.kernel
+def noop_kernel():
+    tid = wp.tid()
+
+
 def test1d(test, device):
     a = np.arange(0, dim_x).reshape(dim_x)
 
@@ -400,6 +405,12 @@ def kernel_single_tuple_bound(x: wp.array(dtype=float)):
     x[tid] = x[tid] * 2.0
 
 
+@wp.kernel(launch_bounds=256)
+def bounded_square_kernel(data: wp.array(dtype=float), output: wp.array(dtype=float)):
+    i = wp.tid()
+    output[i] = data[i] * data[i]
+
+
 def test_launch_bounds_none(test, device):
     """Test kernel without launch_bounds"""
     n = 1024
@@ -436,7 +447,61 @@ def test_launch_bounds_single_tuple(test, device):
     assert_np_equal(x.numpy(), np.full(n, 2.0, dtype=np.float32))
 
 
+def test_launch_device_block_dim_failure(test, device):
+    """Raise when CUDA rejects an oversized launch block.
+
+    Protects users from continuing after native stderr with kernel outputs left unchanged.
+    """
+    with test.assertRaisesRegex(RuntimeError, r"Error launching kernel: .*noop_kernel.*Warp CUDA error"):
+        wp.launch(noop_kernel, dim=1, block_dim=2048, device=device)
+
+
+def test_launch_bounds_block_dim_failure(test, device):
+    """Raise when CUDA rejects a launch-bounds violation.
+
+    Protects users from silently skipping kernels whose outputs feed later simulation stages.
+    """
+    x = wp.ones(1, dtype=float, device=device)
+
+    with test.assertRaisesRegex(RuntimeError, r"Error launching kernel: .*kernel_single_bound.*Warp CUDA error"):
+        wp.launch(kernel_single_bound, dim=1, inputs=[x], block_dim=512, device=device)
+
+
+def test_launch_cmd_block_dim_failure(test, device):
+    """Raise when recorded launches hit CUDA launch errors.
+
+    Protects recorded command replay from returning normally with stale outputs.
+    """
+    x = wp.ones(1, dtype=float, device=device)
+    cmd = wp.launch(kernel_single_bound, dim=1, inputs=[x], block_dim=512, device=device, record_cmd=True)
+
+    with test.assertRaisesRegex(RuntimeError, r"Error launching kernel: .*kernel_single_bound.*Warp CUDA error"):
+        cmd.launch()
+
+
+def test_launch_adjoint_block_dim_failure(test, device):
+    """Raise when adjoint launches hit CUDA launch errors.
+
+    Protects differentiable simulations from using missing or partial gradients.
+    """
+    input_arr = wp.array([1.0], dtype=float, requires_grad=True, device=device)
+    output_arr = wp.empty_like(input_arr)
+    output_arr.grad.fill_(1.0)
+
+    with test.assertRaisesRegex(RuntimeError, r"Error launching kernel: .*bounded_square_kernel.*Warp CUDA error"):
+        wp.launch(
+            bounded_square_kernel,
+            dim=input_arr.size,
+            inputs=[input_arr, output_arr],
+            adj_inputs=[None, None],
+            adjoint=True,
+            block_dim=512,
+            device=device,
+        )
+
+
 devices = get_test_devices()
+cuda_devices = get_cuda_test_devices()
 
 
 class TestLaunch(unittest.TestCase):
@@ -462,6 +527,18 @@ add_function_test(TestLaunch, "test_launch_bounds_none", test_launch_bounds_none
 add_function_test(TestLaunch, "test_launch_bounds_single", test_launch_bounds_single, devices=devices)
 add_function_test(TestLaunch, "test_launch_bounds_tuple", test_launch_bounds_tuple, devices=devices)
 add_function_test(TestLaunch, "test_launch_bounds_single_tuple", test_launch_bounds_single_tuple, devices=devices)
+add_function_test(
+    TestLaunch, "test_launch_device_block_dim_failure", test_launch_device_block_dim_failure, devices=cuda_devices
+)
+add_function_test(
+    TestLaunch, "test_launch_bounds_block_dim_failure", test_launch_bounds_block_dim_failure, devices=cuda_devices
+)
+add_function_test(
+    TestLaunch, "test_launch_cmd_block_dim_failure", test_launch_cmd_block_dim_failure, devices=cuda_devices
+)
+add_function_test(
+    TestLaunch, "test_launch_adjoint_block_dim_failure", test_launch_adjoint_block_dim_failure, devices=cuda_devices
+)
 
 
 if __name__ == "__main__":

--- a/warp/tests/test_tape.py
+++ b/warp/tests/test_tape.py
@@ -303,7 +303,29 @@ def test_tape_visualize_subscript(test, device):
     test.assertIn("array: dtype=", dot_code)
 
 
+def test_tape_backward_cuda_launch_failure(test, device):
+    """Raise when Tape backward hits CUDA launch errors.
+
+    Corrupt the recorded backward launch block size to reproduce the stale-gradient failure mode.
+    Protects ``Tape.backward()`` from returning after a failed replay with stale or missing gradients.
+    """
+    x = wp.array([1.0], dtype=wp.float32, device=device, requires_grad=True)
+    y = wp.empty_like(x, requires_grad=True)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(kernel=mul_constant, dim=x.size, inputs=[x], outputs=[y], block_dim=256, device=device)
+
+    launch = tape.launches[0]
+    test.assertEqual(len(launch), 8)
+    launch[6] = 2048  # block_dim
+
+    with test.assertRaisesRegex(RuntimeError, r"Error launching kernel: .*mul_constant.*Warp CUDA error"):
+        tape.backward(grads={y: wp.ones_like(y)})
+
+
 devices = get_test_devices()
+cuda_devices = get_cuda_test_devices()
 
 
 class TestTape(unittest.TestCase):
@@ -367,6 +389,9 @@ add_function_test(TestTape, "test_tape_visualize", test_tape_visualize, devices=
 add_function_test(TestTape, "test_tape_struct_subscript", test_tape_struct_subscript, devices=devices)
 add_function_test(TestTape, "test_tape_nested_struct_subscript", test_tape_nested_struct_subscript, devices=devices)
 add_function_test(TestTape, "test_tape_visualize_subscript", test_tape_visualize_subscript, devices=devices)
+add_function_test(
+    TestTape, "test_tape_backward_cuda_launch_failure", test_tape_backward_cuda_launch_failure, devices=cuda_devices
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Surface CUDA kernel launch failures as Python `RuntimeError` exceptions.
Closes #1535.

CUDA can reject a launch synchronously from `cuLaunchKernel()`, but the Python launch paths were ignoring the
`wp_cuda_launch_kernel()` return value. That left users with native stderr only, while Python code could continue with
stale outputs or gradients.

This PR checks the existing native return value without adding synchronization or an extra CUDA query on the hot path.

## Changes

- Raise `RuntimeError` when CUDA launch rejection is reported from direct `wp.launch()` forward and adjoint paths.
- Raise the same error from recorded `Launch.launch()` replay.
- Return structured failure from the JAX FFI callback when launch rejection occurs.
- Propagate APIC loaded-graph replay failure if the rebuilt CUDA launch is rejected.
- Add CUDA regression tests for direct launches, `launch_bounds` violations, recorded commands, adjoint launches, and
  `Tape.backward()`.
- Add a changelog entry for the user-facing fix.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Rebuilt Warp after the native APIC change using `build_lib.py --quick`.
- Verified the new CUDA launch failure tests pass on both CUDA devices.
- Verified the `Tape.backward()` launch failure regression passes on both CUDA devices.
- Verified APIC loaded save/load replay still works for normal loaded graph launches.
- Ran pre-commit on the changed files.
- Verified the changelog diff after rebasing onto `upstream/main` contains only the intended `GH-1535` entry.

## Bug fix

Without this PR, a rejected launch can leave outputs unchanged while Python continues:

```python
import warp as wp

wp.init()
wp.config.verify_cuda = False
device = wp.get_device("cuda:0")


@wp.kernel
def write_value(out: wp.array[float], value: float):
    out[wp.tid()] = value


out = wp.array([-1.0], dtype=float, device=device)
wp.launch(write_value, dim=1, inputs=[out, 42.0], block_dim=2048, device=device)

print(float(out.numpy()[0]))  # -1.0, because CUDA rejected the launch.
```

The only immediate diagnostic was native stderr, e.g.:

```text
Warp CUDA error 1: invalid argument (in function wp_cuda_launch_kernel, .../warp/native/warp.cu:5229)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CUDA kernel launch failures now properly raise `RuntimeError` with detailed error messages instead of silently continuing with stale outputs or gradients.

* **Tests**
  * Added test coverage for CUDA kernel launch failures, including oversized block dimensions, launch bounds violations, and recorded/adjoint launch error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->