### PR TITLE
Migrate optimizer state across devices [GH-1615]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,9 @@
   ([GH-1562](https://github.com/NVIDIA/warp/issues/1562)).
 - Fix CUDA graph capture when constructing an environment-first `warp.fem` space partition with a fixed
   `max_node_count` capacity ([GH-1607](https://github.com/NVIDIA/warp/issues/1607)).
+- Fix `warp.optim.Adam.set_params()` and `warp.optim.SGD.set_params()` reusing optimizer state on the wrong device
+  when replacement parameters move devices. Compatible buffers now migrate with the parameters while preserving
+  accumulated state ([GH-1615](https://github.com/NVIDIA/warp/issues/1615)).
 
 ### Documentation
 

--- a/warp/_src/optim/adam.py
+++ b/warp/_src/optim/adam.py
@@ -133,8 +133,12 @@ class Adam:
                 # buffer dtype), not ``param.dtype``, otherwise the buffers are re-zeroed on every call.
                 if self.m[i] is None or self.m[i].shape != param.shape or self.m[i].dtype != dtype:
                     self.m[i] = wp.zeros(shape=param.shape, dtype=dtype, device=param.device)
+                elif self.m[i].device != param.device:
+                    self.m[i] = self.m[i].to(param.device)
                 if self.v[i] is None or self.v[i].shape != param.shape or self.v[i].dtype != dtype:
                     self.v[i] = wp.zeros(shape=param.shape, dtype=dtype, device=param.device)
+                elif self.v[i].device != param.device:
+                    self.v[i] = self.v[i].to(param.device)
 
     def reset_internal_state(self):
         """Reset moment buffers and timestep to zero."""

--- a/warp/_src/optim/sgd.py
+++ b/warp/_src/optim/sgd.py
@@ -82,6 +82,8 @@ class SGD:
                 param = params[i]
                 if self.b[i] is None or self.b[i].shape != param.shape or self.b[i].dtype != param.dtype:
                     self.b[i] = wp.zeros_like(param)
+                elif self.b[i].device != param.device:
+                    self.b[i] = self.b[i].to(param.device)
                 # Overload the kernel for each parameter so we can precompile the SGD kernel
                 if param is not None:
                     wp.overload(sgd_step_kernel, {"g": param, "b": param, "params": param})

--- a/warp/tests/test_adam.py
+++ b/warp/tests/test_adam.py
@@ -159,6 +159,46 @@ def test_adam_set_params_preserves_fp16_state(test, device):
                 test.assertTrue((opt.v[0].numpy() == 1.0).all(), f"second moment reset for {param_dtype}")
 
 
+def test_adam_set_params_migrates_state(test, device):
+    """Verify compatible moment buffers follow parameters that move devices."""
+    moved_param = wp.zeros(4, dtype=wp.float32, device="cpu")
+    unmoved_param = wp.zeros(4, dtype=wp.float32, device="cpu")
+    opt = warp.optim.Adam([moved_param, unmoved_param], lr=0.02)
+
+    moved_m, moved_v = opt.m[0], opt.v[0]
+    unmoved_m, unmoved_v = opt.m[1], opt.v[1]
+    moved_m.fill_(1.0)
+    moved_v.fill_(2.0)
+
+    expected_m = moved_m.numpy().copy()
+    expected_v = moved_v.numpy().copy()
+    replacement = wp.zeros(4, dtype=wp.float32, device=device)
+    opt.set_params([replacement, unmoved_param])
+
+    test.assertEqual(opt.m[0].device, device)
+    test.assertEqual(opt.v[0].device, device)
+    np.testing.assert_array_equal(opt.m[0].numpy(), expected_m)
+    np.testing.assert_array_equal(opt.v[0].numpy(), expected_v)
+    test.assertIs(opt.m[1], unmoved_m)
+    test.assertIs(opt.v[1], unmoved_v)
+
+    opt.step([wp.ones_like(replacement), wp.ones_like(unmoved_param)])
+    replacement.numpy()
+    unmoved_param.numpy()
+
+    expected_m = opt.m[0].numpy().copy()
+    expected_v = opt.v[0].numpy().copy()
+    replacement = wp.zeros(4, dtype=wp.float32, device="cpu")
+    opt.set_params([replacement, unmoved_param])
+
+    test.assertEqual(opt.m[0].device, wp.get_device("cpu"))
+    test.assertEqual(opt.v[0].device, wp.get_device("cpu"))
+    np.testing.assert_array_equal(opt.m[0].numpy(), expected_m)
+    np.testing.assert_array_equal(opt.v[0].numpy(), expected_v)
+    test.assertIs(opt.m[1], unmoved_m)
+    test.assertIs(opt.v[1], unmoved_v)
+
+
 devices = get_test_devices()
 
 
@@ -171,6 +211,12 @@ add_function_test(TestAdam, "test_adam_solve_vec3", test_adam_solve_vec3, device
 add_function_test(TestAdam, "test_adam_solve_two_inputs", test_adam_solve_two_inputs, devices=devices)
 add_function_test(
     TestAdam, "test_adam_set_params_preserves_fp16_state", test_adam_set_params_preserves_fp16_state, devices=devices
+)
+add_function_test(
+    TestAdam,
+    "test_adam_set_params_migrates_state",
+    test_adam_set_params_migrates_state,
+    devices=get_cuda_test_devices(),
 )
 
 

--- a/warp/tests/test_sgd.py
+++ b/warp/tests/test_sgd.py
@@ -3,6 +3,8 @@
 
 import unittest
 
+import numpy as np
+
 import warp as wp
 import warp.optim
 from warp.tests.unittest_utils import *
@@ -205,6 +207,37 @@ def test_sgd_reset_internal_state(test, device):
         test.assertAlmostEqual(result2[0], 0.9, places=5)
 
 
+def test_sgd_set_params_migrates_state(test, device):
+    """Verify compatible momentum buffers follow parameters that move devices."""
+    moved_param = wp.zeros(4, dtype=wp.float32, device="cpu")
+    unmoved_param = wp.zeros(4, dtype=wp.float32, device="cpu")
+    opt = warp.optim.SGD([moved_param, unmoved_param], lr=0.02, momentum=0.9)
+
+    moved_b = opt.b[0]
+    unmoved_b = opt.b[1]
+    moved_b.fill_(1.0)
+
+    expected_b = moved_b.numpy().copy()
+    replacement = wp.zeros(4, dtype=wp.float32, device=device)
+    opt.set_params([replacement, unmoved_param])
+
+    test.assertEqual(opt.b[0].device, device)
+    np.testing.assert_array_equal(opt.b[0].numpy(), expected_b)
+    test.assertIs(opt.b[1], unmoved_b)
+
+    opt.step([wp.ones_like(replacement), wp.ones_like(unmoved_param)])
+    replacement.numpy()
+    unmoved_param.numpy()
+
+    expected_b = opt.b[0].numpy().copy()
+    replacement = wp.zeros(4, dtype=wp.float32, device="cpu")
+    opt.set_params([replacement, unmoved_param])
+
+    test.assertEqual(opt.b[0].device, wp.get_device("cpu"))
+    np.testing.assert_array_equal(opt.b[0].numpy(), expected_b)
+    test.assertIs(opt.b[1], unmoved_b)
+
+
 devices = get_test_devices()
 
 
@@ -219,6 +252,12 @@ add_function_test(TestSGD, "test_sgd_nesterov_momentum", test_sgd_nesterov_momen
 add_function_test(TestSGD, "test_sgd_combined_features", test_sgd_combined_features, devices=devices)
 add_function_test(TestSGD, "test_sgd_no_momentum", test_sgd_no_momentum, devices=devices)
 add_function_test(TestSGD, "test_sgd_reset_internal_state", test_sgd_reset_internal_state, devices=devices)
+add_function_test(
+    TestSGD,
+    "test_sgd_set_params_migrates_state",
+    test_sgd_set_params_migrates_state,
+    devices=get_cuda_test_devices(),
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Closes #1615.

Adam and SGD reused shape- and dtype-compatible optimizer state buffers
when replacement parameters moved to another device. This could leave the
parameters and their state on different devices. Migrate compatible state
buffers to the replacement parameter's device while preserving their values.
Shape or dtype changes continue to allocate zeroed state.

## Changes

- Migrate compatible Adam first- and second-moment buffers across devices.
- Migrate compatible SGD momentum buffers across devices.
- Cover CPU-to-CUDA migration with mixed moved and unmoved parameters.
- Document the corrected optimizer state reuse behavior in the changelog.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Verified `test_adam_set_params_migrates_state` preserves both moment
  buffers and reuses the state of an unmoved parameter.
- Verified `test_sgd_set_params_migrates_state` preserves the momentum
  buffer and reuses the state of an unmoved parameter.
- Ran the focused Adam and SGD suites on CPU and two CUDA devices: 37 tests
  passed.
- Ran pre-commit checks on all changed files.

## Bug fix

Without this change, the optimizer state remains on the CPU after replacing
the parameter with one on CUDA:

```python
import warp as wp

param = wp.zeros(4, dtype=wp.float32, device="cpu")
optimizer = wp.optim.Adam([param])
optimizer.m[0].fill_(1.0)

param = wp.zeros(4, dtype=wp.float32, device="cuda:0")
optimizer.set_params([param])

assert optimizer.m[0].device == param.device
optimizer.step([wp.ones_like(param)])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed optimizer state handling when replacing parameters on a different device. Adam moment buffers and SGD momentum buffers now migrate to the replacement parameter’s device when sizes/dtypes match, preserving accumulated values and avoiding incorrect cross-device reuse.
* **Tests**
  * Added new unit tests for Adam and SGD verifying device migration, value preservation across `set_params()` calls, and that unchanged parameters’ state buffers keep the same object identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->