### PR TITLE
Stop FEM example tests from littering the working directory

### DIFF
--- a/warp/tests/fem/test_fem_examples.py
+++ b/warp/tests/fem/test_fem_examples.py
@@ -14,14 +14,17 @@ import sys
 import tempfile
 import unittest
 from typing import Any
+from unittest import mock
 
 import warp as wp
 import warp.tests.unittest_utils
 from warp._src.utils import check_p2p
 from warp.tests.unittest_utils import (
+    USD_AVAILABLE,
     add_function_test,
     get_selected_cuda_test_devices,
     get_selected_cuda_test_devices_with_mempool,
+    sanitize_identifier,
 )
 
 
@@ -57,6 +60,34 @@ def add_fem_example_test(
             options = test_options | test_options_cuda
         else:
             options = test_options | test_options_cpu
+
+        # Default any USD output into the gitignored warp/tests/outputs/ directory
+        # (mirroring the core example harness) and remove it after a passing run,
+        # so examples run via the suite never litter the working directory (e.g.
+        # the repo root). A test can still pass stage_path=None to disable output.
+        outputs_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "outputs")
+        short_name = name.rsplit(".", maxsplit=1)[-1]
+        if USD_AVAILABLE:
+            stage_path = options.pop(
+                "stage_path",
+                os.path.join(outputs_dir, f"{short_name}_{sanitize_identifier(device)}.usd"),
+            )
+        else:
+            options.pop("stage_path", None)
+            stage_path = "None"
+
+        if stage_path is None:
+            # Forward stage_path=None so the example disables USD output entirely
+            # (the example maps the literal "None" back to None).
+            options["stage_path"] = None
+        else:
+            options["stage_path"] = stage_path
+            if stage_path != "None":
+                os.makedirs(outputs_dir, exist_ok=True)
+                try:
+                    os.remove(stage_path)
+                except OSError:
+                    pass
 
         env_vars = os.environ.copy()
 
@@ -98,6 +129,13 @@ def add_fem_example_test(
             msg=f"Failed with return code {result.returncode}, command: {' '.join(command)}\n\nOutput:\n{result.stdout}\n{result.stderr}",
         )
 
+        # Clean up the output stage on success (mirrors the core example harness).
+        if stage_path not in (None, "None") and result.returncode == 0:
+            try:
+                os.remove(stage_path)
+            except OSError:
+                pass
+
     add_function_test(cls, f"test_{name}", run, devices=devices, check_output=False)
 
 
@@ -111,6 +149,39 @@ class TestFemExamples(unittest.TestCase):
 
 class TestFemDiffusionExamples(unittest.TestCase):
     pass
+
+
+class TestFemExampleHarness(unittest.TestCase):
+    def test_stage_path_none_when_usd_unavailable(self):
+        cls = type("HarnessCase", (unittest.TestCase,), {})
+        add_fem_example_test(
+            cls,
+            name="fem.example_apic_fluid",
+            devices=["cpu"],
+            test_options={"num_frames": 1},
+        )
+
+        commands = []
+
+        def fake_run(command, *args, **kwargs):
+            commands.append(command)
+            return subprocess.CompletedProcess(command, returncode=0, stdout="", stderr="")
+
+        module = sys.modules[__name__]
+        test_name = "test_fem.example_apic_fluid_cpu"
+        test = cls(methodName=test_name)
+        with (
+            mock.patch.object(module, "USD_AVAILABLE", False),
+            mock.patch.object(subprocess, "run", side_effect=fake_run),
+            mock.patch.object(os, "makedirs") as makedirs,
+            mock.patch.object(os, "remove"),
+        ):
+            getattr(test, test_name)()
+
+        self.assertEqual(len(commands), 1)
+        stage_path_index = commands[0].index("--stage-path") + 1
+        self.assertEqual(commands[0][stage_path_index], "None")
+        makedirs.assert_not_called()
 
 
 # MGPU tests may fail on systems where P2P transfers are misconfigured

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -98,7 +98,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.cuda.test_streams import TestStreams
     from warp.tests.cuda.test_texture import TestTexture
     from warp.tests.cuda.test_unified_memory import TestUnifiedMemory
-    from warp.tests.fem.test_fem_examples import TestFemDiffusionExamples, TestFemExamples
+    from warp.tests.fem.test_fem_examples import TestFemDiffusionExamples, TestFemExampleHarness, TestFemExamples
     from warp.tests.fem.test_fem_field import TestFemField
     from warp.tests.fem.test_fem_fp64 import TestFemFp64
     from warp.tests.fem.test_fem_geometry import TestFemGeometry
@@ -300,6 +300,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestFastcall,
         TestFastcallAvailable,
         TestFemDiffusionExamples,
+        TestFemExampleHarness,
         TestFemExamples,
         TestFemField,
         TestFemFp64,


### PR DESCRIPTION
## Description

The FEM example test harness (`warp/tests/fem/test_fem_examples.py`) forwarded test
options as CLI flags but, unlike the core example harness (`warp/tests/test_examples.py`),
never set a default `--stage-path` or cleaned up output. The `fem.example_apic_fluid` test
runs with USD output enabled and no `stage_path` override, so the example fell back to its
bare-filename default (`example_apic_fluid.usd`) and wrote it to the subprocess working
directory (the repo root when running the suite from there), leaving the file behind.

It was the only offender because every other FEM example is headless or passes
`stage_path=None` (output disabled).

## Changes

- Default the FEM example output stage into the gitignored `warp/tests/outputs/` directory
  (matching the core example harness), keyed by example name and device.
- Remove the output stage after a passing run.
- Preserve `stage_path=None` semantics so a test can still disable USD output entirely.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

  This is an internal test-harness fix with no user-facing behavior change, so no CHANGELOG
  entry was added.

## Validation summary

- Confirmed the root cause: among FEM example tests, only `fem.example_apic_fluid` runs with
  USD output enabled and no `stage_path` override, so it wrote `example_apic_fluid.usd` to the
  working directory with no cleanup.
- Ran the `fem.example_apic_fluid` test on CUDA with the fix applied and verified the output
  was written to `warp/tests/outputs/example_apic_fluid_cuda_0.usd` (the gitignored location)
  rather than the repo root. No stray file appeared at the repo root during the run.
- Verified `stage_path=None` is still forwarded as `--stage-path None`, so tests that disable
  USD output (e.g. `fem.example_apic_fluid_multi_env`) behave unchanged.
- Pre-commit (ruff, ruff-format, typos) passes on the changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved FEM example subprocess test harness by managing per-device USD output paths when USD is available, cleaning up generated output after successful runs, and handling cases where USD output is disabled.
  * Added coverage to verify the subprocess receives the correct `--stage-path` behavior when USD is not available, without attempting output directory creation.
* **Chores**
  * Updated the default unit test suite to include the FEM example harness test class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->