### PR TITLE
Fix Windows CUDA static linking

### DIFF
--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -713,7 +713,7 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str
                     )
                 else:
                     linkopts.append(
-                        f'cudart_static.lib nvrtc_static.lib nvrtc-builtins_static.lib nvptxcompiler_static.lib ws2_32.lib user32.lib /LIBPATH:"{cuda_home}/lib/x64"'
+                        f'cudart_static.lib nvrtc_static.lib nvrtc-builtins_static.lib nvptxcompiler_static.lib ws2_32.lib user32.lib ntdll.lib /LIBPATH:"{cuda_home}/lib/x64"'
                     )
 
                 if args.libmathdx_path:


### PR DESCRIPTION
## Description

Fix Windows source builds with CUDA 13.3. CUDA 13.3's static NVRTC
library references `RtlGetLastNtStatus`, but Warp did not link the Windows
SDK import library that provides it, causing `warp.dll` to fail at the final
link step.

## Changes

- Link `ntdll.lib` when building Warp with static CUDA libraries on Windows.
- Leave dynamic-CUDA and non-Windows linker paths unchanged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Reproduced the CUDA 13.3 failure before the change: native compilation
  completed, then `warp.dll` failed to link with `LNK2019` and `LNK1120` for
  `RtlGetLastNtStatus`.
- Ran the applicable pre-commit checks for `warp/_src/build_dll.py`.
- Rebuilt Warp with CUDA 13.3 after the change. Both `warp.dll` and
  `warp-clang.dll` built successfully without unresolved linker symbols.
- Initialized the rebuilt Warp 1.16.0.dev0 successfully with CUDA Toolkit
  13.3. Existing CI builds cover Windows CUDA 12.9 and CUDA 13.0 compatibility.

## Bug fix

Before this change, the following command fails while linking `warp.dll` on
Windows with CUDA 13.3:

```powershell
uv run build_lib.py
```

The build now completes successfully because the static NVRTC dependency is
resolved through `ntdll.lib`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows CUDA static linking issue by adding a missing required system library, improving build reliability for affected setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->