### PR TITLE
Fix get_arg_type to preserve Any on Python <3.11

### DIFF
--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -966,6 +966,14 @@ def func_match_args(func, arg_types, kwarg_types):
 def get_arg_type(arg: Var | Any) -> type:
     arg = strip_reference(arg)
 
+    # `Any` marks an unspecialized generic parameter. Return it unchanged so
+    # downstream signature logic can treat it as generic. Before Python 3.11
+    # `Any` is a `typing._SpecialForm` instance rather than a `type`, so the
+    # `isinstance(arg, type)` check below would otherwise fall through to
+    # `type(arg)` and yield `typing._SpecialForm`.
+    if arg is Any:
+        return Any
+
     if isinstance(arg, str):
         return str
 

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -1622,6 +1622,18 @@ class TestCodeGen(unittest.TestCase):
         finally:
             linecache.cache.pop(filename, None)
 
+    def test_get_arg_type_preserves_any(self):
+        """Verify ``get_arg_type`` returns ``Any`` for generic parameters.
+
+        ``Any`` marks an unspecialized generic parameter and must be returned
+        as-is, both when passed directly and when carried on a ``Var``. Before
+        Python 3.11 ``Any`` is a ``typing._SpecialForm`` instance rather than a
+        ``type``, so a regressed implementation falls through to ``type(arg)``
+        and yields ``typing._SpecialForm``, which has no type code.
+        """
+        self.assertIs(codegen.get_arg_type(Any), Any)
+        self.assertIs(codegen.get_arg_type(codegen.Var("coords", Any)), Any)
+
     def test_line_directive_escapes_filename(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             filename = os.path.join(tmpdir, 'warp_poc"\n\r\t\x00\x1f\x7fint injected_from_filename;\n//.py')


### PR DESCRIPTION
## Description

While developing Callable function parameters ([GH-1424](https://github.com/NVIDIA/warp/issues/1424)), the Python 3.10 CI job (`test-warp-gpu-linux-mgpu-python310`) failed across ~200 tests — most of the `warp.fem` suite plus a few others — with:

```
RuntimeError: Failed to determine type code for argument 'coords' of function
element_inner_weight_linear_...: Unrecognized type '<class 'typing._SpecialForm'>'
```

The root cause is in `get_arg_type` and is independent of that feature, so it is fixed here on its own.

`get_arg_type` returns the type used for a function argument during signature and overload computation. An unspecialized generic parameter has type `typing.Any`, which should be returned unchanged so downstream logic treats the parameter as generic.

On Python 3.11+ `Any` is a class and satisfied the `isinstance(arg, type)` check, so it was returned as-is. Before 3.11 `Any` is a `typing._SpecialForm` instance rather than a `type`, so `get_arg_type` fell through to `type(arg)` and returned `typing._SpecialForm`. `get_type_code` has no mapping for that and raises `Unrecognized type`, so any path that feeds a generic parameter type into signature computation fails on Python 3.10 while succeeding on newer versions.

### Why fix this now, and separately

The bug is latent on `main`: no current code path feeds a generic (`Any`) parameter's type into `get_signature`/`get_type_code`, so there is no user-facing impact today (hence no CHANGELOG entry). The Callable-parameters work adds the first such path — it scans every call's arguments during module hashing to discover Callable targets, which routes a generic parameter's type into signature computation. Since `warp.fem` defines generic device functions with `Any`-typed parameters (e.g. `coords: Any`) that forward those arguments to other functions, the entire FEM suite breaks on the Python 3.10 lane.

Because the fix is independent of the feature, landing it as a standalone PR keeps it reviewable in isolation and lets it merge first; the feature branch then only needs a rebase to pick it up.

## Changes

- `get_arg_type` (`warp/_src/codegen.py`): return `Any` early so the result is consistent across Python versions, instead of falling through to `type(arg)` and yielding `typing._SpecialForm` on Python <3.11.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

> No CHANGELOG entry: the bug is not reachable through any code path on `main`, so there is no user-facing behavior change on this branch.

## Validation summary

- Added `TestCodeGen.test_get_arg_type_preserves_any`, which asserts `get_arg_type` returns `Any` both when passed `Any` directly and when passed a `Var` whose type is `Any`.
- Verified the new test **fails on Python 3.10 without this change** (`AssertionError: <class 'typing._SpecialForm'> is not typing.Any`) and **passes with it**.
- Verified the new test passes on Python 3.12.
- Ran the full `warp/tests/test_codegen.py` suite on CPU under Python 3.10 (81 tests) — all passing.
- `pre-commit` (ruff, ruff-format, typos, generated-file checks) clean on the changed files.
