### PR TITLE
Fix sparse group-root lookups (GH-1612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,8 @@
   accumulated state ([GH-1615](https://github.com/NVIDIA/warp/issues/1615)).
 - Fix `wp.from_dlpack()` support for standards-conformant 8-bit Boolean tensors
   ([GH-1619](https://github.com/NVIDIA/warp/issues/1619)).
+- Fix group-root lookups for `wp.Bvh` and `wp.Mesh` with sparse group IDs so queries remain isolated to the requested
+  group ([GH-1612](https://github.com/NVIDIA/warp/issues/1612)).
 
 ### Documentation
 

--- a/warp/native/bvh.h
+++ b/warp/native/bvh.h
@@ -310,6 +310,23 @@ CUDA_CALLABLE inline int lower_bound_group(const BVH& bvh, int group)
     return lo;
 }
 
+CUDA_CALLABLE inline int upper_bound_group(const BVH& bvh, int group)
+{
+    int lo = 0;
+    int hi = bvh.num_leaf_nodes;
+
+    while (lo < hi) {
+        int mid = (lo + hi) >> 1;
+        if (get_leaf_group(bvh, mid) <= group) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+
+    return lo;
+}
+
 CUDA_CALLABLE inline uint64_t bvh_query_node_pack(const BVHPackedNodeHalf& lower, const BVHPackedNodeHalf& upper)
 {
     return (uint64_t(lower.b) << 62) | (uint64_t(upper.i) << 31) | uint64_t(lower.i);
@@ -361,14 +378,12 @@ CUDA_CALLABLE inline int bvh_get_group_root(uint64_t id, int group_id)
 {
     BVH bvh = bvh_get(id);
     // locate first leaf of the current group
-    int first = lower_bound_group(bvh, group_id);
+    const int first = lower_bound_group(bvh, group_id);
     if (first < 0)
         return -1;
 
-    // find first leaf of next group to find the last leaf of the current group
-    const int next_group = static_cast<int>(group_id) + 1;
-    int next = lower_bound_group(bvh, next_group);
-    int last = (next < 0 ? bvh.num_leaf_nodes : next) - 1;
+    // find the first leaf with a greater group id to locate the last leaf of the current group
+    const int last = upper_bound_group(bvh, group_id) - 1;
 
     return lca(first, last, bvh.node_parents);
 }

--- a/warp/tests/geometry/test_grouped_bvh.py
+++ b/warp/tests/geometry/test_grouped_bvh.py
@@ -63,6 +63,20 @@ def bvh_query_ray_group(
 
 
 @wp.kernel
+def mesh_query_ray_group(
+    mesh_id: wp.uint64,
+    start: wp.vec3,
+    direction: wp.vec3,
+    group_id: int,
+    face: wp.array[int],
+):
+    root = wp.mesh_get_group_root(mesh_id, group_id)
+    hit = wp.mesh_query_ray(mesh_id, start, direction, 1.0e6, root)
+    if hit.result:
+        face[0] = hit.face
+
+
+@wp.kernel
 def get_group_root(bvh_id: wp.uint64, roots: wp.array[int]):
     tid = wp.tid()
     roots[tid] = wp.bvh_get_group_root(bvh_id, tid)
@@ -261,7 +275,7 @@ def test_bvh_query_ray(test, device):
     test_bvh(test, "ray", device)
 
 
-def test_heterogenous_with_sparse_groups(test, device):
+def test_heterogeneous_group_sizes(test, device):
     rng = np.random.default_rng(123)
 
     if device.is_cpu:
@@ -291,6 +305,102 @@ def test_heterogenous_with_sparse_groups(test, device):
         wp.launch(kernel=get_group_root, dim=num_groups + 1, inputs=[bvh.id, roots], device=device)
         roots_host = roots.numpy()
         test.assertTrue(np.all(roots_host >= 0))
+
+
+def test_sparse_group_root_isolation(test, device):
+    if device.is_cpu:
+        constructors = ["sah", "median"]
+    else:
+        constructors = ["sah", "median", "lbvh"]
+
+    leaf_sizes = [1, 4]
+
+    lowers = wp.array(
+        [
+            [0.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [100.0, 0.0, 0.0],
+            [102.0, 0.0, 0.0],
+        ],
+        dtype=wp.vec3,
+        device=device,
+    )
+    uppers = wp.array(
+        [
+            [1.0, 1.0, 1.0],
+            [3.0, 1.0, 1.0],
+            [101.0, 1.0, 1.0],
+            [103.0, 1.0, 1.0],
+        ],
+        dtype=wp.vec3,
+        device=device,
+    )
+    points = wp.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [2.0, 0.0, 0.0],
+            [3.0, 0.0, 0.0],
+            [2.0, 1.0, 0.0],
+            [100.0, 0.0, 0.0],
+            [101.0, 0.0, 0.0],
+            [100.0, 1.0, 0.0],
+            [102.0, 0.0, 0.0],
+            [103.0, 0.0, 0.0],
+            [102.0, 1.0, 0.0],
+        ],
+        dtype=wp.vec3,
+        device=device,
+    )
+    indices = wp.array(np.arange(12, dtype=np.int32), dtype=int, device=device)
+
+    for sparse_group_id in (2, np.iinfo(np.int32).max):
+        groups = wp.array([0, 0, sparse_group_id, sparse_group_id], dtype=int, device=device)
+
+        for leaf_size, constructor in itertools.product(leaf_sizes, constructors):
+            bvh = wp.Bvh(lowers, uppers, groups=groups, constructor=constructor, leaf_size=leaf_size)
+            mesh = wp.Mesh(
+                points,
+                indices,
+                groups=groups,
+                bvh_constructor=constructor,
+                bvh_leaf_size=leaf_size,
+            )
+
+            for group_id, expected_hits, expected_face in (
+                (0, [1, 1, 0, 0], -1),
+                (sparse_group_id, [0, 0, 1, 1], 2),
+            ):
+                hits = wp.zeros(4, dtype=int, device=device)
+                wp.launch(
+                    bvh_query_aabb_group,
+                    dim=1,
+                    inputs=[
+                        bvh.id,
+                        wp.vec3(-10.0, -10.0, -10.0),
+                        wp.vec3(200.0, 10.0, 10.0),
+                        wp.array([group_id], dtype=int, device=device),
+                    ],
+                    outputs=[hits],
+                    device=device,
+                )
+                np.testing.assert_array_equal(hits.numpy(), expected_hits)
+
+                face = wp.full(1, -1, dtype=int, device=device)
+                wp.launch(
+                    mesh_query_ray_group,
+                    dim=1,
+                    inputs=[
+                        mesh.id,
+                        wp.vec3(100.2, 0.2, -1.0),
+                        wp.vec3(0.0, 0.0, 1.0),
+                        group_id,
+                    ],
+                    outputs=[face],
+                    device=device,
+                )
+                test.assertEqual(int(face.numpy()[0]), expected_face)
 
 
 def test_gh_288(test, device):
@@ -551,9 +661,8 @@ class TestGroupedBvh(unittest.TestCase):
 add_function_test(TestGroupedBvh, "test_grouped_bvh_aabb", test_bvh_query_aabb, devices=devices)
 add_function_test(TestGroupedBvh, "test_grouped_bvh_ray", test_bvh_query_ray, devices=devices)
 add_function_test(TestGroupedBvh, "test_grouped_gh_288", test_gh_288, devices=devices)
-add_function_test(
-    TestGroupedBvh, "test_heterogenous_with_sparse_groups", test_heterogenous_with_sparse_groups, devices=devices
-)
+add_function_test(TestGroupedBvh, "test_heterogeneous_group_sizes", test_heterogeneous_group_sizes, devices=devices)
+add_function_test(TestGroupedBvh, "test_sparse_group_root_isolation", test_sparse_group_root_isolation, devices=devices)
 
 add_function_test(
     TestGroupedBvh,


### PR DESCRIPTION
## Description

Fix group-root lookup for `wp.Bvh` and `wp.Mesh` when group IDs are
sparse or equal to `INT32_MAX`.

The lookup previously searched for `group_id + 1` to find the end of a
group. When the next numeric ID was absent, the resulting root could span
into a later group. Adding one also overflowed for the maximum 32-bit group
ID. This caused queries rooted at one group to return primitives from
another group.

Closes #1612.

## Changes

- Find the first leaf with a group ID greater than the requested group,
  avoiding assumptions about consecutive IDs and avoiding arithmetic
  overflow.
- Add BVH AABB-query and mesh ray-query coverage for sparse IDs and
  `INT32_MAX` across supported constructors and leaf sizes.
- Document the user-facing fix in the changelog.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

1. Rebuilt the native Warp libraries with CUDA 13.0 enabled to verify the
   CPU and CUDA implementation compiles and links.
2. Ran the complete grouped-BVH test module. All 19 tests passed on CPU and
   both available CUDA devices. The regression covers group IDs `0`, `2`,
   and `INT32_MAX` with SAH, median, and LBVH construction where supported,
   using leaf sizes 1 and 4.
3. Ran the applicable pre-commit hooks for the changed files. Generated-file
   checks, version consistency, Ruff, formatting, typos, and ClangFormat all
   passed.

## Bug fix

Before this change, querying group `0` in a BVH whose next group is `2`
could also return bounds from group `2`:

```python
import warp as wp


@wp.kernel
def query_group_zero(bvh_id: wp.uint64, hits: wp.array[int]):
    root = wp.bvh_get_group_root(bvh_id, 0)
    query = wp.bvh_query_aabb(
        bvh_id,
        wp.vec3(-10.0, -10.0, -10.0),
        wp.vec3(200.0, 10.0, 10.0),
        root,
    )
    index = int(0)
    while wp.bvh_query_next(query, index):
        hits[index] = 1


lowers = wp.array(
    [[0.0, 0.0, 0.0], [2.0, 0.0, 0.0],
     [100.0, 0.0, 0.0], [102.0, 0.0, 0.0]],
    dtype=wp.vec3,
)
uppers = wp.array(
    [[1.0, 1.0, 1.0], [3.0, 1.0, 1.0],
     [101.0, 1.0, 1.0], [103.0, 1.0, 1.0]],
    dtype=wp.vec3,
)
groups = wp.array([0, 0, 2, 2], dtype=int)
bvh = wp.Bvh(lowers, uppers, groups=groups)
hits = wp.zeros(4, dtype=int)
wp.launch(query_group_zero, dim=1, inputs=[bvh.id], outputs=[hits])
print(hits.numpy())  # Fixed result: [1, 1, 0, 0]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed group-root lookups for `wp.Bvh` and `wp.Mesh` when group IDs are sparse or non-sequential.
  - Improved isolation of group-restricted bounding-box and ray queries so they return results only from the requested group.

- **Tests**
  - Added coverage for sparse group IDs and groups with varying sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->