### PR TITLE
Validate function argument annotations by name

### DIFF
--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -1639,8 +1639,9 @@ class Adjoint:
         # ensure all arguments are annotated
         if overload_annotations is None:
             # use source-level argument annotations
-            if len(argspec.annotations) < len(argspec.args):
-                raise WarpCodegenError(f"Incomplete argument annotations on function {adj.fun_name}")
+            missing = [name for name in argspec.args if name not in argspec.annotations]
+            if missing:
+                raise WarpCodegenError(f"Argument '{missing[0]}' in function '{adj.fun_name}' must be type annotated")
             adj.arg_types = {k: v for k, v in argspec.annotations.items() if not (k == "return" and v is None)}
         else:
             # use overload argument annotations
@@ -1656,11 +1657,8 @@ class Adjoint:
         # IR while Python-level semantics expose pass-by-reference.
         adj.ref_params: dict[str, Var] = {}
 
-        for name, type in adj.arg_types.items():
-            # skip return hint
-            if name == "return":
-                continue
-
+        for name in argspec.args:
+            type = adj.arg_types[name]
             # add variable for argument
             arg = Var(name, type, requires_grad=False)
             adj.args.append(arg)

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -135,8 +135,9 @@ def get_function_args(func):
     argspec = warp._src.codegen.get_full_arg_spec(func)
 
     # use source-level argument annotations
-    if len(argspec.annotations) < len(argspec.args):
-        raise RuntimeError(f"Incomplete argument annotations on function {func.__qualname__}")
+    missing = [name for name in argspec.args if name not in argspec.annotations]
+    if missing:
+        raise RuntimeError(f"Argument '{missing[0]}' in function '{func.__qualname__}' must be type annotated")
     return argspec.annotations
 
 
@@ -1908,20 +1909,19 @@ def overload(kernel: Kernel | Callable, arg_types: dict[str, Any] | list[Any] | 
 
         # ensure all arguments are annotated
         argspec = warp._src.codegen.get_full_arg_spec(fn)
-        if len(argspec.annotations) < len(argspec.args):
-            raise RuntimeError(f"Incomplete argument annotations on kernel overload {fn.__name__}")
+        missing = [name for name in argspec.args if name not in argspec.annotations]
+        if missing:
+            raise RuntimeError(f"Argument '{missing[0]}' in kernel overload '{fn.__name__}' must be type annotated")
 
         # get type annotation list
         arg_list = []
-        for arg_name, arg_type in argspec.annotations.items():
-            if arg_name == "return":
-                if arg_type is not None and arg_type is not types.NoneType:
-                    raise TypeError(
-                        "Return annotations are not allowed on @wp.overload stubs; "
-                        "omit the return annotation or use `-> None`."
-                    )
-            else:
-                arg_list.append(arg_type)
+        return_type = argspec.annotations.get("return")
+        if return_type is not None and return_type is not types.NoneType:
+            raise TypeError(
+                "Return annotations are not allowed on @wp.overload stubs; omit the return annotation or use `-> None`."
+            )
+        for arg_name in argspec.args:
+            arg_list.append(argspec.annotations[arg_name])
 
         # add new overload, but we must return the original kernel from @wp.overload decorator!
         kernel.add_overload(arg_list)

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -138,7 +138,7 @@ def get_function_args(func):
     missing = [name for name in argspec.args if name not in argspec.annotations]
     if missing:
         raise RuntimeError(f"Argument '{missing[0]}' in function '{func.__qualname__}' must be type annotated")
-    return argspec.annotations
+    return {name: argspec.annotations[name] for name in argspec.args}
 
 
 complex_type_hints = (Any, Callable, tuple)

--- a/warp/_src/jax/ffi.py
+++ b/warp/_src/jax/ffi.py
@@ -562,8 +562,13 @@ class FfiCallable:
         if self.num_outputs < self.num_in_out:
             raise ValueError("Number of outputs cannot be smaller than the number of in_out_argnames")
 
-        if len(argspec.annotations) < num_args:
-            raise RuntimeError(f"Incomplete argument annotations on function {self.name}")
+        missing = [name for name in argspec.args if name not in argspec.annotations]
+        if missing:
+            raise RuntimeError(f"Argument '{missing[0]}' in function '{self.name}' must be type annotated")
+
+        return_type = argspec.annotations.get("return")
+        if return_type is not None:
+            raise TypeError("Function must not return a value")
 
         # parse type annotations
         self.args = []
@@ -571,19 +576,15 @@ class FfiCallable:
         self.arg_output_indices = [None] * num_args  # index in FFI output buffers
         arg_idx = 0
         output_idx = 0
-        for arg_name, arg_type in argspec.annotations.items():
-            if arg_name == "return":
-                if arg_type is not None:
-                    raise TypeError("Function must not return a value")
-                continue
-            else:
-                arg = FfiArg(arg_name, arg_type, arg_name in in_out_argnames)
-                if arg.in_out:
-                    in_out_argnames.remove(arg_name)
-                if arg.is_array:
-                    if arg_idx < self.num_inputs and self.first_array_arg is None:
-                        self.first_array_arg = arg_idx
-                self.args.append(arg)
+        for arg_name in argspec.args:
+            arg_type = argspec.annotations[arg_name]
+            arg = FfiArg(arg_name, arg_type, arg_name in in_out_argnames)
+            if arg.in_out:
+                in_out_argnames.remove(arg_name)
+            if arg.is_array:
+                if arg_idx < self.num_inputs and self.first_array_arg is None:
+                    self.first_array_arg = arg_idx
+            self.args.append(arg)
 
             if arg.in_out and arg_idx >= self.num_inputs:
                 raise AssertionError(

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -862,6 +862,15 @@ def test_ffi_jax_kernel_launch_dims_custom(test, device):
 
 
 @unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
+def test_ffi_jax_callable_incomplete_argument_annotations(test, device):
+    def missing_annotation(a: wp.array[float], b) -> None:
+        pass
+
+    with test.assertRaisesRegex(RuntimeError, r"Argument 'b' in function '.*' must be type annotated"):
+        wp.jax_callable(missing_annotation, num_outputs=1)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
 def test_ffi_jax_callable_scale_constant(test, device):
     # scale two arrays using a constant
     jp = _import_jax_numpy()
@@ -2246,6 +2255,12 @@ try:
     )
     add_function_test(TestJax, "test_dtype_from_jax", test_dtype_from_jax, devices=None)
     add_function_test(TestJax, "test_dtype_to_jax", test_dtype_to_jax, devices=None)
+    add_function_test(
+        TestJax,
+        "test_ffi_jax_callable_incomplete_argument_annotations",
+        test_ffi_jax_callable_incomplete_argument_annotations,
+        devices=None,
+    )
     if jax_compatible_devices:
         add_function_test(TestJax, "test_device_conversion", test_device_conversion, devices=jax_compatible_devices)
 

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -645,6 +645,14 @@ def test_error_kernel_return_value(test, device):
 
 
 def test_error_incomplete_argument_annotations(test, device):
+    def annotated_with_return(a: float, b: int) -> float:
+        return a + b
+
+    test.assertEqual(
+        wp._src.context.get_function_args(annotated_with_return),
+        {"a": float, "b": int},
+    )
+
     def missing_annotation(a: float, b) -> None:
         pass
 

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -644,6 +644,43 @@ def test_error_kernel_return_value(test, device):
         wp.launch(f6, dim=1, inputs=[3.0], device=device)
 
 
+def test_error_incomplete_argument_annotations(test, device):
+    def missing_annotation(a: float, b) -> None:
+        pass
+
+    with test.assertRaisesRegex(
+        RuntimeError, r"Argument 'b' in function '.*missing_annotation' must be type annotated"
+    ):
+        wp._src.context.get_function_args(missing_annotation)
+
+    with test.assertRaisesRegex(
+        wp.WarpCodegenError, r"Argument 'b' in function 'missing_kernel' must be type annotated"
+    ):
+
+        @wp.kernel(module="unique")
+        def missing_kernel(a: float, b) -> None:
+            pass
+
+    with test.assertRaisesRegex(wp.WarpCodegenError, r"Argument 'b' in function 'missing_func' must be type annotated"):
+
+        @wp.func
+        def missing_func(a: float, b) -> None:
+            pass
+
+    @wp.kernel
+    def generic_kernel(a: Any, b: Any):
+        pass
+
+    with test.assertRaisesRegex(
+        RuntimeError,
+        r"Argument 'b' in kernel overload 'generic_kernel' must be type annotated",
+    ):
+
+        @wp.overload
+        def generic_kernel(a: float, b) -> None:
+            pass
+
+
 def test_error_kernel_return_alias_unique_module_reuse(test, device):
     """Verify aliased kernel return annotations prevent unique-module reuse."""
 
@@ -2055,6 +2092,12 @@ add_function_test(
     func=test_error_kernel_return_value,
     name="test_error_kernel_return_value",
     devices=devices,
+)
+add_function_test(
+    TestCodeGen,
+    func=test_error_incomplete_argument_annotations,
+    name="test_error_incomplete_argument_annotations",
+    devices=None,
 )
 add_function_test(
     TestCodeGen,


### PR DESCRIPTION
## Summary

- Validate required parameter annotations by name across code generation, replay helpers, kernel overloads, and JAX FFI callables.
- Parse arguments in declaration order while preserving return annotations for function return validation.
- Add regressions for kernels, functions, overload stubs, and JAX callables.

## Why

The old count-based validation treated a return annotation as an argument annotation. A function such as `f(a: int, b) -> None` therefore passed validation and failed later with a less useful codegen or FFI error.

## Validation

- Ruff lint and format checks pass for all changed Python files.
- Targeted codegen regression passes with the CPU-only native runtime.
- Targeted JAX FFI regression passes with CPU JAX 0.5+.
- Python compilation and `git diff --check` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for incomplete function/kernel/JAX FFI argument type annotations.
  * Improved errors to name the first specific missing parameter.
  * Preserved positional argument order when processing kernels, overloads, and JAX FFI callables.
  * Tightened return annotation handling to require `None` where applicable.
* **Tests**
  * Added new test coverage for incomplete argument annotations across codegen, overloads, and JAX interoperability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->