### PR TITLE
Fix CPU PCH compiler flag cache [GH-1649]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
   group ([GH-1612](https://github.com/NVIDIA/warp/issues/1612)).
 - Fix `wp.quat_twist_angle()` losing precision for small `wp.float32` rotations
   ([GH-1631](https://github.com/NVIDIA/warp/issues/1631)).
+- Fix CPU modules with different `cpu_compiler_flags` reusing incompatible precompiled headers, avoiding Clang
+  target-feature errors and fallback compilation ([GH-1649](https://github.com/NVIDIA/warp/issues/1649)).
 
 ### Documentation
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -7511,6 +7511,8 @@ class Runtime:
     def get_clang_pch_dir(self) -> str | None:
         """Return a per-thread temporary directory for Clang precompiled header files.
 
+        Warp does not discover or reuse directories created by earlier runtime instances.
+
         Returns ``None`` when ``warp-clang`` is not loaded.
         """
         if self.llvm is None:

--- a/warp/native/clang/clang.cpp
+++ b/warp/native/clang/clang.cpp
@@ -15,6 +15,7 @@
 #include <llvm/Support/VirtualFileSystem.h>
 #endif
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <string>
@@ -384,6 +385,44 @@ static std::unique_ptr<llvm::Module> source_to_llvm(
     return success ? std::move(emit_llvm_only_action.takeModule()) : nullptr;
 }
 
+// Return a stable filename component for the ordered flag tokens passed to
+// create_compiler(). Hash at the native boundary so the PCH key reflects the
+// tokenized flags, not inconsequential whitespace in the Python option string.
+//
+// FNV-1a is sufficient for this ephemeral cache key; this is not a security or
+// content-integrity hash. A null byte terminates each token in the hashed byte
+// stream, making token boundaries unambiguous because C strings cannot contain
+// embedded nulls. A null pointer and an empty array both represent no flags.
+static std::string hash_compiler_flags(const char** extra_flags)
+{
+    constexpr std::uint64_t fnv_offset_basis = 14695981039346656037ull;
+    constexpr std::uint64_t fnv_prime = 1099511628211ull;
+
+    std::uint64_t hash = fnv_offset_basis;
+    const auto hash_byte = [&hash, fnv_prime](unsigned char byte) {
+        hash ^= byte;
+        hash *= fnv_prime;
+    };
+
+    if (extra_flags) {
+        for (const char** flag = extra_flags; *flag; ++flag) {
+            const auto* byte = reinterpret_cast<const unsigned char*>(*flag);
+            while (*byte) {
+                hash_byte(*byte++);
+            }
+            hash_byte(0);
+        }
+    }
+
+    constexpr char hex_digits[] = "0123456789abcdef";
+    std::string hex_hash(16, '0');
+    for (size_t i = hex_hash.size(); i > 0; --i) {
+        hex_hash[i - 1] = hex_digits[hash & 0xf];
+        hash >>= 4;
+    }
+    return hex_hash;
+}
+
 extern "C" {
 
 WP_API int wp_compile_cpp(
@@ -411,25 +450,14 @@ WP_API int wp_compile_cpp(
     std::string pch_path_str;
     const char* pch_path = nullptr;
     if (use_precompiled_headers && pch_dir) {
-        // Encode preprocessor-affecting flags into the filename so that
-        // modules with different settings get separate PCH files.
-        // Note: extra_flags are not encoded — they are assumed constant
-        // within a session. If they differ, Clang rejects the PCH and
-        // the fallback path handles it. The one exception is -fsanitize=address:
-        // an ASan-instrumented PCH is ABI-incompatible with a non-ASan one, so
-        // tag the filename to keep them from colliding across sessions/installs.
-        bool sanitize_address = false;
-        if (extra_flags) {
-            for (const char** flag = extra_flags; *flag; ++flag) {
-                if (strcmp(*flag, "-fsanitize=address") == 0) {
-                    sanitize_address = true;
-                    break;
-                }
-            }
-        }
+        // Keep fixed, bounded PCH inputs readable in the filename. Hash the
+        // compiler flag sequence because it is ordered, variable-length, and may
+        // contain characters unsuitable for filenames. Any new input that can
+        // change PCH contents or compatibility must be represented here, either
+        // directly or by a separately named digest.
+        const std::string compiler_flags_hash = hash_compiler_flags(extra_flags);
         pch_path_str = std::string(pch_dir) + "/builtin_bd" + std::to_string(block_dim) + (verify_fp ? "_vfp" : "")
-            + (debug ? "_dbg" : "") + (tiles_in_stack_memory ? "_tis" : "") + (sanitize_address ? "_asan" : "")
-            + ".pch";
+            + (debug ? "_dbg" : "") + (tiles_in_stack_memory ? "_tis" : "") + "_cf" + compiler_flags_hash + ".pch";
 
         // Check if the PCH file already exists
         FILE* f = fopen(pch_path_str.c_str(), "rb");

--- a/warp/tests/test_cpu_precompiled_headers.py
+++ b/warp/tests/test_cpu_precompiled_headers.py
@@ -7,11 +7,13 @@ import glob
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 import numpy as np
 
 import warp as wp
 import warp._src.build
+import warp._src.context as warp_context
 
 _original_use_precompiled_headers = None
 
@@ -86,56 +88,82 @@ class TestCpuPrecompiledHeaders(unittest.TestCase):
         finally:
             wp.config.use_precompiled_headers = old_val
 
+    def test_compiler_flags_cache_key(self):
+        """Verify that compiler flags produce distinct PCH cache keys."""
+        with tempfile.TemporaryDirectory(prefix="wp_pch_flags_test_") as pch_dir:
+            with mock.patch.object(warp_context.Runtime, "get_clang_pch_dir", return_value=pch_dir), _use_temp_cache():
+
+                @wp.kernel(module="unique", module_options={"cpu_compiler_flags": "-march=native"})
+                def double(a: wp.array[float]):
+                    tid = wp.tid()
+                    a[tid] *= 2.0
+
+                @wp.kernel(module="unique", module_options={"cpu_compiler_flags": ""})
+                def triple(a: wp.array[float]):
+                    tid = wp.tid()
+                    a[tid] *= 3.0
+
+                a = wp.array([1.0, 2.0, 3.0], dtype=float, device="cpu")
+                b = wp.array([1.0, 2.0, 3.0], dtype=float, device="cpu")
+                wp.launch(double, dim=3, inputs=[a], device="cpu")
+                wp.launch(triple, dim=3, inputs=[b], device="cpu")
+
+                np.testing.assert_allclose(a.numpy(), [2.0, 4.0, 6.0])
+                np.testing.assert_allclose(b.numpy(), [3.0, 6.0, 9.0])
+
+            pch_files = sorted(glob.glob(os.path.join(pch_dir, "*.pch")))
+            self.assertEqual(len(pch_files), 2)
+            self.assertTrue(all("_cf" in os.path.basename(pch_file) for pch_file in pch_files))
+
+            compiler_flag_keys = {
+                os.path.basename(pch_file).rsplit("_cf", 1)[1].removesuffix(".pch") for pch_file in pch_files
+            }
+            self.assertEqual(len(compiler_flag_keys), 2)
+            self.assertTrue(all(len(key) == 16 for key in compiler_flag_keys))
+            self.assertTrue(all(set(key) <= set("0123456789abcdef") for key in compiler_flag_keys))
+
     def test_fallback(self):
         """Verify graceful fallback when PCH file is corrupted."""
-        pch_dir = wp._src.context.runtime.get_clang_pch_dir()
-        if pch_dir is None:
+        if wp._src.context.runtime.get_clang_pch_dir() is None:
             self.skipTest("CPU PCH dir not available")
 
-        with _use_temp_cache():
-            # Snapshot PCH files before compiling so we can identify which
-            # files this test created (the PCH dir may already contain files
-            # from prior test suites reusing the same worker process).
-            pre_existing = set(glob.glob(os.path.join(pch_dir, "*.pch")))
+        # Isolate the PCH directory so the test only ever sees the PCH it
+        # generates. The real per-thread PCH dir is shared across the whole
+        # suite, and distinct cpu_compiler_flags now map to distinct PCH files;
+        # corrupting every file in a shared dir would sweep up PCHs these
+        # kernels never recompile, leaving them uncleaned by the fallback.
+        with tempfile.TemporaryDirectory(prefix="wp_pch_fallback_") as pch_dir:
+            with mock.patch.object(warp_context.Runtime, "get_clang_pch_dir", return_value=pch_dir), _use_temp_cache():
+                # Ensure a PCH exists by compiling something first
+                @wp.kernel(module="unique")
+                def iota(a: wp.array[float]):
+                    tid = wp.tid()
+                    a[tid] = float(tid)
 
-            # Ensure PCH exists by compiling something first
-            @wp.kernel(module="unique")
-            def iota(a: wp.array[float]):
-                tid = wp.tid()
-                a[tid] = float(tid)
+                a = wp.zeros(3, dtype=float, device="cpu")
+                wp.launch(iota, dim=3, inputs=[a], device="cpu")
 
-            a = wp.zeros(3, dtype=float, device="cpu")
-            wp.launch(iota, dim=3, inputs=[a], device="cpu")
+                pch_files = sorted(glob.glob(os.path.join(pch_dir, "*.pch")))
+                self.assertGreater(len(pch_files), 0, "No PCH files found to corrupt")
 
-            post_compile = set(glob.glob(os.path.join(pch_dir, "*.pch")))
-            new_pch_files = sorted(post_compile - pre_existing)
+                for pch_file in pch_files:
+                    with open(pch_file, "wb") as f:
+                        f.write(b"not a valid AST file")
 
-            # iota may reuse a pre-existing PCH (same flags).  Only target
-            # block_dim=1 files (CPU launches always use block_dim=1) to
-            # avoid corrupting unrelated PCH files left by prior test suites.
-            target_files = new_pch_files or sorted(
-                f for f in post_compile if os.path.basename(f).startswith("builtin_bd1")
-            )
-            self.assertGreater(len(target_files), 0, "No PCH files found to corrupt")
+                # Next compilation should detect the invalid PCH and fall back
+                @wp.kernel(module="unique")
+                def triple(b: wp.array[float]):
+                    tid = wp.tid()
+                    b[tid] = float(tid) * 3.0
 
-            for pch_file in target_files:
-                with open(pch_file, "wb") as f:
-                    f.write(b"not a valid AST file")
+                b = wp.zeros(3, dtype=float, device="cpu")
+                wp.launch(triple, dim=3, inputs=[b], device="cpu")
 
-            # Next compilation should detect the invalid PCH and fall back
-            @wp.kernel(module="unique")
-            def triple(b: wp.array[float]):
-                tid = wp.tid()
-                b[tid] = float(tid) * 3.0
+                np.testing.assert_allclose(b.numpy(), [0, 3, 6])
 
-            b = wp.zeros(3, dtype=float, device="cpu")
-            wp.launch(triple, dim=3, inputs=[b], device="cpu")
-
-            np.testing.assert_allclose(b.numpy(), [0, 3, 6])
-
-            # Verify the corrupt PCH files were cleaned up
-            for pch_file in target_files:
-                self.assertFalse(os.path.exists(pch_file), f"Corrupt PCH not cleaned up: {pch_file}")
+                # Verify the corrupt PCH files were cleaned up
+                for pch_file in pch_files:
+                    self.assertFalse(os.path.exists(pch_file), f"Corrupt PCH not cleaned up: {pch_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fix CPU modules with different `cpu_compiler_flags` reusing an incompatible Clang precompiled header. The collision produced target-feature errors and forced compilation through the existing no-PCH fallback even though the kernel eventually ran successfully. Closes #1649.

## Changes

- Add a stable hash of the ordered compiler flag tokens to the CPU PCH filename while keeping fixed, bounded PCH inputs human readable.
- Cover AddressSanitizer through the general compiler-flags hash and preserve the existing fallback for corrupt or incompatible PCH files.
- Add regression coverage for native and generic CPU compiler flags sharing one process, and update the Unreleased changelog.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Rebuilt the native Warp libraries after changing the embedded Clang implementation.
- Ran all four CPU precompiled-header tests, including distinct compiler-flag cache keys and corrupt-PCH fallback coverage.
- Ran all 14 option tests to verify native and generic CPU compiler flags compile without the incompatible-PCH fallback.
- Ran the focused pre-commit checks for the changed files.

## Bug fix

```python
import warp as wp


@wp.kernel(module="unique", module_options={"cpu_compiler_flags": "-march=native"})
def double(a: wp.array[float]):
    a[wp.tid()] *= 2.0


@wp.kernel(module="unique", module_options={"cpu_compiler_flags": ""})
def triple(a: wp.array[float]):
    a[wp.tid()] *= 3.0


a = wp.array([1.0, 2.0, 3.0], dtype=float, device="cpu")
b = wp.array([1.0, 2.0, 3.0], dtype=float, device="cpu")
wp.launch(double, dim=3, inputs=[a], device="cpu")
wp.launch(triple, dim=3, inputs=[b], device="cpu")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPU module compilation when compiler flags differ by making the precompiled-header cache key reflect the active compiler flags, avoiding incompatible reuse, Clang target-feature errors, and enabling reliable fallback compilation.
* **Tests**
  * Added coverage ensuring different `cpu_compiler_flags` produce distinct precompiled-header cache entries, including validation of the generated cache filename markers.
  * Strengthened the PCH fallback test by isolating its temporary precompiled-header directory.
* **Documentation**
  * Clarified that precompiled-header directories created by earlier runtime instances are not discovered or reused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->