### PR TITLE
fix(types): support PEP 604 union syntax for array annotations

### DIFF
--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -5023,6 +5023,14 @@ class _ArrayAnnotationBase:
     def __hash__(self):
         return hash((self._concrete_cls, self.dtype, self.ndim))
 
+    def __or__(self, other):
+        from typing import Union
+        return Union[self, other]
+
+    def __ror__(self, other):
+        from typing import Union
+        return Union[other, self]
+
 
 class _ArrayAnnotation(_ArrayAnnotationBase):
     """Lightweight annotation for :class:`array` types."""

--- a/warp/tests/test_subscript_types.py
+++ b/warp/tests/test_subscript_types.py
@@ -690,6 +690,28 @@ class TestSubscriptTypes(unittest.TestCase):
 
 devices = get_test_devices()
 
+
+def test_union_syntax_with_array_annotation(test, device):
+    """Test that PEP 604 union syntax works with array annotations."""
+    import typing
+
+    # wp.array[float] | float should not raise
+    result = wp.array[float] | float
+    test.assertIsInstance(result, typing.UnionType if hasattr(typing, 'UnionType') else type)
+
+    # wp.array2d[float] | None should not raise
+    result = wp.array2d[float] | None
+    test.assertIsNotNone(result)
+
+    # float | wp.array[float] should also work ( __ror__)
+    result = float | wp.array[float]
+    test.assertIsNotNone(result)
+
+    # wp.array[float] | wp.array[int] should work
+    result = wp.array[float] | wp.array[int]
+    test.assertIsNotNone(result)
+
+
 add_function_test(
     TestSubscriptTypes, "test_subscript_kernel_actually_runs", test_subscript_kernel_actually_runs, devices=devices
 )
@@ -719,6 +741,9 @@ add_function_test(
     test_subscript_indexedarray_kernel,
     devices=devices,
 )
+
+
+add_function_test(TestSubscriptTypes, "test_union_syntax_with_array_annotation", test_union_syntax_with_array_annotation, devices=devices)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1548

## Problem

Using PEP 604 union syntax (`X | Y` from Python 3.10) with `wp.array[...]` annotations raises `TypeError: unsupported operand type(s) for |: '_ArrayAnnotation' and 'type'`.

This affects all array annotation types: `wp.array`, `wp.array2d`, `wp.array3d`, `wp.array4d`, `wp.indexedarray`, `wp.fabricarray`, `wp.indexedfabricarray`.

## What changed

Added `__or__` and `__ror__` methods to `_ArrayAnnotationBase` that return `typing.Union[self, other]`. This enables:

```python
wp.array[float] | float       # ✅ Now works
wp.array2d[float] | None      # ✅ Now works
wp.indexedarray[float] | int  # ✅ Now works
```

## Validation

- `__or__` handles `wp.array[float] | float` (annotation on left side)
- `__ror__` handles `float | wp.array[float]` (annotation on right side)
- No behavior change when `|` is not used
- Uses `typing.Union` for Python 3.9+ compatibility (warp supports 3.9+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Array annotation types now support modern union-style type hints using the `|` operator (PEP 604), enabling more readable and Pythonic type composition syntax.
* **Tests**
  * Added coverage to validate union (`|`) behavior with array subscript types and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->