### PR TITLE
Fix Python-scope calls with Function parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@
   later `while` or dynamic `for` loop; mutating the index now carries across iterations whether or not it is
   first re-declared (for example, `i = int(0)`), instead of being silently dropped
   ([GH-1534](https://github.com/NVIDIA/warp/issues/1534)).
+- Fix Python-scope calls to user-defined `@wp.func` functions with `wp.Function` parameters, which previously rejected
+  Warp function targets during argument type inference ([GH-1648](https://github.com/NVIDIA/warp/issues/1648)).
 
 ### Documentation
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -427,8 +427,32 @@ class Function:
                 template_types = list(overload.input_types.values())
                 arg_names = list(overload.input_types.keys())
 
-                # attempt to unify argument types with function template types
-                warp._src.types.infer_argument_types(arguments, template_types, arg_names)
+                if len(arguments) != len(template_types):
+                    raise RuntimeError(
+                        f"Invalid number of arguments for function '{self.key}', "
+                        f"expected {len(template_types)}, got {len(arguments)}"
+                    )
+
+                inference_arguments = []
+                inference_template_types = []
+                inference_arg_names = []
+                for argument, template_type, arg_name in zip(arguments, template_types, arg_names, strict=True):
+                    # Function objects do not have an ordinary Warp value type. Overload
+                    # selection already validated Function-annotated slots, so exclude them
+                    # from value argument inference at Python scope.
+                    if warp._src.types.is_warp_function_annotation(template_type) and isinstance(argument, Function):
+                        continue
+
+                    inference_arguments.append(argument)
+                    inference_template_types.append(template_type)
+                    inference_arg_names.append(arg_name)
+
+                # Attempt to unify ordinary argument types with function template types.
+                warp._src.types.infer_argument_types(
+                    inference_arguments,
+                    inference_template_types,
+                    inference_arg_names,
+                )
                 return overload.func(*arguments)
 
             # We got here without ever calling an overload.func

--- a/warp/tests/test_func_parameter_targets.py
+++ b/warp/tests/test_func_parameter_targets.py
@@ -12,6 +12,7 @@ parameter tests in this module so ``test_func.py`` remains focused on general
 
 import unittest
 from typing import Any
+from unittest import mock
 
 import numpy as np
 
@@ -463,6 +464,37 @@ class TestFuncParameterTargets(unittest.TestCase):
         wp.launch(function_apply_kernel, dim=1, outputs=[out], device="cpu")
 
         assert_np_equal(out.numpy(), np.array([6.0, np.sin(0.5)], dtype=np.float32))
+
+    def test_function_parameter_python_scope(self):
+        """Verify Function parameters accept Warp function targets at Python scope."""
+        actual = np.array(
+            [
+                function_apply_unary(function_square_it, 3.0),
+                function_apply_unary(g=function_triple_it, x=8.0),
+                function_apply_default(),
+                function_apply_unary(wp.sin, 0.5),
+                function_apply_nested(7.0),
+                function_apply_generic(function_double_it, 11.0),
+            ]
+        )
+        expected = np.array([9.0, 24.0, 6.0, np.sin(0.5), 14.0, 22.0])
+
+        np.testing.assert_allclose(actual, expected)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"^Error calling function 'function_apply_unary', no overload found",
+        ):
+            function_apply_unary(lambda x: x, 3.0)
+
+    def test_function_parameter_python_scope_argument_count_mismatch(self):
+        """Verify Python-scope argument count errors include useful context."""
+        with mock.patch.object(function_apply_unary, "get_overload", return_value=function_apply_nested):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                r"^Invalid number of arguments for function 'function_apply_unary', expected 1, got 2$",
+            ):
+                function_apply_unary(function_square_it, 3.0)
 
     def test_function_argument_target_affects_module_hash(self):
         """Verify explicit Function targets participate in module hashes."""


### PR DESCRIPTION
## Description

Python-scope calls to user-defined `@wp.func` functions reject valid Warp function arguments after overload selection. The selected overload already validates `wp.Function` parameters, but subsequent value-type inference tries to process those arguments as ordinary Warp values.

This change excludes validated function arguments from value-type inference while preserving inference and validation for every other argument.

Closes #1648.

## Changes

- Allow Python-scope calls with positional, keyword, default, built-in, nested, and generic `wp.Function` targets.
- Continue rejecting non-Warp callables such as Python lambdas.
- Add regression coverage and an `Unreleased` changelog entry.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Added `test_function_parameter_python_scope` to exercise positional, keyword, default, built-in, nested, and generic function targets. The test also verifies that non-Warp callables remain invalid.

Ran the complete `test_func_parameter_targets.py` module. All 33 tests passed, including CPU and CUDA coverage on both available CUDA devices.

## Bug fix

Without this change, calling a user-defined Warp function with a `wp.Function` argument from Python raises an overload error:

```python
import warp as wp


@wp.func
def square(x: float):
    return x * x


@wp.func
def apply(g: wp.Function, x: float):
    return g(x)


result = apply(square, 3.0)
assert result == 9.0
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Python-scope calls to user-defined `wp.func` overloads when `wp.Function` parameters receive Warp function targets.
  * Improved overload dispatch by validating argument counts at runtime and raising clearer errors on mismatches.
  * Adjusted type inference for function-annotated parameters to avoid incorrect rejection of Warp function targets.
* **Tests**
  * Added coverage ensuring Warp function targets are accepted from Python scope across multiple call patterns.
  * Added negative tests for non-Warp callables and expected-vs-received argument count mismatch errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
