### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         pass_filenames: false
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.9
+    rev: v0.15.20
     hooks:
       # Run the linter.
       - id: ruff
@@ -43,16 +43,16 @@ repos:
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.3
+    rev: 0.11.26
     hooks:
       # Update the uv lockfile
       - id: uv-lock
   - repo: https://github.com/crate-ci/typos
-    rev: v1.45.0
+    rev: v1.48.0
     hooks:
       - id: typos
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.2
+    rev: v22.1.5
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]

--- a/warp/examples/tile/example_tile_mlp.py
+++ b/warp/examples/tile/example_tile_mlp.py
@@ -52,7 +52,7 @@ def create_array(dim_in, dim_hid, dtype=float):
 # number of frequencies for the positional encoding
 NUM_FREQ = wp.constant(8)
 
-DIM_IN = wp.constant(4 * NUM_FREQ)  # sin,cos for both x,y at each frequenecy
+DIM_IN = wp.constant(4 * NUM_FREQ)  # sin,cos for both x,y at each frequency
 DIM_HID = 32
 DIM_OUT = 3
 


### PR DESCRIPTION
## Description

Updates the pre-commit hooks proposed in #1623 while pinning
`crate-ci/typos` to the exact `v1.48.0` release instead of the floating
`v1` branch. The exact tag keeps pre-commit runs reproducible and prevents
unreviewed hook changes.

## Changes

- Update Ruff to `v0.15.20`, uv to `0.11.26`, and clang-format to
  `v22.1.5`.
- Update typos to the pinned `v1.48.0` release.
- Correct an existing misspelling detected by the updated typos hook.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Ran the full pre-commit suite across all tracked files. The first run
corrected the existing typo detected by typos `v1.48.0`; a second full run
passed every hook, confirming that the updated hooks converge cleanly and do
not introduce additional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling to newer versions for improved formatting, linting, and typo detection.

* **Documentation**
  * Corrected a spelling error in an example comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->