### PR TITLE
Update Sphinx toolchain and fix docs warnings

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,0 +1,29 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   {% block methods %}
+   {%- set documented_methods = [] %}
+   {%- for item in methods if item != "__init__" %}
+   {%- set _ = documented_methods.append(item) %}
+   {%- endfor %}
+   {% if documented_methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in documented_methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,7 @@ nitpick_ignore_regex = [
         r"warp\.(vec|mat|quat|transform|spatial_vector|spatial_matrix)\w*\.(from_ptr|scalar_export|scalar_import)",
     ),
     # Matrix accessor methods
-    (r"py:obj", r"warp\.(mat|spatial_matrix)\w+\.(get_col|get_row|set_col|set_row)"),
+    (r"py:obj", r"warp\.(mat|spatial_matrix)\w*\.(get_col|get_row|set_col|set_row)"),
     # Built-in numeric methods/properties inherited by enums/int/float subclasses
     (
         r"py:obj",
@@ -230,6 +230,14 @@ autodoc_default_options = {
 # Mock external dependencies that might not be installed.
 autodoc_mock_imports = ["jax", "paddle", "pxr", "torch"]
 
+# Merge the ``__init__`` docstring into the class description. Many Warp classes
+# (e.g. ``warp.array``, ``warp.Mesh``, ``warp.fem`` geometries) document their
+# constructor arguments on ``__init__`` rather than the class docstring. The
+# autosummary class template intentionally omits ``.. automethod:: __init__``
+# (it fails to resolve for the dynamically generated ctypes vec/mat/quat types),
+# so this setting is what keeps those constructor arguments in the rendered docs.
+autoclass_content = "both"
+
 # Show typehints as content of the function or method instead of in the signature.
 autodoc_typehints = "description"
 
@@ -238,6 +246,36 @@ autodoc_preserve_defaults = True
 
 # Prevent docstrings from being inherited from parent classes or methods.
 autodoc_inherit_docstrings = False
+
+
+# Work around a Sphinx 9 formatting bug: when a class is documented as an
+# attribute alias (``doc_as_attr``), ``sphinx.ext.autodoc._generate`` appends
+# the "alias of ..." note directly after the directive's content without a
+# separating blank line. Our public vec/mat/quat/transform and ``warp.fem``
+# index-type aliases carry autosummary "Methods"/"Attributes" tables, so the
+# unindented "alias of" line runs into the preceding ``.. autosummary::``
+# block and docutils reports "Explicit markup ends without a blank line".
+# Prepend a blank line so the generated reST stays well-formed. The private
+# ``_generate`` module was added in Sphinx 9, while Python <3.11 docs builds
+# still resolve to Sphinx 8 from ``uv.lock``.
+try:
+    import sphinx.ext.autodoc._generate as _autodoc_generate
+except ModuleNotFoundError as e:
+    if e.name != "sphinx.ext.autodoc._generate":
+        raise
+else:
+    if hasattr(_autodoc_generate, "_body_alias_lines"):
+        _orig_body_alias_lines = _autodoc_generate._body_alias_lines
+
+        def _body_alias_lines_with_blank(**kwargs):
+            emitted = False
+            for line in _orig_body_alias_lines(**kwargs):
+                if not emitted:
+                    yield ""  # separate the alias note from any preceding directive content
+                    emitted = True
+                yield line
+
+        _autodoc_generate._body_alias_lines = _body_alias_lines_with_blank
 
 
 # -- sphinx.ext.autosummary --------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -935,12 +935,44 @@ wheels = [
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version < '3.11' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version < '3.11' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version < '3.11' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+]
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.12.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version >= '3.13' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version >= '3.13' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version >= '3.13' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version == '3.12.*' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version == '3.12.*' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version == '3.12.*' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version == '3.11.*' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version == '3.11.*' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version == '3.11.*' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version >= '3.13' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.12.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+]
+dependencies = [
+    { name = "mdurl", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -1106,14 +1138,15 @@ wheels = [
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.5.0"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -1185,18 +1218,55 @@ wheels = [
 name = "myst-parser"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version < '3.11' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version < '3.11' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version < '3.11' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+]
 dependencies = [
-    { name = "docutils" },
-    { name = "jinja2" },
-    { name = "markdown-it-py" },
-    { name = "mdit-py-plugins" },
-    { name = "pyyaml" },
+    { name = "docutils", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "jinja2", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "markdown-it-py", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "mdit-py-plugins", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "pyyaml", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
+]
+
+[[package]]
+name = "myst-parser"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.12.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version >= '3.13' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version >= '3.13' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version >= '3.13' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version == '3.12.*' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version == '3.12.*' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version == '3.12.*' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version == '3.11.*' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version == '3.11.*' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version == '3.11.*' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version >= '3.13' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.12.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+]
+dependencies = [
+    { name = "docutils", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "jinja2", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "markdown-it-py", version = "4.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "mdit-py-plugins", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/dc/f3dfb7488b770f3f67e6545085bf2abea5172e88f57b8ad25ef860ca704c/myst_parser-5.1.0-py3-none-any.whl", hash = "sha256:9c91c52b3cdb4d94a6506e4fab4e2f296c7623a0da0dcbe6de1565c3dad67a8a", size = 85817, upload-time = "2026-05-13T09:38:17.904Z" },
 ]
 
 [[package]]
@@ -1800,9 +1870,11 @@ name = "nvidia-sphinx-theme"
 version = "0.0.9.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydata-sphinx-theme" },
+    { name = "pydata-sphinx-theme", version = "0.19.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "pydata-sphinx-theme", version = "0.20.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/79/017fab2f7167a9a9795665f894d04f77aafceca80821b51589bb4b23ff5c/nvidia_sphinx_theme-0.0.9.post1-py3-none-any.whl", hash = "sha256:21ca60206dff2f380d7783d64bbaf71a5b9cacae53c7d0686f089c16b5a3d45a", size = 143816, upload-time = "2025-11-09T23:16:55.719Z" },
@@ -1999,21 +2071,60 @@ wheels = [
 
 [[package]]
 name = "pydata-sphinx-theme"
-version = "0.16.1"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "accessible-pygments" },
-    { name = "babel" },
-    { name = "beautifulsoup4" },
-    { name = "docutils" },
-    { name = "pygments" },
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "typing-extensions" },
+resolution-markers = [
+    "python_full_version < '3.11' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version < '3.11' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version < '3.11' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version < '3.11' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version < '3.11' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/20/bb50f9de3a6de69e6abd6b087b52fa2418a0418b19597601605f855ad044/pydata_sphinx_theme-0.16.1.tar.gz", hash = "sha256:a08b7f0b7f70387219dc659bff0893a7554d5eb39b59d3b8ef37b8401b7642d7", size = 2412693, upload-time = "2024-12-17T10:53:39.537Z" }
+dependencies = [
+    { name = "accessible-pygments", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "babel", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "beautifulsoup4", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "docutils", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "pygments", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/7e/e3defb93f30557ae825a3b3fbc2c6728301e5e9505a85e00d8503345c42c/pydata_sphinx_theme-0.19.0.tar.gz", hash = "sha256:148ba092bd6937b3321385dc482cc69a29ad2ede36547b4f010ade782bc6a062", size = 5004933, upload-time = "2026-06-15T09:31:02.268Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/0d/8ba33fa83a7dcde13eb3c1c2a0c1cc29950a048bfed6d9b0d8b6bd710b4c/pydata_sphinx_theme-0.16.1-py3-none-any.whl", hash = "sha256:225331e8ac4b32682c18fcac5a57a6f717c4e632cea5dd0e247b55155faeccde", size = 6723264, upload-time = "2024-12-17T10:53:35.645Z" },
+    { url = "https://files.pythonhosted.org/packages/54/77/bdb5a4c0e8e33c08f31fd175a5af0bc5e29f1b43ffa9e963f4c4f9bfbc97/pydata_sphinx_theme-0.19.0-py3-none-any.whl", hash = "sha256:5d7dfe3beb0facc88b5d78ff4a4c948f214cc0e03aae27e7fc58286e963b588b", size = 6201132, upload-time = "2026-06-15T09:30:59.966Z" },
+]
+
+[[package]]
+name = "pydata-sphinx-theme"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.12.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version >= '3.13' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version >= '3.13' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version >= '3.13' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version == '3.12.*' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version == '3.12.*' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version == '3.12.*' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version == '3.11.*' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version == '3.11.*' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version == '3.11.*' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version >= '3.13' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.12.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+]
+dependencies = [
+    { name = "accessible-pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "babel", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "beautifulsoup4", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "docutils", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "jinja2", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "requests", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/8e/add936feaaa9dade7d5b87c6852566d85e518b38ad32224dea32ef958984/pydata_sphinx_theme-0.20.0.tar.gz", hash = "sha256:0da172d41e19a66de875f4002f7054b385372ec65763852193791e658d50bb4a", size = 5004756, upload-time = "2026-07-09T09:09:14.693Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/08/28e2194ed1c3c3a3e86e0600e2dcc7f21dcd670bd31f3efab2e3e2cf0cbd/pydata_sphinx_theme-0.20.0-py3-none-any.whl", hash = "sha256:56744483c9d72c783e075de716ab95d486108b69605df7528078090b73f11f69", size = 6201166, upload-time = "2026-07-09T09:09:12.899Z" },
 ]
 
 [[package]]
@@ -2144,18 +2255,6 @@ wheels = [
 ]
 
 [[package]]
-name = "roman-numerals-py"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "roman-numerals", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/2c/daca29684cbe9fd4bc711f8246da3c10adca1ccc4d24436b17572eb2590e/roman_numerals_py-4.1.0-py3-none-any.whl", hash = "sha256:553114c1167141c1283a51743759723ecd05604a1b6b507225e91dc1a6df0780", size = 4547, upload-time = "2025-12-17T18:25:40.136Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2227,44 +2326,74 @@ wheels = [
 
 [[package]]
 name = "sphinx"
-version = "8.2.3"
+version = "9.0.4"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
+    "(python_full_version == '3.11.*' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version == '3.11.*' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
+    "python_full_version == '3.11.*' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
+]
+dependencies = [
+    { name = "alabaster", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "babel", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "colorama", marker = "(python_full_version == '3.11.*' and sys_platform == 'win32') or (python_full_version != '3.11.*' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "docutils", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "imagesize", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "jinja2", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "packaging", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "pygments", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "requests", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "roman-numerals", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "snowballstemmer", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/3f/4bbd76424c393caead2e1eb89777f575dee5c8653e2d4b6afd7a564f5974/sphinx-9.0.4-py3-none-any.whl", hash = "sha256:5bebc595a5e943ea248b99c13814c1c5e10b3ece718976824ffa7959ff95fffb", size = 3917713, upload-time = "2025-12-04T07:45:24.944Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.13' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
     "python_full_version == '3.12.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
-    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13'",
     "(python_full_version >= '3.13' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version >= '3.13' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
     "python_full_version >= '3.13' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
     "(python_full_version == '3.12.*' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version == '3.12.*' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
     "python_full_version == '3.12.*' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
-    "(python_full_version == '3.11.*' and platform_machine != 'AMD64' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13') or (python_full_version == '3.11.*' and sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13')",
-    "python_full_version == '3.11.*' and platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
     "python_full_version >= '3.13' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
     "python_full_version == '3.12.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
-    "python_full_version == '3.11.*' and extra != 'extra-9-warp-lang-torch-cu12' and extra != 'extra-9-warp-lang-torch-cu13'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "babel", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "colorama", marker = "(python_full_version >= '3.11' and sys_platform == 'win32') or (python_full_version < '3.11' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "docutils", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "imagesize", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "jinja2", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "packaging", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "pygments", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "requests", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "roman-numerals-py", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "alabaster", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "babel", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "colorama", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or (python_full_version < '3.12' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (sys_platform != 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "docutils", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "imagesize", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "jinja2", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "packaging", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "pygments", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "requests", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741, upload-time = "2025-03-02T22:31:56.836Z" },
+    { url = "https://files.pythonhosted.org/packages/73/f7/b1884cb3188ab181fc81fa00c266699dab600f927a964df02ec3d5d1916a/sphinx-9.1.0-py3-none-any.whl", hash = "sha256:c84fdd4e782504495fe4f2c0b3413d6c2bf388589bb352d439b2a3bb99991978", size = 3921742, upload-time = "2025-12-31T15:09:25.561Z" },
 ]
 
 [[package]]
@@ -2273,7 +2402,8 @@ version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
 wheels = [
@@ -2612,7 +2742,8 @@ dev = [
     { name = "coverage", extra = ["toml"] },
     { name = "matplotlib" },
     { name = "ml-dtypes" },
-    { name = "myst-parser" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
     { name = "nvidia-sphinx-theme" },
     { name = "nvtx" },
     { name = "pillow" },
@@ -2624,7 +2755,8 @@ dev = [
     { name = "usd-exchange", marker = "(python_full_version < '3.13' and platform_machine == 'aarch64') or (python_full_version >= '3.13' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine != 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
 docs = [
-    { name = "myst-parser" },
+    { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
     { name = "nvidia-sphinx-theme" },
     { name = "pre-commit" },
     { name = "sphinx-copybutton" },

--- a/warp/_src/fem/space/topology.py
+++ b/warp/_src/fem/space/topology.py
@@ -28,6 +28,12 @@ class SpaceTopology:
     .. note:: This will change to be defined per-element in future versions
     """
 
+    ElementArg: type
+    """Structure type holding the geometry element arguments passed to device functions.
+
+    Assigned per instance from the underlying geometry.
+    """
+
     _dynamic_attribute_constructors: ClassVar = {
         "element_node_count": lambda obj: obj._make_constant_element_node_count(),
         "element_node_sign": lambda obj: obj._make_constant_element_node_sign(),
@@ -78,7 +84,7 @@ class SpaceTopology:
 
     @staticmethod
     def element_node_count(
-        geo_arg: "ElementArg",  # noqa: F821
+        geo_arg: "SpaceTopology.ElementArg",
         topo_arg: "TopologyArg",
         element_index: ElementIndex,
     ) -> int:
@@ -87,7 +93,7 @@ class SpaceTopology:
 
     @staticmethod
     def element_node_index(
-        geo_arg: "ElementArg",  # noqa: F821
+        geo_arg: "SpaceTopology.ElementArg",
         topo_arg: "TopologyArg",
         element_index: ElementIndex,
         node_index_in_elt: int,
@@ -97,7 +103,7 @@ class SpaceTopology:
 
     @staticmethod
     def side_neighbor_node_counts(
-        side_arg: "ElementArg",  # noqa: F821
+        side_arg: "SpaceTopology.ElementArg",
         topo_arg: "TopologyArg",
         side_index: ElementIndex,
     ) -> tuple[int, int]:


### PR DESCRIPTION
## Description

Bump the Sphinx docs toolchain in `uv.lock` (Sphinx 9, myst-parser 5, pydata-sphinx-theme 0.20, and related packages). Sphinx 9's stricter autodoc and cross-reference resolution surfaces 49 documentation warnings that were previously silent, and CI builds the docs with `--warnings-as-errors`, so the upgrade would otherwise fail the docs jobs. This PR fixes the underlying issues so the build stays clean.

## Changes

- **uv.lock**: Bump the Sphinx docs toolchain (Sphinx 9, myst-parser 5, pydata-sphinx-theme 0.20, and related packages).
- **docs/_templates/autosummary/class.rst**: Add a custom autosummary class template that omits the `.. automethod:: __init__` directive and `__init__` summary entry; the generated ctypes vector and matrix types have no importable `__init__` for Sphinx 9 to document.
- **docs/conf.py**: Set `autoclass_content` to `"both"` so classes documenting constructor arguments on `__init__` (`warp.array`, `warp.Mesh`, and several `warp.fem` geometries) keep them in the rendered output; widen the `spatial_matrix` accessor pattern in `nitpick_ignore_regex` to cover the base type; work around a Sphinx 9 change that emits the "alias of" note without a separating blank line.
- **warp/_src/fem/space/topology.py**: Qualify the ambiguous `ElementArg` annotation on `SpaceTopology` so it resolves to a single cross-reference target.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes. _(N/A: docs toolchain and dependency update; no library behavior change.)_
- [x] The documentation is up to date with these changes.
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section. _(N/A: dependency bump and docs build fix, not user-facing.)_

## Validation summary

Built the docs locally with `--warnings-as-errors` after the upgrade:

- HTML build: 0 warnings.
- doctest build: 102 doctests passing.

Both docs CI jobs run with `--warnings-as-errors` and would previously fail on the 49 warnings Sphinx 9 surfaces; they now build clean. Opened as a draft primarily to exercise the GitHub Actions workflows on this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced generated class reference pages with more accurate class-name rendering and improved method/attribute organization.
  * Included constructor (`__init__`) documentation in rendered class summaries.
  * Fixed Sphinx formatting/markup issues affecting autosummary and attribute alias directives.
  * Updated documentation validation patterns for Mat/SpatialMatrix accessor naming.
* **Refactor**
  * Added a documented public `ElementArg` type to the finite element topology interface and clarified related type annotations (no runtime behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->