### PR TITLE
Fix Adam.set_params re-zeroing fp16 moment buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,10 @@
   capture, which APIC cannot record for replay ([GH-1559](https://github.com/NVIDIA/warp/issues/1559)).
 - Fix APIC graph capture for `warp.fem` workflows by making partition node counts graph-capture safe
   ([GH-1407](https://github.com/NVIDIA/warp/issues/1407)).
+- Fix `warp.optim.Adam.set_params()` re-zeroing the optimizer moment buffers on every call for `fp16`
+  parameters, which silently discarded accumulated state. The reuse check now compares against the
+  moment-buffer dtype rather than the parameter dtype
+  ([GH-1593](https://github.com/NVIDIA/warp/issues/1593)).
 
 ### Documentation
 

--- a/warp/_src/optim/adam.py
+++ b/warp/_src/optim/adam.py
@@ -129,9 +129,11 @@ class Adam:
                 else:
                     raise RuntimeError(f"Unsupported dtype for Warp Adam optimizer: {param.dtype}")
 
-                if self.m[i] is None or self.m[i].shape != param.shape or self.m[i].dtype != param.dtype:
+                # Moments are always fp32 even for fp16 params, so compare against ``dtype`` (the moment
+                # buffer dtype), not ``param.dtype``, otherwise the buffers are re-zeroed on every call.
+                if self.m[i] is None or self.m[i].shape != param.shape or self.m[i].dtype != dtype:
                     self.m[i] = wp.zeros(shape=param.shape, dtype=dtype, device=param.device)
-                if self.v[i] is None or self.v[i].shape != param.shape or self.v[i].dtype != param.dtype:
+                if self.v[i] is None or self.v[i].shape != param.shape or self.v[i].dtype != dtype:
                     self.v[i] = wp.zeros(shape=param.shape, dtype=dtype, device=param.device)
 
     def reset_internal_state(self):

--- a/warp/tests/test_adam.py
+++ b/warp/tests/test_adam.py
@@ -133,6 +133,32 @@ def test_adam_solve_two_inputs(test, device):
                 test.assertLessEqual(v, tol)
 
 
+def test_adam_set_params_preserves_fp16_state(test, device):
+    """Verify repeated ``set_params()`` calls with unchanged params reuse the existing moment buffers.
+
+    The buffers must not be re-allocated (and zeroed). Moments are always fp32, so for fp16 params
+    the realloc guard must compare against the moment dtype, not the param dtype, otherwise fp16
+    optimizer state is silently reset on every call.
+    """
+    with wp.ScopedDevice(device):
+        for param_dtype in (wp.float32, wp.float16, wp.vec3):
+            params = wp.zeros(4, dtype=param_dtype, requires_grad=True)
+            opt = warp.optim.Adam([params], lr=0.02)
+
+            m_buffer, v_buffer = opt.m[0], opt.v[0]
+            # Dirty the moment state so a spurious realloc would be observable.
+            m_buffer.fill_(1.0)
+            v_buffer.fill_(1.0)
+
+            for _ in range(2):
+                opt.set_params([params])  # same params -> must be a no-op
+
+                test.assertIs(opt.m[0], m_buffer, f"first moment re-allocated for {param_dtype}")
+                test.assertIs(opt.v[0], v_buffer, f"second moment re-allocated for {param_dtype}")
+                test.assertTrue((opt.m[0].numpy() == 1.0).all(), f"first moment reset for {param_dtype}")
+                test.assertTrue((opt.v[0].numpy() == 1.0).all(), f"second moment reset for {param_dtype}")
+
+
 devices = get_test_devices()
 
 
@@ -143,6 +169,9 @@ class TestAdam(unittest.TestCase):
 add_function_test(TestAdam, "test_adam_solve_float", test_adam_solve_float, devices=devices)
 add_function_test(TestAdam, "test_adam_solve_vec3", test_adam_solve_vec3, devices=devices)
 add_function_test(TestAdam, "test_adam_solve_two_inputs", test_adam_solve_two_inputs, devices=devices)
+add_function_test(
+    TestAdam, "test_adam_set_params_preserves_fp16_state", test_adam_set_params_preserves_fp16_state, devices=devices
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes #1593.

`warp.optim.Adam.set_params()` silently re-zeroed its moment buffers on every call when the parameters are `fp16`, discarding accumulated optimizer state. Moment buffers are intentionally kept in `float32` even for `fp16` params, but the reuse check compared the existing buffer dtype against the *parameter* dtype (`self.m[i].dtype != param.dtype`), which for `fp16` is always `float32 != float16` → always true → reallocate to zeros. This affects the documented "set params later via `set_params`" path; the first call from `__init__` allocates regardless. `SGD.set_params()` is not affected because its buffer dtype matches the param dtype.

## Changes

- `warp/_src/optim/adam.py`: compare the existing moment buffers against the moment-buffer dtype (`dtype`) instead of `param.dtype` when deciding whether to reuse them. `float32`/`vec3` behavior is unchanged (there `dtype == param.dtype`).
- `warp/tests/test_adam.py`: add `test_adam_set_params_preserves_fp16_state` covering `fp32`/`fp16`/`vec3`.
- `CHANGELOG.md`: add a `Fixed` entry.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Added `test_adam_set_params_preserves_fp16_state`, which dirties the moment buffers, calls `set_params` again with the same parameters, and asserts the buffers are reused (same object) and their contents preserved, for `fp32`, `fp16`, and `vec3`.

- Verified the new test **fails on `main`** without this change (the `fp16` case re-zeros the buffers): `python -m warp.tests -k set_params_preserves` → `FAILED (failures=2)` on CPU and CUDA.
- Verified the new test **passes with this change**: same command → `OK` on CPU and CUDA.
- No regression: `test_adam`, `test_sgd`, `test_grad`, and `test_linear_solvers` all pass on CPU and CUDA.

## Bug fix

Reproduces without this PR applied (CPU or CUDA):

```python
import warp as wp
import warp.optim
wp.init()

p = wp.zeros(8, dtype=wp.float16, requires_grad=True)
opt = warp.optim.Adam([p], lr=1e-3)
opt.m[0].fill_(1.0)          # pretend we have accumulated moment state
opt.set_params([p])          # same params -> should be a no-op
print((opt.m[0].numpy() == 1.0).all())   # main: False (state wiped); with fp32 params: True
```
