### PR TITLE
tile: fix histogram-merge out-of-bounds for warp counts that do not divide 16

### DIFF
--- a/warp/native/tile_radix_sort.h
+++ b/warp/native/tile_radix_sort.h
@@ -684,8 +684,6 @@ inline CUDA_CALLABLE void radix_sort_thread_block_core(
     const int lowest_bits_mask = (1 << bits_per_pass) - 1;
     const int num_scan_buckets = (1 << bits_per_pass);
 
-    const int num_warp_passes = (num_scan_buckets + num_warps - 1) / num_warps;
-
     __shared__ int buckets[num_scan_buckets];
     __shared__ int buckets2[num_scan_buckets];
     __shared__ int buckets_cumulative_sum[num_scan_buckets];
@@ -718,7 +716,7 @@ inline CUDA_CALLABLE void radix_sort_thread_block_core(
             }
             __syncthreads();
 
-            for (int b = warp_id; b < num_warp_passes * num_warps; b += num_warps) {
+            for (int b = warp_id; b < num_scan_buckets; b += num_warps) {
                 int f = lane_id < num_warps ? shared_mem[lane_id][b] : 0;
                 f = warp_scan_inclusive(lane_id, f);
                 if (lane_id == 31)


### PR DESCRIPTION
## Summary

`radix_sort_thread_block_core` (`warp/native/tile_radix_sort.h`) reads and writes past its 16-element histogram arrays when the block's warp count does not evenly divide `num_scan_buckets` (16).

The per-warp histogram-merge loop:

```cpp
for (int b = warp_id; b < num_warp_passes * num_warps; b += num_warps) {
    int f = lane_id < num_warps ? shared_mem[lane_id][b] : 0;
    f = warp_scan_inclusive(lane_id, f);
    if (lane_id == 31)
        buckets[b] += f;
}
```

`shared_mem` is `[num_warps][num_scan_buckets]` and `buckets` is `[num_scan_buckets]`, both sized to `num_scan_buckets = 1 << bits_per_pass = 16`. But the loop bound is `num_warp_passes * num_warps = ceil(16 / num_warps) * num_warps`, which rounds **up** to a multiple of `num_warps` and so exceeds 16 whenever `num_warps ∤ 16`. Those iterations index `shared_mem[lane_id][b]` and `buckets[b]` with `b >= 16` — out of bounds.

`num_warps = ceil(block_dim / 32)` comes straight from the user launch `block_dim`, which is not constrained to a divisor of 16. Overflowing configurations:

| block_dim | num_warps | loop bound | max `b` | array extent |
|---:|---:|---:|---:|---:|
| 96 | 3 | 18 | 17 | 16 |
| 160 | 5 | 20 | 19 | 16 |
| 192 | 6 | 18 | 17 | 16 |
| 224 | 7 | 21 | 20 | 16 |
| 288 | 9 | 18 | 17 | 16 |
| 1024 | 32 | 32 | 31 | 16 |

The default `block_dim=256` gives `num_warps=8` (a divisor of 16), so the OOB is normally latent. The corrupted `buckets` / `buckets2` / `buckets_cumulative_sum` feed the final scatter offsets, so on affected configs the sort produces wrong output and can scatter out of range. The radix path is used for tiles with >2048 elements and <=4-byte keys.

## Fix

`b` is a bucket index in `[0, num_scan_buckets)`; bound the loop by `num_scan_buckets`, matching the sibling finalization loop `for (int b = 0; b < num_scan_buckets; b++)`. Warps beyond 16 then do zero iterations. `num_warp_passes` becomes unused and is removed.

## Testing

I can't run Warp's GPU test suite on my hardware, so **please validate on the non-divisor configs** — e.g. a `tile_sort` of >2048 int/float keys launched with `block_dim=1024` (32 warps) or `block_dim=96` (3 warps), compared against a reference sort, ideally under `compute-sanitizer --tool memcheck`. The change is a pure loop-bound correction that matches the bounds already used by the sibling loop.
