### PR TITLE
Enable Union notation at Python-scope for warp arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@
 - Fix the gradient of `wp.copy()` when `src_offset` and `dest_offset` differ.
 - Fix `warp.init()` segfault while loading `warp-clang.so` on some Linux systems caused by aggressive symbol stripping.
   ([GH-1554](https://github.com/NVIDIA/warp/issues/1554)).
+- Fix `wp.array[...]`-style subscript annotations to allow for PEP 604 unions (for example, `wp.array[float] | float`)
+  on Python methods ([GH-1548](https://github.com/NVIDIA/warp/issues/1548)).
 
 ### Documentation
 

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -5023,6 +5023,12 @@ class _ArrayAnnotationBase:
     def __hash__(self):
         return hash((self._concrete_cls, self.dtype, self.ndim))
 
+    def __or__(self, other):
+        return Union[self, other]  # noqa: UP007
+
+    def __ror__(self, other):
+        return Union[other, self]  # noqa: UP007
+
 
 class _ArrayAnnotation(_ArrayAnnotationBase):
     """Lightweight annotation for :class:`array` types."""
@@ -7201,6 +7207,10 @@ def get_type_code(arg_type) -> str:
         # This must come before isinstance(arg_type, type) check
         arg_types = arg_type.__args__
         return f"tpl{len(arg_types)}{''.join(get_type_code(x) for x in arg_types)}"
+    elif get_origin(arg_type) is Union or isinstance(arg_type, types.UnionType):
+        raise TypeError(
+            "Union type annotations are only supported at Python scope and are invalid in Warp kernels/functions"
+        )
     elif isinstance(arg_type, type):
         if hasattr(arg_type, "_wp_scalar_type_"):
             # vector/matrix type

--- a/warp/tests/test_subscript_types.py
+++ b/warp/tests/test_subscript_types.py
@@ -3,8 +3,9 @@
 
 """Tests for subscript-style type annotations on arrays and tiles, plus the internal Vector/Matrix/Quaternion/Transformation generics."""
 
+import sys
 import unittest
-from typing import Any, Literal, TypeVar, get_origin
+from typing import Any, Literal, TypeVar, Union, get_origin
 
 import numpy as np
 
@@ -484,6 +485,65 @@ class TestSubscriptTypes(unittest.TestCase):
         vars1 = arr_ann.vars
         vars2 = arr_ann.vars
         self.assertIs(vars1, vars2)
+
+    @unittest.skipIf(
+        sys.version_info < (3, 11),
+        "Python 3.10 type.__or__ raises TypeError for non-type operands instead of "
+        "returning NotImplemented, so the __ror__ fallback is never triggered.",
+    )
+    def test_annotation_union_operator(self):
+        """Array annotations support runtime union expressions in both operand orders."""
+        arr_ann = wp.array[float]
+        ia_ann = wp.indexedarray[wp.float64]
+
+        u1 = arr_ann | float
+        self.assertIs(get_origin(u1), Union)
+        self.assertEqual(u1.__args__, (arr_ann, float))
+
+        u2 = float | arr_ann
+        self.assertIs(get_origin(u2), Union)
+        self.assertEqual(u2.__args__, (float, arr_ann))
+
+        u3 = arr_ann | None
+        self.assertIs(get_origin(u3), Union)
+        self.assertCountEqual(u3.__args__, (arr_ann, type(None)))
+
+        u4 = None | ia_ann
+        self.assertIs(get_origin(u4), Union)
+        self.assertCountEqual(u4.__args__, (ia_ann, type(None)))
+
+        # Chaining produces a regular Union annotation.
+        chained = arr_ann | float | ia_ann | float
+        self.assertIs(get_origin(chained), Union)
+        self.assertIn(arr_ann, chained.__args__)
+        self.assertIn(float, chained.__args__)
+        self.assertIn(ia_ann, chained.__args__)
+
+    @unittest.skipIf(
+        sys.version_info < (3, 11),
+        "Python 3.10 type.__or__ raises TypeError for non-type operands instead of "
+        "returning NotImplemented, so the __ror__ fallback is never triggered.",
+    )
+    def test_annotation_union_invalid_for_codegen(self):
+        """Union annotations are intentionally invalid in Warp codegen."""
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Union type annotations are only supported at Python scope",
+        ):
+
+            @wp.func
+            def _invalid_union_arg(a: wp.array[float] | float) -> float:
+                return 0.0
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"Union type annotations are only supported at Python scope",
+        ):
+
+            @wp.func
+            def _invalid_native_union_arg(a: int | float) -> float:
+                return 0.0
 
     def test_annotation_helpers(self):
         """Test matches_array_class and concrete_array_type helpers."""


### PR DESCRIPTION
## Description

Array subscript annotations such as wp.array[...] still return lightweight annotation instances but they now support PEP 604 union expressions at Python scope through instance operator support (for example, `wp.array[float] | float and float | wp.array[float]`).

Closes #1548

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] CHANGELOG.md is updated for any user-facing changes under the Unreleased section.

## Validation Summary

- Updated and added tests in warp/tests/test_subscript_types.py.
- Ran:
    uv run test_subscript_types.py

## Bug Fix Repro

```python
import warp as wp
wp.init()
# PEP 604 union support at Python scope
T = wp.array[float] | float
U = float | wp.array[float]
# Union annotations remain invalid in Warp codegen signatures
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed runtime handling of `wp.array[...]`-style subscript annotations to support PEP 604 union expressions (e.g., `wp.array[float] | float`) in Python method contexts.

* **Tests**
  * Added coverage for `|`/`|`-reverse union syntax with array annotations, and verified that union-typed annotations are rejected for code generation beyond Python scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->