### PR TITLE
Fix DLPack byte_offset handling on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 
 ### Fixed
 
+- Fix `wp.from_dlpack()` to honor `DLTensor.byte_offset` when importing external DLPack tensors.
 - Fix `wp.load_module()` and `wp.ScopedCapture(force_module_load=True)` after CPU launches so CUDA graph capture
   precompiles the correct CUDA kernel variant. On CUDA drivers older than 12.3 this previously raised
   `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED`; on newer drivers it silently recompiled inside the capture window

--- a/warp/_src/dlpack.py
+++ b/warp/_src/dlpack.py
@@ -390,8 +390,10 @@ def _unpack_array(dlt: DLTensor, dtype=None):
         # incompatible dtype requested
         raise RuntimeError(f"Incompatible data types: {dlt.dtype} and {dtype}")
 
+    ptr = dlt.data + dlt.byte_offset if dlt.data is not None else None
+
     a = warp._src.types.array(
-        ptr=dlt.data, dtype=dtype, shape=shape, strides=strides, copy=False, device=device, pinned=pinned
+        ptr=ptr, dtype=dtype, shape=shape, strides=strides, copy=False, device=device, pinned=pinned
     )
 
     return a

--- a/warp/tests/interop/test_dlpack.py
+++ b/warp/tests/interop/test_dlpack.py
@@ -97,7 +97,7 @@ def test_dlpack_from_dlpack_byte_offset(test, device):
     shape = (3,)
 
     managed_tensor_size = ctypes.sizeof(DLManagedTensor)
-    padding = managed_tensor_size & 7
+    padding = (-managed_tensor_size) & 7
     shape_size = len(shape) * ctypes.sizeof(ctypes.c_int64)
     mem_size = managed_tensor_size + padding + shape_size
     mem_ptr = wp._src.dlpack.PyMem_RawMalloc(mem_size)

--- a/warp/tests/interop/test_dlpack.py
+++ b/warp/tests/interop/test_dlpack.py
@@ -8,6 +8,7 @@ import unittest
 import numpy as np
 
 import warp as wp
+from warp._src.thirdparty.dlpack import DLDataTypeCode, DLDeviceType, DLManagedTensor, _c_str_dltensor
 from warp.tests.unittest_utils import *
 
 # Configure JAX memory behavior before any module-level JAX version checks.
@@ -16,6 +17,16 @@ os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.5")
 os.environ.setdefault("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")
 
 N = 1024 * 1024
+
+
+@ctypes.CFUNCTYPE(None, ctypes.c_void_p)
+def _free_dlpack_managed_tensor(managed_ptr):
+    wp._src.dlpack.PyMem_RawFree(ctypes.c_void_p(managed_ptr))
+
+
+PyCapsule_New = ctypes.pythonapi.PyCapsule_New
+PyCapsule_New.argtypes = [ctypes.c_void_p, ctypes.c_char_p, wp._src.dlpack.PyCapsule_Destructor]
+PyCapsule_New.restype = ctypes.py_object
 
 
 def _jax_version():
@@ -79,6 +90,49 @@ def test_dlpack_warp_to_warp(test, device):
     wp.launch(inc, dim=a2.size, inputs=[a2], device=device)
 
     assert_np_equal(a1.numpy(), a2.numpy())
+
+
+def test_dlpack_from_dlpack_byte_offset(test, device):
+    backing = np.arange(8, dtype=np.int32)
+    shape = (3,)
+
+    managed_tensor_size = ctypes.sizeof(DLManagedTensor)
+    padding = managed_tensor_size & 7
+    shape_size = len(shape) * ctypes.sizeof(ctypes.c_int64)
+    mem_size = managed_tensor_size + padding + shape_size
+    mem_ptr = wp._src.dlpack.PyMem_RawMalloc(mem_size)
+    test.assertTrue(mem_ptr)
+
+    managed_tensor = DLManagedTensor.from_address(mem_ptr)
+    managed_tensor.dl_tensor.data = backing.ctypes.data
+    managed_tensor.dl_tensor.device.device_type = DLDeviceType.kDLCPU
+    managed_tensor.dl_tensor.device.device_id = 0
+    managed_tensor.dl_tensor.ndim = len(shape)
+    managed_tensor.dl_tensor.dtype.type_code = DLDataTypeCode.kDLInt
+    managed_tensor.dl_tensor.dtype.bits = 32
+    managed_tensor.dl_tensor.dtype.lanes = 1
+    managed_tensor.dl_tensor.byte_offset = 3 * backing.dtype.itemsize
+
+    shape_ptr = ctypes.cast(mem_ptr + managed_tensor_size + padding, ctypes.POINTER(ctypes.c_int64))
+    for i, dim in enumerate(shape):
+        shape_ptr[i] = dim
+    managed_tensor.dl_tensor.shape = shape_ptr
+    managed_tensor.dl_tensor.strides = None
+    managed_tensor.manager_ctx = None
+    managed_tensor.deleter = _free_dlpack_managed_tensor
+
+    capsule = PyCapsule_New(ctypes.byref(managed_tensor), _c_str_dltensor, wp._src.dlpack._dlpack_capsule_deleter)
+
+    arr = wp.from_dlpack(capsule)
+    expected_ptr = backing.ctypes.data + managed_tensor.dl_tensor.byte_offset
+    test.assertEqual(arr.ptr, expected_ptr)
+    assert_np_equal(arr.numpy(), backing[3:6])
+
+    values = wp.array(np.array([20, 21, 22], dtype=np.int32), device="cpu")
+    wp.copy(arr, values)
+
+    expected = np.array([0, 1, 2, 20, 21, 22, 6, 7], dtype=np.int32)
+    assert_np_equal(backing, expected)
 
 
 def test_dlpack_dtypes_and_shapes(test, device):
@@ -656,6 +710,7 @@ class TestDLPack(unittest.TestCase):
 devices = get_test_devices()
 
 add_function_test(TestDLPack, "test_dlpack_warp_to_warp", test_dlpack_warp_to_warp, devices=devices)
+add_function_test(TestDLPack, "test_dlpack_from_dlpack_byte_offset", test_dlpack_from_dlpack_byte_offset, devices=None)
 add_function_test(TestDLPack, "test_dlpack_dtypes_and_shapes", test_dlpack_dtypes_and_shapes, devices=devices)
 add_function_test(TestDLPack, "test_dlpack_stream_arg", test_dlpack_stream_arg, devices=devices)
 


### PR DESCRIPTION
## Description

`DLTensor.byte_offset` is part of the logical address of element zero in the DLPack tensor: consumers should read from `data + byte_offset`. Warp imported DLPack arrays using `dlt.data` directly, so a valid producer that keeps `data` at the allocation base and describes a view with `byte_offset` would be imported at the wrong address.

I found this while checking Warp's DLPack import path against the DLPack tensor layout. I have not seen this from a production failure. The new regression test builds a small valid CPU DLPack capsule with a nonzero `byte_offset` and shows that the imported Warp array should read and write the logical view, not the allocation base.

## Changes

- Apply `DLTensor.byte_offset` when constructing the imported Warp array pointer.
- Add a focused DLPack import regression test that verifies both reads and writes through the imported array use the offset view.
- Add a short changelog entry for the `wp.from_dlpack()` fix.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

I verified the change locally on macOS arm64 with a CPU-only Warp build:

- `uv run build_lib.py --quick`
- `uv run warp/tests/interop/test_dlpack.py -k test_dlpack_from_dlpack_byte_offset`
- `uv run warp/tests/interop/test_dlpack.py`
- `uvx pre-commit run --files CHANGELOG.md warp/_src/dlpack.py warp/tests/interop/test_dlpack.py`
- `git diff --check`

The local run does not have Torch, JAX, or Paddle installed, so those optional DLPack interop tests were skipped. The new regression test does not depend on those packages.

## Bug fix

The added test is the minimal repro: it creates a DLPack tensor whose `data` points to the start of an `int32` NumPy allocation while `byte_offset` points to element 3. `wp.from_dlpack()` should import the logical three-element view `[3, 4, 5]` and writes through the Warp array should update only that slice.

```python
arr = wp.from_dlpack(capsule_with_data_base_and_nonzero_byte_offset)
assert arr.ptr == backing.ctypes.data + byte_offset
```

## New feature / enhancement

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DLPack tensor import to correctly respect `DLTensor.byte_offset` when converting external (zero-copy) DLPack tensors into Warp arrays.
* **Tests**
  * Added coverage for byte-offset handling in DLPack interop, including validation that writes through the imported array update the expected memory region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->