### PR TITLE
Fix empty mesh CUDA construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 
 ### Fixed
 
+- Fix CUDA `wp.Mesh` construction and refit for empty meshes ([GH-1602](https://github.com/NVIDIA/warp/issues/1602)).
 - Fix eager Python calls to generic `@wp.func` functions to resolve a matching generic template after other concrete
   overloads have already been instantiated ([GH-1603](https://github.com/NVIDIA/warp/issues/1603)).
 - Fix `wp.tile_dot()` compilation failure for scalar `wp.float64` and `wp.float16` tiles, which previously narrowed

--- a/warp/native/bvh.cpp
+++ b/warp/native/bvh.cpp
@@ -730,7 +730,13 @@ void bvh_refit_recursive(BVH& bvh, int index)
     }
 }
 
-void bvh_refit_host(BVH& bvh) { bvh_refit_recursive(bvh, *bvh.root); }
+void bvh_refit_host(BVH& bvh)
+{
+    if (!bvh.root || bvh.num_items == 0)
+        return;
+
+    bvh_refit_recursive(bvh, *bvh.root);
+}
 void bvh_rebuild_host(BVH& bvh, int constructor_type)
 {
     if (constructor_type == BVH_CONSTRUCTOR_CUBQL) {

--- a/warp/native/bvh.cu
+++ b/warp/native/bvh.cu
@@ -664,6 +664,18 @@ void bvh_create_device(
 )
 {
     ContextGuard guard(context);
+
+    if (num_items <= 0) {
+        memset(&bvh_device_on_host, 0, sizeof(BVH));
+        bvh_device_on_host.item_lowers = lowers;
+        bvh_device_on_host.item_uppers = uppers;
+        bvh_device_on_host.item_groups = groups;
+        bvh_device_on_host.leaf_size = leaf_size;
+        bvh_device_on_host.context = context ? context : wp_cuda_context_get_current();
+        bvh_device_on_host.constructor_type = constructor_type;
+        return;
+    }
+
     if (constructor_type == BVH_CONSTRUCTOR_CUBQL) {
         if (groups) {
             wp::set_error_string("Warp error: grouped BVHs are not supported with cuBQL construction");

--- a/warp/native/mesh.cpp
+++ b/warp/native/mesh.cpp
@@ -113,7 +113,13 @@ void bvh_refit_with_solid_angle_recursive_host(BVH& bvh, int index, Mesh& mesh)
     }
 }
 
-void bvh_refit_with_solid_angle_host(BVH& bvh, Mesh& mesh) { bvh_refit_with_solid_angle_recursive_host(bvh, 0, mesh); }
+void bvh_refit_with_solid_angle_host(BVH& bvh, Mesh& mesh)
+{
+    if (!bvh.root || bvh.num_items == 0)
+        return;
+
+    bvh_refit_with_solid_angle_recursive_host(bvh, 0, mesh);
+}
 
 uint64_t wp_mesh_create_host(
     array_t<wp::vec3> points,
@@ -152,7 +158,7 @@ uint64_t wp_mesh_create_host(
         // compute edge lengths
         sum += length(p0 - p1) + length(p0 - p2) + length(p2 - p1);
     }
-    m->average_edge_length = sum / (num_tris * 3);
+    m->average_edge_length = (num_tris > 0) ? sum / (3.0f * num_tris) : 0.0f;
 
 #ifndef WP_DISABLE_CUBQL
     if (use_cubql) {
@@ -180,7 +186,7 @@ uint64_t wp_mesh_create_host(
         return 0;
     }
 
-    if (support_winding_number) {
+    if (support_winding_number && num_tris > 0) {
         int num_bvh_nodes = 2 * num_tris - 1;
         m->solid_angle_props
             = static_cast<SolidAngleProps*>(wp_alloc_host(sizeof(SolidAngleProps) * num_bvh_nodes, "(native:mesh)"));
@@ -228,9 +234,9 @@ void wp_mesh_refit_host(uint64_t id)
 
         sum += length(p0 - p1) + length(p0 - p2) + length(p2 - p1);
     }
-    m->average_edge_length = sum / (m->num_tris * 3);
+    m->average_edge_length = (m->num_tris > 0) ? sum / (3.0f * m->num_tris) : 0.0f;
 
-    if (m->solid_angle_props) {
+    if (m->solid_angle_props && m->num_tris > 0) {
         // If solid angle were used, use refit solid angle
         bvh_refit_with_solid_angle_host(m->bvh, *m);
     } else {

--- a/warp/native/mesh.cu
+++ b/warp/native/mesh.cu
@@ -56,7 +56,7 @@ __global__ void compute_mesh_edge_lengths(int n, const vec3* points, const int* 
 
 __global__ void compute_average_mesh_edge_length(int n, float* sum_edge_lengths, Mesh* m)
 {
-    m->average_edge_length = sum_edge_lengths[n - 1] / (3 * n);
+    m->average_edge_length = (n > 0) ? sum_edge_lengths[n - 1] / (3.0f * n) : 0.0f;
 }
 
 __global__ void bvh_refit_with_solid_angle_kernel(
@@ -224,6 +224,11 @@ void bvh_refit_with_solid_angle_device(BVH& bvh, Mesh& mesh)
 {
     ContextGuard guard(bvh.context);
 
+    if (!bvh.node_lowers || !bvh.node_uppers || !bvh.node_parents || !bvh.node_counts || !bvh.primitive_indices
+        || bvh.num_leaf_nodes <= 0) {
+        return;
+    }
+
     // clear child counters
     wp_memset_device(WP_CURRENT_CONTEXT, bvh.node_counts, 0, sizeof(int) * bvh.max_nodes);
     wp_launch_device(
@@ -279,7 +284,7 @@ uint64_t wp_mesh_create_device(
     mesh.lowers = (wp::vec3*)wp_alloc_device(WP_CURRENT_CONTEXT, sizeof(wp::vec3) * num_tris, "(native:mesh)");
     mesh.uppers = (wp::vec3*)wp_alloc_device(WP_CURRENT_CONTEXT, sizeof(wp::vec3) * num_tris, "(native:mesh)");
 
-    if (support_winding_number && !use_cubql) {
+    if (support_winding_number && !use_cubql && num_tris > 0) {
         int num_bvh_nodes = 2 * num_tris;
         mesh.solid_angle_props = (wp::SolidAngleProps*)wp_alloc_device(
             WP_CURRENT_CONTEXT, sizeof(wp::SolidAngleProps) * num_bvh_nodes, "(native:mesh)"
@@ -295,16 +300,18 @@ uint64_t wp_mesh_create_device(
     // we compute mesh the average edge length
     // for use in mesh_query_point_sign_normal()
     // since it relies on an epsilon for welding
-    // reuse bounds memory temporarily for computing edge lengths
-    float* length_tmp_ptr = (float*)mesh.lowers;
-    wp_launch_device(
-        WP_CURRENT_CONTEXT, wp::compute_mesh_edge_lengths, mesh.num_tris,
-        (mesh.num_tris, mesh.points, mesh.indices, length_tmp_ptr)
-    );
-    scan_device(length_tmp_ptr, length_tmp_ptr, mesh.num_tris, true);
-    wp_launch_device(
-        WP_CURRENT_CONTEXT, wp::compute_average_mesh_edge_length, 1, (mesh.num_tris, length_tmp_ptr, mesh_device)
-    );
+    if (mesh.num_tris > 0) {
+        // reuse bounds memory temporarily for computing edge lengths
+        float* length_tmp_ptr = (float*)mesh.lowers;
+        wp_launch_device(
+            WP_CURRENT_CONTEXT, wp::compute_mesh_edge_lengths, mesh.num_tris,
+            (mesh.num_tris, mesh.points, mesh.indices, length_tmp_ptr)
+        );
+        scan_device(length_tmp_ptr, length_tmp_ptr, mesh.num_tris, true);
+        wp_launch_device(
+            WP_CURRENT_CONTEXT, wp::compute_average_mesh_edge_length, 1, (mesh.num_tris, length_tmp_ptr, mesh_device)
+        );
+    }
 
     // compute triangle bound and construct BVH
     wp_launch_device(
@@ -338,7 +345,7 @@ uint64_t wp_mesh_create_device(
 
     mesh_add_descriptor(mesh_id, mesh);
 
-    if (support_winding_number && !use_cubql)
+    if (support_winding_number && !use_cubql && num_tris > 0)
         wp_mesh_refit_device(mesh_id);
 
     return mesh_id;
@@ -376,24 +383,26 @@ int wp_mesh_refit_device(uint64_t id)
         // for use in mesh_query_point_sign_normal()
         // since it relies on an epsilon for welding
 
-        // reuse bounds memory temporarily for computing edge lengths
-        float* length_tmp_ptr = (float*)m.lowers;
-        wp_launch_device(
-            WP_CURRENT_CONTEXT, wp::compute_mesh_edge_lengths, m.num_tris,
-            (m.num_tris, m.points, m.indices, length_tmp_ptr)
-        );
+        if (m.num_tris > 0) {
+            // reuse bounds memory temporarily for computing edge lengths
+            float* length_tmp_ptr = (float*)m.lowers;
+            wp_launch_device(
+                WP_CURRENT_CONTEXT, wp::compute_mesh_edge_lengths, m.num_tris,
+                (m.num_tris, m.points, m.indices, length_tmp_ptr)
+            );
 
-        scan_device(length_tmp_ptr, length_tmp_ptr, m.num_tris, true);
+            scan_device(length_tmp_ptr, length_tmp_ptr, m.num_tris, true);
 
-        wp_launch_device(
-            WP_CURRENT_CONTEXT, wp::compute_average_mesh_edge_length, 1, (m.num_tris, length_tmp_ptr, (wp::Mesh*)id)
-        );
+            wp_launch_device(
+                WP_CURRENT_CONTEXT, wp::compute_average_mesh_edge_length, 1, (m.num_tris, length_tmp_ptr, (wp::Mesh*)id)
+            );
+        }
         wp_launch_device(
             WP_CURRENT_CONTEXT, wp::compute_triangle_bounds, m.num_tris,
             (m.num_tris, m.points, m.indices, m.lowers, m.uppers)
         );
 
-        if (m.solid_angle_props) {
+        if (m.solid_angle_props && m.num_tris > 0) {
             // update solid angle data
             bvh_refit_with_solid_angle_device(m.bvh, m);
         } else {

--- a/warp/tests/geometry/test_mesh.py
+++ b/warp/tests/geometry/test_mesh.py
@@ -383,6 +383,39 @@ def test_mesh_refit_graph(test, device):
         wp.synchronize_device(device)
 
 
+def test_empty_mesh_create_and_refit(test, device):
+    if device.is_cpu:
+        constructors = ["sah", "median"]
+    else:
+        constructors = ["sah", "median", "lbvh"]
+
+    if wp.is_cubql_available():
+        constructors.append("cubql")
+
+    for constructor in constructors:
+        points = wp.zeros(0, dtype=wp.vec3, device=device)
+        indices = wp.zeros(0, dtype=wp.int32, device=device)
+        mesh = wp.Mesh(points=points, indices=indices, bvh_constructor=constructor)
+
+        test.assertEqual(mesh.points.size, 0)
+        test.assertEqual(mesh.indices.size, 0)
+
+        mesh.refit()
+        if device.is_cuda:
+            wp.synchronize_device(device)
+
+        if constructor != "cubql":
+            mesh = wp.Mesh(
+                points=points,
+                indices=indices,
+                bvh_constructor=constructor,
+                support_winding_number=True,
+            )
+            mesh.refit()
+            if device.is_cuda:
+                wp.synchronize_device(device)
+
+
 def test_mesh_exceptions(test, device):
     # points and indices must be on same device
     with test.assertRaises(RuntimeError):
@@ -491,6 +524,7 @@ add_function_test(TestMesh, "test_mesh_query_ray", test_mesh_query_ray, devices=
 add_function_test(TestMesh, "test_grouped_mesh_query_ray", test_grouped_mesh_query_ray, devices=devices)
 add_function_test(TestMesh, "test_mesh_refit", test_mesh_refit, devices=devices)
 add_function_test(TestMesh, "test_mesh_refit_graph", test_mesh_refit_graph, devices=cuda_devices_with_mempool)
+add_function_test(TestMesh, "test_empty_mesh_create_and_refit", test_empty_mesh_create_and_refit, devices=devices)
 add_function_test(TestMesh, "test_mesh_exceptions", test_mesh_exceptions, devices=get_selected_cuda_test_devices())
 
 


### PR DESCRIPTION
## Description

Closes #1602.

Empty CUDA meshes can hit unsafe native paths during construction and refit.

## Changes

- Skip mesh edge-length stats when `num_tris == 0`.
- Keep `compute_average_mesh_edge_length()` safe for `n == 0`.
- Return an empty CUDA BVH descriptor for zero-item BVHs.
- No-op empty host BVH refit.
- Skip solid-angle allocation/refit for empty winding-number meshes.
- Add an empty mesh create/refit test.
- Add a changelog entry.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

On unpatched `main`, empty CUDA mesh construction under `compute-sanitizer --tool memcheck` failed on an L40S with CUDA 12.8: `ERROR SUMMARY: 38 errors`.

With only the kernel-side ternary guard, the same repro still failed: `ERROR SUMMARY: 14 errors`.

With this branch, empty CUDA mesh construction/refit passes under memcheck: `ERROR SUMMARY: 0 errors`.

Also verified empty CUDA meshes with `support_winding_number=True` for `sah`, `median`, and `lbvh` constructors under memcheck: `ERROR SUMMARY: 0 errors`.

Also ran:

```text
python -m unittest warp.tests.geometry.test_mesh.TestMesh.test_empty_mesh_create_and_refit_cuda_0
uv run python -m unittest warp.tests.geometry.test_mesh
uv run --with pre-commit pre-commit run --all-files
```

## Bug fix

```python
import warp as wp

wp.init()

device = "cuda:0"
points = wp.zeros(0, dtype=wp.vec3, device=device)
indices = wp.zeros(0, dtype=wp.int32, device=device)

mesh = wp.Mesh(points=points, indices=indices)
mesh.refit()
wp.synchronize_device(device)
```

