### PR TITLE
Guard APIC CUDA conditional tests

### DIFF
--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -873,11 +873,14 @@ def test_capture_replay_with_tile_kernel_no_stack_overflow(test, device):
     itself takes was enough to blow the 1 MB Windows main-thread stack —
     Newton's basic_conveyor / basic_plotting / IK examples all hit this."""
     n = 32
+    block_dim = 64
     out = wp.zeros(n, dtype=float, device=device)
 
     wp.load_module(device=device)
+    if device.is_cuda:
+        wp.load_module(module=_tile_using_kernel.module, device=device, block_dim=block_dim)
     with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
-        wp.launch_tiled(_tile_using_kernel, dim=n, inputs=[out], block_dim=64, device=device)
+        wp.launch_tiled(_tile_using_kernel, dim=n, inputs=[out], block_dim=block_dim, device=device)
 
     # Multiple launches verify there's no slow leak / cumulative stack use.
     for _ in range(3):
@@ -2101,6 +2104,9 @@ def test_capture_with_padded_bsr_transpose(test, device):
     At_too_small = bsr_zeros(3, 2, block_type=wp.float32, device=device, row_capacity=1)
 
     wp.load_module(device=device)
+    if device.is_cuda:
+        # Specialize and load the internal values kernel before CUDA graph capture.
+        bsr_set_transpose(At, A, topology="padded")
     with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
         bsr_set_transpose(At, A, topology="padded")
         bsr_set_transpose(At_too_small, A, topology="padded")
@@ -2152,6 +2158,9 @@ def test_capture_padded_bsr_transpose_rebuilds_offsets(test, device):
     At = bsr_zeros(2, 2, block_type=wp.float32, device=device, row_capacity=2)
 
     wp.load_module(device=device)
+    if device.is_cuda:
+        # Specialize and load the internal values kernel before CUDA graph capture.
+        bsr_set_transpose(At, A, topology="padded")
     with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
         bsr_set_transpose(At, A, topology="padded")
 
@@ -2186,6 +2195,8 @@ def test_save_load_padded_bsr_transpose_cuda_rebuild(test, device):
     At = bsr_zeros(3, 2, block_type=wp.float32, device=device, row_capacity=2)
 
     wp.load_module(device=device)
+    # Specialize and load the internal values kernel before CUDA graph capture.
+    bsr_set_transpose(At, A, topology="padded")
     with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
         bsr_set_transpose(At, A, topology="padded")
 

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -220,6 +220,9 @@ def test_apic_capture_while_body_raises_cleanup(test, device):
     capture state consistent (parent graph restored, parent capture resumed, APIC recording
     torn down, no leaked branch) so a subsequent capture works. The broken capture is never
     launched -- its while node has an empty body and would loop forever."""
+    if device.is_cuda and not wp.is_conditional_graph_supported():
+        test.skipTest("CUDA conditional graph nodes require Toolkit and driver 12.4+")
+
     cond = wp.ones(1, dtype=wp.int32, device=device)
 
     class Sentinel(Exception):
@@ -250,6 +253,9 @@ def test_apic_capture_if_body_raises_cleanup(test, device):
     """Companion to the capture_while case -- a raising capture_if branch body
     propagates cleanly (branch rolled back, parent graph restored and capture resumed) and
     leaves the device reusable for a subsequent capture."""
+    if device.is_cuda and not wp.is_conditional_graph_supported():
+        test.skipTest("CUDA conditional graph nodes require Toolkit and driver 12.4+")
+
     cond = wp.ones(1, dtype=wp.int32, device=device)
 
     class Sentinel(Exception):
@@ -1317,6 +1323,9 @@ def decrement_counter_kernel(c: wp.array(dtype=wp.int32)):
 
 def test_capture_if_cpu(test, device):
     """APIC_OP_IF on CPU: condition selects which branch runs at replay."""
+    if device.is_cuda and not wp.is_conditional_graph_supported():
+        test.skipTest("CUDA conditional graph nodes require Toolkit and driver 12.4+")
+
     n = 4
     out = wp.zeros(n, dtype=float, device=device)
     cond = wp.array([1], dtype=wp.int32, device=device)
@@ -1350,6 +1359,9 @@ def test_save_load_capture_if_cuda(test, device):
     apic_replay_ops_into_cuda_capture rebuilds the conditional nodes from the
     byte stream. Save/load a capture_if graph and confirm the recorded branch
     runs on the rebuilt graph."""
+    if not wp.is_conditional_graph_supported():
+        test.skipTest("CUDA conditional graph nodes require Toolkit and driver 12.4+")
+
     n = 4
     out = wp.zeros(n, dtype=float, device=device)
     cond = wp.array([1], dtype=wp.int32, device=device)  # selects on_true at capture
@@ -1379,6 +1391,9 @@ def test_save_load_capture_if_cuda(test, device):
 
 def test_capture_while_cpu(test, device):
     """APIC_OP_WHILE on CPU: body re-runs while the condition int32 is nonzero."""
+    if device.is_cuda and not wp.is_conditional_graph_supported():
+        test.skipTest("CUDA conditional graph nodes require Toolkit and driver 12.4+")
+
     counter = wp.array([5], dtype=wp.int32, device=device)
 
     def body():


### PR DESCRIPTION
## Description

Conditional APIC tests newly registered for CUDA attempted to create CUDA
conditional graph nodes on hosts whose Toolkit or driver predates CUDA 12.4.
Those configurations failed in the capability assertion instead of reporting
the CUDA cases as skipped. CPU APIC conditionals do not share this requirement
and should continue to run.

## Changes

- Add device-aware conditional graph capability checks to the five affected
  APIC tests.
- Preserve CPU conditional coverage while skipping only unsupported CUDA test
  variants.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

Documentation and CHANGELOG updates are unnecessary because this only changes
test gating on unsupported CUDA configurations.

## Validation summary

- Reproduced the original error by simulating Toolkit 12.3: a generated CUDA
  APIC conditional test reached `assert_conditional_graph_support()` and failed.
- With this change under simulated Toolkit 12.3, four CPU conditional tests ran
  successfully and all five affected CUDA variants were reported skipped.
- Repeated the unsupported-path check with a simulated pre-12.4 driver and saw
  the same four CPU passes and five CUDA skips.
- Ran all 194 tests in `warp/tests/test_apic.py` successfully with Toolkit and
  driver 13.0.
- Ran the repository pre-commit hooks for `warp/tests/test_apic.py`.

## Bug fix

On a host with a CUDA Toolkit or driver older than 12.4, run an affected CUDA
test variant:

```bash
uv run warp/tests/test_apic.py TestApic.test_capture_if_cpu_cuda_0
```

Before this change the test errors in the conditional graph capability check.
After this change it is reported skipped, while
`TestApic.test_capture_if_cpu_cpu` continues to run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated several capture-related test cases to automatically skip on CUDA environments where conditional graph nodes aren’t supported, preventing spurious failures.
  * Improved CUDA capture/replay test setup by preloading the required CUDA-specific kernel specialization before capture.
  * Ensured padded BSR transpose CUDA tests perform necessary CUDA specialization/loading before capture, improving reliability during APIC capture runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->