### PR TITLE
Infer wp.array DType from argument in constructor

### DIFF
--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -1724,13 +1724,13 @@ class transformd:
 @over
 def zeros(
     shape: int | tuple[int, ...] | list[int] | None = None,
-    dtype: type = float,
+    dtype: type[DType] | None = None,
     device: DeviceLike = None,
     requires_grad: _builtins.bool = False,
     pinned: _builtins.bool = False,
     retain_grad: _builtins.bool = False,
     **kwargs,
-) -> array:
+) -> array[DType]:
     """Return a zero-initialized array."""
     ...
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -66,7 +66,7 @@ import warp.config
 from warp._src.codegen import WarpCodegenTypeError, synchronized
 from warp._src.logger import LOG_DEBUG, LOG_WARNING, get_logger, log_debug, log_error, log_info, log_warning
 from warp._src.texture import Texture1D, Texture2D, Texture3D, texture1d_t, texture2d_t, texture3d_t
-from warp._src.types import LAUNCH_MAX_DIMS, Array, LaunchBounds, launch_bounds_t, type_repr
+from warp._src.types import LAUNCH_MAX_DIMS, Array, DType, LaunchBounds, launch_bounds_t, type_repr
 
 _wp_module_name_ = "warp.context"
 
@@ -7647,13 +7647,13 @@ class RegisteredGLBuffer:
 
 def zeros(
     shape: int | tuple[int, ...] | list[int] | None = None,
-    dtype: type = float,
+    dtype: type[DType] | None = None,
     device: DeviceLike = None,
     requires_grad: bool = False,
     pinned: bool = False,
     retain_grad: bool = False,
     **kwargs,
-) -> warp.array:
+) -> warp.array[DType]:
     """Return a zero-initialized array.
 
     Args:
@@ -7667,6 +7667,8 @@ def zeros(
     Returns:
         A warp.array object representing the allocation
     """
+    if dtype is None:
+        dtype = float
 
     arr = empty(
         shape=shape,
@@ -7712,13 +7714,13 @@ def zeros_like(
 
 def ones(
     shape: int | tuple[int, ...] | list[int] | None = None,
-    dtype: type = float,
+    dtype: type[DType] | None = None,
     device: DeviceLike = None,
     requires_grad: bool = False,
     pinned: bool = False,
     retain_grad: bool = False,
     **kwargs,
-) -> warp.array:
+) -> warp.array[DType]:
     """Return a one-initialized array.
 
     Args:
@@ -7732,6 +7734,8 @@ def ones(
     Returns:
         A warp.array object representing the allocation
     """
+    if dtype is None:
+        dtype = float
 
     return full(
         shape=shape,
@@ -7771,13 +7775,13 @@ def ones_like(
 def full(
     shape: int | tuple[int, ...] | list[int] | None = None,
     value: Any = 0,
-    dtype: type | None = None,
+    dtype: type[DType] | None = None,
     device: DeviceLike = None,
     requires_grad: bool = False,
     pinned: bool = False,
     retain_grad: bool = False,
     **kwargs,
-) -> warp.array:
+) -> warp.array[DType]:
     """Return an array with all elements initialized to the given value.
 
     Args:
@@ -7902,13 +7906,13 @@ def clone(
 
 def empty(
     shape: int | tuple[int, ...] | list[int] | None = None,
-    dtype=float,
+    dtype: type[DType] | None = None,
     device: DeviceLike = None,
     requires_grad: bool = False,
     pinned: bool = False,
     retain_grad: bool = False,
     **kwargs,
-) -> warp.array:
+) -> warp.array[DType]:
     """Return an uninitialized array.
 
     Args:
@@ -7922,6 +7926,9 @@ def empty(
     Returns:
         A warp.array object representing the allocation
     """
+
+    if dtype is None:
+        dtype = float
 
     # backwards compatibility for case where users called wp.empty(n=length, ...)
     if "n" in kwargs:
@@ -7998,12 +8005,12 @@ def empty_like(
 
 def from_numpy(
     arr: np.ndarray,
-    dtype: type | None = None,
+    dtype: type[DType] | None = None,
     shape: Sequence[int] | None = None,
     device: DeviceLike | None = None,
     requires_grad: bool = False,
     retain_grad: bool = False,
-) -> warp.array:
+) -> warp.array[DType]:
     """Return a Warp array created from a NumPy array.
 
     Args:

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -3072,7 +3072,7 @@ class array(Array[DType, NDim]):
     def __init__(
         self,
         data: list | tuple | npt.NDArray | None = None,
-        dtype: Any = Any,
+        dtype: type[DType] = Any,
         shape: int | tuple[int, ...] | list[int] | None = None,
         strides: tuple[int, ...] | None = None,
         ptr: int | None = None,


### PR DESCRIPTION
## Description

_NOTE: this is a draft. Opening this PR for comments/feedback._

Currently, `wp.array` constructors & factories (zeros/ones/empty/full/from_numpy/...) infer the type as `array[Any, int]` because their signatures don't expose the dtype as a generic parameter.

For instance, notice how the `DType` of the `class array(Array[DType, NDim])` is always `Any`:

```python
a = wp.array([1, 2, 3], dtype=wp.int32)
reveal_type(a)
# output: array[Any, int]

f = wp.full(10, 7, dtype=wp.float32)
reveal_type(f)
# output: array[Any, int]
```

This causes `mypy` to complain when in strict mode: `error: Need type annotation for "a"  [var-annotated]`

To fix this, users must either explicitly set the type or ignore the error. Either fix is a workaround and imo suboptimal.

Here, I'm proposing to set the array's `DType` according to the `dtype` argument in the constructor. With this, the type is correctly set:

```python
a = wp.array([1, 2, 3], dtype=wp.int32)
reveal_type(a)
# output: array[int32, int]

f = wp.full(10, 7, dtype=wp.float32)
reveal_type(f)
# output: array[float32, int]
```

There are no open issues specifically describing this. This is somewhat of an extension to https://github.com/NVIDIA/warp/issues/549.

Is there interest in fixing this? If so, I'd update this MR to:
- add tests for this (potentially calling mypy to assert that the revealed types match the expectations), and,
- extend this pattern to other constructors (zeros_like/*_like, from_torch/paddle/jax/dlpack).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type annotations for array creation functions (`zeros`, `ones`, `empty`, `full`, `from_numpy`) with support for generic type parameters, enabling better type inference and IDE support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->