### PR TITLE
Render array annotation repr in subscript form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,10 @@
   entire array). It also rejects copies between contiguous arrays whose element sizes differ, matching the existing
   behavior for non-contiguous arrays ([GH-1584](https://github.com/NVIDIA/warp/issues/1584)).
 - Speed up CPU APIC graph replay for launch-dense graphs ([GH-1431](https://github.com/NVIDIA/warp/issues/1431)).
+- Render `repr()` of array type annotations in their subscript form (such as `wp.array4d[wp.uint32]`) so that it matches
+  the written annotation and can be evaluated back to the same annotation, instead of the previous
+  `wp.array(dtype=..., ndim=...)` form. Warp array return types now read more naturally in Sphinx-generated API
+  documentation ([GH-1628](https://github.com/NVIDIA/warp/issues/1628)).
 
 ### Fixed
 

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -5181,25 +5181,49 @@ class _ArrayAnnotationBase:
         self.dtype = dtype if dtype is Any else type_to_warp(dtype)
         self.ndim = ndim
 
+    def _dtype_repr(self):
+        """Render ``self.dtype`` for the annotation subscript, preferring a ``wp.`` alias when one exists."""
+        dtype = self.dtype
+        if dtype is Any:
+            return "Any"
+        if hasattr(dtype, "key"):
+            # Struct instances carry a .key rather than a __name__
+            return dtype.key
+        name = getattr(dtype, "__name__", None)
+        if name and getattr(warp, name, None) is dtype:
+            # Type with a matching public alias (e.g. wp.float32, wp.vec3f)
+            return f"wp.{name}"
+        repr_name = type_repr(dtype)
+        if getattr(warp, repr_name, None) is not None:
+            # Canonical alias for an equivalent dynamic type (e.g. a freshly
+            # built vector(3, float64) whose type_repr is the cached "vec3d")
+            return f"wp.{repr_name}"
+        if type_is_vector(dtype) or type_is_quaternion(dtype) or type_is_matrix(dtype) or type_is_transformation(dtype):
+            # Warp generic vector/matrix/quaternion/transformation without an
+            # alias: type_repr already gives a descriptive, unambiguous form
+            # (e.g. "matrix(shape=(7, 7), dtype=float32)") rather than the
+            # internal generic class name (vec_t, mat_t, quat_t, transform_t).
+            return repr_name
+        # User-defined type with a meaningful name
+        return name or repr_name
+
     def __repr__(self):
-        if self.dtype is Any:
-            dtype_str = "Any"
-        elif hasattr(self.dtype, "key"):
-            # Struct instances use .key instead of __name__
-            dtype_str = self.dtype.key
-        else:
-            name = getattr(self.dtype, "__name__", None)
-            if name and getattr(warp, name, None) is self.dtype:
-                dtype_str = f"wp.{name}"
-            else:
-                # Custom vector/matrix/quaternion/transformation types
-                repr_name = type_repr(self.dtype)
-                if getattr(warp, repr_name, None) is not None:
-                    dtype_str = f"wp.{repr_name}"
-                else:
-                    dtype_str = repr_name
-        ndim_str = "Any" if self.ndim is Any else self.ndim
-        return f"wp.{self._concrete_cls.__name__}(dtype={dtype_str}, ndim={ndim_str})"
+        dtype_str = self._dtype_repr()
+        cls_name = self._concrete_cls.__name__
+        ndim = self.ndim
+        # Every case renders as a subscript annotation so that repr() matches
+        # the source syntax and round-trips through eval().
+        if ndim is Any:
+            # Two-argument form: wp.array[dtype, Any] parses back to ndim=Any.
+            return f"wp.{cls_name}[{dtype_str}, Any]"
+        if cls_name == "array":
+            # array1d..4d are subscriptable aliases mirroring idiomatic source.
+            return f"wp.array{ndim}d[{dtype_str}]" if ndim >= 2 else f"wp.array[{dtype_str}]"
+        if ndim == 1:
+            return f"wp.{cls_name}[{dtype_str}]"
+        # indexedarray/fabricarray have no Nd subscript classes; use the
+        # explicit dimension form instead.
+        return f"wp.{cls_name}[{dtype_str}, Literal[{ndim}]]"
 
     def __eq__(self, other):
         if isinstance(other, _ArrayAnnotationBase):

--- a/warp/tests/test_subscript_types.py
+++ b/warp/tests/test_subscript_types.py
@@ -582,45 +582,62 @@ class TestSubscriptTypes(unittest.TestCase):
         self.assertNotEqual(a1, ia)
 
     def test_annotation_repr(self):
-        """repr() produces readable dtype names instead of raw class paths."""
+        """repr() produces subscript forms that match source syntax and round-trip."""
         # Built-in scalar dtypes
-        self.assertEqual(repr(wp.array[wp.float32]), "wp.array(dtype=wp.float32, ndim=1)")
-        self.assertEqual(repr(wp.array[wp.uint32]), "wp.array(dtype=wp.uint32, ndim=1)")
+        self.assertEqual(repr(wp.array[wp.float32]), "wp.array[wp.float32]")
+        self.assertEqual(repr(wp.array[wp.uint32]), "wp.array[wp.uint32]")
 
-        # Higher-dimensional arrays
-        self.assertEqual(repr(wp.array4d[wp.uint32]), "wp.array(dtype=wp.uint32, ndim=4)")
-        self.assertEqual(repr(wp.array3d[wp.vec3f]), "wp.array(dtype=wp.vec3f, ndim=3)")
-        self.assertEqual(repr(wp.array2d[wp.float32]), "wp.array(dtype=wp.float32, ndim=2)")
+        # Higher-dimensional arrays use the arrayNd shorthand
+        self.assertEqual(repr(wp.array4d[wp.uint32]), "wp.array4d[wp.uint32]")
+        self.assertEqual(repr(wp.array3d[wp.vec3f]), "wp.array3d[wp.vec3f]")
+        self.assertEqual(repr(wp.array2d[wp.float32]), "wp.array2d[wp.float32]")
 
         # Vector/matrix/quaternion/transform dtypes with wp.* aliases
-        self.assertEqual(repr(wp.array[wp.vec3f]), "wp.array(dtype=wp.vec3f, ndim=1)")
-        self.assertEqual(repr(wp.array[wp.mat44f]), "wp.array(dtype=wp.mat44f, ndim=1)")
-        self.assertEqual(repr(wp.array[wp.quatf]), "wp.array(dtype=wp.quatf, ndim=1)")
-        self.assertEqual(repr(wp.array[wp.transformf]), "wp.array(dtype=wp.transformf, ndim=1)")
+        self.assertEqual(repr(wp.array[wp.vec3f]), "wp.array[wp.vec3f]")
+        self.assertEqual(repr(wp.array[wp.mat44f]), "wp.array[wp.mat44f]")
+        self.assertEqual(repr(wp.array[wp.quatf]), "wp.array[wp.quatf]")
+        self.assertEqual(repr(wp.array[wp.transformf]), "wp.array[wp.transformf]")
 
-        # indexedarray uses its own class name
-        self.assertEqual(repr(wp.indexedarray[wp.float32]), "wp.indexedarray(dtype=wp.float32, ndim=1)")
+        # indexedarray has no arrayNd aliases, so it uses the explicit Literal form
+        self.assertEqual(repr(wp.indexedarray[wp.float32]), "wp.indexedarray[wp.float32]")
         self.assertEqual(
             repr(wp.indexedarray[wp.float32, Literal[3]]),
-            "wp.indexedarray(dtype=wp.float32, ndim=3)",
+            "wp.indexedarray[wp.float32, Literal[3]]",
         )
 
-        # Any dtype / ndim
-        ann = _ArrayAnnotation(dtype=Any, ndim=4)
-        self.assertEqual(repr(ann), "wp.array(dtype=Any, ndim=4)")
-        ann = _ArrayAnnotation(dtype=wp.float32, ndim=Any)
-        self.assertEqual(repr(ann), "wp.array(dtype=wp.float32, ndim=Any)")
+        # Any dtype / ndim still render as subscript forms
+        self.assertEqual(repr(_ArrayAnnotation(dtype=Any, ndim=4)), "wp.array4d[Any]")
+        self.assertEqual(repr(_ArrayAnnotation(dtype=wp.float32, ndim=Any)), "wp.array[wp.float32, Any]")
+        self.assertEqual(repr(_ArrayAnnotation(dtype=Any, ndim=Any)), "wp.array[Any, Any]")
 
-        # Custom vector/matrix dtypes with no wp.* alias use type_repr
+        # repr() round-trips: eval(repr(x)) == x
+        for annotation in [
+            wp.array[wp.float32],
+            wp.array4d[wp.uint32],
+            wp.array3d[wp.vec3f],
+            wp.array[wp.float32, Any],
+            wp.indexedarray[wp.float32],
+            wp.indexedarray[wp.float32, Literal[3]],
+        ]:
+            self.assertEqual(eval(repr(annotation)), annotation)
+
+        # Custom vector/matrix dtypes with no wp.* alias fall back to the
+        # descriptive type_repr form, never the internal generic class name
         my_vec5 = wp.types.vector(length=5, dtype=wp.float32)
         r = repr(wp.array[my_vec5])
         self.assertIn("vector(length=5", r)
+        self.assertNotIn("vec_t", r)
         self.assertNotIn("<class", r)
 
         my_mat7x7 = wp.types.matrix(shape=(7, 7), dtype=wp.float32)
         r = repr(wp.array[my_mat7x7])
         self.assertIn("matrix(shape=(7, 7)", r)
+        self.assertNotIn("mat_t", r)
         self.assertNotIn("<class", r)
+
+        # Exotic quaternion/transform dtypes must not leak the internal name
+        self.assertNotIn("quat_t", repr(wp.array[wp.types.quaternion(dtype=wp.float16)]))
+        self.assertNotIn("transform_t", repr(wp.array[wp.types.transformation(dtype=wp.float16)]))
 
         # Struct dtype uses struct key, no wp. prefix
         @wp.struct
@@ -634,9 +651,9 @@ class TestSubscriptTypes(unittest.TestCase):
 
         # Dynamic types that resolve to a wp.* alias
         vec3d_dynamic = wp.types.vector(3, dtype=wp.float64)
-        self.assertEqual(repr(wp.array[vec3d_dynamic]), "wp.array(dtype=wp.vec3d, ndim=1)")
+        self.assertEqual(repr(wp.array[vec3d_dynamic]), "wp.array[wp.vec3d]")
         mat44f_dynamic = wp.types.matrix((4, 4), dtype=wp.float32)
-        self.assertEqual(repr(wp.array[mat44f_dynamic]), "wp.array(dtype=wp.mat44f, ndim=1)")
+        self.assertEqual(repr(wp.array[mat44f_dynamic]), "wp.array[wp.mat44f]")
 
         # Custom passthrough dtype whose __name__ collides with a warp symbol
         # should NOT get a wp. prefix (it's not the real wp.float32)


### PR DESCRIPTION
## Description

Follow-up to #1341. That issue stopped `repr()` of array type annotations from emitting raw `<class '...'>` paths, but the output kept the constructor-style `wp.array(dtype=..., ndim=...)` shape. That form looks like a call to the `wp.array` constructor (which builds a real array, not an annotation) and does not round-trip through `eval()`.

This renders array annotations in their subscript form instead, so `repr()` matches how the annotation is written in source and evaluates back to the same annotation. The main motivation is Sphinx autodoc: a function annotated `-> wp.array4d[wp.uint32]` now documents its return type as `wp.array4d[wp.uint32]` rather than `wp.array(dtype=wp.uint32, ndim=4)`.

Closes #1628.

## Changes

- Render every array annotation as its subscript form: `wp.array4d[wp.uint32]`, `wp.indexedarray[wp.float32, Literal[3]]`, and `wp.array[wp.float32, Any]` for the unspecified-ndim case. The regular `array` family uses the `arrayNd` aliases; `indexedarray`/`fabricarray` use the explicit `Literal[N]` form because they have no subscriptable `Nd` classes.
- Move dtype rendering into a helper that detects Warp generic vector/matrix/quaternion/transformation types via the `type_is_*` predicates, so exotic types (for example a 7x7 matrix) fall back to a descriptive form without leaking internal generic class names (`vec_t`, `mat_t`, `quat_t`, `transform_t`).
- Rewrite `test_annotation_repr` for the subscript output and add an `eval(repr(x)) == x` round-trip check.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Updated `test_annotation_repr` in `warp/tests/test_subscript_types.py` to expect the subscript forms. These assertions fail against `main` (which produces the `wp.array(dtype=..., ndim=...)` form) and pass with this change.
- Ran the full `test_subscript_types.py` suite on CPU: 36 tests pass, including the round-trip check and the assertions that the internal generic names never appear in `repr()`.
- `uvx pre-commit run` passes on the changed files (ruff, ruff format, typos, version consistency).
- Searched the codebase for other dependence on the old repr format. The only matches are kernel parameter annotations using the callable `wp.array(dtype=...)` form, which are unrelated to `repr()`.

## New feature / enhancement

```python
import warp as wp

repr(wp.array4d[wp.uint32])       # "wp.array4d[wp.uint32]"
repr(wp.array[wp.vec3f])          # "wp.array[wp.vec3f]"
eval(repr(wp.array[wp.float32]))  # returns wp.array[wp.float32]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved how Warp array type annotations render in Sphinx API docs, using consistent subscript-style output.
* **Bug Fixes**
  * Updated `repr()` for Warp array type annotations to a canonical, eval/parseable subscript form (replacing the prior constructor-style output), ensuring it round-trips back to the same type.
  * Scalar, multi-dimensional, and vector/matrix/quaternion/transform array dtypes now render using consistent public aliases.
  * `Any` dtype/ndim cases now follow the same consistent subscript formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->