### PR TITLE
Build CPU precompiled header at the module's optimization level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
 
 ### Fixed
 
+- Fix CPU precompiled headers being rejected on every module build when Warp is built against LLVM 22, which
+  newly validates codegen options against the PCH. The PCH was generated at a fixed `-O3` while kernel modules
+  compile at `-O2`, causing a per-module generate/reject/delete cycle on LLVM 22 (and a silently mismatched PCH
+  on older LLVM). The PCH is now generated at the module's optimization level, keyed per level in the cache.
 - Fix CPU kernel compilation failures for power-of-two exponentiation on some Windows on Arm systems
   ([GH-1562](https://github.com/NVIDIA/warp/issues/1562)).
 - Fix unbounded memory growth when repeatedly launching identical kernels created by a factory or closure

--- a/warp/native/clang/clang.cpp
+++ b/warp/native/clang/clang.cpp
@@ -322,6 +322,7 @@ static bool generate_pch(
     bool verify_fp,
     bool tiles_in_stack_memory,
     const char** extra_flags,
+    int optimization_level,
     bool verbose,
     int block_dim
 )
@@ -332,8 +333,15 @@ static bool generate_pch(
 
     std::string input_file = "pch_gen.cpp";
 
-    auto compiler
-        = create_compiler(input_file, include_dir, false, debug, verify_fp, tiles_in_stack_memory, extra_flags);
+    // Build the PCH at the same optimization level as the modules that will
+    // consume it. Clang records the -O level in the PCH and rejects it with
+    // "OptimizationLevel differs in precompiled file" if a module is compiled
+    // at a different level. Without this the PCH defaulted to -O3 while CPU
+    // modules build at -O2 (see build_cpu in build.py), so every module failed
+    // the PCH check and paid a full no-PCH recompile.
+    auto compiler = create_compiler(
+        input_file, include_dir, false, debug, verify_fp, tiles_in_stack_memory, extra_flags, optimization_level
+    );
 
     // Create a source buffer that includes the main header.
     // WP_NO_CRT skips system headers (assert.h, math.h, etc.) which aren't
@@ -476,7 +484,8 @@ WP_API int wp_compile_cpp(
         // directly or by a separately named digest.
         const std::string compiler_flags_hash = hash_compiler_flags(extra_flags);
         pch_path_str = std::string(pch_dir) + "/builtin_bd" + std::to_string(block_dim) + (verify_fp ? "_vfp" : "")
-            + (debug ? "_dbg" : "") + (tiles_in_stack_memory ? "_tis" : "") + "_cf" + compiler_flags_hash + ".pch";
+            + (debug ? "_dbg" : "") + (tiles_in_stack_memory ? "_tis" : "") + "_ol" + std::to_string(optimization_level)
+            + "_cf" + compiler_flags_hash + ".pch";
 
         // Check if the PCH file already exists
         FILE* f = fopen(pch_path_str.c_str(), "rb");
@@ -488,7 +497,8 @@ WP_API int wp_compile_cpp(
         } else {
             // Generate the PCH file
             if (!generate_pch(
-                    include_dir, pch_path_str, debug, verify_fp, tiles_in_stack_memory, extra_flags, verbose, block_dim
+                    include_dir, pch_path_str, debug, verify_fp, tiles_in_stack_memory, extra_flags, optimization_level,
+                    verbose, block_dim
                 )) {
                 std::cerr << "Warp: PCH generation failed, compiling without precompiled headers" << std::endl;
                 remove(pch_path_str.c_str());


### PR DESCRIPTION
## Description

Warp's CPU precompiled header is generated at a fixed `-O3` (the `create_compiler` default) while kernel modules compile at `-O2`, and the PCH cache filename carries no optimization-level component. This mismatch has existed on all platforms, but it is harmless on LLVM ≤ 21 because clang did not validate codegen options against a PCH. Since llvm/llvm-project#146422 (first shipped in LLVM 22), clang rejects such a PCH with `error: OptimizationLevel differs in precompiled file ... vs. current file`. Warp's fallback then deletes the PCH and recompiles without it — so on LLVM 22 every module build pays PCH generation, rejection, deletion, and a full non-PCH compile, and `test_cpu_precompiled_headers` fails.

This change generates the PCH at the module's optimization level and adds the level to the PCH cache key, so distinct levels get distinct PCH files. On LLVM ≤ 21 the only behavioral difference is that the PCH is now built at the consumers' `-O2` instead of `-O3`.

Found while bringing up the CPU backend on Windows ARM64 against LLVM 22.1.8 (the first configuration to exercise Warp on LLVM 22 in CI); reproduced identically on Windows x86-64 + LLVM 22, confirming it is LLVM-version-gated rather than platform-specific.

## Changes

- `warp/native/clang/clang.cpp`: thread `optimization_level` from `wp_compile_cpp` into `generate_pch`/`create_compiler`; append `_ol<N>` to the PCH cache filename.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Red: on `main` built against LLVM 22.1.8 (Windows x86-64, `--no-cuda`), a verbose cold-cache run shows every module build emit `error: OptimizationLevel differs in precompiled file ...` followed by `Warp: Compilation with PCH failed, retrying without precompiled headers`, with the PCH directory left empty (the fallback deletes the rejected PCH, so the next module regenerates it and fails again). `python -m unittest warp.tests.test_cpu_precompiled_headers` fails (`test_basic`, `test_fallback` assertions on PCH presence/cleanup).
- Green: same machine, same LLVM 22.1.8, with this change: the rejection and churn are gone, PCH files persist and are consumed, and the PCH tests pass.
- LLVM ≤ 21 is unaffected by the bug (clang's `checkCodegenOptions` PCH validation does not exist on `release/21.x`); with this change those versions simply build the PCH at `-O2`.
- The change also ran as part of a full CPU test suite pass (3478 tests, 0 failures) on a `windows-11-arm` runner against LLVM 22.1.8 during Windows ARM64 bring-up.

## Bug fix

Reproduces only when Warp is built against LLVM ≥ 22 (e.g. `build_lib.py --llvm-path <llvm-22 install>`):

```python
import tempfile
import warp as wp
import warp._src.build

wp.config.verbose = True
wp.config.use_precompiled_headers = True

with tempfile.TemporaryDirectory() as cache:
    warp._src.build.init_kernel_cache(path=cache)

    @wp.kernel(module="unique")
    def k(a: wp.array(dtype=float)):
        tid = wp.tid()
        a[tid] = float(tid)

    a = wp.zeros(8, dtype=float, device="cpu")
    wp.launch(k, dim=8, inputs=[a], device="cpu")
    # stderr: "error: OptimizationLevel differs in precompiled file ..."
    #         "Warp: Compilation with PCH failed, retrying without precompiled headers"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed CPU precompiled headers being rejected and regenerated during module builds when using LLVM 22.
  - Ensured precompiled headers match each module’s optimization level for more reliable reuse and improved build performance.
- **Documentation**
  - Added a changelog entry describing the precompiled-header build fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->