### PR TITLE
Validate negative offsets in wp.copy

### DIFF
--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -11156,6 +11156,12 @@ def copy(
     if not warp._src.types.is_array(src) or not warp._src.types.is_array(dest):
         raise RuntimeError("Copy source and destination must be arrays")
 
+    if src_offset < 0:
+        raise RuntimeError(f"Source offset must be non-negative, got {src_offset}")
+
+    if dest_offset < 0:
+        raise RuntimeError(f"Destination offset must be non-negative, got {dest_offset}")
+
     # backwards compatibility, if count is zero then copy entire src array
     if count <= 0:
         count = src.size

--- a/warp/tests/test_copy.py
+++ b/warp/tests/test_copy.py
@@ -264,6 +264,17 @@ def test_copy_adjoint(test, device):
     assert_np_equal(state_in.grad.numpy(), np.array([1.0, 1.0, 1.0]).astype(np.float32))
 
 
+def test_copy_negative_offsets(test, device):
+    src = wp.array([1, 2, 3, 4], dtype=wp.int32, device=device)
+    dest = wp.zeros_like(src)
+
+    with test.assertRaisesRegex(RuntimeError, "Source offset must be non-negative"):
+        wp.copy(dest, src, src_offset=-1)
+
+    with test.assertRaisesRegex(RuntimeError, "Destination offset must be non-negative"):
+        wp.copy(dest, src, dest_offset=-1)
+
+
 devices = get_test_devices()
 
 
@@ -301,6 +312,7 @@ for src_device in devices:
         )
 
 add_function_test(TestCopy, "test_copy_adjoint", test_copy_adjoint, devices=devices)
+add_function_test(TestCopy, "test_copy_negative_offsets", test_copy_negative_offsets, devices=devices)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`wp.copy()` now rejects negative source and destination offsets before converting them to byte offsets or adding them to raw array pointers. Previously, negative offsets could pass the upper-bound checks and produce pointers before the start of the array allocation.

## Validation

- Built Warp locally with CPU support: `python build_lib.py --no-cuda --no-use-libmathdx -j 8`
- Ran `python -m unittest warp.tests.test_copy.TestCopy.test_copy_negative_offsets_cpu`
- Ran `python -m unittest warp.tests.test_copy.TestCopy.test_copy_adjoint_cpu`
- Ran `uvx ruff@0.15.9 check warp/_src/context.py warp/tests/test_copy.py`
- Ran `uvx ruff@0.15.9 format --check warp/_src/context.py warp/tests/test_copy.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation in copy operations to explicitly reject negative offset values with clear error messages before processing begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->