### PR TITLE
Fix/free threaded python fastcall

### DIFF
--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -23,6 +23,7 @@ import platform
 import re
 import shutil
 import sys
+import sysconfig
 import tempfile
 import textwrap
 import threading
@@ -6630,6 +6631,13 @@ class Runtime:
         # ctypes function objects with plain Python callables that lack those attributes.
         self.fastcall = None
         try:
+            # The pre-built native library uses a PyModuleDef compiled against the
+            # regular CPython ABI.  Free-threaded Python (3.13t+) has a different
+            # PyObject_HEAD layout (32 vs 16 bytes), so loading the module would
+            # dereference garbage offsets and segfault.  Skip the fast path until
+            # the library is rebuilt for the free-threaded ABI.
+            if sysconfig.get_config_var("Py_GIL_DISABLED"):
+                raise ImportError("_warp_fastcall is not compatible with free-threaded Python")
             loader = importlib.machinery.ExtensionFileLoader("_warp_fastcall", warp_lib)
             spec = importlib.util.spec_from_file_location("_warp_fastcall", warp_lib, loader=loader)
             fastcall = importlib.util.module_from_spec(spec)

--- a/warp/native/fastcall.cpp
+++ b/warp/native/fastcall.cpp
@@ -58,21 +58,45 @@ static PyMethodDef fastcall_methods[] = {
 };
 
 #ifdef Py_GIL_DISABLED
+static int fastcall_exec(PyObject* module)
+{
+    PyObject* builtins = PyImport_AddModule("builtins");
+    if (!builtins)
+        return -1;
+
+    g_python_type_error = PyObject_GetAttrString(builtins, "TypeError");
+    if (!g_python_type_error)
+        return -1;
+
+    return 0;
+}
+
 static PyModuleDef_Slot fastcall_slots[] = {
+    { Py_mod_exec, reinterpret_cast<void*>(fastcall_exec) },
     { Py_mod_gil, Py_MOD_GIL_NOT_USED },
     { 0, nullptr },
 };
 #endif
 
 static PyModuleDef fastcall_module = {
-    PyModuleDef_HEAD_INIT, "_warp_fastcall", "Warp METH_FASTCALL native bindings", -1, fastcall_methods,
+    PyModuleDef_HEAD_INIT,
+    "_warp_fastcall",
+    "Warp METH_FASTCALL native bindings",
 #ifdef Py_GIL_DISABLED
+    0,
+    fastcall_methods,
     fastcall_slots,
+#else
+    -1,
+    fastcall_methods,
 #endif
 };
 
 extern "C" WP_API PyObject* PyInit__warp_fastcall()
 {
+#ifdef Py_GIL_DISABLED
+    return PyModuleDef_Init(&fastcall_module);
+#else
     PyObject* builtins = PyImport_AddModule("builtins");
     if (!builtins)
         return nullptr;
@@ -82,4 +106,5 @@ extern "C" WP_API PyObject* PyInit__warp_fastcall()
         return nullptr;
 
     return PyModule_Create(&fastcall_module);
+#endif
 }

--- a/warp/native/fastcall.cpp
+++ b/warp/native/fastcall.cpp
@@ -57,8 +57,18 @@ static PyMethodDef fastcall_methods[] = {
     { nullptr, nullptr, 0, nullptr },
 };
 
+#ifdef Py_GIL_DISABLED
+static PyModuleDef_Slot fastcall_slots[] = {
+    { Py_mod_gil, Py_MOD_GIL_NOT_USED },
+    { 0, nullptr },
+};
+#endif
+
 static PyModuleDef fastcall_module = {
     PyModuleDef_HEAD_INIT, "_warp_fastcall", "Warp METH_FASTCALL native bindings", -1, fastcall_methods,
+#ifdef Py_GIL_DISABLED
+    fastcall_slots,
+#endif
 };
 
 extern "C" WP_API PyObject* PyInit__warp_fastcall()


### PR DESCRIPTION
## Description

`wp.init()` crashes with a segfault on free-threaded Python (3.13t+) when loading the `_warp_fastcall` extension module.

The pre-built `warp.so` embeds a `PyModuleDef` compiled against the regular CPython ABI, where `PyObject_HEAD` is 16 bytes. Free-threaded Python doubles this to 32 bytes (extra fields for `ob_tid`, `ob_mutex`, etc.), so every field in the struct — starting with `m_name` — is at the wrong offset. When `PyModule_New` reads the module name, it dereferences a garbage pointer and segfaults. Since this is a native crash, the existing `try`/`except` in `Runtime.__init__` cannot catch it.

## Changes

**`warp/native/fastcall.cpp`** — Add a `Py_mod_gil` slot (`Py_MOD_GIL_NOT_USED`) to the module definition, conditionally compiled under `Py_GIL_DISABLED`. This is required for extension modules to load on free-threaded Python when built from source. The two fastcall wrappers are stateless, so `NOT_USED` is correct.

**`warp/_src/context.py`** — Guard the `ExtensionFileLoader` path with a `sys.abiflags` check. On free-threaded Python (`"t" in sys.abiflags`), raise `ImportError` before attempting to load the ABI-incompatible binary. The existing fallback handler catches it and uses the ctypes path. This guard can be removed once the wheels are built against free-threaded headers.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Reproduced the segfault on Python 3.14.0 free-threading build (3.14t) by running `wp.init()` — crash occurs in `PyModule_New` during `_warp_fastcall` loading.
- After the `context.py` guard, `wp.init()` completes successfully with a warning about falling back to ctypes.
- Verified the ctypes fallback path is fully functional — a GPU cloth simulation (XPBD with CUDA graph capture, HashGrid, RegisteredGLBuffer) runs correctly.

## Bug fix

```python
import warp as wp
wp.init()  # Segfaults on free-threaded Python 3.13t / 3.14t
```

```
Fatal Python error: Segmentation fault

Current thread 0x000076160e7d0740 [python] (most recent call first):
  File "<frozen importlib._bootstrap>", line 491 in _call_with_frames_removed
  File "<frozen importlib._bootstrap_external>", line 1056 in create_module
  File "warp/_src/context.py", line 5970 in __init__
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with free-threaded Python 3.13+ by automatically bypassing the fast native path and using the existing safer bindings instead.
  * Updated the fast native module’s execution behavior and metadata to correctly reflect that it does not rely on the global interpreter lock, reducing import-time issues and ensuring consistent initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->