### PR TITLE
Fix wp.func script-scope capture (GH-1544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@
 - Fix unary minus on referenced 64-bit scalar constants, such as values declared with `wp.constant(wp.float64(...))`,
   being silently dropped when the constant appears as the leading operand of a multiply or divide expression, e.g.
   `-a * b` producing the wrong sign ([GH-1540](https://github.com/NVIDIA/warp/issues/1540)).
+- Fix parameterized `@wp.func(...)` decorators, such as `@wp.func(module="unique")`, in directly executed scripts to
+  register successfully instead of raising `AttributeError` during decoration
+  ([GH-1544](https://github.com/NVIDIA/warp/issues/1544)).
 
 ### Documentation
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -958,13 +958,17 @@ def func(
         :func:`warp.kernel` for defining kernels that can be launched on devices.
     """
 
+    frame = inspect.currentframe()
+    if frame is None or frame.f_back is None:
+        scope_locals = {}
+    else:
+        scope_locals = frame.f_back.f_locals
+
     def wrapper(f, *args, **kwargs):
         if name is None:
             key = warp._src.codegen.make_full_qualified_name(f)
         else:
             key = name
-
-        scope_locals = inspect.currentframe().f_back.f_back.f_locals
 
         if module is None:
             m = get_module(f.__module__)

--- a/warp/tests/test_func.py
+++ b/warp/tests/test_func.py
@@ -3,8 +3,11 @@
 
 import inspect
 import math
+import subprocess
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -615,6 +618,25 @@ class TestFunc(unittest.TestCase):
         self.assertIn("offsets", params)
         self.assertIn("row_count", params)
         self.assertIn("block_index", params)
+
+    def test_parameterized_func_decorator_script_scope(self):
+        """Verify @wp.func(module="unique") registers in directly executed scripts."""
+
+        script = """\
+import warp as wp
+
+@wp.func(module="unique")
+def f(x: float):
+    return x + 1.0
+"""
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            script_path = Path(temp_dir) / "repro_wp_func_unique.py"
+            script_path.write_text(script, encoding="utf-8")
+
+            result = subprocess.run([sys.executable, script_path], capture_output=True, text=True, check=False)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
 
 devices = get_test_devices()


### PR DESCRIPTION
## Description

Fix script-mode registration for parameterized `@wp.func(...)` decorators.
The decorator factory previously looked up caller locals when the wrapper ran,
which assumed two caller frames. Direct script execution only has one relevant
caller frame, so `@wp.func(module="unique")` could fail before registration.

Fixes #1544.

## Changes

- Capture the defining scope when `wp.func()` is invoked and reuse it for bare
  and parameterized decorator forms.
- Add a subprocess regression that executes the `@wp.func(module="unique")`
  direct-script repro from GH-1544.
- Update `CHANGELOG.md` under `Unreleased` for the user-facing fix
  ([GH-1544](https://github.com/NVIDIA/warp/issues/1544)).

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Ran the focused regression with a worktree-specific Warp cache:

```bash
WARP_CACHE_PATH=/tmp/warp-cache-warp-worktree-func-script-scope-pr \
WARP_CACHE_ROOT=/tmp/warp-cache-warp-worktree-func-script-scope-pr \
uv run warp/tests/test_func.py TestFunc.test_parameterized_func_decorator_script_scope
```

The test passed and verified that direct-script registration succeeds for
`@wp.func(module="unique")`.

## Bug fix

Before this PR, running a script like this could crash during decoration:

```python
import warp as wp

@wp.func(module="unique")
def f(x: float):
    return x + 1.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parameterized decorators (e.g., `@wp.func(module="unique")`) now work correctly in directly executed scripts and properly register function overloads instead of raising errors during decoration.

* **Tests**
  * Added a test that runs a script using a parameterized decorator in isolation to validate successful registration in directly executed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->