### PR TITLE
Add name argument to @wp.kernel (GH-1561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   ([GH-1378](https://github.com/NVIDIA/warp/issues/1378))
 - **Experimental:** Record `wp.utils.array_sum()` and `wp.utils.array_inner()` in APIC capture so saved and replayed
   graphs recompute them from current inputs on CPU and CUDA ([GH-1663](https://github.com/NVIDIA/warp/issues/1663)).
+- Add a `name` argument to `@wp.kernel` to override the kernel's generated key
+  ([GH-1561](https://github.com/NVIDIA/warp/issues/1561)).
 
 ### Removed
 

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -6317,6 +6317,16 @@ def make_full_qualified_name(func: str | Callable) -> str:
     return re.sub("[^0-9a-zA-Z_]+", "", func.replace(".", "__"))
 
 
+# matches a valid C identifier: a letter or underscore followed by letters, digits, or underscores
+_C_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def is_valid_c_identifier(name: str) -> bool:
+    # Note: This only validates the lexical shape. It does not reject reserved
+    # C/C++/CUDA keywords.
+    return _C_IDENTIFIER_RE.match(name) is not None
+
+
 def codegen_struct(struct, device="cpu", indent_size=4, include_tile_helpers=False):
     name = struct.native_name
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -1041,8 +1041,13 @@ class Kernel:
         else:
             self.module = module
 
+        # Keep track of the qualified name of the Python function used to create
+        # this kernel, so it can still be identified even when the kernel is given
+        # a custom name (key).
+        self.qualname = warp._src.codegen.make_full_qualified_name(func)
+
         if key is None:
-            self.key = warp._src.codegen.make_full_qualified_name(func)
+            self.key = self.qualname
         else:
             self.key = key
 
@@ -1610,6 +1615,7 @@ def grad(func: Callable) -> GradWrapper:
 def kernel(
     f: Callable | None = None,
     *,
+    name: str | None = None,
     enable_backward: bool | None = None,
     launch_bounds: tuple[int, ...] | int | None = None,
     cluster_dim: int | None = None,
@@ -1660,6 +1666,9 @@ def kernel(
 
     Args:
         f: The function to be registered as a kernel.
+        name: Overrides the kernel's key. If ``None``, the function's
+            qualified name will be used as the key. The name must have the
+            shape of a valid C identifier; raises a ``ValueError`` otherwise.
         enable_backward: If False, the backward pass will not be
             generated.
         launch_bounds: CUDA ``__launch_bounds__`` attribute for the
@@ -1702,6 +1711,13 @@ def kernel(
 
     def wrapper(f, *args, **kwargs):
         kernel_options = {}
+
+        if name is None:
+            key = warp._src.codegen.make_full_qualified_name(f)
+        else:
+            if not warp._src.codegen.is_valid_c_identifier(name):
+                raise ValueError(f"@wp.kernel for '{f.__name__}': name '{name}' is not a valid C identifier.")
+            key = name
 
         if enable_backward is not None:
             kernel_options["enable_backward"] = enable_backward
@@ -1755,7 +1771,7 @@ def kernel(
         # Create the kernel object and register it with the module
         k = Kernel(
             func=f,
-            key=warp._src.codegen.make_full_qualified_name(f),
+            key=key,
             module=m,
             options=kernel_options,
         )
@@ -3536,7 +3552,28 @@ class Module:
     # find kernel corresponding to a Python function
     def _find_kernel(self, func):
         qualname = warp._src.codegen.make_full_qualified_name(func)
-        return self.kernels.get(qualname)
+
+        # A kernel's key matches the qualified name unless the user specifies a
+        # custom name for the kernel.
+        # First, check the fast path: kernels registered under their ``qualname``.
+        kernel = self.kernels.get(qualname)
+        if kernel is not None:
+            return kernel
+
+        # Otherwise, the kernel was renamed via ``@wp.kernel(name=...)``. Fall
+        # back to manually matching based on the ``qualname`` attribute.
+        # Several kernels may share the same qualified name (e.g. kernels
+        # generated in a closure). We return the most recently registered match.
+        # This should correspond to the correct kernel, since ``@wp.overload`` is
+        # defined just after the overloaded kernel, and ``self.kernels``
+        # preserves insertion order.
+        # For ambiguous cases, use the direct form ``wp.overload(kernel, [...])``.
+        match = None
+        for kernel in self.kernels.values():
+            if kernel.qualname == qualname:
+                match = kernel
+
+        return match
 
     # collect all referenced functions / structs
     # given the AST of a function or kernel

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -1868,6 +1868,14 @@ class TestCodeGen(unittest.TestCase):
 
         self.assertEqual(directive, '#line 1 "C:/warp/kernels/example.py"')
 
+    def test_is_valid_c_identifier(self):
+        for name in ("foo", "_foo", "Foo123", "_", "a1_b2"):
+            with self.subTest(name=name):
+                self.assertTrue(codegen.is_valid_c_identifier(name))
+        for name in ("", "1leading_digit", "has space", "has-dash", "a.b", "a+b", "naïve"):
+            with self.subTest(name=name):
+                self.assertFalse(codegen.is_valid_c_identifier(name))
+
     def test_extract_function_source_slow_path_when_fast_returns_none(self):
         """When ``_try_extract_function_source`` returns ``None`` (e.g. for an
         ``exec``-defined function with no linecache entry), ``extract_function_source``

--- a/warp/tests/test_context.py
+++ b/warp/tests/test_context.py
@@ -16,6 +16,37 @@ class TestContext(unittest.TestCase):
         self.assertEqual(wp._src.context.type_str(tuple[int, float]), "tuple[int, float]")
         self.assertEqual(wp._src.context.type_str(tuple[int, ...]), "tuple[int, ...]")
 
+    def test_kernel_name_override(self):
+        """@wp.kernel(name=...) should override the kernel's key."""
+
+        @wp.kernel(name="custom_kernel_name")
+        def some_kernel(x: wp.array(dtype=float)):
+            i = wp.tid()
+            x[i] = x[i]
+
+        self.assertEqual(some_kernel.key, "custom_kernel_name")
+
+    def test_kernel_name_default(self):
+        """Omitting name should fall back to the qualified name."""
+
+        @wp.kernel
+        def default_named_kernel(x: wp.array(dtype=float)):
+            i = wp.tid()
+            x[i] = x[i]
+
+        self.assertTrue(default_named_kernel.key.endswith("default_named_kernel"))
+
+    def test_kernel_name_invalid(self):
+        """A name that is not a valid C identifier should raise ValueError."""
+        with self.assertRaises(ValueError) as cm:
+
+            @wp.kernel(name="has space")
+            def bad_kernel(x: wp.array(dtype=float)):
+                i = wp.tid()
+                x[i] = x[i]
+
+        self.assertIn("not a valid C identifier", str(cm.exception))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/warp/tests/test_generics.py
+++ b/warp/tests/test_generics.py
@@ -663,7 +663,44 @@ def test_annotations_kernel():
 
 
 class TestGenerics(unittest.TestCase):
-    pass
+    def test_overload_with_renamed_kernel(self):
+        @wp.kernel(name="renamed_overload_kernel")
+        def scale(x: Any):
+            return
+
+        @wp.overload
+        def scale(x: float): ...
+
+        @wp.overload
+        def scale(x: int): ...
+
+        self.assertEqual(scale.key, "renamed_overload_kernel")
+        self.assertEqual(len(scale.overloads), 2)
+
+    def test_overload_renamed_kernel_closure(self):
+        # A closure that yields one renamed kernel per call produces several kernels
+        # sharing the same qualified name. Decorator-form @wp.overload is defined
+        # inline next to each kernel, so it must bind to that call's kernel.
+        def make(suffix):
+            @wp.kernel(name=f"closure_overload_kernel_{suffix}")
+            def scale(x: Any):
+                return
+
+            @wp.overload
+            def scale(x: float): ...
+
+            @wp.overload
+            def scale(x: int): ...
+
+            return scale
+
+        first = make("a")
+        second = make("b")
+
+        self.assertEqual(first.key, "closure_overload_kernel_a")
+        self.assertEqual(second.key, "closure_overload_kernel_b")
+        self.assertEqual(len(first.overloads), 2)
+        self.assertEqual(len(second.overloads), 2)
 
 
 devices = get_test_devices()


### PR DESCRIPTION
## Description

Addresses https://github.com/NVIDIA/warp/issues/1561.

`@wp.kernel` derives a kernel's key from `make_full_qualified_name(func)`, which in turn uses the function's `__qualname__`. There's no way to override it.

The `@wp.func` decorator already exposes a `name` argument for the same purpose.

## Changes

Here I'm adding support for a `name` argument for the `wp.kernel` decorator, enabling overriding the kernel's name.

I chose `name` to be consistent with the `wp.func` API. However, internally this is called `key`.

A potential pitfall is if the user passes a name that is not a valid C name. I've added an explicit check for this, otherwise users are faced with a somewhat cryptic compiler error.

## New feature / enhancement

This is especially useful when generating kernels with the [closure pattern](https://nvidia.github.io/warp/stable/deep_dive/codegen.html#kernel-closures). In this case, different kernels have the same key and only differ by their hashes:

```python
import warp as wp

def make_scaler(factor: float) -> wp.Kernel:
    @wp.kernel
    def scale(x: wp.array(dtype=wp.float32)):
        i = wp.tid()
        x[i] = x[i] * factor
    return scale

double = make_scaler(2.0)
triple = make_scaler(3.0)

print(double.key)  # make_scaler__locals__scale
print(triple.key)  # make_scaler__locals__scale  <-- identical!
```

With these changes, users can now specify a name for the kernel:

```python
def make_scaler(factor: float) -> wp.Kernel:
    @wp.kernel(name=f"scale{factor}".replace(".", "_"))
    def scale(x: wp.array(dtype=wp.float32)):
        i = wp.tid()
        x[i] = x[i] * factor
    return scale
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Ran all tests and linter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `@wp.kernel` now accepts an optional `name` to control the kernel identifier, with C-identifier validation.
  * Added a public utility to check whether a string is a valid C identifier.
* **Bug Fixes**
  * Improved kernel lookup to correctly resolve renamed kernels (preferring the most recently registered match).
* **Tests**
  * Added unit coverage for `@wp.kernel` name override/default/invalid cases, identifier validation, and renamed-kernel behavior with `@wp.overload`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->