### PR TITLE
optim: don't reallocate Adam fp16 moment buffers on every set_params

### DIFF
--- a/warp/_src/optim/adam.py
+++ b/warp/_src/optim/adam.py
@@ -129,9 +129,9 @@ class Adam:
                 else:
                     raise RuntimeError(f"Unsupported dtype for Warp Adam optimizer: {param.dtype}")
 
-                if self.m[i] is None or self.m[i].shape != param.shape or self.m[i].dtype != param.dtype:
+                if self.m[i] is None or self.m[i].shape != param.shape or self.m[i].dtype != dtype:
                     self.m[i] = wp.zeros(shape=param.shape, dtype=dtype, device=param.device)
-                if self.v[i] is None or self.v[i].shape != param.shape or self.v[i].dtype != param.dtype:
+                if self.v[i] is None or self.v[i].shape != param.shape or self.v[i].dtype != dtype:
                     self.v[i] = wp.zeros(shape=param.shape, dtype=dtype, device=param.device)
 
     def reset_internal_state(self):

--- a/warp/tests/test_adam.py
+++ b/warp/tests/test_adam.py
@@ -133,6 +133,31 @@ def test_adam_solve_two_inputs(test, device):
                 test.assertLessEqual(v, tol)
 
 
+def test_adam_fp16_moments_preserved_on_set_params(test, device):
+    # Regression test for #1593: for fp16 params, set_params() reallocated (and
+    # therefore zeroed) the fp32 moment buffers on every call, because the
+    # realloc guard compared the moment dtype against param.dtype (fp32 != fp16)
+    # instead of the intended moment dtype.
+    with wp.ScopedDevice(device):
+        params = wp.array(np.array([0.1, 0.2], dtype=np.float16), dtype=wp.float16, requires_grad=True)
+        opt = warp.optim.Adam([params], lr=0.02)
+
+        m0, v0 = opt.m[0], opt.v[0]
+        # Moments are kept in fp32 even when the params are fp16.
+        test.assertEqual(m0.dtype, wp.float32)
+        # Write a sentinel so a spurious reset is observable.
+        m0.fill_(1.0)
+        v0.fill_(1.0)
+
+        # Re-setting the same params must not reallocate or zero the moments.
+        opt.set_params([params])
+
+        test.assertIs(opt.m[0], m0)
+        test.assertIs(opt.v[0], v0)
+        assert_np_equal(opt.m[0].numpy(), np.ones(2, dtype=np.float32))
+        assert_np_equal(opt.v[0].numpy(), np.ones(2, dtype=np.float32))
+
+
 devices = get_test_devices()
 
 
@@ -143,6 +168,12 @@ class TestAdam(unittest.TestCase):
 add_function_test(TestAdam, "test_adam_solve_float", test_adam_solve_float, devices=devices)
 add_function_test(TestAdam, "test_adam_solve_vec3", test_adam_solve_vec3, devices=devices)
 add_function_test(TestAdam, "test_adam_solve_two_inputs", test_adam_solve_two_inputs, devices=devices)
+add_function_test(
+    TestAdam,
+    "test_adam_fp16_moments_preserved_on_set_params",
+    test_adam_fp16_moments_preserved_on_set_params,
+    devices=devices,
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`warp.optim.Adam` keeps its first/second moment buffers in fp32 even when the optimized parameters are fp16 (`set_params` forces `dtype = wp.float32` for an fp16 param). But the reallocation guard compares the *existing* moment's dtype against `param.dtype`:

```python
if self.m[i] is None or self.m[i].shape != param.shape or self.m[i].dtype != param.dtype:
    self.m[i] = wp.zeros(shape=param.shape, dtype=dtype, device=param.device)
```

For an fp16 param this is `float32 != float16`, which is always true, so the moment buffers are reallocated — and therefore zeroed — on **every** `set_params` call. Any code that re-sets the params on a persistent optimizer (e.g. to swap in new tensors between iterations) silently wipes Adam's accumulated `m`/`v` state, breaking fp16 convergence. Closes #1593.

## Changes

- `warp/_src/optim/adam.py`: compare the existing moment dtype against the intended moment `dtype` (fp32 for fp16 params) rather than `param.dtype`. For fp32 / vec3 params `dtype == param.dtype`, so their behavior is unchanged; for fp16 params the moments are now preserved across repeated `set_params` calls.
- `warp/tests/test_adam.py`: add `test_adam_fp16_moments_preserved_on_set_params`, which writes a sentinel into the moments and asserts a second `set_params` neither reallocates nor zeros them.

## Testing

- `python -m py_compile` clean on both files.
- The change is a self-contained control-flow fix; the added regression test exercises it on whatever devices CI runs. (I develop on a single-GPU WSL2 box without a full Warp native build, so I could not run the suite locally — flagging that for the reviewer.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved optimizer parameter refresh behavior so moment buffers keep the correct precision and are only recreated when needed.
  * Fixed an issue where moment buffers for half-precision parameters could be unnecessarily reallocated or reset.

* **Tests**
  * Added a regression test covering half-precision parameters to ensure optimizer moment buffers remain stable across parameter updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->