### PR TITLE
Build CPU precompiled header at the module's optimization level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 
 ### Fixed
 
+- Fix CPU precompiled headers not being reused when Warp is built against LLVM 22, avoiding repeated full kernel
+  compilation ([GH-1658](https://github.com/NVIDIA/warp/issues/1658)).
 - Fix CPU kernel compilation failures for power-of-two exponentiation on some Windows on Arm systems
   ([GH-1562](https://github.com/NVIDIA/warp/issues/1562)).
 - Fix unbounded memory growth when repeatedly launching identical kernels created by a factory or closure

--- a/warp/native/clang/clang.cpp
+++ b/warp/native/clang/clang.cpp
@@ -142,6 +142,22 @@ static const HostCpuInfo& get_host_cpu_info()
     return info;
 }
 
+static int get_effective_optimization_level(bool debug, int optimization_level)
+{
+    if (debug) {
+        return 0;
+    }
+
+    switch (optimization_level) {
+    case 0:
+    case 1:
+    case 2:
+        return optimization_level;
+    default:
+        return 3;
+    }
+}
+
 static std::unique_ptr<clang::CompilerInstance> create_compiler(
     const std::string& input_file,
     const char* include_dir,
@@ -162,23 +178,19 @@ static std::unique_ptr<clang::CompilerInstance> create_compiler(
     args.push_back(include_dir);
     args.push_back("-std=c++17");
 
-    if (debug) {
+    switch (get_effective_optimization_level(debug, optimization_level)) {
+    case 0:
         args.push_back("-O0");
-    } else {
-        switch (optimization_level) {
-        case 0:
-            args.push_back("-O0");
-            break;
-        case 1:
-            args.push_back("-O1");
-            break;
-        case 2:
-            args.push_back("-O2");
-            break;
-        default:
-            args.push_back("-O3");
-            break;
-        }
+        break;
+    case 1:
+        args.push_back("-O1");
+        break;
+    case 2:
+        args.push_back("-O2");
+        break;
+    default:
+        args.push_back("-O3");
+        break;
     }
 
     if (is_cuda) {
@@ -322,6 +334,7 @@ static bool generate_pch(
     bool verify_fp,
     bool tiles_in_stack_memory,
     const char** extra_flags,
+    int optimization_level,
     bool verbose,
     int block_dim
 )
@@ -332,8 +345,15 @@ static bool generate_pch(
 
     std::string input_file = "pch_gen.cpp";
 
-    auto compiler
-        = create_compiler(input_file, include_dir, false, debug, verify_fp, tiles_in_stack_memory, extra_flags);
+    // Build the PCH at the same optimization level as the modules that will
+    // consume it. Clang records the -O level in the PCH and rejects it with
+    // "OptimizationLevel differs in precompiled file" if a module is compiled
+    // at a different level. Without this the PCH defaulted to -O3 while CPU
+    // modules build at -O2 (see build_cpu in build.py), so every module failed
+    // the PCH check and paid a full no-PCH recompile.
+    auto compiler = create_compiler(
+        input_file, include_dir, false, debug, verify_fp, tiles_in_stack_memory, extra_flags, optimization_level
+    );
 
     // Create a source buffer that includes the main header.
     // WP_NO_CRT skips system headers (assert.h, math.h, etc.) which aren't
@@ -462,6 +482,7 @@ WP_API int wp_compile_cpp(
 )
 {
     initialize_llvm();
+    const int effective_optimization_level = get_effective_optimization_level(debug, optimization_level);
 
     // Determine PCH path if requested.
     // Each block_dim value gets its own PCH file because tile.h templates
@@ -476,7 +497,8 @@ WP_API int wp_compile_cpp(
         // directly or by a separately named digest.
         const std::string compiler_flags_hash = hash_compiler_flags(extra_flags);
         pch_path_str = std::string(pch_dir) + "/builtin_bd" + std::to_string(block_dim) + (verify_fp ? "_vfp" : "")
-            + (debug ? "_dbg" : "") + (tiles_in_stack_memory ? "_tis" : "") + "_cf" + compiler_flags_hash + ".pch";
+            + (debug ? "_dbg" : "") + (tiles_in_stack_memory ? "_tis" : "") + "_o"
+            + std::to_string(effective_optimization_level) + "_f" + compiler_flags_hash + ".pch";
 
         // Check if the PCH file already exists
         FILE* f = fopen(pch_path_str.c_str(), "rb");
@@ -488,7 +510,8 @@ WP_API int wp_compile_cpp(
         } else {
             // Generate the PCH file
             if (!generate_pch(
-                    include_dir, pch_path_str, debug, verify_fp, tiles_in_stack_memory, extra_flags, verbose, block_dim
+                    include_dir, pch_path_str, debug, verify_fp, tiles_in_stack_memory, extra_flags,
+                    effective_optimization_level, verbose, block_dim
                 )) {
                 std::cerr << "Warp: PCH generation failed, compiling without precompiled headers" << std::endl;
                 remove(pch_path_str.c_str());
@@ -506,7 +529,7 @@ WP_API int wp_compile_cpp(
     auto llvm_context = std::make_unique<llvm::LLVMContext>();
     std::unique_ptr<llvm::Module> module = source_to_llvm(
         false, input_file, cpp_src, include_dir, debug, verify_fp, *llvm_context, tiles_in_stack_memory, extra_flags,
-        optimization_level, pch_path
+        effective_optimization_level, pch_path
     );
 
     // Fallback: if compilation failed with PCH, retry without it
@@ -521,7 +544,7 @@ WP_API int wp_compile_cpp(
         llvm_context = std::make_unique<llvm::LLVMContext>();
         module = source_to_llvm(
             false, input_file, cpp_src, include_dir, debug, verify_fp, *llvm_context, tiles_in_stack_memory,
-            extra_flags, optimization_level, nullptr
+            extra_flags, effective_optimization_level, nullptr
         );
     }
 
@@ -568,23 +591,19 @@ WP_API int wp_compile_cpp(
     llvm::CodeGenOpt::Level codegen_opt;
 #define CodeGenOptLevel CodeGenOpt
 #endif
-    if (debug) {
+    switch (effective_optimization_level) {
+    case 0:
         codegen_opt = llvm::CodeGenOptLevel::None;
-    } else {
-        switch (optimization_level) {
-        case 0:
-            codegen_opt = llvm::CodeGenOptLevel::None;
-            break;
-        case 1:
-            codegen_opt = llvm::CodeGenOptLevel::Less;
-            break;
-        case 2:
-            codegen_opt = llvm::CodeGenOptLevel::Default;
-            break;
-        default:
-            codegen_opt = llvm::CodeGenOptLevel::Aggressive;
-            break;
-        }
+        break;
+    case 1:
+        codegen_opt = llvm::CodeGenOptLevel::Less;
+        break;
+    case 2:
+        codegen_opt = llvm::CodeGenOptLevel::Default;
+        break;
+    default:
+        codegen_opt = llvm::CodeGenOptLevel::Aggressive;
+        break;
     }
 
 #if LLVM_VERSION_MAJOR >= 20

--- a/warp/tests/test_cpu_precompiled_headers.py
+++ b/warp/tests/test_cpu_precompiled_headers.py
@@ -113,14 +113,38 @@ class TestCpuPrecompiledHeaders(unittest.TestCase):
 
             pch_files = sorted(glob.glob(os.path.join(pch_dir, "*.pch")))
             self.assertEqual(len(pch_files), 2)
-            self.assertTrue(all("_cf" in os.path.basename(pch_file) for pch_file in pch_files))
+            self.assertTrue(all("_f" in os.path.basename(pch_file) for pch_file in pch_files))
 
             compiler_flag_keys = {
-                os.path.basename(pch_file).rsplit("_cf", 1)[1].removesuffix(".pch") for pch_file in pch_files
+                os.path.basename(pch_file).rsplit("_f", 1)[1].removesuffix(".pch") for pch_file in pch_files
             }
             self.assertEqual(len(compiler_flag_keys), 2)
             self.assertTrue(all(len(key) == 16 for key in compiler_flag_keys))
             self.assertTrue(all(set(key) <= set("0123456789abcdef") for key in compiler_flag_keys))
+
+    def test_debug_optimization_level_cache_key(self):
+        """Verify that debug modules share the PCH for their effective optimization level."""
+        with tempfile.TemporaryDirectory(prefix="wp_pch_debug_opt_test_") as pch_dir:
+            with mock.patch.object(warp_context.Runtime, "get_clang_pch_dir", return_value=pch_dir), _use_temp_cache():
+
+                @wp.kernel(module="unique", module_options={"mode": "debug", "optimization_level": 1})
+                def increment(a: wp.array[int]):
+                    a[0] += 1
+
+                @wp.kernel(module="unique", module_options={"mode": "debug", "optimization_level": 2})
+                def double(a: wp.array[int]):
+                    a[0] *= 2
+
+                a = wp.array([1], dtype=int, device="cpu")
+                wp.launch(increment, dim=1, inputs=[a], device="cpu")
+                wp.launch(double, dim=1, inputs=[a], device="cpu")
+
+                np.testing.assert_array_equal(a.numpy(), [4])
+
+            pch_files = glob.glob(os.path.join(pch_dir, "*.pch"))
+            self.assertEqual(len(pch_files), 1)
+            self.assertIn("_dbg_", os.path.basename(pch_files[0]))
+            self.assertIn("_o0_", os.path.basename(pch_files[0]))
 
     def test_fallback(self):
         """Verify graceful fallback when PCH file is corrupted."""


### PR DESCRIPTION
## Description

Warp's CPU precompiled header is generated at a fixed `-O3` (the `create_compiler` default) while kernel modules compile at `-O2`, and the PCH cache filename carries no optimization-level component. This mismatch has existed on all platforms, but it is harmless on LLVM ≤ 21 because clang did not validate codegen options against a PCH. Since llvm/llvm-project#146422 (first shipped in LLVM 22), clang rejects such a PCH with `error: OptimizationLevel differs in precompiled file ... vs. current file`. Warp's fallback then deletes the PCH and recompiles without it — so on LLVM 22 every module build pays PCH generation, rejection, deletion, and a full non-PCH compile, and `test_cpu_precompiled_headers` fails.

This change generates the PCH at the module's optimization level and adds the level to the PCH cache key, so distinct levels get distinct PCH files. On LLVM ≤ 21 the only behavioral difference is that the PCH is now built at the consumers' `-O2` instead of `-O3`.

Found while bringing up the CPU backend on Windows ARM64 against LLVM 22.1.8 (the first configuration to exercise Warp on LLVM 22 in CI); reproduced identically on Windows x86-64 + LLVM 22, confirming it is LLVM-version-gated rather than platform-specific.

## Changes

- `warp/native/clang/clang.cpp`: thread `optimization_level` from `wp_compile_cpp` into `generate_pch`/`create_compiler`; append `_ol<N>` to the PCH cache filename.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Red: on `main` built against LLVM 22.1.8 (Windows x86-64, `--no-cuda`), a verbose cold-cache run shows every module build emit `error: OptimizationLevel differs in precompiled file ...` followed by `Warp: Compilation with PCH failed, retrying without precompiled headers`, with the PCH directory left empty (the fallback deletes the rejected PCH, so the next module regenerates it and fails again). `python -m unittest warp.tests.test_cpu_precompiled_headers` fails (`test_basic`, `test_fallback` assertions on PCH presence/cleanup).
- Green: same machine, same LLVM 22.1.8, with this change: the rejection and churn are gone, PCH files persist and are consumed, and the PCH tests pass.
- LLVM ≤ 21 is unaffected by the bug (clang's `checkCodegenOptions` PCH validation does not exist on `release/21.x`); with this change those versions simply build the PCH at `-O2`.
- The change also ran as part of a full CPU test suite pass (3478 tests, 0 failures) on a `windows-11-arm` runner against LLVM 22.1.8 during Windows ARM64 bring-up.

## Bug fix

Reproduces only when Warp is built against LLVM ≥ 22 (e.g. `build_lib.py --llvm-path <llvm-22 install>`):

```python
import tempfile
import warp as wp
import warp._src.build

wp.config.verbose = True
wp.config.use_precompiled_headers = True

with tempfile.TemporaryDirectory() as cache:
    warp._src.build.init_kernel_cache(path=cache)

    @wp.kernel(module="unique")
    def k(a: wp.array(dtype=float)):
        tid = wp.tid()
        a[tid] = float(tid)

    a = wp.zeros(8, dtype=float, device="cpu")
    wp.launch(k, dim=8, inputs=[a], device="cpu")
    # stderr: "error: OptimizationLevel differs in precompiled file ..."
    #         "Warp: Compilation with PCH failed, retrying without precompiled headers"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPU builds with LLVM 22 where CPU precompiled headers (PCH) weren’t being reused, leading to repeated full kernel compilation.
  * CPU PCH caching now correctly accounts for the effective optimization level used during compilation (including debug-mode behavior).
  * Prevented incorrect/mismatched PCH reuse across CPU modules compiled with different optimization settings, improving build consistency.
* **Tests**
  * Added coverage to verify PCH cache reuse behavior for debug-mode kernels across different `optimization_level` values.
* **Documentation**
  * Updated the Unreleased changelog entry to reflect the LLVM 22 PCH reuse fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->