### PR TITLE
Pass MSVC preprocessor flag to nvcc

### DIFF
--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -588,6 +588,10 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str
             "-diag-suppress=221",  # suppress "floating-point value does not fit" warning from INFINITY macro in CUDA headers
         ]
 
+        if sys.platform == "win32":
+            # CCCL headers require MSVC's standard conforming preprocessor.
+            nvcc_opts.append("-Xcompiler /Zc:preprocessor")
+
         # Clang options
         clang_opts = [
             *clang_arch_flags,


### PR DESCRIPTION
## Description

Draft PR to exercise the GitHub Windows build workflows while fixing a Windows CUDA build failure seen with CUDA 13.2.

Building Warp on Windows with CUDA 13.2 fails immediately during `.cu` compilation. Every CUDA translation unit reports the same CCCL error from `cuda/std/__cccl/preprocessor.h`:

```text
fatal error C1189: #error: MSVC/cl.exe with traditional preprocessor is used.
This may lead to unexpected compilation errors.
Please switch to the standard conforming preprocessor by passing `/Zc:preprocessor` to cl.exe.
```

The failure is not caused by warning policy. CCCL emits an unconditional `#error` when it detects MSVC's traditional preprocessor, so changing warning flags or suppressing `-Werror`-style behavior would not help. Defining `CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING` would bypass the guard but leave MSVC on the legacy preprocessor path that CCCL is explicitly rejecting.

When `nvcc` invokes `cl.exe` as the Windows host compiler, it does not automatically forward `/Zc:preprocessor`. This PR forwards that flag through `-Xcompiler`, so the option is passed to `cl.exe` only and does not affect device compilation.

## Changes

- Add `-Xcompiler /Zc:preprocessor` to shared `nvcc_opts` for Windows CUDA builds.
- Keep the change unconditional for `sys.platform == "win32"` rather than gating on a CUDA Toolkit version.
- Add a short comment explaining that CCCL headers require MSVC's standard conforming preprocessor.

## Why this is safe

`/Zc:preprocessor` is supported by the MSVC toolchains Warp already accepts. Using the conforming preprocessor aligns MSVC behavior with the C/C++ standard and avoids carrying CUDA-version-specific build logic for a host compiler flag. Non-Windows platforms are unaffected by the `sys.platform == "win32"` guard.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Local validation was limited to Linux because the reported failure requires Windows, CUDA 13.2, and MSVC. The touched Python build file compiles, and the file-scoped pre-commit checks pass.

Commands run locally:

```bash
uv run python -m compileall warp/_src/build_dll.py
uvx pre-commit run --files warp/_src/build_dll.py
```

This draft PR is intentionally opened to run the GitHub Windows build workflows and verify the flag in the target CI environment.

## Bug fix

On Windows 11 with CUDA 13.2 and MSVC 19.51, building Warp without this PR fails during the first `.cu` compile, for example:

```text
nvcc.exe --std=c++17 -O3 ... -o warp\native/bvh.cu.warp.o -c warp\native/bvh.cu

cuda/std/__cccl/preprocessor.h(20): fatal error C1189: #error: MSVC/cl.exe with traditional preprocessor is used.
```

With this PR, Windows CUDA `nvcc` builds pass `/Zc:preprocessor` to `cl.exe` via `-Xcompiler`, satisfying the CCCL guard without suppressing it.

## New feature / enhancement

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows platform compilation issues to ensure proper preprocessing of dependencies during CUDA builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->