### PR TITLE
Fix APIC padded BSR transpose overflow [GH-1630]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@
   group ([GH-1612](https://github.com/NVIDIA/warp/issues/1612)).
 - Fix `wp.quat_twist_angle()` losing precision for small `wp.float32` rotations
   ([GH-1631](https://github.com/NVIDIA/warp/issues/1631)).
+- Fix heap corruption when capturing `wp.sparse.bsr_set_transpose()` with `topology="padded"`
+  into a destination without enough row capacity
+  ([GH-1630](https://github.com/NVIDIA/warp/issues/1630)).
 
 ### Documentation
 

--- a/warp/native/apic.cpp
+++ b/warp/native/apic.cpp
@@ -2109,24 +2109,8 @@ static bool apic_cpu_replay_stream(
                       static_cast<size_t>(rec->col_count) * sizeof(int32_t)
                   )
                 : nullptr;
-            size_t transposed_capacity_bytes = int_bytes;
-            if (t_offsets && rec->transposed_row_counts_region_id >= 0)
-                transposed_capacity_bytes = std::max(
-                    transposed_capacity_bytes,
-                    static_cast<size_t>(reinterpret_cast<const int*>(t_offsets)[rec->col_count]) * sizeof(int32_t)
-                );
-            void* t_columns = resolve_ptr(
-                rec->transposed_columns_region_id, rec->transposed_columns_offset, transposed_capacity_bytes
-            );
-            void* block_indices
-                = resolve_ptr(rec->block_indices_region_id, rec->block_indices_offset, transposed_capacity_bytes);
-            void* status = rec->status_region_id >= 0
-                ? resolve_ptr(rec->status_region_id, rec->status_offset, sizeof(int32_t))
-                : nullptr;
-            if (!bsr_offsets || !bsr_columns || !t_offsets || !t_columns || !block_indices
-                || (rec->bsr_row_counts_region_id >= 0 && !bsr_row_counts)
-                || (rec->transposed_row_counts_region_id >= 0 && !t_row_counts)
-                || (rec->status_region_id >= 0 && !status)) {
+            if (!bsr_offsets || !bsr_columns || !t_offsets || (rec->bsr_row_counts_region_id >= 0 && !bsr_row_counts)
+                || (rec->transposed_row_counts_region_id >= 0 && !t_row_counts)) {
                 fprintf(stderr, "APIC: Error - bsr-transpose pointer resolution failed at operation %u\n", i);
                 return false;
             }
@@ -2134,10 +2118,38 @@ static bool apic_cpu_replay_stream(
             // capture time, so replay reconstructs the destination even if the
             // caller reset its offsets buffer before capture_launch. Compact
             // transposes recompute the offsets and carry no tail (GH-1587).
+            // This must happen before sizing the destination spans below: the
+            // recorded tail, not the (possibly reset) live offsets, is the
+            // authoritative capacity layout.
+            size_t transposed_capacity_bytes = int_bytes;
             if (rec->transposed_row_counts_region_id >= 0) {
                 size_t tail_bytes = static_cast<size_t>(rec->header.total_size) - sizeof(APICBsrTransposeRecord);
-                if (tail_bytes >= colp1_bytes)
+                if (tail_bytes >= colp1_bytes) {
                     memcpy(t_offsets, ptr + sizeof(APICBsrTransposeRecord), colp1_bytes);
+                    // The transpose touches the destination columns only within
+                    // the padded capacity (offsets[col_count] blocks), which may
+                    // be smaller than the source's nnz upper bound. Match the
+                    // span claimed at capture so resolution is bounds-checked
+                    // against the destination's real extent.
+                    int32_t capacity = reinterpret_cast<const int32_t*>(t_offsets)[rec->col_count];
+                    transposed_capacity_bytes = capacity > 0 ? static_cast<size_t>(capacity) * sizeof(int32_t) : 0;
+                }
+            }
+            void* t_columns = resolve_ptr(
+                rec->transposed_columns_region_id, rec->transposed_columns_offset, transposed_capacity_bytes
+            );
+            // block_indices carries the sorted source blocks (up to nnz entries)
+            // and, for padded destinations, per-slot gap markers up to the
+            // destination capacity.
+            void* block_indices = resolve_ptr(
+                rec->block_indices_region_id, rec->block_indices_offset, std::max(int_bytes, transposed_capacity_bytes)
+            );
+            void* status = rec->status_region_id >= 0
+                ? resolve_ptr(rec->status_region_id, rec->status_offset, sizeof(int32_t))
+                : nullptr;
+            if (!t_columns || !block_indices || (rec->status_region_id >= 0 && !status)) {
+                fprintf(stderr, "APIC: Error - bsr-transpose pointer resolution failed at operation %u\n", i);
+                return false;
             }
             // g_apic_state is null during replay, so this executes the real
             // transpose. Same entry point wp.sparse.bsr_set_transpose uses.

--- a/warp/native/apic.cu
+++ b/warp/native/apic.cu
@@ -720,18 +720,20 @@ static bool apic_replay_ops_into_cuda_capture(
                       static_cast<size_t>(rec->col_count) * sizeof(int32_t)
                   )
                 : nullptr;
-            // The transposed-columns and block-index regions are allocated at
-            // their full registered (padded) capacity, so resolve them with the
-            // source span -- apic_resolve_region_ptr bounds-checks the access
-            // against the region size. Do NOT read t_offsets[col_count] on the
-            // host to size them: t_offsets is device memory and dereferencing it
-            // here, during the active rebuild capture, is undefined behavior
-            // (GH-1431).
+            // The transposed-columns span is the destination's capacity
+            // (t_offsets[col_count]), which is device memory that must NOT be
+            // dereferenced here during the active rebuild capture (GH-1431), and
+            // which may be smaller than the source's nnz upper bound. Resolve it
+            // with a minimal span; the device transpose bounds its own accesses
+            // by the capacity offsets. The block-index buffer doubles as CUB
+            // sort scratch (DoubleBuffer key halves span 2*nnz entries), so
+            // resolve it with the full scratch span.
             void* t_columns = apic_resolve_region_ptr(
-                graph, rec->transposed_columns_region_id, rec->transposed_columns_offset, int_bytes
+                graph, rec->transposed_columns_region_id, rec->transposed_columns_offset, sizeof(int32_t)
             );
-            void* block_indices
-                = apic_resolve_region_ptr(graph, rec->block_indices_region_id, rec->block_indices_offset, int_bytes);
+            void* block_indices = apic_resolve_region_ptr(
+                graph, rec->block_indices_region_id, rec->block_indices_offset, 2 * int_bytes
+            );
             void* status = rec->status_region_id >= 0
                 ? apic_resolve_region_ptr(graph, rec->status_region_id, rec->status_offset, sizeof(int32_t))
                 : nullptr;

--- a/warp/native/sparse.cpp
+++ b/warp/native/sparse.cpp
@@ -214,7 +214,19 @@ bool apic_capture_bsr_transpose(
     // capture_launch (GH-1587). For a compact destination it is an output the
     // transpose recomputes, so no snapshot is taken.
     const bool padded = transposed_bsr_row_counts != nullptr;
-    uint64_t block_indices_bytes = int_bytes;
+    // The transpose touches transposed_bsr_columns only within the destination's
+    // capacity: offsets[col_count] blocks for a padded destination (which may be
+    // smaller than the source's nnz upper bound — that is the capacity-overflow
+    // case the padded API reports via status), nnz blocks for a compact one (the
+    // caller guarantees fit). Claiming nnz on a smaller padded destination would
+    // grow the region past the real allocation, corrupting pointer resolution
+    // (and the host snapshot) for the rest of the capture.
+    uint64_t transposed_capacity
+        = padded ? static_cast<uint64_t>(std::max(transposed_bsr_offsets[col_count], 0)) : static_cast<uint64_t>(nnz);
+    uint64_t transposed_columns_bytes = transposed_capacity * sizeof(int32_t);
+    // block_indices carries the sorted source blocks (up to nnz entries) and, for
+    // padded destinations, per-slot gap markers up to the destination capacity.
+    uint64_t block_indices_bytes = std::max(int_bytes, transposed_columns_bytes);
 
     APICAddress bo_addr = apic_resolve_host_ptr(state, reinterpret_cast<uint64_t>(bsr_offsets), rowp1_bytes);
     APICAddress brc_addr;
@@ -231,7 +243,7 @@ bool apic_capture_bsr_transpose(
             static_cast<uint64_t>(col_count) * sizeof(int32_t)
         );
     APICAddress tc_addr
-        = apic_resolve_host_ptr(state, reinterpret_cast<uint64_t>(transposed_bsr_columns), block_indices_bytes);
+        = apic_resolve_host_ptr(state, reinterpret_cast<uint64_t>(transposed_bsr_columns), transposed_columns_bytes);
     APICAddress bi_addr
         = apic_resolve_host_ptr(state, reinterpret_cast<uint64_t>(src_block_indices), block_indices_bytes);
     APICAddress status_addr;

--- a/warp/native/sparse.cu
+++ b/warp/native/sparse.cu
@@ -1344,7 +1344,18 @@ static void apic_capture_bsr_transpose_device(
     // padded destinations) that the live CUDA replay re-reads in place, so no
     // host-side capacity snapshot is recorded here (unlike the CPU path, which
     // snapshots it for byte-stream replay -- GH-1587).
-    uint64_t block_indices_bytes = int_bytes;
+    //
+    // transposed_bsr_columns spans the destination's capacity, which is also
+    // device-resident (transposed_bsr_offsets[col_count]) and cannot be read
+    // during capture. Resolve it with a minimal span: Python tracks the array's
+    // real extent before the native call, so the pointer resolves into that
+    // region. Claiming the source's nnz upper bound instead would grow the
+    // region past the real allocation of a smaller padded destination,
+    // corrupting pointer resolution for the rest of the capture.
+    uint64_t transposed_columns_bytes = sizeof(int32_t);
+    // src_block_indices doubles as CUB sort scratch: the DoubleBuffer key
+    // halves span 2*nnz entries.
+    uint64_t block_indices_bytes = 2 * int_bytes;
 
     APICAddress bo_addr = apic_resolve_live_ptr(state, reinterpret_cast<uint64_t>(bsr_offsets), rowp1_bytes);
     APICAddress brc_addr;
@@ -1361,7 +1372,7 @@ static void apic_capture_bsr_transpose_device(
             static_cast<uint64_t>(col_count) * sizeof(int32_t)
         );
     APICAddress tc_addr
-        = apic_resolve_live_ptr(state, reinterpret_cast<uint64_t>(transposed_bsr_columns), block_indices_bytes);
+        = apic_resolve_live_ptr(state, reinterpret_cast<uint64_t>(transposed_bsr_columns), transposed_columns_bytes);
     APICAddress bi_addr
         = apic_resolve_live_ptr(state, reinterpret_cast<uint64_t>(src_block_indices), block_indices_bytes);
     APICAddress status_addr;

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -14,6 +14,12 @@ import numpy as np
 import warp as wp
 import warp._src.context as wp_context
 from warp._src.apic.capture import APICapture
+from warp.sparse import (
+    BSR_STATUS_ROW_CAPACITY_EXCEEDED,
+    bsr_set_from_triplets,
+    bsr_set_transpose,
+    bsr_zeros,
+)
 from warp.tests.unittest_utils import (
     add_function_test,
     get_cuda_test_devices,
@@ -2279,6 +2285,74 @@ def test_save_load_padded_bsr_transpose_cuda_rebuild(test, device):
         assert_loaded_matches(loaded, "stale-offsets save/load")
 
 
+def test_save_load_padded_bsr_transpose_too_small(test, device):
+    """Save/load a padded transpose into a destination that is too small for the source.
+
+    The destination's total block capacity (3) is smaller than the source's nnz
+    upper bound (6), which is the capacity-overflow case the padded API reports
+    through ``status``. The capture hooks used to claim the source bound for
+    the destination-columns span, so the tracked region grew past the
+    destination's real allocation: the CPU host snapshot read past the buffer
+    and pointer resolution was corrupted for the rest of the capture (seen in
+    CI as ``free(): invalid next size`` aborts). Record and replay now size
+    that span from the destination capacity. The test asserts the exact-span
+    record and resolve survive a save/load round-trip and that the overflow
+    status is still reported.
+    """
+    rows = wp.array(np.array([0, 0, 1, 1], dtype=np.int32), dtype=wp.int32, device=device)
+    columns = wp.array(np.array([0, 2, 1, 2], dtype=np.int32), dtype=wp.int32, device=device)
+    values = wp.array(np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32), dtype=wp.float32, device=device)
+    A = bsr_zeros(2, 3, block_type=wp.float32, device=device, row_capacity=3)
+    bsr_set_from_triplets(A, rows, columns, values, topology="padded")
+
+    # 3 destination rows at row_capacity 1: total capacity 3 < source nnz upper
+    # bound 6, and destination row 2 receives 2 blocks so it overflows.
+    At = bsr_zeros(3, 2, block_type=wp.float32, device=device, row_capacity=1)
+    status = At._ensure_status()
+
+    wp.load_module(device=device)
+    if device.is_cuda:
+        # Specialize and load the internal values kernel before CUDA graph capture.
+        bsr_set_transpose(At, A, topology="padded")
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        bsr_set_transpose(At, A, topology="padded")
+
+    # Reset every destination buffer so the loaded graph must rebuild them.
+    At.row_counts.zero_()
+    At.columns.fill_(-1)
+    At.values.zero_()
+    status.zero_()
+
+    outputs = {"row_counts": At.row_counts, "columns": At.columns, "values": At.values, "status": status}
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "padded_transpose_too_small")
+        wp.capture_save(capture.graph, path, outputs=outputs)
+        loaded = wp.capture_load(path, device=device)
+        for i in range(2):
+            wp.capture_launch(loaded)
+
+            rc = wp.zeros_like(At.row_counts)
+            cols = wp.zeros_like(At.columns)
+            vals = wp.zeros_like(At.values)
+            st = wp.zeros_like(status)
+            loaded.get_param("row_counts", rc)
+            loaded.get_param("columns", cols)
+            loaded.get_param("values", vals)
+            loaded.get_param("status", st)
+
+            label = f"launch {i + 1}"
+            np.testing.assert_array_equal(
+                rc.numpy(), np.array([1, 1, 0], dtype=np.int32), err_msg=f"{label}: row_counts"
+            )
+            np.testing.assert_array_equal(
+                cols.numpy().reshape(-1)[:2], np.array([0, 1], dtype=np.int32), err_msg=f"{label}: columns"
+            )
+            np.testing.assert_allclose(
+                vals.numpy().reshape(-1)[:2], np.array([1.0, 3.0], dtype=np.float32), err_msg=f"{label}: values"
+            )
+            test.assertEqual(st.numpy()[0], BSR_STATUS_ROW_CAPACITY_EXCEEDED, msg=f"{label}: status")
+
+
 def test_apic_cpu_op_not_rejected_under_cuda_capture(test, device):
     """Device-scoping: the CPU-only ``NotImplementedError`` guards for
     non-contiguous ``fill_()`` / ``wp.copy()`` are scoped to a CPU APIC capture
@@ -2869,6 +2943,12 @@ add_function_test(
     "test_save_load_padded_bsr_transpose_cuda_rebuild",
     test_save_load_padded_bsr_transpose_cuda_rebuild,
     devices=[d for d in devices if d.is_cuda],
+)
+add_function_test(
+    TestApic,
+    "test_save_load_padded_bsr_transpose_too_small",
+    test_save_load_padded_bsr_transpose_too_small,
+    devices=devices,
 )
 add_function_test(
     TestApic,


### PR DESCRIPTION
## Description

Fix a heap-buffer-overflow in APIC capture and replay of padded BSR transposes when the destination has less capacity than the source's `nnz` upper bound. This bug shipped in v1.15.0 and first appeared in CI as intermittent `free(): invalid next size (fast)` aborts in the GitLab `linux-x86_64 python free-threaded test` job.

The transpose's scatter logic already bounded its destination writes using `transposed_bsr_offsets` and reported `BSR_STATUS_ROW_CAPACITY_EXCEEDED` when a row did not fit. However, the APIC capture hooks passed the source's `nnz` upper bound to the pointer resolver as the span of the destination columns buffer. That span can exceed the allocation of a padded destination.

This was not a harmless overestimate. APIC trusts the span supplied by a capture hook. If the span extends past a tracked region, APIC grows the region to include it; on CPU, APIC then snapshots the grown region immediately. For example, the regression case has a source bound of 6 blocks and a destination capacity of 3 blocks. The old hook expanded APIC's view of the destination columns allocation from 12 bytes to 24 bytes, then copied 24 bytes from the 12-byte allocation. AddressSanitizer reports that operation as a deterministic heap-buffer-overflow.

The inflated region could also overlap a neighboring allocation in APIC's region table. Later pointer lookups could consequently resolve to the wrong region or offset, allowing subsequent capture or replay operations to access unrelated memory. That is how an incorrect span at capture time could progress from an out-of-bounds read to the heap corruption detected by glibc during `free()`.

The fix prevents APIC from extending or snapshotting the destination beyond its real allocation:

- CPU capture uses `transposed_bsr_offsets[col_count]`, the padded destination's actual capacity. Compact destinations continue to use `nnz` because they are guaranteed to fit.
- CPU replay restores the recorded padded offsets before reading the capacity from them. This also handles callers that reset the live offsets between capture and replay.
- CUDA capture and graph rebuild use a minimal destination span because the capacity lives in device memory and cannot be read safely by the host. The Python capture layer has already registered the array's full allocation, so the minimal span locates the pointer without growing its region. The transpose continues to use the device offsets to bound its accesses.
- The block-index scratch spans now match their actual uses: the CPU needs `max(nnz, destination capacity)`, while CUDA's CUB `DoubleBuffer` needs `2 * nnz`.

No native API or serialized `.wrp` format change is required.

Closes #1630

## Changes

- Correct destination-column and block-index region sizing in the CPU and CUDA APIC capture hooks.
- Restore recorded padded offsets before resolving destination buffers during CPU replay.
- Apply the same CUDA sizing rules while rebuilding a saved graph.
- Add a CPU/CUDA save-load regression test in which the destination capacity is intentionally smaller than the source bound. The test verifies safe repeated replay and the expected capacity-overflow status.
- Add a CHANGELOG entry under `Unreleased`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- On the target branch, an AddressSanitizer debug build reports a deterministic heap-buffer-overflow in `apic_capture_bsr_transpose`: a 24-byte snapshot read from a 12-byte `wp_alloc_host` allocation.
- With this fix, the same AddressSanitizer build runs the complete `test_apic.py` module without a report: 198/198 tests pass, including all three device variants of the new regression test.
- Release builds pass `test_apic.py` 198/198 on Python 3.14t and 3.12 across CPU, `cuda:0`, and `cuda:1`; `test_sparse.py` passes 89/89.
- The existing tests covering the adjacent padded-transpose capture and capacity-restore behavior also pass: `test_capture_padded_bsr_transpose_rebuilds_offsets`, `test_save_load_padded_bsr_transpose_cuda_rebuild`, and `test_capture_with_padded_bsr_transpose`.

## Bug fix

Without this PR, run this example under an AddressSanitizer build to reproduce the out-of-bounds snapshot during APIC capture:

```python
import numpy as np

import warp as wp
from warp.sparse import bsr_set_from_triplets, bsr_set_transpose, bsr_zeros

device = "cpu"
rows = wp.array(np.array([0, 0, 1, 1], dtype=np.int32), dtype=wp.int32, device=device)
columns = wp.array(np.array([0, 2, 1, 2], dtype=np.int32), dtype=wp.int32, device=device)
values = wp.array(np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32), dtype=wp.float32, device=device)
A = bsr_zeros(2, 3, block_type=wp.float32, device=device, row_capacity=3)
bsr_set_from_triplets(A, rows, columns, values, topology="padded")

# The destination holds 3 blocks; the source has an nnz upper bound of 6.
At = bsr_zeros(3, 2, block_type=wp.float32, device=device, row_capacity=1)

wp.load_module(device=device)
with wp.ScopedCapture(device=device, apic=True, force_module_load=False):
    bsr_set_transpose(At, A, topology="padded")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash risk during padded BSR transpose capture when the destination row capacity is too small.
  * Improved stability of save/load and replay for padded BSR transpose graphs by correcting temporary-buffer sizing and validation, while ensuring overflow handling remains consistent.
* **Tests**
  * Added a regression test verifying save/load and repeated replay of padded BSR transpose when the destination capacity is intentionally undersized, and that the overflow status is still reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
