### PR TITLE
Fix tile_dot for scalar float64 tiles

### DIFF
--- a/warp/native/builtin.h
+++ b/warp/native/builtin.h
@@ -2576,6 +2576,7 @@ inline CUDA_CALLABLE void adj_dot(float a, float b, float& adj_a, float& adj_b, 
     adj_mul(a, b, adj_a, adj_b, adj_ret);
 }
 inline CUDA_CALLABLE float tensordot(float a, float b) { return mul(a, b); }
+inline CUDA_CALLABLE float64 tensordot(float64 a, float64 b) { return mul(a, b); }
 
 
 #define DECLARE_INTERP_FUNCS(T) \

--- a/warp/tests/tile/test_tile_fused_ops.py
+++ b/warp/tests/tile/test_tile_fused_ops.py
@@ -264,7 +264,6 @@ def test_tile_dot_float64_scalar(test, device):
         b_in: wp.array[wp.float64],
         out: wp.array[wp.float64],
     ):
-        i = wp.tid()
         a = wp.tile_load(a_in, shape=N, offset=0, storage="register")
         b = wp.tile_load(b_in, shape=N, offset=0, storage="register")
         result = wp.tile_dot(a, b)

--- a/warp/tests/tile/test_tile_fused_ops.py
+++ b/warp/tests/tile/test_tile_fused_ops.py
@@ -254,6 +254,35 @@ def test_tile_dot_basic(test, device):
     test.assertAlmostEqual(out.numpy()[0], expected, places=4)
 
 
+def test_tile_dot_float64_scalar(test, device):
+    """Scalar float64 tiles produce a float64 result tile."""
+    N = 64
+
+    @wp.kernel(enable_backward=False, module="unique")
+    def compute(
+        a_in: wp.array[wp.float64],
+        b_in: wp.array[wp.float64],
+        out: wp.array[wp.float64],
+    ):
+        i = wp.tid()
+        a = wp.tile_load(a_in, shape=N, offset=0, storage="register")
+        b = wp.tile_load(b_in, shape=N, offset=0, storage="register")
+        result = wp.tile_dot(a, b)
+        wp.tile_store(out, result)
+
+    a_np = np.arange(N, dtype=np.float64)
+    b_np = np.arange(N, dtype=np.float64) * 0.5
+
+    a_in = wp.array(a_np, dtype=wp.float64, device=device)
+    b_in = wp.array(b_np, dtype=wp.float64, device=device)
+    out = wp.zeros(1, dtype=wp.float64, device=device)
+
+    wp.launch_tiled(compute, dim=[1], inputs=[a_in, b_in, out], block_dim=BLOCK_DIM, device=device)
+
+    expected = np.dot(a_np, b_np)
+    test.assertAlmostEqual(out.numpy()[0], expected, places=8)
+
+
 def test_tile_dot_nonuniform(test, device):
     """Dot product with non-uniform values."""
     N = 32
@@ -642,6 +671,7 @@ add_function_test(TestTileFusedOps, "test_tile_axpy_zero_alpha", test_tile_axpy_
 add_function_test(TestTileFusedOps, "test_tile_axpy_1d", test_tile_axpy_1d, devices=devices)
 add_function_test(TestTileFusedOps, "test_tile_axpy_grad", test_tile_axpy_grad, devices=devices)
 add_function_test(TestTileFusedOps, "test_tile_dot_basic", test_tile_dot_basic, devices=devices)
+add_function_test(TestTileFusedOps, "test_tile_dot_float64_scalar", test_tile_dot_float64_scalar, devices=devices)
 add_function_test(TestTileFusedOps, "test_tile_dot_nonuniform", test_tile_dot_nonuniform, devices=devices)
 add_function_test(TestTileFusedOps, "test_tile_dot_shared_shared", test_tile_dot_shared_shared, devices=devices)
 add_function_test(TestTileFusedOps, "test_tile_dot_2d", test_tile_dot_2d, devices=devices)


### PR DESCRIPTION
## Summary
- add the missing scalar `float64` native `tensordot()` overload
- cover `wp.tile_dot()` on scalar `wp.float64` tiles with a CPU regression test

## Validation
- `python build_lib.py --no-cuda --no-use-libmathdx -j 4`
- `python -m unittest warp.tests.tile.test_tile_fused_ops.TestTileFusedOps.test_tile_dot_basic_cpu warp.tests.tile.test_tile_fused_ops.TestTileFusedOps.test_tile_dot_float64_scalar_cpu -v`

Closes #1563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended tensor dot support by adding a float64-specific overload, ensuring float64 scalar dot/tensordot code paths compile and dispatch correctly.

* **Tests**
  * Added a new fused-tile dot test for float64 scalar outputs, comparing tiled `tile_dot` results against NumPy with float64-appropriate tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->