### PR TITLE
Add free-threaded Python CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,56 @@ jobs:
           retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
       
 
+  build-warp-python-free-threaded:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: "0.11.16"
+
+      - name: Set up Python
+        run: uv python install 3.14t
+
+      - name: Cache build artifacts
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        id: cache-build
+        with:
+          path: warp/bin/
+          # Hash only native-binary inputs. VERSION.md changes flow through
+          # generated warp/native/version.h, which is covered by native headers.
+          key: build-ubuntu-x86_64-cuda13-python314t-13.0.2-${{ hashFiles('build_lib.py', 'build_llvm.py', 'warp/_src/build_dll.py', 'warp/native/**/*.cpp', 'warp/native/**/*.cu', 'warp/native/**/*.cuh', 'warp/native/**/*.h', 'warp/native/libdevice/*.bc', 'warp/native/warp.map', 'deps/libmathdx-deps.packman.xml') }}
+
+      - name: Install CTK
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76  # v0.2.35
+        with:
+          cuda: "13.0.2"
+          sub-packages: '["cudart-dev", "nvcc", "nvrtc-dev"]'
+          non-cuda-sub-packages: '["libnvjitlink-dev"]'
+          method: 'network'
+
+      - name: Build Warp
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: uv run --python 3.14t build_lib.py
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: build-artifact-ubuntu-x86_64-cuda13-python314t
+          path: warp/bin/
+          retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
+
+
   build-warp-cmake:
     if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ${{ matrix.os }}
@@ -499,6 +549,71 @@ jobs:
           files: ./coverage.xml
           flags: test-warp-gpu-linux-${{ matrix.gpu-name }}
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-warp-gpu-linux-python-free-threaded:
+    runs-on: linux-amd64-gpu-rtxpro6000-latest-1
+    needs: [build-warp-python-free-threaded, gpu-changes]
+    if: |
+      github.repository == 'NVIDIA/warp' && (
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/') ||
+        github.ref == 'refs/heads/main' ||
+        startsWith(github.ref, 'refs/heads/release-') ||
+        needs.gpu-changes.outputs.gpu_relevant == 'true'
+      )
+    permissions:
+      contents: read
+    container:
+      image: ubuntu:24.04
+      options: -u root --security-opt seccomp=unconfined --shm-size 16g
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    timeout-minutes: 45
+    steps:
+      - name: Display GPU information
+        run: nvidia-smi
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y git git-lfs curl gpg build-essential
+          git lfs install
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: "0.11.16"
+
+      - name: Set up Python
+        run: uv python install 3.14t
+
+      - name: Download Warp build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifact-ubuntu-x86_64-cuda13-python314t
+          path: warp/bin/
+
+      - name: Run Tests
+        run: uv run --python 3.14t --extra dev -m warp.tests --junit-report-xml rspec.xml -s autodetect --failfast
+
+      - name: Test Summary
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        with:
+          paths: "rspec.xml"
+          show: "fail"
+        if: always()
 
   test-warp-gpu-linux-mgpu-python310:
     runs-on: linux-amd64-gpu-rtxpro6000-latest-2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,9 +36,9 @@ variables:
   UV_PYTHON_PREFERENCE: only-managed
   
   # Standard container images (pinned with SHA256 for supply chain security)
-  UV_TRIXIE_IMAGE: "ghcr.io/astral-sh/uv:0.10.0-trixie@sha256:b6fa78dd57c8a1a6c5da74a36a13e309f67f0e925bc89bbd16d6f0628475e052"
-  UV_TRIXIE_SLIM_IMAGE: "ghcr.io/astral-sh/uv:0.10.0-trixie-slim@sha256:ea4142f234c115bda9927e49c63efc8a5a7c1db35b2355dc8bc45080fa299bf5"
-  UV_TRIXIE_SLIM_ARM_IMAGE: "ghcr.io/astral-sh/uv:0.10.0-trixie-slim@sha256:12c27f31bbaec60e4e98900bcad6bc775a3dc182ef1a79bc1a3ed6248d3f2fb5"
+  UV_TRIXIE_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-trixie@sha256:3a10099599f370305314be6af0cf18fdbc65ea5ddadb3731561dd920f1d185b8"
+  UV_TRIXIE_SLIM_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-trixie-slim@sha256:bf3ae2823f0399092f2e47ec7bae6a8e0b389d2310a9bc7f0741f0fa1629040f"
+  UV_TRIXIE_SLIM_ARM_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-trixie-slim@sha256:e4e5baeeb366609825aadbe4387686c39dab036b0cc68d938fcb9a61aa05bf75"
   MINIFORGE_IMAGE: "condaforge/miniforge3:25.11.0-0@sha256:d2fadb08950045962fd1cfb1eeb6224442027f03095862e725f4c1c7b17a3caf"
   WARP_BUILDER_IMAGE_CU12: "${CI_REGISTRY_IMAGE}/warp-builder:cuda12.9.1-llvm21-latest"
   WARP_BUILDER_IMAGE_CU13: "${CI_REGISTRY_IMAGE}/warp-builder:cuda13.0.2-llvm21-latest"
@@ -139,6 +139,22 @@ linux-x86_64 cuda 13 build:
     - .ipp_lnx_x86_64_cpu_medium
   script:
     - uv run build_lib.py --cuda-path=/usr/local/cuda
+    - mkdir -p warp/bin/linux-x86_64
+    - mv warp/bin/warp.so warp/bin/linux-x86_64
+    - mv warp/bin/warp-clang.so warp/bin/linux-x86_64
+
+linux-x86_64 python free-threaded build:
+  stage: build
+  image: $WARP_BUILDER_IMAGE_CU13
+  variables:
+    IPP_RUNNER_EXECUTION_DURATION: "3600"
+    UV_PYTHON: "3.14t"
+  extends:
+    - .save_warp_bin_artifact
+    - .ipp_lnx_x86_64_cpu_medium
+  script:
+    - uv python install 3.14t
+    - uv run --python 3.14t build_lib.py --cuda-path=/usr/local/cuda
     - mkdir -p warp/bin/linux-x86_64
     - mv warp/bin/warp.so warp/bin/linux-x86_64
     - mv warp/bin/warp-clang.so warp/bin/linux-x86_64
@@ -491,6 +507,27 @@ linux-x86_64-blackwell test:
     - gpu/B40
     - os/linux
     - platform/horde
+
+linux-x86_64 python free-threaded test:
+  stage: test
+  needs: [linux-x86_64 python free-threaded build]
+  image: $UV_TRIXIE_SLIM_IMAGE
+  variables:
+    IPP_RUNNER_EXECUTION_DURATION: "3600"
+    UV_PYTHON: "3.14t"
+  extends:
+    - .ipp_lnx_x86_64_gpu
+    - .save_test_report_artifact
+    - .basic_test_changes_rules
+  before_script:
+    - !reference [.snippets, section-start-install-deps]
+    - df -h
+    - apt-get update && apt-get install build-essential --no-install-recommends -y
+    - uv python install 3.14t
+    - !reference [.snippets, move-linux-x86_64-binaries]
+    - !reference [.snippets, section-end-install-deps]
+  script:
+    - uv run --python 3.14t --extra dev -m warp.tests --junit-report-xml rspec.xml -s autodetect --failfast
 
 linux-x86_64 test debug mode:
   stage: test


### PR DESCRIPTION
## Description

Add CI coverage for Warp build and GPU tests using uv's free-threaded
Python 3.14 selector, `3.14t`. This keeps the first coverage focused on
Warp's core build and test path before broadening optional dependency
coverage.

## Changes

- Add a GitHub Actions build job that installs Python `3.14t`, builds Warp
  with CUDA 13, and uploads a separate build artifact.
- Add a GitHub Actions GPU test job on `linux-amd64-gpu-rtxpro6000-latest-1`
  that consumes the `3.14t` build artifact and runs the Warp test suite
  with `--extra dev`.
- Add matching GitLab build and GPU test jobs for Python `3.14t`.
- Keep optional JAX, Torch, USD, and RMM dependencies out of this first
  coverage.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Parsed `.github/workflows/ci.yml` and `.gitlab-ci.yml` and structurally
checked the new jobs for `3.14t` commands, artifact wiring, runner labels,
and GitLab `needs`.

Ran `uvx pre-commit run --files .github/workflows/ci.yml .gitlab-ci.yml`.

Built Warp locally with `uv run --python 3.14t build_lib.py`; diagnostics
reported Python `3.14.6 free-threading build`.

Ran a local Python `3.14t` smoke selection of Warp tests (`374 tests`) and
the deterministic scatter tests (`57 tests`) successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Ubuntu-only CI build for Warp using Python free-threaded (Python 3.14t) with CUDA 13, producing dedicated build artifacts.
  * Added a matching GPU test job that runs Warp tests on the new Python 3.14t environment and publishes results in the existing JUnit format.
* **Chores**
  * Updated pinned UV container image digests used by the CI pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->