### PR TITLE
Harden CUDA graph capture tests

### DIFF
--- a/warp/tests/deterministic/test_deterministic_graph_capture.py
+++ b/warp/tests/deterministic/test_deterministic_graph_capture.py
@@ -23,6 +23,11 @@ from warp.tests.deterministic.test_deterministic_scatter import (
 from warp.tests.unittest_utils import add_function_test
 
 
+def _load_capture_modules(device, *kernels):
+    for kernel in kernels:
+        wp.load_module(module=kernel.module, device=device)
+
+
 def test_record_cmd_deterministic_launch(test, device):
     """Verify ``record_cmd=True`` works for deterministic CUDA launches."""
     n = 128
@@ -77,6 +82,7 @@ def test_graph_capture_deterministic_launch(test, device):
     indices = wp.array(indices_np, dtype=wp.int32, device=device)
     output = wp.zeros(8, dtype=wp.float32, device=device)
 
+    _load_capture_modules(device, scatter_add_kernel)
     wp.launch(scatter_add_kernel, dim=n, inputs=[data, indices], outputs=[output], device=device)
     output.zero_()
 
@@ -116,6 +122,7 @@ def test_graph_capture_sliced_array(test, device):
     col_idx = wp.array(col_np, dtype=wp.int32, device=device)
     output = wp.zeros(shape=(rows, cols), dtype=wp.float32, device=device)
 
+    _load_capture_modules(device, sliced_2d_atomic_add_kernel)
     wp.launch(sliced_2d_atomic_add_kernel, dim=n, inputs=[data, row_idx, col_idx], outputs=[output], device=device)
     output.zero_()
 
@@ -142,6 +149,7 @@ def test_graph_capture_deterministic_closure_kernel(test, device):
     data = wp.array(data_np, dtype=wp.float32, device=device)
     output = wp.zeros(8, dtype=wp.float32, device=device)
 
+    _load_capture_modules(device, kernel)
     wp.launch(kernel, dim=n, inputs=[data], outputs=[output], device=device)
     output.zero_()
 
@@ -169,6 +177,7 @@ def test_graph_capture_deterministic_func_kernel(test, device):
     indices = wp.array(indices_np, dtype=wp.int32, device=device)
     output = wp.zeros(8, dtype=wp.float32, device=device)
 
+    _load_capture_modules(device, func_scatter_add_kernel)
     wp.launch(func_scatter_add_kernel, dim=n, inputs=[data, indices], outputs=[output], device=device)
     output.zero_()
 
@@ -199,6 +208,7 @@ def test_graph_capture_vec3_atomic_minmax(test, device):
 
     out_min.fill_(min_init)
     out_max.fill_(max_init)
+    _load_capture_modules(device, vec3_atomic_minmax_kernel)
     wp.launch(vec3_atomic_minmax_kernel, dim=n, inputs=[points], outputs=[out_min, out_max], device=device)
     out_min.fill_(min_init)
     out_max.fill_(max_init)
@@ -230,6 +240,7 @@ def test_graph_capture_consumed_return_counter(test, device):
     counter = wp.zeros(1, dtype=wp.int32, device=device)
     output = wp.zeros(n, dtype=wp.float32, device=device)
 
+    _load_capture_modules(device, counter_kernel)
     wp.launch(counter_kernel, dim=n, inputs=[data, counter], outputs=[output], device=device)
     counter.zero_()
     output.zero_()
@@ -263,6 +274,7 @@ def test_graph_capture_indexed_counter(test, device):
     counter = wp.zeros(bin_count, dtype=wp.int32, device=device)
     output = wp.full((bin_count, n), value=-1, dtype=wp.int32, device=device)
 
+    _load_capture_modules(device, indexed_counter_kernel)
     wp.launch(indexed_counter_kernel, dim=n, inputs=[values, bins, counter], outputs=[output], device=device)
     counter.zero_()
     output.fill_(-1)
@@ -304,6 +316,7 @@ def test_apic_capture_rejects_deterministic_cuda_kernel(test, device):
     indices = wp.array(indices_np, dtype=wp.int32, device=device)
     output = wp.zeros(4, dtype=wp.float32, device=device)
 
+    _load_capture_modules(device, scatter_add_kernel)
     wp.launch(scatter_add_kernel, dim=n, inputs=[data, indices], outputs=[output], device=device)
     output.zero_()
 
@@ -341,6 +354,7 @@ def test_capture_while_deterministic_scatter(test, device):
     iters = wp.zeros(1, dtype=wp.int32, device=device)
 
     # Warm up modules outside capture.
+    _load_capture_modules(device, scatter_add_kernel, _decrement_iter_kernel)
     wp.launch(scatter_add_kernel, dim=n, inputs=[data, indices], outputs=[output], device=device)
     wp.launch(_decrement_iter_kernel, dim=1, inputs=[iters], device=device)
     output.zero_()
@@ -384,6 +398,7 @@ def test_capture_while_deterministic_counter(test, device):
     iters = wp.zeros(1, dtype=wp.int32, device=device)
 
     # Warm up modules outside capture.
+    _load_capture_modules(device, counter_kernel, _decrement_iter_kernel)
     wp.launch(counter_kernel, dim=n, inputs=[data, counter], outputs=[output], device=device)
     wp.launch(_decrement_iter_kernel, dim=1, inputs=[iters], device=device)
     counter.zero_()

--- a/warp/tests/fem/test_fem_integrate.py
+++ b/warp/tests/fem/test_fem_integrate.py
@@ -560,7 +560,7 @@ def test_padded_sparse_assembly(test, device):
         test.assertEqual(padded.values.ptr, padded_values_ptr)
         assert_np_equal((padded @ x).numpy(), (compact @ x).numpy(), tol=1.0e-5)
 
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             fem.integrate(
                 bilinear_form,
                 fields={"v": test_field, "u": trial_field},
@@ -704,7 +704,7 @@ def test_capturability(test, device):
         bsr_set_zero(A)
         assert A.nnz_sync() == 0
 
-        with wp.ScopedCapture() as capture:
+        with wp.ScopedCapture(force_module_load=False) as capture:
             test_body()
         wp.capture_launch(capture.graph)
         assert A.nnz_sync() == nnz_ref

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -966,6 +966,9 @@ def test_ffi_jax_callable_graph_cache(test, device):
         experimental_ffi = importlib.import_module("warp.jax_experimental.ffi")
 
     _clear_jax_experimental_warning_cache()
+    wp.load_module(module=scale_kernel.module, device=device)
+    old_force_module_load = wp.config.enable_graph_capture_module_load_by_default
+    wp.config.enable_graph_capture_module_load_by_default = False
     try:
         JaxCallableGraphMode = wp.JaxCallableGraphMode
         clear_jax_callable_graph_cache = wp.clear_jax_callable_graph_cache
@@ -1077,6 +1080,7 @@ def test_ffi_jax_callable_graph_cache(test, device):
             ffi_module.set_jax_callable_default_graph_cache_max(saved_max)
 
     finally:
+        wp.config.enable_graph_capture_module_load_by_default = old_force_module_load
         _clear_jax_experimental_warning_cache()
 
 


### PR DESCRIPTION
## Description

Old CUDA drivers cannot compile modules during graph capture. The linked
CUDA 12.2 CI failure showed later graph-capture tests force-loading every
registered Warp module after the deterministic tests had expanded the module
registry. That made unrelated pending modules part of those captures' setup.

## Changes

- Preload deterministic graph-capture test kernels before entering captures.
- Capture the FEM capturability and padded sparse assembly tests without
  force-loading unrelated modules after their warm-up paths have already loaded
  the dynamic FEM kernels they need.
- Preload the JAX graph-cache test kernel and temporarily disable default
  all-module forced loading while that test exercises Warp graph caching.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Verified a static RED check failed because the deterministic graph-capture
  tests had `ScopedCapture` calls but no explicit `wp.load_module()` preloads.
- Verified the updated deterministic graph-capture tests now preload captured
  modules before capture.
- Verified the old-driver FEM and JAX failure sites avoid forced all-module
  loads in their targeted capture paths.
- Ran `TestDeterministicGraph` locally on CUDA 13.
- Ran `TestFemIntegrate.test_capturability_cuda_0` locally on CUDA 13.
- Ran `TestFemIntegrate.test_padded_sparse_assembly_cuda_0` locally on CUDA 13.
- Ran `TestJax.test_ffi_jax_callable_graph_cache_cuda_0` locally with
  `jax[cuda13]` installed through `uv run --with`.
- Ran `uvx pre-commit run --files` on the touched files.
- Verified the PR's CUDA 12 old-driver L4 job passed in GitHub Actions.

## Bug fix

The failure requires an old CUDA driver that does not support module loading
inside graph capture, plus unrelated registered modules that cannot be safely
force-loaded. On that setup, a capture path like this can fail before the graph
starts:

```python
import warp as wp

# A previous test imports and registers unrelated Warp modules.
# A warm-up call loads the modules this test actually needs.

with wp.ScopedCapture():
    # On old drivers, the default can force-load all registered modules here.
    pass
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deterministic GPU graph capture consistency by preloading required kernels before capture and replay.
  * Updated FEM integration capture to disable forced module loading, preserving expected sparse matrix values during replay.
  * Stabilized JAX interop graph-cache behavior by preloading the needed kernel and restoring the graph-capture module-loading setting after the test.

* **Tests**
  * Refined deterministic, FEM, and JAX capture test setups to ensure the same module availability and replay results across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
