### PR TITLE
Run GB300 tests nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,21 +462,21 @@ jobs:
           - runner-label: linux-amd64-gpu-h100-latest-1
             gpu-name: h100
             artifact-name: build-artifact-ubuntu-x86_64-cuda13
-            torch-extra: torch-cu13
-            jax-extra: jax[cuda13]
-            rmm-args: ""
+            test-dependency-args: --extra torch-cu13 --with "jax[cuda13]"
           - runner-label: linux-amd64-gpu-rtxpro6000-latest-1
             gpu-name: rtxpro6000
             artifact-name: build-artifact-ubuntu-x86_64-cuda13
-            torch-extra: torch-cu13
-            jax-extra: jax[cuda13]
-            rmm-args: ""
+            test-dependency-args: --extra torch-cu13 --with "jax[cuda13]"
+          # Temporarily validate GB300 runner access from this PR before moving
+          # the job to scheduled-only coverage.
+          - runner-label: linux-arm64-gpu-gb300-latest-1
+            gpu-name: gb300
+            artifact-name: build-artifact-ubuntu-aarch64-cuda13
+            test-dependency-args: --with "jax[cuda13]"
           - runner-label: linux-amd64-gpu-l4-earliest-1
             gpu-name: l4
             artifact-name: build-artifact-ubuntu-x86_64-cuda12
-            torch-extra: torch-cu12
-            jax-extra: jax[cuda12]
-            rmm-args: --with rmm-cu12
+            test-dependency-args: --extra torch-cu12 --with "jax[cuda12]" --with rmm-cu12
     container:
       image: ubuntu:24.04
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
@@ -520,7 +520,7 @@ jobs:
           path: warp/bin/
 
       - name: Run Tests
-        run: uv run --extra dev --extra ${{ matrix.torch-extra }} --with "${{ matrix.jax-extra }}" ${{ matrix.rmm-args }} -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
+        run: uv run --extra dev ${{ matrix.test-dependency-args }} -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
 
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,21 +462,21 @@ jobs:
           - runner-label: linux-amd64-gpu-h100-latest-1
             gpu-name: h100
             artifact-name: build-artifact-ubuntu-x86_64-cuda13
-            test-dependency-args: --extra torch-cu13 --with "jax[cuda13]"
+            torch-extra: torch-cu13
+            jax-extra: jax[cuda13]
+            rmm-args: ""
           - runner-label: linux-amd64-gpu-rtxpro6000-latest-1
             gpu-name: rtxpro6000
             artifact-name: build-artifact-ubuntu-x86_64-cuda13
-            test-dependency-args: --extra torch-cu13 --with "jax[cuda13]"
-          # Temporarily validate GB300 runner access from this PR before moving
-          # the job to scheduled-only coverage.
-          - runner-label: linux-arm64-gpu-gb300-latest-1
-            gpu-name: gb300
-            artifact-name: build-artifact-ubuntu-aarch64-cuda13
-            test-dependency-args: --with "jax[cuda13]"
+            torch-extra: torch-cu13
+            jax-extra: jax[cuda13]
+            rmm-args: ""
           - runner-label: linux-amd64-gpu-l4-earliest-1
             gpu-name: l4
             artifact-name: build-artifact-ubuntu-x86_64-cuda12
-            test-dependency-args: --extra torch-cu12 --with "jax[cuda12]" --with rmm-cu12
+            torch-extra: torch-cu12
+            jax-extra: jax[cuda12]
+            rmm-args: --with rmm-cu12
     container:
       image: ubuntu:24.04
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
@@ -520,7 +520,7 @@ jobs:
           path: warp/bin/
 
       - name: Run Tests
-        run: uv run --extra dev ${{ matrix.test-dependency-args }} -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
+        run: uv run --extra dev --extra ${{ matrix.torch-extra }} --with "${{ matrix.jax-extra }}" ${{ matrix.rmm-args }} -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
 
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
@@ -548,6 +548,86 @@ jobs:
           disable_search: true
           files: ./coverage.xml
           flags: test-warp-gpu-linux-${{ matrix.gpu-name }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  test-warp-gpu-linux-gb300:
+    # GB300 capacity is intentionally limited to one scheduled nightly job.
+    if: github.repository == 'NVIDIA/warp' && github.event_name == 'schedule'
+    runs-on: linux-arm64-gpu-gb300-latest-1
+    needs: [build-warp]
+    permissions:
+      contents: read
+    container:
+      image: ubuntu:24.04
+      options: -u root --security-opt seccomp=unconfined --shm-size 16g
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    timeout-minutes: 45
+    steps:
+      - name: Display GPU information
+        run: nvidia-smi
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
+      - name: Install system dependencies
+        # curl and gpg are required by codecov/codecov-action@v6 to download and verify the uploader.
+        run: |
+          apt-get update
+          apt-get install -y git git-lfs curl gpg
+          git lfs install
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: "0.11.16"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Download Warp build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifact-ubuntu-aarch64-cuda13
+          path: warp/bin/
+
+      - name: Run Tests
+        run: uv run --extra dev --with "jax[cuda13]" -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
+
+      - name: Test Summary
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        with:
+          paths: "rspec.xml"
+          show: "fail"
+        if: always()
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          disable_search: true
+          files: ./rspec.xml
+          report_type: test_results
+          flags: test-warp-gpu-linux-gb300
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ !cancelled() }}
+        continue-on-error: true  # codecov upload is best-effort; do not fail the job on upload errors.
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        with:
+          disable_search: true
+          files: ./coverage.xml
+          flags: test-warp-gpu-linux-gb300
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-warp-gpu-linux-python-free-threaded:


### PR DESCRIPTION
## Description

Add scheduled-nightly GitHub Actions coverage for the Linux ARM64 GB300 GPU runner. Warp now has access to `linux-arm64-gpu-gb300-latest-1`, but this job is intentionally limited to the daily scheduled CI run so pull requests, main branch pushes, release branch pushes, tags, and manual workflow dispatches do not consume the shared GB300 runner.

## Changes

- Add a dedicated `test-warp-gpu-linux-gb300` job guarded by `github.event_name == 'schedule'`.
- Run the job on `linux-arm64-gpu-gb300-latest-1` using the existing Ubuntu aarch64 CUDA 13 build artifact.
- Install JAX with `--with "jax[cuda13]"` for CUDA 13 interop coverage.
- Omit `torch-cu13` from the GB300 job because PyTorch may not support the newest GPU generation immediately.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Verified the workflow edit with `git diff --check` and `uvx pre-commit run --files .github/workflows/ci.yml`.

Before moving the job to schedule-only, PR CI successfully ran the temporary GB300 proof lane on runner `db74-l-arm-g-gb300-l-1-gz5bf-runner-hpk4j`. The `Run Tests` step completed successfully from 2026-07-13 19:52:29 UTC to 2026-07-13 20:04:33 UTC, and the full job completed successfully at 2026-07-13 20:04:44 UTC.

After that proof run, the branch tip moves GB300 coverage into the schedule-only `test-warp-gpu-linux-gb300` job. The current PR diff no longer includes GB300 in the shared pull request/main GPU matrix.

## New feature / enhancement

This PR does not add a user-facing Warp feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a scheduled GPU test job for GB300 Linux ARM64 to improve automated coverage of CUDA 13 runs.
  * Standardized the CI execution flow for fetching CUDA build artifacts and running GPU test suites.
  * Updated test reporting and coverage publication to align with existing GPU CI patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->