### PR TITLE
Support Boolean DLPack imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,8 @@
   ([GH-1562](https://github.com/NVIDIA/warp/issues/1562)).
 - Fix CUDA graph capture when constructing an environment-first `warp.fem` space partition with a fixed
   `max_node_count` capacity ([GH-1607](https://github.com/NVIDIA/warp/issues/1607)).
+- Fix `wp.from_dlpack()` support for standards-conformant 8-bit Boolean tensors
+  ([GH-1619](https://github.com/NVIDIA/warp/issues/1619)).
 
 ### Documentation
 

--- a/warp/_src/dlpack.py
+++ b/warp/_src/dlpack.py
@@ -315,7 +315,7 @@ def dtype_is_compatible(dl_dtype, wp_dtype):
         raise RuntimeError("Data types with less than 8 bits are not supported")
 
     if dl_dtype.type_code.value == DLDataTypeCode.kDLBool:
-        return dl_dtype.bits == 8 and wp_dtype == warp.bool
+        return dl_dtype.bits == 8 and wp_dtype in (warp.bool, warp.int8, warp.uint8)
     elif dl_dtype.type_code.value == DLDataTypeCode.kDLFloat:
         if dl_dtype.bits == 16:
             return wp_dtype == warp.float16
@@ -340,6 +340,13 @@ def dtype_is_compatible(dl_dtype, wp_dtype):
         raise RuntimeError("Complex data types are not supported")
     else:
         raise RuntimeError(f"Unsupported DLPack dtype {(str(dl_dtype.type_code), dl_dtype.bits)}")
+
+
+def _dtype_name(dl_dtype: DLDataType) -> str:
+    name = f"{dl_dtype.type_code}{dl_dtype.bits}"
+    if dl_dtype.lanes > 1:
+        name += f"x{dl_dtype.lanes}"
+    return name
 
 
 def _unpack_array(dlt: DLTensor, dtype=None):
@@ -368,7 +375,9 @@ def _unpack_array(dlt: DLTensor, dtype=None):
         # handle vector/matrix types
 
         if not dtype_is_compatible(dlt.dtype, dtype._wp_scalar_type_):
-            raise RuntimeError(f"Incompatible data types: {dlt.dtype} and {dtype}")
+            raise RuntimeError(
+                f"Incompatible data types: DLPack {_dtype_name(dlt.dtype)} and Warp {warp._src.types.type_repr(dtype)}"
+            )
 
         dtype_shape = dtype._shape_
         dtype_dims = len(dtype._shape_)
@@ -392,7 +401,9 @@ def _unpack_array(dlt: DLTensor, dtype=None):
 
     elif not dtype_is_compatible(dlt.dtype, dtype):
         # incompatible dtype requested
-        raise RuntimeError(f"Incompatible data types: {dlt.dtype} and {dtype}")
+        raise RuntimeError(
+            f"Incompatible data types: DLPack {_dtype_name(dlt.dtype)} and Warp {warp._src.types.type_repr(dtype)}"
+        )
 
     a = warp._src.types.array(
         ptr=dlt.data, dtype=dtype, shape=shape, strides=strides, copy=False, device=device, pinned=pinned

--- a/warp/_src/dlpack.py
+++ b/warp/_src/dlpack.py
@@ -155,6 +155,8 @@ def dtype_from_dlpack(dl_dtype):
 
     if dl_dtype == (DLDataTypeCode.kDLUInt, 1):
         raise RuntimeError("Warp does not support bit boolean types")
+    elif dl_dtype == (DLDataTypeCode.kDLBool, 8):
+        return warp._src.types.bool
     elif dl_dtype == (DLDataTypeCode.kDLInt, 8):
         return warp._src.types.int8
     elif dl_dtype == (DLDataTypeCode.kDLInt, 16):
@@ -312,7 +314,9 @@ def dtype_is_compatible(dl_dtype, wp_dtype):
     if dl_dtype.bits % 8 != 0:
         raise RuntimeError("Data types with less than 8 bits are not supported")
 
-    if dl_dtype.type_code.value == DLDataTypeCode.kDLFloat:
+    if dl_dtype.type_code.value == DLDataTypeCode.kDLBool:
+        return dl_dtype.bits == 8 and wp_dtype == warp.bool
+    elif dl_dtype.type_code.value == DLDataTypeCode.kDLFloat:
         if dl_dtype.bits == 16:
             return wp_dtype == warp.float16
         elif dl_dtype.bits == 32:

--- a/warp/tests/interop/test_dlpack.py
+++ b/warp/tests/interop/test_dlpack.py
@@ -81,6 +81,26 @@ def test_dlpack_warp_to_warp(test, device):
     assert_np_equal(a1.numpy(), a2.numpy())
 
 
+def test_dlpack_bool_round_trip(test, device):
+    values = np.array([True, False, True, True, False], dtype=np.bool_)
+    source = wp.array(values, dtype=wp.bool, device=device)
+
+    for explicit_dtype in (False, True):
+        with test.subTest(explicit_dtype=explicit_dtype):
+            capsule = wp.to_dlpack(source)
+            if explicit_dtype:
+                result = wp.from_dlpack(capsule, dtype=wp.bool)
+            else:
+                result = wp.from_dlpack(capsule)
+
+            test.assertEqual(result.ptr, source.ptr)
+            test.assertEqual(result.device, source.device)
+            test.assertEqual(result.dtype, wp.bool)
+            test.assertEqual(result.shape, source.shape)
+            test.assertEqual(result.strides, source.strides)
+            np.testing.assert_array_equal(result.numpy(), values)
+
+
 def test_dlpack_dtypes_and_shapes(test, device):
     # automatically determine scalar dtype
     def wrap_scalar_tensor_implicit(dtype):
@@ -656,6 +676,7 @@ class TestDLPack(unittest.TestCase):
 devices = get_test_devices()
 
 add_function_test(TestDLPack, "test_dlpack_warp_to_warp", test_dlpack_warp_to_warp, devices=devices)
+add_function_test(TestDLPack, "test_dlpack_bool_round_trip", test_dlpack_bool_round_trip, devices=devices)
 add_function_test(TestDLPack, "test_dlpack_dtypes_and_shapes", test_dlpack_dtypes_and_shapes, devices=devices)
 add_function_test(TestDLPack, "test_dlpack_stream_arg", test_dlpack_stream_arg, devices=devices)
 

--- a/warp/tests/interop/test_dlpack.py
+++ b/warp/tests/interop/test_dlpack.py
@@ -101,6 +101,30 @@ def test_dlpack_bool_round_trip(test, device):
             np.testing.assert_array_equal(result.numpy(), values)
 
 
+def test_dlpack_bool_aliases(test, device):
+    values = np.array([True, False, True, True, False], dtype=np.bool_)
+    source = wp.array(values, dtype=wp.bool, device=device)
+
+    for target_dtype in (wp.int8, wp.uint8):
+        with test.subTest(target_dtype=target_dtype):
+            result = wp.from_dlpack(wp.to_dlpack(source), dtype=target_dtype)
+
+            test.assertEqual(result.ptr, source.ptr)
+            test.assertEqual(result.device, source.device)
+            test.assertEqual(result.dtype, target_dtype)
+            test.assertEqual(result.shape, source.shape)
+            test.assertEqual(result.strides, source.strides)
+            np.testing.assert_array_equal(result.numpy(), values.astype(wp.dtype_to_numpy(target_dtype)))
+
+
+def test_dlpack_incompatible_dtype_error(test, device):
+    source = wp.zeros(1, dtype=wp.bool, device=device)
+
+    expected_error = r"Incompatible data types: DLPack bool8 and Warp float32"
+    with test.assertRaisesRegex(RuntimeError, expected_error):
+        wp.from_dlpack(wp.to_dlpack(source), dtype=wp.float32)
+
+
 def test_dlpack_dtypes_and_shapes(test, device):
     # automatically determine scalar dtype
     def wrap_scalar_tensor_implicit(dtype):
@@ -677,6 +701,10 @@ devices = get_test_devices()
 
 add_function_test(TestDLPack, "test_dlpack_warp_to_warp", test_dlpack_warp_to_warp, devices=devices)
 add_function_test(TestDLPack, "test_dlpack_bool_round_trip", test_dlpack_bool_round_trip, devices=devices)
+add_function_test(TestDLPack, "test_dlpack_bool_aliases", test_dlpack_bool_aliases, devices=devices)
+add_function_test(
+    TestDLPack, "test_dlpack_incompatible_dtype_error", test_dlpack_incompatible_dtype_error, devices=devices
+)
 add_function_test(TestDLPack, "test_dlpack_dtypes_and_shapes", test_dlpack_dtypes_and_shapes, devices=devices)
 add_function_test(TestDLPack, "test_dlpack_stream_arg", test_dlpack_stream_arg, devices=devices)
 


### PR DESCRIPTION
## Description

Closes #1619.

Warp already exports `wp.bool` arrays with DLPack's standard `kDLBool` type code and 8-bit storage. The importer did not recognize the same metadata, so Boolean tensors failed to round-trip through DLPack. The importer now maps this representation to `wp.bool` for automatic and explicit dtype handling. Legacy one-bit `kDLUInt` data remains unsupported.

## Changes

- Import `(kDLBool, 8)` as `wp.bool`, including explicit `dtype=wp.bool` requests.
- Allow 8-bit Boolean DLPack metadata to alias `wp.int8` and `wp.uint8`, matching Warp's framework-specific interop.
- Add CPU and CUDA round-trip coverage and an Unreleased changelog entry.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Added the Boolean round-trip test before the implementation. On `main`, automatic imports failed with `Unknown DLPack datatype (6, 8)`, while explicit imports failed with `Unsupported DLPack dtype ('bool', 8)` on the CPU and two CUDA devices.
- With the fix applied, all 15 `TestDLPack` tests pass on the CPU, `cuda:0`, and `cuda:1`.
- Changed-file pre-commit hooks pass, including Ruff, formatting, generated-file checks, and typos.

Torch, JAX, and Paddle were not installed in the test environment, so their optional integration tests were skipped.

## Bug fix

```python
import warp as wp

source = wp.array([True, False, True], dtype=wp.bool)

# Both calls fail without this PR.
implicit = wp.from_dlpack(wp.to_dlpack(source))
explicit = wp.from_dlpack(wp.to_dlpack(source), dtype=wp.bool)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DLPack import for standards-conformant 8-bit boolean tensors, resolving failures when loading boolean data via `from_dlpack`.
  * Improved DLPack boolean dtype compatibility handling and more informative runtime error messages for incompatible dtype scenarios.
* **Tests**
  * Added DLPack interop tests for 8-bit boolean round-trips, boolean alias conversions to `int8`/`uint8`, and validation of the expected error when requesting an incompatible target dtype.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->