### PR TITLE
Pin Windows builds to VS 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2025
+          # CUDA 12.x and CUDA 13.0 reject the VS 2026 image.
+          - os: windows-2022
             platform: windows
             cuda-version: "12.9.1"
             artifact-name: build-artifact-windows-cuda12
             cuda-sub-packages: '["cudart", "nvcc", "nvrtc_dev", "nvjitlink"]'
             cuda-non-cuda-packages: ''
-          - os: windows-2025
+          - os: windows-2022
             platform: windows
             cuda-version: "13.0.2"
             artifact-name: build-artifact-windows-cuda13
@@ -136,7 +137,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2025
+          # CUDA 12.x and CUDA 13.0 reject the VS 2026 image.
+          - os: windows-2022
             platform: windows
             cuda-version: "13.0.2"
             cuda-sub-packages: '["cudart", "crt", "nvcc", "nvrtc_dev", "nvjitlink", "nvvm", "nvptxcompiler"]'


### PR DESCRIPTION
## Description

GitHub is migrating the `windows-2025` runner image to Visual Studio 2026. The Windows CUDA build jobs now run on `windows-2022` so they keep using a CUDA-supported MSVC toolchain.

CUDA 12.x rejects the VS 2026 image, and the CUDA 13.0 build used by this workflow rejects it as well. The CPU-only Windows test job remains on `windows-2025` so CI still covers that OS image where `nvcc` is not involved.

## Changes

- Pin Windows CUDA `build-warp` matrix entries to `windows-2022`.
- Pin the Windows CMake CUDA build matrix entry to `windows-2022`.
- Add a short workflow comment explaining the CUDA/VS 2026 compatibility reason.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Verified the failing workflow-label check caught all Windows CUDA build matrix entries still using `windows-2025` before the change.
- Verified the same check passes after the change, with the CPU-only Windows test matrix still on `windows-2025`.
- Ran `uvx pre-commit run --files .github/workflows/ci.yml`; all applicable hooks passed.
- Ran `git diff --check -- .github/workflows/ci.yml`; no whitespace issues were reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Updated CI configuration to improve build system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->