### PR TITLE
fix(examples): use wp.Device in jacobi_mpi type hint

### DIFF
--- a/warp/examples/distributed/example_jacobi_mpi.py
+++ b/warp/examples/distributed/example_jacobi_mpi.py
@@ -35,7 +35,7 @@ wptype = wp.float32  # Global precision setting, can set wp.float64 here for dou
 pi = wptype(math.pi)  # GitHub #485
 
 
-def calc_default_device(mpi_comm: "MPI.Comm") -> wp.context.Device:
+def calc_default_device(mpi_comm: "MPI.Comm") -> wp.Device:
     """Return the device that should be used for the current rank.
 
     This function is used to ensure that multiple MPI ranks running on the same


### PR DESCRIPTION
wp.context is not exposed on the public warp module; referencing wp.context.Device at import time raises AttributeError before MPI runs.

Fixes #1577

## Description

<!--
Explain what changed, why it matters, and reference issues with "closes #1234"
when applicable.
-->

## Changes

<!--
List the main changes grouped by behavior or subsystem. Keep this high-level;
avoid repeating the diff.
-->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

<!--
Explain what was verified and why it is sufficient for review. Write a short
step-by-step validation narrative, not a command dump. Prefer test names plus
behavior summaries.

For test-driven changes, include red/green evidence when applicable, e.g.:
- Verified the new test fails on the target branch without this change.
- Verified the new test passes on this branch with the fix.

If testing was not run, say so and explain the risk or blocker. Include
commands only when they help reproduce the validation.
-->

## Bug fix

<!-- If this is a bug fix, provide a minimal code example that reproduces
     the issue WITHOUT this PR applied. Delete this section if not applicable. -->

```python
import warp as wp
# Code that demonstrates the bug
```

## New feature / enhancement

<!-- If this is a new feature or enhancement, provide a code example showing
     what this PR enables. Delete this section if not applicable. -->

```python
import warp as wp
# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the public type annotation in the distributed Jacobi example for consistency with the current device API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->