### PR TITLE
Fix example_jacobi_mpi import crash with public wp.Device (GH-1577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@
 - Fix `wp.tile_dot()` compilation failure for scalar `wp.float64` and `wp.float16` tiles, which previously narrowed
   the result to `float` and mismatched the inferred result type
   ([GH-1563](https://github.com/NVIDIA/warp/issues/1563)).
+- Fix `example_jacobi_mpi.py` crashing at import with `AttributeError: module 'warp' has no attribute 'context'` by
+  annotating `calc_default_device()` with the public `wp.Device` type instead of the non-public `wp.context.Device`
+  ([GH-1577](https://github.com/NVIDIA/warp/issues/1577)).
 - Fix `wp.load_module()` and `wp.ScopedCapture(force_module_load=True)` after CPU launches so CUDA graph capture
   precompiles the correct CUDA kernel variant. On CUDA drivers older than 12.3 this previously raised
   `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED`; on newer drivers it silently recompiled inside the capture window

--- a/warp/examples/distributed/example_jacobi_mpi.py
+++ b/warp/examples/distributed/example_jacobi_mpi.py
@@ -35,7 +35,7 @@ wptype = wp.float32  # Global precision setting, can set wp.float64 here for dou
 pi = wptype(math.pi)  # GitHub #485
 
 
-def calc_default_device(mpi_comm: "MPI.Comm") -> wp.context.Device:
+def calc_default_device(mpi_comm: "MPI.Comm") -> wp.Device:
     """Return the device that should be used for the current rank.
 
     This function is used to ensure that multiple MPI ranks running on the same


### PR DESCRIPTION
## Description

Closes #1577. `warp/examples/distributed/example_jacobi_mpi.py` crashes at import, before any MPI or GPU work:

```
File ".../example_jacobi_mpi.py", line 38, in <module>
    def calc_default_device(mpi_comm: "MPI.Comm") -> wp.context.Device:
                                                     ^^^^^^^^^^
AttributeError: module 'warp' has no attribute 'context'. Did you mean: 'constant'?
```

The return annotation references `wp.context.Device`, but Warp no longer exposes a public `context` attribute (`Device` is re-exported at the top level from `warp/__init__.py`). Because the file does not use `from __future__ import annotations`, the annotation is evaluated at function-definition time and the missing attribute aborts the import.

## Changes

- Annotate `calc_default_device()` with the public `wp.Device` type instead of the non-public `wp.context.Device`.
- Add a `### Fixed` CHANGELOG entry under `Unreleased`.

This follows the project guideline to import from `warp` in public-facing code rather than `warp._src` (`wp.Device` is `warp._src.context.Device` re-exported).

## Checklist

- [x] I am familiar with the Contributing Guidelines.
- [x] New or existing tests cover these changes. (No new test: this is a one-line annotation fix to an example; the existing example now imports.)
- [x] The documentation is up to date with these changes.
- [x] CHANGELOG.md is updated under the `Unreleased` section.

## Validation summary

Verified against the installed Warp public API that the fix is correct and the original is broken:

- `python -c "import warp as wp; print(wp.Device); print(hasattr(wp, 'context'))"` prints
  `<class 'warp._src.context.Device'>` and `False`, confirming `wp.Device` resolves and `wp.context` does not exist (the source of the AttributeError).
- Grepped the example: `wp.context` appeared only on line 38; no other references remain after the change.

Full `mpirun` execution needs a CUDA-aware MPI build and multiple GPUs, which is out of scope for this import-time annotation fix.

## Bug fix

Reproduce without this PR (any platform, no GPU needed):

```python
import warp as wp
wp.context.Device  # AttributeError: module 'warp' has no attribute 'context'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an import-time crash in the distributed Jacobi example by correcting the device type annotation to use the supported public device type.
* **Documentation**
  * Updated the changelog under Unreleased → Fixed to document the issue and the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->