### PR TITLE
Add CPU support for JAX FFI (GH-1661)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,15 +314,19 @@ jobs:
           - os: windows-2025
             platform: windows
             artifact-name: build-artifact-windows-cuda12
+            jax-extra: jax>=0.5
           - os: ubuntu-24.04
             platform: ubuntu-x86_64
             artifact-name: build-artifact-ubuntu-x86_64-cuda13
+            jax-extra: jax[cuda13]>=0.5
           - os: ubuntu-24.04-arm
             platform: ubuntu-aarch64
             artifact-name: build-artifact-ubuntu-aarch64-cuda13
+            jax-extra: jax[cuda13]>=0.5
           - os: macos-latest
             platform: macos
             artifact-name: build-artifact-macos
+            jax-extra: jax>=0.5
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -345,7 +349,7 @@ jobs:
           path: warp/bin/
       
       - name: Run Tests
-        run: uv run --extra dev -m warp.tests --junit-report-xml rspec.xml -s autodetect
+        run: uv run --extra dev --with "${{ matrix.jax-extra }}" -m warp.tests --junit-report-xml rspec.xml -s autodetect
       
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -418,7 +418,7 @@ linux-aarch64 test:
     - df -h
     - !reference [.snippets, move-linux-aarch64-binaries]
   script:
-    - uv run --extra dev --with rmm-cu12 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
+    - uv run --extra dev --with "jax[cuda12]>=0.5" --with rmm-cu12 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
 
 linux-aarch64 cuda 13 test:
   image: $UV_TRIXIE_SLIM_ARM_IMAGE
@@ -430,7 +430,7 @@ linux-aarch64 cuda 13 test:
     - df -h
     - !reference [.snippets, move-linux-aarch64-binaries]
   script:
-    - uv run --extra dev --with rmm-cu13 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
+    - uv run --extra dev --with "jax[cuda13]>=0.5" --with rmm-cu13 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
 
 linux-aarch64 test orin:
   needs: [linux-aarch64 build]
@@ -525,7 +525,7 @@ linux-x86_64 test:
     # HACK: disable P2P tests due to misbehaving agents
     - export WARP_DISABLE_P2P_TESTS=1
   script:
-    - uv run --extra dev --extra torch-cu12 --with "jax[cuda12]" --with rmm-cu12 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
+    - uv run --extra dev --extra torch-cu12 --with "jax[cuda12]>=0.5" --with rmm-cu12 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
 
 linux-x86_64 cuda 13 test:
   needs: [linux-x86_64 cuda 13 build]
@@ -541,7 +541,7 @@ linux-x86_64 cuda 13 test:
     # HACK: disable P2P tests due to misbehaving agents
     - export WARP_DISABLE_P2P_TESTS=1
   script:
-    - uv run --extra dev --extra torch-cu13 --with "jax[cuda13]" --with rmm-cu13 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
+    - uv run --extra dev --extra torch-cu13 --with "jax[cuda13]>=0.5" --with rmm-cu13 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
 
 # A temporary job for testing on Blackwell until more runners are available
 linux-x86_64-blackwell test:
@@ -553,7 +553,7 @@ linux-x86_64-blackwell test:
     - df -h
     - !reference [.snippets, move-linux-x86_64-binaries]
   script:
-    - uv run --extra dev --extra torch-cu13 --with "jax[cuda13]" --with rmm-cu13 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
+    - uv run --extra dev --extra torch-cu13 --with "jax[cuda13]>=0.5" --with rmm-cu13 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
   tags:
     - arch/x86_64
     - gpu/B40
@@ -620,7 +620,7 @@ windows-x86_64 test:
     # Locking usd-core to 25.5.1 to work around a frequent loading crash
     - |
       $env:PATH = "$env:CI_PROJECT_DIR\_uv;$env:PATH"
-      uv run --extra dev --extra torch-cu12 --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
+      uv run --extra dev --extra torch-cu12 --with "jax>=0.5" --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
 
 windows-x86_64 cuda 13 test:
   stage: test
@@ -639,7 +639,7 @@ windows-x86_64 cuda 13 test:
     # Locking usd-core to 25.5.1 to work around a frequent loading crash
     - |
       $env:PATH = "$env:CI_PROJECT_DIR\_uv;$env:PATH"
-      uv run --extra dev --extra torch-cu13 --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
+      uv run --extra dev --extra torch-cu13 --with "jax>=0.5" --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect --failfast
 
 windows-x86_64-blackwell test:
   stage: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   ([GH-1378](https://github.com/NVIDIA/warp/issues/1378))
 - **Experimental:** Record `wp.utils.array_sum()` and `wp.utils.array_inner()` in APIC capture so saved and replayed
   graphs recompute them from current inputs on CPU and CUDA ([GH-1663](https://github.com/NVIDIA/warp/issues/1663)).
+- Add CPU support for `wp.jax_kernel()` and `wp.jax_callable()` FFI calls, with automatic dispatch between CPU and
+  CUDA based on the device selected by JAX ([GH-1661](https://github.com/NVIDIA/warp/issues/1661)).
 
 ### Removed
 

--- a/docs/user_guide/interoperability/jax.rst
+++ b/docs/user_guide/interoperability/jax.rst
@@ -46,6 +46,29 @@ Warp kernels can be used as JAX primitives, which allows calling them inside of 
 
 
 
+Device Selection
+^^^^^^^^^^^^^^^^
+
+JAX selects an FFI implementation based on the device used to lower the call.
+The same wrapper works on CPU and CUDA without a Warp device argument. Warp
+wraps XLA buffers without copying them.
+
+For example, when JAX exposes both CPU and CUDA devices and Warp includes CUDA
+support, the same jitted function can run on either device::
+
+    import numpy as np
+
+    jax_triple = wp.jax_kernel(triple_kernel)
+
+    @jax.jit
+    def f(x):
+        return jax_triple(x)[0]
+
+    x = np.arange(64, dtype=np.float32)
+    cpu_result = f(jax.device_put(x, jax.devices("cpu")[0]))
+    cuda_result = f(jax.device_put(x, jax.devices("cuda")[0]))
+
+
 Input and Output Semantics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -664,13 +687,17 @@ just focus on the differences:
   ``JaxCallableGraphMode.JAX`` (default) lets JAX capture the graph, which may be used as a subgraph in an enclosing capture for maximal benefit.
   ``JaxCallableGraphMode.WARP`` lets Warp capture the graph. Use this mode when the callable cannot be used as a subgraph, such as when the callable uses conditional graph nodes.
   ``JaxCallableGraphMode.NONE`` disables graph capture. Use this mode if the callable performs operations that are not allowed during graph capture, such as host synchronization.
+  On CPU, ``JaxCallableGraphMode.JAX`` and ``JaxCallableGraphMode.NONE`` run
+  without graph capture. The Warp graph modes require CUDA and raise an error
+  on CPU.
   When using ``JaxCallableGraphMode.WARP``, captured graphs are cached for reuse. Use ``graph_cache_max`` to limit the
   number of cached graphs, and call :func:`clear_jax_callable_graph_cache() <warp.clear_jax_callable_graph_cache>` to
   release cached graph memory for one callable or all registered JAX callables.
 - :func:`jax_kernel() <warp.jax_kernel>` and :func:`jax_callable() <warp.jax_callable>` take an optional
-  ``module_preload_mode`` argument. ``JaxModulePreloadMode.CURRENT_DEVICE`` (default) preloads the module on the
-  current JAX device, ``JaxModulePreloadMode.ALL_DEVICES`` preloads on all local JAX devices that map to CUDA devices,
-  and ``JaxModulePreloadMode.NONE`` disables preloading.
+  ``module_preload_mode`` argument. The default, ``JaxModulePreloadMode.CURRENT_DEVICE``, preloads the module on the
+  current JAX device. ``JaxModulePreloadMode.ALL_DEVICES`` preloads it on the host CPU and every supported local CUDA
+  device. ``JaxModulePreloadMode.NONE`` disables preloading. Preloading skips JAX devices that Warp cannot map. The
+  callback loads the module for the device on which it runs. Warp still raises any module-loading errors.
 
 See `example_jax_callable.py <https://github.com/NVIDIA/warp/blob/main/warp/examples/interop/example_jax_callable.py>`_ for examples.
 

--- a/warp/_src/jax/ffi.py
+++ b/warp/_src/jax/ffi.py
@@ -18,6 +18,7 @@ from warp._src.context import (
     _build_launch_bounds,
     _raise_cuda_launch_error,
     _validate_cluster_launch,
+    invoke,
 )
 from warp._src.jax import get_jax_device
 from warp._src.logger import log_warning
@@ -66,6 +67,31 @@ def check_jax_version():
         raise RuntimeError(msg)
 
 
+# JAX platform identifiers are case-sensitive and intentionally use different casing.
+_FFI_PLATFORM_CPU = "cpu"
+_FFI_PLATFORM_CUDA = "CUDA"
+
+
+def _register_ffi_targets(name, callback):
+    """Register one FFI callback for CPU and CUDA without initializing either backend."""
+    jax = _get_jax()
+    callback_type = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.POINTER(XLA_FFI_CallFrame))
+    callback_funcs = {}
+
+    for platform in (_FFI_PLATFORM_CPU, _FFI_PLATFORM_CUDA):
+
+        def platform_callback(call_frame, platform=platform):
+            return callback(call_frame, platform)
+
+        callback_func = callback_type(platform_callback)
+        callback_address = ctypes.cast(callback_func, ctypes.c_void_p)
+        callback_capsule = jax.ffi.pycapsule(callback_address.value)
+        jax.ffi.register_ffi_target(name, callback_capsule, platform=platform)
+        callback_funcs[platform] = callback_func
+
+    return callback_funcs
+
+
 def collapse_batch_dims(shape, desired_ndim):
     # roll leading batch dims into one
     while len(shape) > desired_ndim:
@@ -112,6 +138,61 @@ class JaxModulePreloadMode(IntEnum):
 
 
 ModulePreloadMode = JaxModulePreloadMode
+
+
+def _get_ffi_block_dim(device):
+    return 1 if device.is_cpu else 256
+
+
+def _load_ffi_module(module, device):
+    module_exec = module.load(device, _get_ffi_block_dim(device))
+    if module_exec is None:
+        raise RuntimeError(
+            f"Failed to load Warp module '{module.name}' on device '{device}' after a previous build failure"
+        )
+    return module_exec
+
+
+def _preload_ffi_module(module, mode):
+    if mode == JaxModulePreloadMode.NONE:
+        return
+
+    if mode == JaxModulePreloadMode.CURRENT_DEVICE:
+        jax_device = get_jax_device()
+        try:
+            device = wp.device_from_jax(jax_device)
+        except (IndexError, RuntimeError):
+            return
+        _load_ffi_module(module, device)
+        return
+
+    if mode == JaxModulePreloadMode.ALL_DEVICES:
+        jax = _get_jax()
+        devices = []
+        mapped_device_ids = set()
+        for backend in ("cpu", "cuda"):
+            try:
+                jax_devices = jax.local_devices(backend=backend)
+            except RuntimeError:
+                continue
+
+            for jax_device in jax_devices:
+                try:
+                    device = wp.device_from_jax(jax_device)
+                except (IndexError, RuntimeError):
+                    continue
+
+                device_id = id(device)
+                if device_id in mapped_device_ids:
+                    continue
+                mapped_device_ids.add(device_id)
+                devices.append(device)
+
+        for device in devices:
+            _load_ffi_module(module, device)
+        return
+
+    raise ValueError(f"Unsupported JAX module preload mode '{mode}'")
 
 
 class FfiArg:
@@ -231,12 +312,7 @@ class FfiKernel:
         self.input_output_aliases = input_output_aliases
 
         # register the callback
-        jax = _get_jax()
-        FFI_CCALLFUNC = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.POINTER(XLA_FFI_CallFrame))
-        self.callback_func = FFI_CCALLFUNC(self.ffi_callback)
-        ffi_ccall_address = ctypes.cast(self.callback_func, ctypes.c_void_p)
-        ffi_capsule = jax.ffi.pycapsule(ffi_ccall_address.value)
-        jax.ffi.register_ffi_target(self.name, ffi_capsule, platform="CUDA")
+        self.callback_funcs = _register_ffi_targets(self.name, self.ffi_callback)
 
     def __call__(self, *args, output_dims=None, launch_dims=None, vmap_method=None):
         jax = _get_jax()
@@ -327,20 +403,7 @@ class FfiKernel:
             has_side_effect=self.has_side_effect,
         )
 
-        # preload on the specified devices
-        if self.module_preload_mode == JaxModulePreloadMode.CURRENT_DEVICE:
-            device = wp.device_from_jax(get_jax_device())
-            self.kernel.module.load(device)
-        elif self.module_preload_mode == JaxModulePreloadMode.ALL_DEVICES:
-            for d in jax.local_devices():
-                try:
-                    dev = wp.device_from_jax(d)
-                except Exception:
-                    # ignore unsupported devices like TPUs
-                    pass
-                # we only support CUDA devices for now
-                if dev.is_cuda:
-                    self.kernel.module.load(dev)
+        _preload_ffi_module(self.kernel.module, self.module_preload_mode)
 
         # save launch data to be retrieved by callback
         launch_id = self.launch_id
@@ -351,7 +414,7 @@ class FfiKernel:
 
         return call(*args, launch_id=launch_id)
 
-    def ffi_callback(self, call_frame):
+    def ffi_callback(self, call_frame, platform):
         try:
             # On the first call, XLA runtime will query the API version and traits
             # metadata using the |extension| field. Let us respond to that query
@@ -363,10 +426,11 @@ class FfiKernel:
                     metadata_ext = ctypes.cast(extension, ctypes.POINTER(XLA_FFI_Metadata_Extension))
                     metadata_ext.contents.metadata.contents.api_version.major_version = 0
                     metadata_ext.contents.metadata.contents.api_version.minor_version = 1
-                    # Turn on CUDA graphs for this handler.
-                    metadata_ext.contents.metadata.contents.traits = (
-                        XLA_FFI_Handler_TraitsBits.COMMAND_BUFFER_COMPATIBLE
-                    )
+                    if platform == _FFI_PLATFORM_CUDA:
+                        # Turn on CUDA graphs for this handler.
+                        metadata_ext.contents.metadata.contents.traits = (
+                            XLA_FFI_Handler_TraitsBits.COMMAND_BUFFER_COMPATIBLE
+                        )
                     return None
 
             # Lock is required to prevent race conditions when callback is invoked
@@ -386,8 +450,6 @@ class FfiKernel:
                 assert num_inputs == self.num_inputs
                 assert num_outputs == self.num_outputs
 
-                # first kernel param is the launch bounds
-                kernel_params = (ctypes.c_void_p * (1 + self.num_kernel_args))()
                 arg_refs = []
                 batch_size = None
 
@@ -405,13 +467,11 @@ class FfiKernel:
                                 )
                         strides = strides_from_shape(shape, input_arg.type.dtype)
                         arg = array_t(buffer.data, 0, input_arg.type.ndim, shape, strides)
-                        kernel_params[i + 1] = ctypes.addressof(arg)
                         arg_refs.append(arg)  # keep a reference
                     else:
                         # scalar argument, get stashed value
                         value = launch_desc.static_inputs[input_arg.name]
                         arg = input_arg.type._type_(value)
-                        kernel_params[i + 1] = ctypes.addressof(arg)
                         arg_refs.append(arg)  # keep a reference
 
                 # pure output args (skip in-out FFI buffers)
@@ -427,8 +487,39 @@ class FfiKernel:
                             )
                     strides = strides_from_shape(shape, output_arg.type.dtype)
                     arg = array_t(buffer.data, 0, output_arg.type.ndim, shape, strides)
-                    kernel_params[num_inputs + i + 1] = ctypes.addressof(arg)
                     arg_refs.append(arg)  # keep a reference
+
+                if platform == _FFI_PLATFORM_CPU:
+                    if not wp.is_cpu_available():
+                        return create_ffi_error(
+                            call_frame.contents.api,
+                            XLA_FFI_Error_Code.FAILED_PRECONDITION,
+                            "This Warp build does not include CPU support",
+                        )
+                    device = wp.get_device("cpu")
+                    stream = None
+                elif platform == _FFI_PLATFORM_CUDA:
+                    if wp._src.context.runtime is None:
+                        wp.init()
+                    if not wp._src.context.runtime.is_cuda_enabled:
+                        return create_ffi_error(
+                            call_frame.contents.api,
+                            XLA_FFI_Error_Code.FAILED_PRECONDITION,
+                            "This Warp build does not include CUDA support",
+                        )
+
+                    device = wp.get_cuda_device(get_device_ordinal_from_callframe(call_frame.contents))
+                    stream = get_stream_from_callframe(call_frame.contents)
+                else:
+                    return create_invalid_argument_ffi_error(
+                        call_frame.contents.api,
+                        f"Unsupported JAX FFI platform '{platform}'",
+                    )
+
+                # Preloading is best-effort, so the callback's actual device must
+                # load the module before reading code-generation metadata.
+                module_exec = _load_ffi_module(self.kernel.module, device)
+                block_dim = module_exec.block_dim
 
                 # determine launch bounds
                 if launch_desc.launch_dims is None:
@@ -443,19 +534,27 @@ class FfiKernel:
                         launch_dims = (batch_size * launch_dims[0], *launch_dims[1:])
 
                 launch_bounds = _build_launch_bounds(launch_dims, self.kernel.adj.kernel_dim)
-                kernel_params[0] = ctypes.addressof(launch_bounds)
 
-                # get device and stream
-                device = wp.get_cuda_device(get_device_ordinal_from_callframe(call_frame.contents))
-                stream = get_stream_from_callframe(call_frame.contents)
+                if platform == _FFI_PLATFORM_CPU:
+                    hooks = module_exec.get_kernel_hooks(self.kernel)
+                    if hooks.forward is None:
+                        raise RuntimeError("Failed to find CPU kernel entry point")
+                    invoke(self.kernel, hooks, [launch_bounds, *arg_refs], adjoint=False)
+                    return None
+
+                kernel_params = (ctypes.c_void_p * (1 + self.num_kernel_args))(
+                    ctypes.addressof(launch_bounds),
+                    *(ctypes.addressof(arg) for arg in arg_refs),
+                )
 
                 # get kernel hooks
-                hooks = self.kernel.module.get_kernel_hooks(self.kernel, device)
-                assert hooks.forward, "Failed to find kernel entry point"
+                hooks = module_exec.get_kernel_hooks(self.kernel)
+                if hooks.forward is None:
+                    raise RuntimeError("Failed to find CUDA kernel entry point")
 
                 # reject non-cluster-aligned grids with a clear Python error instead
                 # of a cryptic native CUDA error (block_dim=256, max_blocks=0 below)
-                _validate_cluster_launch(hooks.cluster_dim, launch_bounds.size, 256, 0)
+                _validate_cluster_launch(hooks.cluster_dim, launch_bounds.size, block_dim, 0)
 
                 # launch the kernel (cluster_dim is cached on the hooks at load time)
                 if wp._src.context.runtime.core.wp_cuda_launch_kernel(
@@ -463,7 +562,7 @@ class FfiKernel:
                     hooks.forward,
                     launch_bounds.size,
                     0,
-                    256,
+                    block_dim,
                     int(self.kernel.grid_stride),
                     hooks.cluster_dim,
                     hooks.forward_smem_bytes,
@@ -624,12 +723,7 @@ class FfiCallable:
         self.input_output_aliases = input_output_aliases
 
         # register the callback
-        jax = _get_jax()
-        FFI_CCALLFUNC = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.POINTER(XLA_FFI_CallFrame))
-        self.callback_func = FFI_CCALLFUNC(self.ffi_callback)
-        ffi_ccall_address = ctypes.cast(self.callback_func, ctypes.c_void_p)
-        ffi_capsule = jax.ffi.pycapsule(ffi_ccall_address.value)
-        jax.ffi.register_ffi_target(self.name, ffi_capsule, platform="CUDA")
+        self.callback_funcs = _register_ffi_targets(self.name, self.ffi_callback)
 
     def __call__(self, *args, output_dims=None, vmap_method=None):
         jax = _get_jax()
@@ -708,22 +802,9 @@ class FfiCallable:
             has_side_effect=self.has_side_effect,
         )
 
-        # preload on the specified devices
         # NOTE: if the target function uses kernels from different modules, they will not be loaded here
         module = wp.get_module(self.func.__module__)
-        if self.module_preload_mode == JaxModulePreloadMode.CURRENT_DEVICE:
-            device = wp.device_from_jax(get_jax_device())
-            module.load(device)
-        elif self.module_preload_mode == JaxModulePreloadMode.ALL_DEVICES:
-            for d in jax.local_devices():
-                try:
-                    dev = wp.device_from_jax(d)
-                except Exception:
-                    # ignore unsupported devices like TPUs
-                    pass
-                # we only support CUDA devices for now
-                if dev.is_cuda:
-                    module.load(dev)
+        _preload_ffi_module(module, self.module_preload_mode)
 
         # save call data to be retrieved by callback
         call_id = self.call_id
@@ -731,7 +812,25 @@ class FfiCallable:
         self.call_id += 1
         return call(*args, call_id=call_id)
 
-    def ffi_callback(self, call_frame):
+    def _build_arg_list(self, inputs, outputs, call_desc, device):
+        arg_list = []
+
+        for i, arg in enumerate(self.input_args):
+            if arg.is_array:
+                buffer = inputs[i].contents
+                shape = collapse_batch_dims(buffer.dims[: buffer.rank - arg.dtype_ndim], arg.type.ndim)
+                arg_list.append(wp.array(ptr=buffer.data, dtype=arg.type.dtype, shape=shape, device=device))
+            else:
+                arg_list.append(call_desc.static_inputs[arg.name])
+
+        for i, arg in enumerate(self.output_args):
+            buffer = outputs[i + self.num_in_out].contents
+            shape = collapse_batch_dims(buffer.dims[: buffer.rank - arg.dtype_ndim], arg.type.ndim)
+            arg_list.append(wp.array(ptr=buffer.data, dtype=arg.type.dtype, shape=shape, device=device))
+
+        return arg_list
+
+    def ffi_callback(self, call_frame, platform):
         try:
             # On the first call, XLA runtime will query the API version and traits
             # metadata using the |extension| field. Let us respond to that query
@@ -744,7 +843,7 @@ class FfiCallable:
                     metadata_ext.contents.metadata.contents.api_version.major_version = 0
                     metadata_ext.contents.metadata.contents.api_version.minor_version = 1
                     # Turn on CUDA graphs for this handler.
-                    if self.graph_mode is JaxCallableGraphMode.JAX:
+                    if platform == _FFI_PLATFORM_CUDA and self.graph_mode is JaxCallableGraphMode.JAX:
                         metadata_ext.contents.metadata.contents.traits = (
                             XLA_FFI_Handler_TraitsBits.COMMAND_BUFFER_COMPATIBLE
                         )
@@ -771,8 +870,45 @@ class FfiCallable:
                 assert num_inputs == self.num_inputs
                 assert num_outputs == self.num_outputs
 
+                if platform == _FFI_PLATFORM_CPU:
+                    if self.graph_mode not in (JaxCallableGraphMode.NONE, JaxCallableGraphMode.JAX):
+                        return create_invalid_argument_ffi_error(
+                            call_frame.contents.api,
+                            f"JaxCallableGraphMode.{self.graph_mode.name} is not supported for JAX CPU FFI calls",
+                        )
+
+                    if not wp.is_cpu_available():
+                        return create_ffi_error(
+                            call_frame.contents.api,
+                            XLA_FFI_Error_Code.FAILED_PRECONDITION,
+                            "This Warp build does not include CPU support",
+                        )
+                    device = wp.get_device("cpu")
+                    module = wp.get_module(self.func.__module__)
+                    _load_ffi_module(module, device)
+                    arg_list = self._build_arg_list(inputs, outputs, call_desc, device)
+                    with wp.ScopedDevice(device):
+                        self.func(*arg_list)
+                    return None
+
+                if platform != _FFI_PLATFORM_CUDA:
+                    return create_invalid_argument_ffi_error(
+                        call_frame.contents.api,
+                        f"Unsupported JAX FFI platform '{platform}'",
+                    )
+
+                if wp._src.context.runtime is None:
+                    wp.init()
+                if not wp._src.context.runtime.is_cuda_enabled:
+                    return create_ffi_error(
+                        call_frame.contents.api,
+                        XLA_FFI_Error_Code.FAILED_PRECONDITION,
+                        "This Warp build does not include CUDA support",
+                    )
+
                 cuda_stream = get_stream_from_callframe(call_frame.contents)
                 device_ordinal = get_device_ordinal_from_callframe(call_frame.contents)
+                device = wp.get_cuda_device(device_ordinal)
 
                 if self.graph_mode == JaxCallableGraphMode.WARP:
                     # check if we already captured an identical call
@@ -876,31 +1012,10 @@ class FfiCallable:
                         # early out
                         return
 
-                device_ordinal = get_device_ordinal_from_callframe(call_frame.contents)
-                device = wp.get_cuda_device(device_ordinal)
+                _load_ffi_module(wp.get_module(self.func.__module__), device)
                 stream = wp.Stream(device, cuda_stream=cuda_stream)
 
-                # reconstruct the argument list
-                arg_list = []
-
-                # input and in-out args
-                for i, arg in enumerate(self.input_args):
-                    if arg.is_array:
-                        buffer = inputs[i].contents
-                        shape = collapse_batch_dims(buffer.dims[: buffer.rank - arg.dtype_ndim], arg.type.ndim)
-                        arr = wp.array(ptr=buffer.data, dtype=arg.type.dtype, shape=shape, device=device)
-                        arg_list.append(arr)
-                    else:
-                        # scalar argument, get stashed value
-                        value = call_desc.static_inputs[arg.name]
-                        arg_list.append(value)
-
-                # pure output args (skip in-out FFI buffers)
-                for i, arg in enumerate(self.output_args):
-                    buffer = outputs[i + self.num_in_out].contents
-                    shape = collapse_batch_dims(buffer.dims[: buffer.rank - arg.dtype_ndim], arg.type.ndim)
-                    arr = wp.array(ptr=buffer.data, dtype=arg.type.dtype, shape=shape, device=device)
-                    arg_list.append(arr)
+                arg_list = self._build_arg_list(inputs, outputs, call_desc, device)
 
                 # call the Python function with reconstructed arguments
                 with wp.ScopedStream(stream, sync_enter=False):
@@ -1201,6 +1316,11 @@ def jax_kernel(
             kernel signature. The number of in-out arguments is included in ``num_outputs``.
             Not supported when ``enable_backward=True``.
         module_preload_mode: Specify the devices where the module should be preloaded.
+            ``JaxModulePreloadMode.ALL_DEVICES`` includes the host CPU and all
+            supported local CUDA devices. Preloading is best-effort: JAX devices
+            that cannot be mapped to Warp are skipped, and execution loads the
+            module for the callback's actual device. Module loading errors are
+            not suppressed.
         enable_backward: Enable automatic differentiation for this kernel.
         has_side_effect: Whether the custom call has side effects. When True,
             the FFI call will be executed even when the outputs are not used.
@@ -1210,7 +1330,8 @@ def jax_kernel(
         - Scalars must be static arguments in JAX.
         - Input and input-output arguments must precede the output arguments in the ``kernel`` definition.
         - There must be at least one output or input-output argument.
-        - Only the CUDA backend is supported.
+        - The CPU and CUDA backends are supported. JAX selects the backend from the
+          lowered computation's device.
         - ``output_dims`` and ``in_out_argnames`` are not supported when ``enable_backward=True``.
     """
 
@@ -1568,6 +1689,9 @@ def jax_callable(
             such as when the callable uses conditional graph nodes.
             ``JaxCallableGraphMode.NONE``: Disable graph capture. Use when the callable performs operations that are not legal in a graph,
             such as host synchronization.
+            On CPU, ``JaxCallableGraphMode.NONE`` and ``JaxCallableGraphMode.JAX``
+            both execute without graph capture. The ``WARP``, ``WARP_STAGED``, and
+            ``WARP_STAGED_EX`` modes require CUDA.
         vmap_method: String specifying how the callback transforms under ``vmap()``.
             This argument can also be specified for individual calls.
         output_dims: Specify the default dimensions of output arrays.
@@ -1583,6 +1707,11 @@ def jax_callable(
         graph_cache_max: Maximum number of cached graphs captured using ``JaxCallableGraphMode.WARP``.
             If ``None``, the graph cache is unlimited.
         module_preload_mode: Specify the devices where the module should be preloaded.
+            ``JaxModulePreloadMode.ALL_DEVICES`` includes the host CPU and all
+            supported local CUDA devices. Preloading is best-effort: JAX devices
+            that cannot be mapped to Warp are skipped, and execution loads the
+            module for the callback's actual device. Module loading errors are
+            not suppressed.
         has_side_effect: Whether the custom call has side effects. When True,
             the FFI call will be executed even when the outputs are not used.
 
@@ -1591,10 +1720,12 @@ def jax_callable(
         - Scalars must be static arguments in JAX.
         - Input and input-output arguments must precede the output arguments in the ``func`` definition.
         - There must be at least one output or input-output argument.
-        - Only the CUDA backend is supported.
+        - The CPU and CUDA backends are supported. JAX selects the backend from the
+          lowered computation's device.
     """
 
     check_jax_version()
+    graph_mode = JaxCallableGraphMode(graph_mode)
 
     if isinstance(output_dims, dict):
         hashable_output_dims = tuple(sorted(output_dims.items()))

--- a/warp/tests/interop/aux_test_jax_cpu_ffi.py
+++ b/warp/tests/interop/aux_test_jax_cpu_ffi.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exercise Warp JAX FFI wrappers on a CPU-only JAX runtime with two host devices.
+
+Launched as a subprocess by ``test_jax.py`` because ``JAX_PLATFORMS`` and ``XLA_FLAGS``
+must be configured before JAX initializes.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import warp as wp
+
+
+@wp.kernel
+def triple_kernel(x: wp.array[float], y: wp.array[float]):
+    tid = wp.tid()
+    y[tid] = 3.0 * x[tid]
+
+
+def triple_func(x: wp.array[float], y: wp.array[float]):
+    wp.launch(triple_kernel, dim=x.shape, inputs=[x], outputs=[y])
+
+
+def main():
+    cpu_devices = jax.devices("cpu")
+    assert len(cpu_devices) == 2, cpu_devices
+
+    x = jax.device_put(np.arange(16, dtype=np.float32), cpu_devices[0])
+    expected = 3.0 * np.arange(16, dtype=np.float32)
+    no_preload_wrappers = (
+        ("jax_kernel", wp.jax_kernel(triple_kernel, module_preload_mode=wp.JaxModulePreloadMode.NONE)),
+        ("jax_callable", wp.jax_callable(triple_func, module_preload_mode=wp.JaxModulePreloadMode.NONE)),
+    )
+    for name, wrapper in no_preload_wrappers:
+        run = jax.jit(lambda value, wrapper=wrapper: wrapper(value)[0])
+        result = run(x)
+        jax.block_until_ready(result)
+        np.testing.assert_allclose(np.asarray(result), expected, err_msg=f"{name} with module preloading disabled")
+
+    jax_kernel = wp.jax_kernel(triple_kernel)
+    jax_callable = wp.jax_callable(triple_func)
+
+    @jax.jit
+    def run_kernel(x):
+        return jax_kernel(x)[0]
+
+    @jax.jit
+    def run_callable(x):
+        return jax_callable(x)[0]
+
+    kernel_y = run_kernel(x)
+    jax.block_until_ready(kernel_y)
+    callable_y = run_callable(x)
+    jax.block_until_ready(callable_y)
+    np.testing.assert_allclose(np.asarray(kernel_y), expected)
+    np.testing.assert_allclose(np.asarray(callable_y), expected)
+
+    sharded_x = jnp.arange(16, dtype=jnp.float32).reshape((2, 8))
+    sharded_kernel_y = jax.pmap(lambda row: jax_kernel(row)[0], devices=cpu_devices)(sharded_x)
+    jax.block_until_ready(sharded_kernel_y)
+    sharded_callable_y = jax.pmap(lambda row: jax_callable(row)[0], devices=cpu_devices)(sharded_x)
+    jax.block_until_ready(sharded_callable_y)
+    expected = 3.0 * np.arange(16, dtype=np.float32).reshape((2, 8))
+    np.testing.assert_allclose(np.asarray(sharded_kernel_y), expected)
+    np.testing.assert_allclose(np.asarray(sharded_callable_y), expected)
+
+
+if __name__ == "__main__":
+    main()

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -5,11 +5,14 @@ import contextlib
 import importlib
 import io
 import os
+import subprocess
 import sys
+import tempfile
 import unittest
 import warnings
 from functools import cache, partial
 from typing import Any
+from unittest import mock
 
 import numpy as np
 
@@ -23,6 +26,7 @@ os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
 
 # default array size for tests
 ARRAY_SIZE = 1024 * 1024
+TILE_STORE_SIZE = 64
 
 
 # basic kernel with one input and output
@@ -56,6 +60,12 @@ def inc_1d_kernel(x: wp.array[float], y: wp.array[float]):
 def inc_2d_kernel(x: wp.array2d[float], y: wp.array2d[float]):
     i, j = wp.tid()
     y[i, j] = x[i, j] + 1.0
+
+
+@wp.kernel
+def shaped_tile_store_kernel(output: wp.array[float]):
+    tile = wp.tile_ones(dtype=float, shape=TILE_STORE_SIZE)
+    wp.tile_store(output, tile)
 
 
 # kernel with multiple inputs and outputs
@@ -109,6 +119,22 @@ def _import_jax_numpy():
     import jax.numpy as jp  # noqa: PLC0415
 
     return jp
+
+
+class _RecordingFfiModule:
+    """Minimal Warp module stand-in that records ``load()`` calls and returns a canned result."""
+
+    def __init__(self, load_error=None, load_result=mock.sentinel.module_exec):
+        self.name = "recording_module"
+        self.loaded_devices = []
+        self.load_error = load_error
+        self.load_result = load_result
+
+    def load(self, device, _block_dim=None):
+        self.loaded_devices.append(device)
+        if self.load_error is not None:
+            raise self.load_error
+        return self.load_result
 
 
 _JAX_NAMESPACE_MODULES = ("warp.jax", "warp.jax_experimental")
@@ -1086,6 +1112,116 @@ def test_ffi_jax_callable_graph_cache(test, device):
     finally:
         wp.config.enable_graph_capture_module_load_by_default = old_force_module_load
         _clear_jax_experimental_warning_cache()
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+def test_ffi_jax_callable_graph_replay_skips_module_load(test, device):
+    """Test that FFI graph capture loads no extra modules and graph replay loads none.
+
+    Emulates drivers that cannot compile modules during graph capture by pinning the reported
+    driver version below 12.3. With the required module loaded up front, capture must not
+    force-load every registered module, and replaying the cached graph must not reload the
+    module.
+    """
+    jax = _import_jax()
+    jp = _import_jax_numpy()
+
+    module = wp.get_module(double_func.__module__)
+    wp.load_module(module=module, device=device)
+
+    with (
+        mock.patch.object(wp._src.context.runtime, "driver_version", (12, 2)),
+        mock.patch.object(wp.config, "enable_graph_capture_module_load_by_default", False),
+        mock.patch.object(wp._src.context, "force_load", side_effect=AssertionError("capture loaded modules")),
+    ):
+        for graph_mode in (wp.JaxCallableGraphMode.WARP_STAGED, wp.JaxCallableGraphMode.WARP_STAGED_EX):
+            with test.subTest(graph_mode=graph_mode):
+                jax_double = wp.jax_callable(
+                    double_func,
+                    graph_mode=graph_mode,
+                    module_preload_mode=wp.JaxModulePreloadMode.NONE,
+                )
+                run = jax.jit(lambda value, jax_double=jax_double: jax_double(value)[0])
+
+                with jax.default_device(wp.device_to_jax(device)):
+                    x = jp.arange(32, dtype=jp.float32)
+                    y = run(x)
+                    jax.block_until_ready(y)
+
+                    with mock.patch.object(module, "load", side_effect=AssertionError("replay reloaded the module")):
+                        y = run(x)
+                        jax.block_until_ready(y)
+
+                assert_np_equal(np.asarray(y), 2.0 * np.arange(32, dtype=np.float32))
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+def test_ffi_jax_mixed_devices(test, device):
+    """Test dispatching the same jitted FFI wrappers alternately to CPU and CUDA inputs."""
+    jax = _import_jax()
+    test.assertTrue(device.is_cuda)
+
+    cpu = wp.get_device("cpu")
+    jax_triple = wp.jax_kernel(triple_kernel)
+    jax_double = wp.jax_callable(double_func)
+
+    @jax.jit
+    def run(x):
+        (tripled,) = jax_triple(x)
+        (doubled,) = jax_double(x)
+        return tripled, doubled
+
+    expected = np.arange(32, dtype=np.float32)
+    for target in (cpu, device, cpu, device):
+        with test.subTest(target=target):
+            x = jax.device_put(expected, wp.device_to_jax(target))
+            tripled, doubled = run(x)
+            jax.block_until_ready((tripled, doubled))
+            assert_np_equal(np.asarray(tripled), 3.0 * expected)
+            assert_np_equal(np.asarray(doubled), 2.0 * expected)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+def test_ffi_jax_cuda_requires_cuda_support(test, device):
+    """Test that FFI calls on CUDA arrays report a clear error when Warp lacks CUDA support."""
+    jax = _import_jax()
+    test.assertTrue(device.is_cuda)
+
+    x = jax.device_put(np.arange(32, dtype=np.float32), wp.device_to_jax(device))
+    wrappers = (
+        ("jax_kernel", lambda: wp.jax_kernel(triple_kernel)),
+        ("jax_callable", lambda: wp.jax_callable(double_func)),
+    )
+
+    for name, make_wrapper in wrappers:
+        with test.subTest(wrapper=name):
+            with mock.patch.object(wp._src.context.runtime, "is_cuda_enabled", False):
+                wrapper = make_wrapper()
+                run = jax.jit(lambda value, wrapper=wrapper: wrapper(value)[0])
+                with test.assertRaisesRegex(Exception, "does not include CUDA support"):
+                    jax.block_until_ready(run(x))
+
+
+def _run_ffi_jax_cpu_subprocess(test):
+    """Run the auxiliary CPU FFI script in a CPU-only subprocess and assert that it succeeds."""
+    script = os.path.join(os.path.dirname(__file__), "aux_test_jax_cpu_ffi.py")
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = ""
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=2"
+
+    with tempfile.TemporaryDirectory(prefix="warp-jax-cpu-ffi-") as cache_dir:
+        env["WARP_CACHE_PATH"] = cache_dir
+        result = subprocess.run(
+            [sys.executable, script],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+            timeout=300,
+        )
+
+    test.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
 
 
 @unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
@@ -2200,7 +2336,245 @@ def test_bf16_interop_jax(test, device):
 
 
 class TestJax(unittest.TestCase):
-    pass
+    def _get_jax_cpu_device(self):
+        jax = _import_jax()
+        try:
+            return jax.devices("cpu")[0]
+        except RuntimeError as e:
+            self.skipTest(f"JAX CPU backend is unavailable: {e}")
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_jax_kernel_cpu_shaped_tile_store(self):
+        """Test jax_kernel on CPU with a kernel that stores a fixed-shape tile."""
+        jax = _import_jax()
+        jax_cpu = self._get_jax_cpu_device()
+        jax_tile_store = wp.jax_kernel(
+            shaped_tile_store_kernel,
+            launch_dims=1,
+            output_dims=TILE_STORE_SIZE,
+        )
+
+        with jax.default_device(jax_cpu):
+            (result,) = jax.jit(jax_tile_store)()
+
+        jax.block_until_ready(result)
+        assert_np_equal(np.asarray(result), np.ones(TILE_STORE_SIZE, dtype=np.float32))
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_jax_callable_cpu_graph_modes(self):
+        """Test that the NONE and JAX graph modes run on CPU while CUDA-only graph modes raise."""
+        jax = _import_jax()
+        jp = _import_jax_numpy()
+        jax_cpu = self._get_jax_cpu_device()
+
+        for graph_mode in (wp.JaxCallableGraphMode.NONE, wp.JaxCallableGraphMode.JAX):
+            with self.subTest(graph_mode=graph_mode), jax.default_device(jax_cpu):
+                jax_double = wp.jax_callable(double_func, graph_mode=graph_mode)
+                x = jp.arange(32, dtype=jp.float32)
+                (y,) = jax.jit(jax_double)(x)
+                jax.block_until_ready(y)
+                assert_np_equal(np.asarray(y), 2.0 * np.arange(32, dtype=np.float32))
+
+        cuda_only_modes = (
+            wp.JaxCallableGraphMode.WARP,
+            wp.JaxCallableGraphMode.WARP_STAGED,
+            wp.JaxCallableGraphMode.WARP_STAGED_EX,
+        )
+        for graph_mode in cuda_only_modes:
+            with self.subTest(graph_mode=graph_mode), jax.default_device(jax_cpu):
+                jax_double = wp.jax_callable(double_func, graph_mode=graph_mode)
+                x = jp.arange(32, dtype=jp.float32)
+                with self.assertRaisesRegex(Exception, rf"{graph_mode.name}.*CPU"):
+                    y = jax.jit(jax_double)(x)
+                    jax.block_until_ready(y)
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_jax_callable_integer_graph_mode(self):
+        """Test that an integer graph_mode argument is converted to JaxCallableGraphMode."""
+
+        def func(x: wp.array[float], y: wp.array[float]):
+            wp.launch(double_kernel, dim=x.shape, inputs=[x], outputs=[y])
+
+        jax_func = wp.jax_callable(
+            func,
+            graph_mode=2,
+            module_preload_mode=wp.JaxModulePreloadMode.NONE,
+        )
+
+        self.assertIs(jax_func.graph_mode, wp.JaxCallableGraphMode.WARP)
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_jax_module_load_failure(self):
+        """Test that a failed Warp module load surfaces as a clear FFI error."""
+        jax = _import_jax()
+        jax_cpu = self._get_jax_cpu_device()
+        device = wp.get_device("cpu")
+        module = triple_kernel.module
+        self.assertIsNotNone(module.load(device, 1))
+
+        wrappers = (
+            (
+                "jax_kernel",
+                wp.jax_kernel(triple_kernel, module_preload_mode=wp.JaxModulePreloadMode.NONE),
+            ),
+            (
+                "jax_callable",
+                wp.jax_callable(double_func, module_preload_mode=wp.JaxModulePreloadMode.NONE),
+            ),
+        )
+        x = jax.device_put(np.arange(8, dtype=np.float32), jax_cpu)
+
+        for name, wrapper in wrappers:
+            with self.subTest(wrapper=name):
+                run = jax.jit(lambda value, wrapper=wrapper: wrapper(value)[0])
+                with (
+                    contextlib.redirect_stdout(io.StringIO()),
+                    mock.patch.object(module, "load", return_value=None),
+                    self.assertRaisesRegex(Exception, "Failed to load Warp module"),
+                ):
+                    y = run(x)
+                    jax.block_until_ready(y)
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_jax_cpu_requires_cpu_support(self):
+        """Test that FFI calls on CPU arrays report a clear error when Warp lacks CPU support."""
+        jax = _import_jax()
+        jax_cpu = self._get_jax_cpu_device()
+        x = jax.device_put(np.arange(8, dtype=np.float32), jax_cpu)
+        wrappers = (
+            (
+                "jax_kernel",
+                wp.jax_kernel(triple_kernel, module_preload_mode=wp.JaxModulePreloadMode.NONE),
+            ),
+            (
+                "jax_callable",
+                wp.jax_callable(double_func, module_preload_mode=wp.JaxModulePreloadMode.NONE),
+            ),
+        )
+
+        for name, wrapper in wrappers:
+            with self.subTest(wrapper=name):
+                run = jax.jit(lambda value, wrapper=wrapper: wrapper(value)[0])
+                with (
+                    mock.patch.object(wp, "is_cpu_available", return_value=False),
+                    self.assertRaisesRegex(Exception, "does not include CPU support"),
+                ):
+                    y = run(x)
+                    jax.block_until_ready(y)
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_module_preload_modes(self):
+        """Test _preload_ffi_module device selection for each JaxModulePreloadMode.
+
+        NONE must not load anything, CURRENT_DEVICE loads the Warp device mapped from the
+        default JAX device and skips devices Warp cannot map, and ALL_DEVICES queries the CPU
+        and CUDA backends while tolerating backends that are unavailable.
+        """
+        from warp._src.jax import ffi as ffi_module  # noqa: PLC0415
+
+        with self.subTest(mode="none"):
+            module = _RecordingFfiModule()
+            ffi_module._preload_ffi_module(module, wp.JaxModulePreloadMode.NONE)
+            self.assertEqual(module.loaded_devices, [])
+
+        jax_device = object()
+        warp_device = mock.Mock(is_cpu=False)
+        module = _RecordingFfiModule()
+        with self.subTest(mode="current_device"):
+            with (
+                mock.patch.object(ffi_module, "get_jax_device", return_value=jax_device),
+                mock.patch.object(ffi_module.wp, "device_from_jax", return_value=warp_device),
+            ):
+                ffi_module._preload_ffi_module(module, wp.JaxModulePreloadMode.CURRENT_DEVICE)
+            self.assertEqual(module.loaded_devices, [warp_device])
+
+        with self.subTest(mode="current_device_unavailable"):
+            module = _RecordingFfiModule()
+            with (
+                mock.patch.object(ffi_module, "get_jax_device", return_value=jax_device),
+                mock.patch.object(ffi_module.wp, "device_from_jax", side_effect=RuntimeError("Device unavailable")),
+            ):
+                ffi_module._preload_ffi_module(module, wp.JaxModulePreloadMode.CURRENT_DEVICE)
+            self.assertEqual(module.loaded_devices, [])
+
+        cpu_0 = object()
+        cpu_1 = object()
+        requested_backends = []
+
+        class FakeJax:
+            @staticmethod
+            def local_devices(process_index=None, backend=None, host_id=None):
+                requested_backends.append(backend)
+                if backend == "cpu":
+                    return [cpu_0, cpu_1]
+                if backend == "cuda":
+                    raise RuntimeError("CUDA backend is unavailable")
+                raise AssertionError(f"Unexpected backend: {backend}")
+
+        warp_cpu = mock.Mock(is_cpu=True)
+        module = _RecordingFfiModule()
+        with self.subTest(mode="all_devices"):
+            with (
+                mock.patch.object(ffi_module, "_get_jax", return_value=FakeJax()),
+                mock.patch.object(ffi_module.wp, "device_from_jax", return_value=warp_cpu),
+            ):
+                ffi_module._preload_ffi_module(module, wp.JaxModulePreloadMode.ALL_DEVICES)
+            self.assertEqual(module.loaded_devices, [warp_cpu])
+            self.assertIn("cuda", requested_backends)
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_module_preload_load_error(self):
+        """Test that module preloading propagates load errors and reports previously failed builds.
+
+        A load that raises must propagate to the caller, and a load that returns no executable
+        module (a cached build failure) must raise a RuntimeError for both the CURRENT_DEVICE
+        and ALL_DEVICES preload modes.
+        """
+        from warp._src.jax import ffi as ffi_module  # noqa: PLC0415
+
+        jax_device = object()
+        warp_device = mock.Mock(is_cpu=False)
+        module = _RecordingFfiModule(load_error=ValueError("module load failed"))
+        with (
+            mock.patch.object(ffi_module, "get_jax_device", return_value=jax_device),
+            mock.patch.object(ffi_module.wp, "device_from_jax", return_value=warp_device),
+            self.assertRaisesRegex(ValueError, "module load failed"),
+        ):
+            ffi_module._preload_ffi_module(module, wp.JaxModulePreloadMode.CURRENT_DEVICE)
+
+        self.assertEqual(module.loaded_devices, [warp_device])
+
+        with self.subTest(cached_failure="current_device"):
+            module = _RecordingFfiModule(load_result=None)
+            with (
+                mock.patch.object(ffi_module, "get_jax_device", return_value=jax_device),
+                mock.patch.object(ffi_module.wp, "device_from_jax", return_value=warp_device),
+                self.assertRaisesRegex(RuntimeError, "previous build failure"),
+            ):
+                ffi_module._preload_ffi_module(module, wp.JaxModulePreloadMode.CURRENT_DEVICE)
+
+        class FakeJax:
+            @staticmethod
+            def local_devices(process_index=None, backend=None, host_id=None):
+                return [jax_device] if backend == "cpu" else []
+
+        with self.subTest(cached_failure="all_devices"):
+            module = _RecordingFfiModule(load_result=None)
+            with (
+                mock.patch.object(ffi_module, "_get_jax", return_value=FakeJax()),
+                mock.patch.object(ffi_module.wp, "device_from_jax", return_value=warp_device),
+                self.assertRaisesRegex(RuntimeError, "previous build failure"),
+            ):
+                ffi_module._preload_ffi_module(module, wp.JaxModulePreloadMode.ALL_DEVICES)
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_jax_cpu_subprocess(self):
+        """Test FFI wrappers on a CPU-only JAX runtime configured with two host platform devices.
+
+        JAX_PLATFORMS and XLA_FLAGS must be set before JAX initializes, so the checks run in a
+        separate process via ``aux_test_jax_cpu_ffi.py``.
+        """
+        _run_ffi_jax_cpu_subprocess(self)
 
 
 # try adding Jax tests if Jax is installed correctly
@@ -2214,6 +2588,15 @@ else:
 
     jax_candidate_devices = get_test_devices()
     jax_cuda_candidate_devices = [device for device in jax_candidate_devices if device.is_cuda]
+    jax_cpu_candidate_devices = [device for device in jax_candidate_devices if device.is_cpu]
+
+    # pmap tests dispatch across all local JAX devices; register them when those map onto
+    # candidate test devices and defer the JAX availability probe to run time.
+    try:
+        pmap_warp_devices = [wp.device_from_jax(d) for d in jax.local_devices()]
+    except (IndexError, RuntimeError):
+        pmap_warp_devices = []
+    pmap_devices_are_candidates = bool(pmap_warp_devices) and all(d in jax_candidate_devices for d in pmap_warp_devices)
 
     @cache
     def _jax_device_error(device_alias):
@@ -2235,6 +2618,10 @@ else:
 
     def _check_all_jax_cuda_devices(test, _device):
         for device in jax_cuda_candidate_devices:
+            _check_jax_device(test, device)
+
+    def _check_pmap_devices(test, _device):
+        for device in pmap_warp_devices:
             _check_jax_device(test, device)
 
     add_function_test(
@@ -2266,348 +2653,146 @@ else:
             device_check=_check_jax_device,
         )
 
-    if jax_cuda_candidate_devices:
-        # tests for both custom_call and ffi variants of jax_kernel(), selected by installed JAX version
-        if jax.__version_info__ < (0, 4, 25):
-            # no interop supported
-            ffi_opts = []
-        elif jax.__version_info__ < (0, 5, 0):
-            # only custom_call supported
-            ffi_opts = [False]
-        elif jax.__version_info__ < (0, 8, 0):
-            # both custom_call and ffi supported
-            ffi_opts = [False, True]
-        else:
-            # only ffi supported
-            ffi_opts = [True]
-
-        for use_ffi in ffi_opts:
-            suffix = "ffi" if use_ffi else "cc"
-            add_function_test(
-                TestJax,
-                f"test_jax_kernel_basic_{suffix}",
+    if jax.__version_info__ >= (0, 5, 0):
+        if jax_candidate_devices:
+            # FFI-based tests run on any JAX-compatible device (CPU or CUDA)
+            jax_kernel_ffi_tests = (
                 test_jax_kernel_basic,
-                devices=jax_cuda_candidate_devices,
-                device_check=_check_jax_device,
-                use_ffi=use_ffi,
-            )
-            add_function_test(
-                TestJax,
-                f"test_jax_kernel_scalar_{suffix}",
                 test_jax_kernel_scalar,
-                devices=jax_cuda_candidate_devices,
-                device_check=_check_jax_device,
-                use_ffi=use_ffi,
-            )
-            add_function_test(
-                TestJax,
-                f"test_jax_kernel_vecmat_{suffix}",
                 test_jax_kernel_vecmat,
-                devices=jax_cuda_candidate_devices,
-                device_check=_check_jax_device,
-                use_ffi=use_ffi,
-            )
-            add_function_test(
-                TestJax,
-                f"test_jax_kernel_multiarg_{suffix}",
                 test_jax_kernel_multiarg,
-                devices=jax_cuda_candidate_devices,
-                device_check=_check_jax_device,
-                use_ffi=use_ffi,
-            )
-            add_function_test(
-                TestJax,
-                f"test_jax_kernel_launch_dims_{suffix}",
                 test_jax_kernel_launch_dims,
-                devices=jax_cuda_candidate_devices,
-                device_check=_check_jax_device,
-                use_ffi=use_ffi,
+            )
+            backend_neutral_ffi_tests = (
+                *jax_kernel_ffi_tests,
+                # direct FFI kernels
+                test_ffi_jax_kernel_add,
+                test_ffi_jax_kernel_sincos,
+                test_ffi_jax_kernel_diagonal,
+                test_ffi_jax_kernel_in_out,
+                test_ffi_jax_kernel_scale_vec_constant,
+                test_ffi_jax_kernel_scale_vec_static,
+                test_ffi_jax_kernel_launch_dims_default,
+                test_ffi_jax_kernel_launch_dims_custom,
+                # callables
+                test_ffi_jax_callable_scale_constant,
+                test_ffi_jax_callable_scale_static,
+                test_ffi_jax_callable_in_out,
+                # autodiff and subscript annotations
+                test_ffi_jax_kernel_autodiff_simple,
+                test_ffi_jax_kernel_autodiff_jit_of_grad_simple,
+                test_ffi_jax_kernel_autodiff_multi_output,
+                test_ffi_jax_kernel_autodiff_jit_of_grad_multi_output,
+                test_ffi_jax_kernel_autodiff_2d,
+                test_ffi_jax_kernel_autodiff_vec2,
+                test_ffi_jax_kernel_autodiff_mat22,
+                test_ffi_jax_kernel_autodiff_static_required,
+                test_ffi_jax_kernel_launch_dims_autodiff_basic,
+                test_ffi_jax_kernel_launch_dims_autodiff_gradient,
+                test_ffi_jax_kernel_launch_dims_autodiff_separate_cache,
+                test_ffi_jax_kernel_autodiff_per_call_override_rejected,
+                test_ffi_jax_kernel_output_dims_autodiff_still_blocked,
+                test_ffi_jax_kernel_launch_dims_autodiff_vmap,
+                test_ffi_jax_kernel_subscript_scalar,
+                test_ffi_jax_kernel_subscript_vec,
+                test_ffi_jax_kernel_subscript_autodiff,
             )
 
-        # ffi.jax_kernel() tests
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_add",
-            test_ffi_jax_kernel_add,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_sincos",
-            test_ffi_jax_kernel_sincos,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_diagonal",
-            test_ffi_jax_kernel_diagonal,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_in_out",
-            test_ffi_jax_kernel_in_out,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_scale_vec_constant",
-            test_ffi_jax_kernel_scale_vec_constant,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_scale_vec_static",
-            test_ffi_jax_kernel_scale_vec_static,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_launch_dims_default",
-            test_ffi_jax_kernel_launch_dims_default,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_launch_dims_custom",
-            test_ffi_jax_kernel_launch_dims_custom,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
+            for test_func in backend_neutral_ffi_tests:
+                test_name = test_func.__name__
+                test_kwargs = {}
+                if test_func in jax_kernel_ffi_tests:
+                    test_name = f"{test_name}_ffi"
+                    test_kwargs["use_ffi"] = True
+                add_function_test(
+                    TestJax,
+                    test_name,
+                    test_func,
+                    devices=jax_candidate_devices,
+                    device_check=_check_jax_device,
+                    **test_kwargs,
+                )
 
-        # subscript-style type hint tests (wp.array[dtype] syntax)
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_subscript_scalar",
-            test_ffi_jax_kernel_subscript_scalar,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_subscript_vec",
-            test_ffi_jax_kernel_subscript_vec,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_subscript_autodiff",
-            test_ffi_jax_kernel_subscript_autodiff,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
+            for vmap_method in ["broadcast_all", "sequential"]:
+                add_function_test(
+                    TestJax,
+                    f"test_ffi_vmap_add_{vmap_method}",
+                    partial(test_ffi_vmap_add, vmap_method=vmap_method),
+                    devices=jax_candidate_devices,
+                    device_check=_check_jax_device,
+                )
+                add_function_test(
+                    TestJax,
+                    f"test_ffi_vmap_rowsum_{vmap_method}",
+                    partial(test_ffi_vmap_rowsum, vmap_method=vmap_method),
+                    devices=jax_candidate_devices,
+                    device_check=_check_jax_device,
+                )
+                add_function_test(
+                    TestJax,
+                    f"test_ffi_vmap_lookup_{vmap_method}",
+                    partial(test_ffi_vmap_lookup, vmap_method=vmap_method),
+                    devices=jax_candidate_devices,
+                    device_check=_check_jax_device,
+                )
 
-        # ffi.jax_callable() tests
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_callable_scale_constant",
-            test_ffi_jax_callable_scale_constant,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_callable_scale_static",
-            test_ffi_jax_callable_scale_static,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_callable_in_out",
-            test_ffi_jax_callable_in_out,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_callable_graph_cache",
-            test_ffi_jax_callable_graph_cache,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-
-        # pmap tests
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_callable_pmap_multi_output",
-            test_ffi_jax_callable_pmap_multi_output,
-            devices=None,
-            device_check=_check_all_jax_cuda_devices,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_callable_pmap_mul",
-            test_ffi_jax_callable_pmap_mul,
-            devices=None,
-            device_check=_check_all_jax_cuda_devices,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_callable_pmap_multi_stage",
-            test_ffi_jax_callable_pmap_multi_stage,
-            devices=None,
-            device_check=_check_all_jax_cuda_devices,
-        )
-
-        # ffi callback tests
-        add_function_test(
-            TestJax,
-            "test_ffi_callback",
-            test_ffi_callback,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-
-        # autodiff tests
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_simple",
-            test_ffi_jax_kernel_autodiff_simple,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_jit_of_grad_simple",
-            test_ffi_jax_kernel_autodiff_jit_of_grad_simple,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_multi_output",
-            test_ffi_jax_kernel_autodiff_multi_output,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_jit_of_grad_multi_output",
-            test_ffi_jax_kernel_autodiff_jit_of_grad_multi_output,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_2d",
-            test_ffi_jax_kernel_autodiff_2d,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_vec2",
-            test_ffi_jax_kernel_autodiff_vec2,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_mat22",
-            test_ffi_jax_kernel_autodiff_mat22,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_static_required",
-            test_ffi_jax_kernel_autodiff_static_required,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-
-        # autodiff with pmap tests
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_pmap_triple",
-            test_ffi_jax_kernel_autodiff_pmap_triple,
-            devices=None,
-            device_check=_check_all_jax_cuda_devices,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_pmap_multi_output",
-            test_ffi_jax_kernel_autodiff_pmap_multi_output,
-            devices=None,
-            device_check=_check_all_jax_cuda_devices,
-        )
-
-        # launch_dims + enable_backward=True tests
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_launch_dims_autodiff_basic",
-            test_ffi_jax_kernel_launch_dims_autodiff_basic,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_launch_dims_autodiff_gradient",
-            test_ffi_jax_kernel_launch_dims_autodiff_gradient,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_launch_dims_autodiff_separate_cache",
-            test_ffi_jax_kernel_launch_dims_autodiff_separate_cache,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_autodiff_per_call_override_rejected",
-            test_ffi_jax_kernel_autodiff_per_call_override_rejected,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_output_dims_autodiff_still_blocked",
-            test_ffi_jax_kernel_output_dims_autodiff_still_blocked,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-        add_function_test(
-            TestJax,
-            "test_ffi_jax_kernel_launch_dims_autodiff_vmap",
-            test_ffi_jax_kernel_launch_dims_autodiff_vmap,
-            devices=jax_cuda_candidate_devices,
-            device_check=_check_jax_device,
-        )
-
-        # vmap tests
-        for vmap_method in ["broadcast_all", "sequential"]:
-            add_function_test(
-                TestJax,
-                f"test_ffi_vmap_add_{vmap_method}",
-                partial(test_ffi_vmap_add, vmap_method=vmap_method),
-                devices=jax_cuda_candidate_devices,
-                device_check=_check_jax_device,
+        if pmap_devices_are_candidates:
+            pmap_tests = (
+                test_ffi_jax_callable_pmap_multi_output,
+                test_ffi_jax_callable_pmap_mul,
+                test_ffi_jax_callable_pmap_multi_stage,
+                test_ffi_jax_kernel_autodiff_pmap_triple,
+                test_ffi_jax_kernel_autodiff_pmap_multi_output,
             )
-            add_function_test(
-                TestJax,
-                f"test_ffi_vmap_rowsum_{vmap_method}",
-                partial(test_ffi_vmap_rowsum, vmap_method=vmap_method),
-                devices=jax_cuda_candidate_devices,
-                device_check=_check_jax_device,
+            for test_func in pmap_tests:
+                add_function_test(
+                    TestJax, test_func.__name__, test_func, devices=None, device_check=_check_pmap_devices
+                )
+
+    if jax_cuda_candidate_devices:
+        if (0, 4, 25) <= jax.__version_info__ < (0, 8, 0):
+            # legacy custom_call path is CUDA-only
+            legacy_custom_call_tests = (
+                test_jax_kernel_basic,
+                test_jax_kernel_scalar,
+                test_jax_kernel_vecmat,
+                test_jax_kernel_multiarg,
+                test_jax_kernel_launch_dims,
             )
-            add_function_test(
-                TestJax,
-                f"test_ffi_vmap_lookup_{vmap_method}",
-                partial(test_ffi_vmap_lookup, vmap_method=vmap_method),
-                devices=jax_cuda_candidate_devices,
-                device_check=_check_jax_device,
+            for test_func in legacy_custom_call_tests:
+                add_function_test(
+                    TestJax,
+                    f"{test_func.__name__}_cc",
+                    test_func,
+                    devices=jax_cuda_candidate_devices,
+                    device_check=_check_jax_device,
+                    use_ffi=False,
+                )
+
+        if jax.__version_info__ >= (0, 5, 0):
+            cuda_only_jax_tests = (
+                test_ffi_jax_callable_graph_cache,
+                test_ffi_jax_callable_graph_replay_skips_module_load,
+                test_ffi_jax_cuda_requires_cuda_support,
+                test_ffi_callback,
             )
+            for test_func in cuda_only_jax_tests:
+                add_function_test(
+                    TestJax,
+                    test_func.__name__,
+                    test_func,
+                    devices=jax_cuda_candidate_devices,
+                    device_check=_check_jax_device,
+                )
+
+            if jax_cpu_candidate_devices:
+                add_function_test(
+                    TestJax,
+                    "test_ffi_jax_mixed_devices",
+                    test_ffi_jax_mixed_devices,
+                    devices=jax_cuda_candidate_devices,
+                    device_check=_check_jax_device,
+                )
 
     # bfloat16 tests require arch >= 80
     bf16_jax_devices = [


### PR DESCRIPTION
## Description

Add CPU execution support for `wp.jax_kernel()` and `wp.jax_callable()`
through JAX FFI. The same wrapper is registered for CPU and CUDA, allowing
JAX to select the implementation from the device used during lowering.

Closes #1661.

Related work: #1446 covers the same feature area. This implementation was
developed independently. Its CPU shaped-tile correction follows the
`block_dim=1` issue reported while reviewing that PR:
https://github.com/NVIDIA/warp/pull/1446#issuecomment-4884949378

## Changes

- Register FFI targets for CPU and CUDA without initializing either backend.
- Execute Warp kernels and callables directly against zero-copy JAX CPU
  buffers, while preserving existing CUDA behavior.
- Make module preloading device-aware and compile CPU FFI kernels with a
  single-lane block dimension so shaped tile operations cover their full
  extent.
- Validate CPU graph-mode behavior and report unsupported CUDA execution
  clearly when Warp lacks CUDA support.
- Add JAX to the relevant CI test environments and cover CPU, mixed-device,
  preloading-disabled, and shaped-tile user workflows.
- Document automatic device selection and CPU-specific behavior, and add an
  Unreleased changelog entry.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Ran the complete JAX interop test module across CPU and two CUDA devices:
  146 tests passed, with 12 expected skips.
- Re-ran the CPU subprocess path, including public execution with module
  preloading disabled, plus the CPU shaped-tile, CPU callable graph-mode, and
  mixed CPU/CUDA regression tests. All four passed.
- Ran pre-commit on every changed source and documentation file; all hooks
  passed.
- Built the HTML documentation successfully with no Sphinx warnings.

## Bug fix

Without the CPU-specific block dimension, shaped tile stores only populate the
first element:

```python
import jax
import numpy as np
import warp as wp

TILE_SIZE = 64

@wp.kernel
def fill(output: wp.array(dtype=float)):
    tile = wp.tile_ones(dtype=float, shape=TILE_SIZE)
    wp.tile_store(output, tile)

run = jax.jit(wp.jax_kernel(fill, launch_dims=1, output_dims=TILE_SIZE))
with jax.default_device(jax.devices("cpu")[0]):
    result = run()[0]

np.testing.assert_array_equal(result, np.ones(TILE_SIZE, dtype=np.float32))
```

## New feature / enhancement

The same JAX FFI wrapper can now execute on CPU or CUDA according to the input
device:

```python
import jax
import numpy as np
import warp as wp

@wp.kernel
def triple(x: wp.array(dtype=float), y: wp.array(dtype=float)):
    i = wp.tid()
    y[i] = 3.0 * x[i]

run = jax.jit(wp.jax_kernel(triple))
x = np.arange(64, dtype=np.float32)
cpu_result = run(jax.device_put(x, jax.devices("cpu")[0]))[0]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled CPU execution for **`wp.jax_kernel()`** and **`wp.jax_callable()`**, with automatic dispatch based on the JAX device.
  * Improved module preloading to support **CPU + CUDA** (best-effort device mapping).
* **Documentation**
  * Expanded the JAX interoperability guide with device-selection behavior and clearer CPU vs CUDA graph-mode/capture rules.
* **Tests**
  * Added CPU interop tests, mixed CPU/CUDA validation, sharded CPU execution, and module preload/module-load failure coverage.
* **Chores**
  * Updated CI to install the correct JAX extras per platform/GPU job.
* **Changelog**
  * Recorded the new CPU support for `wp.jax_kernel()` and `wp.jax_callable()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->