### PR TITLE
Fix NVRTC include path option storage

### DIFF
--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -4439,13 +4439,6 @@ size_t wp_cuda_compile_program(
     bool use_ptx = output_ext && strcmp(output_ext + 1, "ptx") == 0;
     const bool print_debug = (std::getenv("WARP_DEBUG") != nullptr);
 
-    // check include dir path len (path + option)
-    const int max_path = 4096 + 16;
-    if (strlen(include_dir) > max_path) {
-        fprintf(stderr, "Warp error: Include path too long\n");
-        return size_t(-1);
-    }
-
     if (print_debug) {
         // Not available in all nvJitLink versions
         // unsigned major = 0;
@@ -4458,9 +4451,10 @@ size_t wp_cuda_compile_program(
         printf("NVRTC version %d.%d\n", major, minor);
     }
 
-    char include_opt[max_path];
-    strcpy(include_opt, "--include-path=");
-    strcat(include_opt, include_dir);
+    // Vector to store dynamically created option strings
+    std::vector<std::string> stored_options;
+    stored_options.reserve(static_cast<size_t>(std::max(num_cuda_include_dirs, 0)) + 3);
+    stored_options.push_back(std::string("--include-path=") + include_dir);
 
     const int max_arch = 128;
     char arch_opt[max_arch];
@@ -4479,7 +4473,7 @@ size_t wp_cuda_compile_program(
 
     std::vector<const char*> opts;
     opts.push_back(arch_opt);
-    opts.push_back(include_opt);
+    opts.push_back(stored_options.back().c_str());
     opts.push_back("--std=c++17");
 
     // CUDA 12.9+ supports --Ofast-compile
@@ -4500,9 +4494,6 @@ size_t wp_cuda_compile_program(
         break;  // 3 and up
     }
 #endif
-
-    // Vector to store dynamically created option strings
-    std::vector<std::string> stored_options;
 
     if (precompiled_headers) {
         // CUDA 12.8+ supports precompiled headers


### PR DESCRIPTION
## Description

`wp_cuda_compile_program()` built the main NVRTC include option in a fixed-size stack buffer. The guard checked only `include_dir`, but the buffer also had to hold the `--include-path=` prefix and the null terminator. That allowed paths that passed the check to overflow the stack buffer while constructing the option.

This changes the main include option to use the same dynamic string storage pattern used for the other generated NVRTC options, while reserving capacity up front so the `c_str()` pointers passed to NVRTC stay stable until compilation.

## Changes

- Store the primary `--include-path=` option in `std::vector<std::string>` instead of a fixed-size `char` buffer.
- Reserve storage for all generated option strings before taking `c_str()` pointers.
- Remove the incorrect length check and the `strcpy()`/`strcat()` construction.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

I verified the focused source diff and formatting locally:

- `git diff --check`
- `uvx pre-commit run --files warp/native/warp.cu`
- `uv run build_lib.py --quick`

The quick build succeeded on macOS arm64 in CPU-only mode. This machine does not have a CUDA toolchain available, so I could not run an NVRTC/CUDA compile-path regression test locally.

## Bug fix

The issue can be triggered when Warp is installed or checked out under a very long path and a CUDA kernel compile uses that path as `warp_home/native` for the include directory. Without this change, the fixed stack buffer can overflow while prepending `--include-path=`.

```python
import warp as wp


@wp.kernel
def noop():
    pass


wp.init()
wp.launch(noop, dim=1, inputs=[], device="cuda:0")
```

## New feature / enhancement

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved CUDA compilation memory management by transitioning include path handling from fixed-size buffers to dynamic allocation. This enhancement increases system reliability, removes previous capacity constraints, and provides better flexibility for projects requiring extensive include path configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->