### PR TITLE
Skip unsupported JAX devices during module preload

### DIFF
--- a/warp/_src/jax/ffi.py
+++ b/warp/_src/jax/ffi.py
@@ -66,6 +66,17 @@ def check_jax_version():
         raise RuntimeError(msg)
 
 
+def _preload_module_on_all_devices(module, jax):
+    for d in jax.local_devices():
+        try:
+            dev = wp.device_from_jax(d)
+        except RuntimeError:
+            continue
+
+        if dev.is_cuda:
+            module.load(dev)
+
+
 def collapse_batch_dims(shape, desired_ndim):
     # roll leading batch dims into one
     while len(shape) > desired_ndim:
@@ -332,15 +343,7 @@ class FfiKernel:
             device = wp.device_from_jax(get_jax_device())
             self.kernel.module.load(device)
         elif self.module_preload_mode == JaxModulePreloadMode.ALL_DEVICES:
-            for d in jax.local_devices():
-                try:
-                    dev = wp.device_from_jax(d)
-                except Exception:
-                    # ignore unsupported devices like TPUs
-                    pass
-                # we only support CUDA devices for now
-                if dev.is_cuda:
-                    self.kernel.module.load(dev)
+            _preload_module_on_all_devices(self.kernel.module, jax)
 
         # save launch data to be retrieved by callback
         launch_id = self.launch_id
@@ -715,15 +718,7 @@ class FfiCallable:
             device = wp.device_from_jax(get_jax_device())
             module.load(device)
         elif self.module_preload_mode == JaxModulePreloadMode.ALL_DEVICES:
-            for d in jax.local_devices():
-                try:
-                    dev = wp.device_from_jax(d)
-                except Exception:
-                    # ignore unsupported devices like TPUs
-                    pass
-                # we only support CUDA devices for now
-                if dev.is_cuda:
-                    module.load(dev)
+            _preload_module_on_all_devices(module, jax)
 
         # save call data to be retrieved by callback
         call_id = self.call_id

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -10,6 +10,7 @@ import unittest
 import warnings
 from functools import partial
 from typing import Any
+from unittest import mock
 
 import numpy as np
 
@@ -859,6 +860,30 @@ def test_ffi_jax_kernel_launch_dims_custom(test, device):
     test.assertEqual(result2.shape, expected2.shape)
     assert_np_equal(result1, expected1)
     assert_np_equal(result2, expected2)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
+def test_ffi_all_devices_preload_skips_unsupported_device(test, device):
+    ffi_module = importlib.import_module("warp._src.jax.ffi")
+    unsupported_device = object()
+    jax_cuda_device = object()
+    warp_cuda_device = mock.Mock(is_cuda=True)
+    module = mock.Mock()
+    fake_jax = mock.Mock()
+
+    def device_from_jax(jax_device):
+        if jax_device is unsupported_device:
+            raise RuntimeError("unsupported device")
+        return warp_cuda_device
+
+    for jax_devices in ([unsupported_device, jax_cuda_device], [jax_cuda_device, unsupported_device]):
+        with test.subTest(jax_devices=jax_devices):
+            fake_jax.local_devices.return_value = jax_devices
+            module.load.reset_mock()
+            with mock.patch.object(ffi_module.wp, "device_from_jax", side_effect=device_from_jax):
+                ffi_module._preload_module_on_all_devices(module, fake_jax)
+
+            module.load.assert_called_once_with(warp_cuda_device)
 
 
 @unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
@@ -2246,6 +2271,12 @@ try:
     )
     add_function_test(TestJax, "test_dtype_from_jax", test_dtype_from_jax, devices=None)
     add_function_test(TestJax, "test_dtype_to_jax", test_dtype_to_jax, devices=None)
+    add_function_test(
+        TestJax,
+        "test_ffi_all_devices_preload_skips_unsupported_device",
+        test_ffi_all_devices_preload_skips_unsupported_device,
+        devices=None,
+    )
     if jax_compatible_devices:
         add_function_test(TestJax, "test_device_conversion", test_device_conversion, devices=jax_compatible_devices)
 

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -862,7 +862,7 @@ def test_ffi_jax_kernel_launch_dims_custom(test, device):
     assert_np_equal(result2, expected2)
 
 
-@unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
 def test_ffi_all_devices_preload_skips_unsupported_device(test, device):
     ffi_module = importlib.import_module("warp._src.jax.ffi")
     unsupported_device = object()


### PR DESCRIPTION
## Summary

- Centralize `ALL_DEVICES` module preloading for `FfiKernel` and `FfiCallable`.
- Skip unsupported JAX platforms when `device_from_jax()` raises its documented `RuntimeError`.
- Add regression coverage for unsupported devices appearing before and after a CUDA device.

## Root cause

The preload loops caught conversion failures but continued into `dev.is_cuda`. That could read an unbound local on the first unsupported device or reuse the previous device on later failures.

## Validation

- Targeted JAX preload regression passes with CPU JAX 0.5+.
- Ruff lint and format checks pass.
- Python compilation and `git diff --check` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JAX interop behavior when preloading modules across devices.
  * Unsupported devices are now skipped, ensuring supported CUDA devices load correctly.
  * Ensured consistent preload behavior for both FFI kernels and FFI callables.
* **Tests**
  * Added coverage for skipping unsupported devices during all-devices preload when JAX is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->