### PR TITLE
mesh: refit host solid-angle BVH from the real root, not node 0

### DIFF
--- a/warp/native/mesh.cpp
+++ b/warp/native/mesh.cpp
@@ -113,7 +113,7 @@ void bvh_refit_with_solid_angle_recursive_host(BVH& bvh, int index, Mesh& mesh)
     }
 }
 
-void bvh_refit_with_solid_angle_host(BVH& bvh, Mesh& mesh) { bvh_refit_with_solid_angle_recursive_host(bvh, 0, mesh); }
+void bvh_refit_with_solid_angle_host(BVH& bvh, Mesh& mesh) { bvh_refit_with_solid_angle_recursive_host(bvh, *bvh.root, mesh); }
 
 uint64_t wp_mesh_create_host(
     array_t<wp::vec3> points,


### PR DESCRIPTION
## Description

The host solid-angle BVH refit always starts the recursion at node index `0`:

```cpp
void bvh_refit_with_solid_angle_host(BVH& bvh, Mesh& mesh) { bvh_refit_with_solid_angle_recursive_host(bvh, 0, mesh); }
```

whereas the sibling non-solid-angle refit correctly starts at the real root — `bvh_refit_host` does `bvh_refit_recursive(bvh, *bvh.root)` (bvh.cpp). For a **grouped** BVH (`groups != nullptr`), `build_with_groups` finishes by calling `reorder_top_down_bvh`, which moves all leaf nodes to the front and sets `*bvh.root` to an index `> 0` for a non-leaf root. Starting the solid-angle refit at node `0` (now a leaf) therefore computes `solid_angle_props` for only that single leaf and returns; the root and all other internal nodes keep their **uninitialized** `solid_angle_props` (allocated via `wp_alloc_host`, not zeroed). `mesh_query_point_sign_winding_number` traverses from `*bvh.root`, so it reads that garbage → wrong sign / winding-number results (and possible NaNs).

This is reachable from Python: `wp.Mesh(..., groups=<array>, support_winding_number=True)` on a CPU device passes both straight through to `wp_mesh_create_host` with no guard (only the cuBQL constructor rejects the combination). The CUDA path is unaffected — `bvh_refit_with_solid_angle_device` does a bottom-up refit over the leaf nodes via `node_parents` and never uses a literal root index.

## Changes

- `warp/native/mesh.cpp`: start the host solid-angle refit at `*bvh.root`, matching `bvh_refit_host`. For a non-grouped host build the root is already `0`, so that path is unchanged; this only fixes the grouped case.

## Testing

- Static: the fix makes `bvh_refit_with_solid_angle_host` use the same root as its sibling `bvh_refit_host` (`*bvh.root`); the `0` was incorrect after `reorder_top_down_bvh` reassigns the root for grouped builds.
- I was not able to build the native CPU library on my single-GPU WSL2 box, so I could not run a host repro / ASan locally — flagging that for the reviewer. A runtime check would build a grouped CPU mesh spanning >1 group with `support_winding_number=True` and compare `mesh_query_point_sign_winding_number` at known inside/outside points against the non-grouped (or CUDA) result; under ASan it would also surface the uninitialized `solid_angle_props` read.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed BVH solid-angle refitting to start from the correct root node, improving bound and solid-angle updates when this feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->