### PR TITLE
Fix kernel hook cache leak for closure-created kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@
 
 ### Fixed
 
+- Fix unbounded memory growth when repeatedly launching identical kernels created by a factory or closure
+  ([GH-1589](https://github.com/NVIDIA/warp/issues/1589)).
 - Fix `wp.load_module()` and `wp.ScopedCapture(force_module_load=True)` after CPU launches so CUDA graph capture
   precompiles the correct CUDA kernel variant. On CUDA drivers older than 12.3 this previously raised
   `CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED`; on newer drivers it silently recompiled inside the capture window

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2977,14 +2977,13 @@ class ModuleExec:
 
     # lookup and cache kernel entry points
     def get_kernel_hooks(self, kernel) -> KernelHooks:
-        # Use kernel.adj as a unique key for cache lookups instead of the kernel itself.
-        # This avoids holding a reference to the kernel and is faster than using
-        # a WeakKeyDictionary with kernels as keys.
-        hooks = self.kernel_hooks.get(kernel.adj)
+        # Key by the mangled name (compiled-symbol identity), not kernel.adj, which pinned one
+        # Adjoint per closure-recreated kernel -- a leak the live-kernel WeakSet can't reclaim.
+        name = kernel.get_mangled_name()
+
+        hooks = self.kernel_hooks.get(name)
         if hooks is not None:
             return hooks
-
-        name = kernel.get_mangled_name()
 
         options = kernel.module.options | kernel.options
 
@@ -3082,7 +3081,7 @@ class ModuleExec:
 
             hooks = KernelHooks(forward, backward)
 
-        self.kernel_hooks[kernel.adj] = hooks
+        self.kernel_hooks[name] = hooks
         return hooks
 
 

--- a/warp/tests/test_codegen_instancing.py
+++ b/warp/tests/test_codegen_instancing.py
@@ -1308,6 +1308,46 @@ def test_garbage_collection(test, device):
 
 # =======================================================================
 
+
+def test_create_kernel_loop_hooks_bounded(test, device):
+    """
+    Relaunching an identical recreated kernel must not grow the per-ModuleExec hook cache
+    (regression for an Adjoint leak when hooks were keyed by kernel.adj).
+    """
+
+    def make():
+        @wp.kernel
+        def k(a: wp.array(dtype=int)):
+            a[0] = 17
+
+        return k
+
+    with wp.ScopedDevice(device):
+        a = wp.zeros(1, dtype=int)
+
+        k0 = make()
+        wp.launch(k0, dim=1, inputs=[a])
+        wp.synchronize_device()
+        module = k0.module
+        del k0
+
+        def hook_count():
+            return sum(len(module_exec.kernel_hooks) for module_exec in module.execs.values())
+
+        baseline = hook_count()
+        for _ in range(16):
+            k = make()
+            wp.launch(k, dim=1, inputs=[a])
+            wp.synchronize_device()
+            del k
+
+        # Identical kernel each iteration: no reload, so the hook cache must not grow.
+        test.assertEqual(hook_count(), baseline)
+        test.assertEqual(a.numpy()[0], 17)
+
+
+# =======================================================================
+
 # Module-level constant used as a fallback when the closure cell is empty.
 _CELL_CONTENT = wp.constant(42)
 
@@ -1518,6 +1558,12 @@ add_function_test(
     TestCodeGenInstancing, func=test_module_mark_modified, name="test_module_mark_modified", devices=devices
 )
 add_function_test(TestCodeGenInstancing, func=test_garbage_collection, name="test_garbage_collection", devices=devices)
+add_function_test(
+    TestCodeGenInstancing,
+    func=test_create_kernel_loop_hooks_bounded,
+    name="test_create_kernel_loop_hooks_bounded",
+    devices=None,
+)
 
 # empty closure cell fallback
 add_function_test(TestCodeGenInstancing, func=test_empty_closure_cell, name="test_empty_closure_cell", devices=devices)


### PR DESCRIPTION
## Description

Closes #1589. `ModuleExec.get_kernel_hooks` keyed its entry-point cache by `kernel.adj`. The live-kernel `WeakSet` drops a re-created `Kernel` object, but its adjoint stays pinned as a dict key, so a kernel factory that rebuilds an identical `@wp.kernel` each step retains one `Adjoint`/AST/`Var` graph per launch — unbounded memory growth even though kernel and module counts stay flat. This keys the cache by the mangled name (the compiled-symbol identity) instead. The kernel hash folds in the adjoint and all per-kernel options, so within a `ModuleExec` the resolved hooks are fully determined by the name; identical specializations collapse to a single entry and no adjoint is retained.

## Changes

- `ModuleExec.get_kernel_hooks` keys `kernel_hooks` by `kernel.get_mangled_name()` rather than `kernel.adj`.
- Add `test_create_kernel_loop_hooks_bounded` to `test_codegen_instancing.py`, asserting the per-`ModuleExec` hook count does not grow when an identical kernel is recreated and relaunched.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

The new test recreates an identical factory kernel in a loop and asserts the hook cache does not grow past its baseline. Verified red/green with the equivalent keying on `1.15.0.dev20260612`: with the current `kernel.adj` keying the hook count grows linearly with launches (the leak), and with name-keying it stays flat at the baseline. The change is device-agnostic — the cache keying is shared by the CPU and CUDA paths, so the test registers once with `devices=None`. Full native test-suite run is left to CI.

## Bug fix

```python
import warp as wp

wp.init()

def make_kernel():
    @wp.kernel
    def k(a: wp.array(dtype=float), b: wp.array(dtype=float)):
        i = wp.tid()
        b[i] = a[i] + 1.0
    return k

a = wp.zeros(8, dtype=float)
b = wp.zeros(8, dtype=float)

k0 = make_kernel()
wp.launch(k0, dim=8, inputs=[a], outputs=[b])
module = k0.module
del k0

for i in range(1, 2001):
    k = make_kernel()
    wp.launch(k, dim=8, inputs=[a], outputs=[b])
    del k
    if i % 500 == 0:
        hooks = sum(len(e.kernel_hooks) for e in module.execs.values())
        print(f"after {i} launches: live_kernels={len(module._get_live_kernels())}, kernel_hooks={hooks}")
```

Without this PR, `kernel_hooks` grows one entry per launch while `live_kernels` stays at 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed unbounded memory growth when repeatedly launching the same kernel created from a factory or closure.
  - Improved kernel hook handling so repeated launches reuse existing cached hooks more reliably.

- **Tests**
  - Added a regression test to verify kernel hook usage stays bounded across repeated kernel creation and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->