### PR TITLE
Fix APIC array reduction replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   ([GH-1618](https://github.com/NVIDIA/warp/issues/1618)).
 - Add adjoint for the out-of-place `wp.tile_lower_solve()` for vector and matrix right-hand sides
   ([GH-1378](https://github.com/NVIDIA/warp/issues/1378))
+- **Experimental:** Record `wp.utils.array_sum()` and `wp.utils.array_inner()` in APIC capture so saved and replayed
+  graphs recompute them from current inputs on CPU and CUDA ([GH-1663](https://github.com/NVIDIA/warp/issues/1663)).
 
 ### Removed
 

--- a/docs/user_guide/runtime.rst
+++ b/docs/user_guide/runtime.rst
@@ -1865,6 +1865,8 @@ The operations recorded on CPU now cover most of the CUDA path:
   (:meth:`array.zero_() <warp.array.zero_>`), plus contiguous
   :meth:`array.fill_() <warp.array.fill_>`.
 - Host library helpers including
+  :func:`wp.utils.array_sum() <warp.utils.array_sum>`,
+  :func:`wp.utils.array_inner() <warp.utils.array_inner>`,
   :func:`wp.utils.array_scan() <warp.utils.array_scan>`,
   :func:`wp.utils.radix_sort_pairs() <warp.utils.radix_sort_pairs>`,
   :func:`wp.utils.segmented_sort_pairs() <warp.utils.segmented_sort_pairs>`,
@@ -1894,6 +1896,13 @@ Current limitations of CPU graph capture:
   (non-contiguous) 1D arrays -- into the CPU APIC byte stream. Negative strides raise
   :exc:`NotImplementedError` inside a CPU :class:`ScopedCapture`; run them outside the
   captured region.
+- :func:`wp.utils.array_sum() <warp.utils.array_sum>` and
+  :func:`wp.utils.array_inner() <warp.utils.array_inner>` require an explicit
+  ``out`` array for non-empty APIC captures. Explicit counts, composite dtypes,
+  and positive-stride axis reductions are recorded; negative strides raise
+  :exc:`NotImplementedError`, and negative counts raise :exc:`RuntimeError`.
+  Counts and reduction strides must fit a signed 32-bit integer, and participating
+  addresses and layout strides must be aligned to the reduction's scalar type.
 - :func:`wp.utils.runlength_encode() <warp.utils.runlength_encode>` requires an explicit
   ``run_count`` array during CPU APIC capture; the host-return form (``run_count=None``) raises
   :exc:`NotImplementedError`, because its capture-time host integer cannot represent the
@@ -1943,7 +1952,8 @@ Saving and Loading Graphs
     :func:`wp.capture_save() <warp.capture_save>` / :func:`wp.capture_load() <warp.capture_load>`
     surface, the C ``wp_apic_*`` API, and the recorded operation set are all
     subject to change without a formal deprecation cycle. ``.wrp`` files written
-    by one version of Warp may not be loadable by another.
+    by one version of Warp may not be loadable by another. The current writer
+    emits format version 15, and the reader accepts versions 13 through 15.
 
 API Capture lets you serialize a captured graph to disk and load it back later, either
 from another Python program, or from a standalone C++ application that links only
@@ -1964,14 +1974,25 @@ mechanism), and ``apic=True`` simply unlocks
 On CUDA, ``apic=True`` records the same extended operation set as the CPU path so saved
 graphs replay it from current inputs: kernel launches (forward, adjoint, and reusable
 ``record_cmd=True`` launches), contiguous same-device memory copies and memsets, contiguous
-:meth:`array.fill_() <warp.array.fill_>`, :func:`wp.utils.array_scan() <warp.utils.array_scan>`,
+:meth:`array.fill_() <warp.array.fill_>`,
+:func:`wp.utils.array_sum() <warp.utils.array_sum>`,
+:func:`wp.utils.array_inner() <warp.utils.array_inner>`,
+:func:`wp.utils.array_scan() <warp.utils.array_scan>`,
 :func:`wp.utils.radix_sort_pairs() <warp.utils.radix_sort_pairs>`,
 :func:`wp.utils.segmented_sort_pairs() <warp.utils.segmented_sort_pairs>`,
 :func:`wp.utils.runlength_encode() <warp.utils.runlength_encode>` (with an explicit
 ``run_count``), :func:`wp.sparse.bsr_set_transpose() <warp.sparse.bsr_set_transpose>`, and
 :func:`wp.capture_if() <warp.capture_if>` / :func:`wp.capture_while() <warp.capture_while>`
-conditionals. Unlike the CPU path (which records only), these still execute during capture so
-the driver also records them into the native CUDA graph.
+conditionals. Unlike the CPU path, CUDA host code for these reductions issues CUDA operations
+while native stream capture is active so the driver records native graph nodes. No GPU
+reduction executes during capture; GPU work begins only when the graph is launched.
+
+During a matching-device CUDA ``apic=True`` capture, non-empty calls to these reductions
+require an explicit ``out`` array. Explicit counts, composite dtypes, and positive-stride axis
+reductions are recorded. A negative count raises :exc:`RuntimeError` in that capture, and any
+negative input or output stride raises :exc:`NotImplementedError`, including for a zero-count
+call. Counts and reduction strides must fit a signed 32-bit integer, and participating
+addresses and layout strides must be aligned to the reduction's scalar type.
 
 A few operations cannot be captured for save/load on CUDA and raise
 :exc:`NotImplementedError` during an ``apic=True`` capture; build these outside the captured

--- a/warp/_src/apic/types.py
+++ b/warp/_src/apic/types.py
@@ -25,6 +25,7 @@ APIC_OP_RADIX_SORT = 12
 APIC_OP_RUNLENGTH_ENCODE = 13
 APIC_OP_BSR_FROM_TRIPLETS = 14
 APIC_OP_BSR_TRANSPOSE = 15
+APIC_OP_REDUCTION = 16
 
 
 # Scalar element types (must match APICType in apic_types.h).

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -16,7 +16,7 @@ from typing import Any
 import numpy as np
 
 import warp as wp
-import warp._src.context
+import warp._src.context as context
 import warp._src.types
 from warp._src import logger as _logger_module
 from warp._src.context import Allocator, CaptureMode, DeviceLike, _validate_allocator, timing_result_t
@@ -467,6 +467,46 @@ def runlength_encode(
     return run_count
 
 
+def _array_reduce_host_zero(dtype):
+    """Return the NumPy-shaped zero used by a whole-array host reduction."""
+    scalar_type = wp._src.types.type_scalar_type(dtype)
+    type_shape = getattr(dtype, "_shape_", ())
+    if not type_shape and wp._src.types.type_size(dtype) > 1:
+        type_shape = (wp._src.types.type_size(dtype),)
+    return np.zeros(type_shape, dtype=wp._src.types.dtype_to_numpy(scalar_type))[()]
+
+
+_APIC_REDUCTION_INT_MAX = (1 << 31) - 1
+
+
+def _validate_apic_array_reduction_layout(operation, inputs, out, axis, output_shape, scalar_size):
+    """Validate reduction metadata that crosses the native signed-int ABI."""
+    if axis is None:
+        reduction_strides = [wp._src.types.type_size_in_bytes(arr.dtype) for arr in inputs]
+    else:
+        reduction_strides = [arr.strides[axis] for arr in inputs]
+
+    if any(stride > _APIC_REDUCTION_INT_MAX for stride in reduction_strides):
+        raise RuntimeError(
+            f"APIC capture does not support {operation}() with a reduction stride greater than "
+            f"{_APIC_REDUCTION_INT_MAX} bytes"
+        )
+
+    participating_arrays = (*inputs, out)
+    if any(not arr.ptr or arr.ptr % scalar_size != 0 for arr in participating_arrays):
+        raise RuntimeError(f"APIC capture requires {operation}() input and output addresses to be scalar-aligned")
+
+    if axis is None:
+        return
+
+    layout_strides = []
+    for arr in inputs:
+        layout_strides.extend(stride for dim, stride in enumerate(arr.strides) if dim == axis or output_shape[dim] > 1)
+    layout_strides.extend(stride for dim, stride in enumerate(out.strides) if output_shape[dim] > 1)
+    if any(stride % scalar_size != 0 for stride in layout_strides):
+        raise RuntimeError(f"APIC capture requires {operation}() participating strides to be scalar-aligned")
+
+
 def array_sum(
     values: wp.array, out: wp.array | None = None, value_count: int | None = None, axis: int | None = None
 ) -> wp.array | float:
@@ -475,8 +515,15 @@ def array_sum(
     This function computes the sum of array elements, optionally along a specified axis.
     The operation can be performed on the entire array or along a specific dimension.
 
+    During matching-device APIC graph capture, non-empty calls require an explicit
+    ``out`` array so replay can store the current result. Existing whole-array,
+    explicit-count, composite-dtype, and positive-stride axis reductions are
+    recorded. Negative strides raise ``NotImplementedError`` during APIC capture.
+    Counts and reduction strides must fit the native signed 32-bit ABI, and
+    participating addresses and strides must be aligned to the scalar type.
+
     Args:
-        values: Input array to sum. Must be of type ``float32`` or ``float64``.
+        values: Input array to sum. Its scalar type must be ``float32`` or ``float64``.
         out: Output array to store results. If ``None``, a new array is created.
         value_count: Number of elements to process. If ``None``, processes entire array.
         axis: Axis along which to compute sum. If ``None``, computes sum of all elements.
@@ -486,7 +533,11 @@ def array_sum(
         otherwise returns the ``out`` array.
 
     Raises:
-        RuntimeError: If output array storage device or data type is incompatible with input array.
+        RuntimeError: If output array storage device or data type is incompatible with input array, or if a
+            matching-device APIC-captured call uses a count or layout that the native reduction ABI cannot represent.
+        NotImplementedError: If a non-empty call under matching-device APIC graph capture omits ``out``. Also raised
+            if any input or output array has a negative stride under matching-device APIC graph capture, including
+            for a zero-count call.
     """
     if value_count is None:
         if axis is None:
@@ -503,11 +554,30 @@ def array_sum(
 
         output_shape = tuple(output_dim(ax, dim) for ax, dim in enumerate(values.shape))
 
+    has_reduction_work = value_count > 0 and all(dim > 0 for dim in output_shape)
     type_size = wp._src.types.type_size(values.dtype)
     scalar_type = wp._src.types.type_scalar_type(values.dtype)
 
-    # User can provide a device output array for storing the number of runs
-    # For convenience, if no such array is provided, number of runs is returned on host
+    apic_capture = context._get_apic_capture_for_device(values.device)
+    if apic_capture is not None:
+        if value_count < 0:
+            raise RuntimeError("APIC capture does not support array_sum() with a negative count")
+        if value_count > _APIC_REDUCTION_INT_MAX:
+            raise RuntimeError(
+                f"APIC capture does not support array_sum() with a count greater than {_APIC_REDUCTION_INT_MAX}"
+            )
+        if has_reduction_work and out is None:
+            raise NotImplementedError("APIC capture requires array_sum() to receive an explicit out array")
+        if any(stride < 0 for stride in values.strides) or (
+            out is not None and any(stride < 0 for stride in out.strides)
+        ):
+            raise NotImplementedError("APIC capture does not support array_sum() with negative strides")
+
+    if apic_capture is not None and value_count == 0 and out is None and axis is None:
+        return _array_reduce_host_zero(values.dtype)
+
+    # Users can provide a device output array for storing the sum result.
+    # For convenience, if no output array is provided, the result is returned on the host.
     if out is None:
         host_return = True
         out = wp.empty(shape=output_shape, dtype=values.dtype, device=values.device)
@@ -520,26 +590,31 @@ def array_sum(
         if out.shape != output_shape:
             raise RuntimeError(f"out array should have shape {output_shape}")
 
+    if apic_capture is not None:
+        if has_reduction_work:
+            scalar_size = wp._src.types.type_size_in_bytes(scalar_type)
+            _validate_apic_array_reduction_layout("array_sum", (values,), out, axis, output_shape, scalar_size)
+        apic_capture.track_array(values)
+        apic_capture.track_array(out)
+
     if value_count == 0:
         out.zero_()
         if axis is None and host_return:
             return out.numpy()[0]
         return out
 
-    from warp._src.context import runtime  # noqa: PLC0415
-
     if values.device.is_cpu:
         if scalar_type == wp.float32:
-            native_func = runtime.core.wp_array_sum_float_host
+            native_func = context.runtime.core.wp_array_sum_float_host
         elif scalar_type == wp.float64:
-            native_func = runtime.core.wp_array_sum_double_host
+            native_func = context.runtime.core.wp_array_sum_double_host
         else:
             raise RuntimeError(f"Unsupported data type: {type_repr(values.dtype)}")
     elif values.device.is_cuda:
         if scalar_type == wp.float32:
-            native_func = runtime.core.wp_array_sum_float_device
+            native_func = context.runtime.core.wp_array_sum_float_device
         elif scalar_type == wp.float64:
-            native_func = runtime.core.wp_array_sum_double_device
+            native_func = context.runtime.core.wp_array_sum_double_device
         else:
             raise RuntimeError(f"Unsupported data type: {type_repr(values.dtype)}")
 
@@ -575,6 +650,13 @@ def array_inner(
     This function computes the dot product between two arrays, optionally along a specified axis.
     The operation can be performed on the entire arrays or along a specific dimension.
 
+    During matching-device APIC graph capture, non-empty calls require an explicit
+    ``out`` array so replay can store the current result. Existing whole-array,
+    explicit-count, composite-dtype, and positive-stride axis reductions are
+    recorded. Negative strides raise ``NotImplementedError`` during APIC capture.
+    Counts and reduction strides must fit the native signed 32-bit ABI, and
+    participating addresses and strides must be aligned to the scalar type.
+
     Args:
         a: First input array.
         b: Second input array. Must match shape and type of a.
@@ -587,7 +669,11 @@ def array_inner(
         otherwise returns the ``out`` array.
 
     Raises:
-        RuntimeError: If array storage devices, sizes, or data types are incompatible.
+        RuntimeError: If array storage devices, sizes, or data types are incompatible, or if a matching-device
+            APIC-captured call uses a count or layout that the native reduction ABI cannot represent.
+        NotImplementedError: If a non-empty call under matching-device APIC graph capture omits ``out``. Also raised
+            if any input or output array has a negative stride under matching-device APIC graph capture, including
+            for a zero-count call.
     """
     if a.size != b.size:
         raise RuntimeError(f"A and b array storage sizes do not match ({a.size} vs {b.size})")
@@ -613,11 +699,27 @@ def array_inner(
 
         output_shape = tuple(output_dim(ax, dim) for ax, dim in enumerate(a.shape))
 
+    has_reduction_work = count > 0 and all(dim > 0 for dim in output_shape)
     type_size = wp._src.types.type_size(a.dtype)
     scalar_type = wp._src.types.type_scalar_type(a.dtype)
 
-    # User can provide a device output array for storing the number of runs
-    # For convenience, if no such array is provided, number of runs is returned on host
+    apic_capture = context._get_apic_capture_for_device(a.device)
+    if apic_capture is not None:
+        if count < 0:
+            raise RuntimeError("APIC capture does not support array_inner() with a negative count")
+        if count > _APIC_REDUCTION_INT_MAX:
+            raise RuntimeError(
+                f"APIC capture does not support array_inner() with a count greater than {_APIC_REDUCTION_INT_MAX}"
+            )
+        if has_reduction_work and out is None:
+            raise NotImplementedError("APIC capture requires array_inner() to receive an explicit out array")
+        has_negative_stride = any(stride < 0 for stride in a.strides) or any(stride < 0 for stride in b.strides)
+        has_negative_stride = has_negative_stride or (out is not None and any(stride < 0 for stride in out.strides))
+        if has_negative_stride:
+            raise NotImplementedError("APIC capture does not support array_inner() with negative strides")
+
+    # Users can provide a device output array for storing the inner-product result.
+    # For convenience, if no output array is provided, the result is returned on the host.
     if out is None:
         host_return = True
         out = wp.empty(shape=output_shape, dtype=scalar_type, device=a.device)
@@ -630,26 +732,32 @@ def array_inner(
         if out.shape != output_shape:
             raise RuntimeError(f"out array should have shape {output_shape}")
 
+    if apic_capture is not None:
+        if has_reduction_work:
+            scalar_size = wp._src.types.type_size_in_bytes(scalar_type)
+            _validate_apic_array_reduction_layout("array_inner", (a, b), out, axis, output_shape, scalar_size)
+        apic_capture.track_array(a)
+        apic_capture.track_array(b)
+        apic_capture.track_array(out)
+
     if count == 0:
         if axis is None and host_return:
             return 0.0
         out.zero_()
         return out
 
-    from warp._src.context import runtime  # noqa: PLC0415
-
     if a.device.is_cpu:
         if scalar_type == wp.float32:
-            native_func = runtime.core.wp_array_inner_float_host
+            native_func = context.runtime.core.wp_array_inner_float_host
         elif scalar_type == wp.float64:
-            native_func = runtime.core.wp_array_inner_double_host
+            native_func = context.runtime.core.wp_array_inner_double_host
         else:
             raise RuntimeError(f"Unsupported data type: {type_repr(a.dtype)}")
     elif a.device.is_cuda:
         if scalar_type == wp.float32:
-            native_func = runtime.core.wp_array_inner_float_device
+            native_func = context.runtime.core.wp_array_inner_float_device
         elif scalar_type == wp.float64:
-            native_func = runtime.core.wp_array_inner_double_device
+            native_func = context.runtime.core.wp_array_inner_double_device
         else:
             raise RuntimeError(f"Unsupported data type: {type_repr(a.dtype)}")
 

--- a/warp/native/apic.cpp
+++ b/warp/native/apic.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <climits>
 #include <cstddef>  // offsetof
 #include <cstdint>  // SIZE_MAX
 #include <cstdio>
@@ -481,6 +482,43 @@ void apic_record_scan(
     rec.type_len = type_len;
     rec.dtype = dtype;
     rec.inclusive = inclusive;
+    state->append_bytes(&rec, sizeof(rec));
+    state->operation_count++;
+}
+
+void apic_record_reduction(
+    APICState* state,
+    int32_t input_a_region_id,
+    uint64_t input_a_offset,
+    int32_t input_b_region_id,
+    uint64_t input_b_offset,
+    int32_t output_region_id,
+    uint64_t output_offset,
+    uint32_t count,
+    int32_t input_a_stride,
+    int32_t input_b_stride,
+    int32_t type_len,
+    uint8_t kind,
+    uint8_t dtype
+)
+{
+    if (!state)
+        return;
+    APICReductionRecord rec = {};
+    rec.header.op_type = APIC_OP_REDUCTION;
+    rec.header.total_size = sizeof(rec);
+    rec.input_a_region_id = input_a_region_id;
+    rec.input_b_region_id = input_b_region_id;
+    rec.output_region_id = output_region_id;
+    rec.count = count;
+    rec.input_a_offset = input_a_offset;
+    rec.input_b_offset = input_b_offset;
+    rec.output_offset = output_offset;
+    rec.input_a_stride = input_a_stride;
+    rec.input_b_stride = input_b_stride;
+    rec.type_len = type_len;
+    rec.kind = kind;
+    rec.dtype = dtype;
     state->append_bytes(&rec, sizeof(rec));
     state->operation_count++;
 }
@@ -1237,6 +1275,14 @@ static bool apic_mul_check(uint64_t a, uint64_t b, uint64_t* out)
     return true;
 }
 
+static bool apic_add_check(uint64_t a, uint64_t b, uint64_t* out)
+{
+    if (a > UINT64_MAX - b)
+        return false;
+    *out = a + b;
+    return true;
+}
+
 // Walks the byte stream once and verifies every record fits in bounds, its
 // variable-length fields don't overflow its declared total_size, and the
 // op_type is recognized. Called once at stream-close time (end of recording
@@ -1442,6 +1488,46 @@ bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t o
                     fprintf(stderr, "APIC: Error - scan span overflow at operation %u\n", i);
                     return false;
                 }
+            }
+            break;
+        }
+        case APIC_OP_REDUCTION: {
+            if (header->total_size != sizeof(APICReductionRecord) || op_end < op_start + sizeof(APICReductionRecord)) {
+                fprintf(stderr, "APIC: Error - reduction record size invalid at operation %u\n", i);
+                return false;
+            }
+            const APICReductionRecord* rec = reinterpret_cast<const APICReductionRecord*>(ptr);
+            bool is_sum = rec->kind == APIC_REDUCTION_SUM;
+            bool is_inner = rec->kind == APIC_REDUCTION_INNER;
+            if ((!is_sum && !is_inner) || (rec->dtype != APIC_TYPE_FLOAT32 && rec->dtype != APIC_TYPE_FLOAT64)
+                || rec->count == 0 || rec->count > static_cast<uint32_t>(INT_MAX) || rec->type_len <= 0
+                || rec->input_a_stride < 0 || rec->input_a_region_id < 0 || rec->output_region_id < 0
+                || (is_sum && (rec->input_b_region_id != -1 || rec->input_b_offset != 0 || rec->input_b_stride != 0))
+                || (is_inner && (rec->input_b_region_id < 0 || rec->input_b_stride < 0))) {
+                fprintf(stderr, "APIC: Error - invalid reduction metadata at operation %u\n", i);
+                return false;
+            }
+
+            uint64_t scalar_size = apic_type_size(rec->dtype);
+            if (rec->input_a_offset % scalar_size != 0 || rec->output_offset % scalar_size != 0
+                || rec->input_a_stride % scalar_size != 0
+                || (is_inner && (rec->input_b_offset % scalar_size != 0 || rec->input_b_stride % scalar_size != 0))) {
+                fprintf(stderr, "APIC: Error - misaligned reduction metadata at operation %u\n", i);
+                return false;
+            }
+            uint64_t input_a_bytes
+                = apic_reduction_input_bytes(rec->count, rec->input_a_stride, rec->type_len, scalar_size);
+            uint64_t input_b_bytes = is_inner
+                ? apic_reduction_input_bytes(rec->count, rec->input_b_stride, rec->type_len, scalar_size)
+                : 0;
+            uint64_t output_bytes = is_sum ? static_cast<uint64_t>(rec->type_len) * scalar_size : scalar_size;
+            uint64_t span_end;
+            if (input_a_bytes == 0 || output_bytes == 0 || (is_inner && input_b_bytes == 0)
+                || !apic_add_check(rec->input_a_offset, input_a_bytes, &span_end)
+                || !apic_add_check(rec->output_offset, output_bytes, &span_end)
+                || (is_inner && !apic_add_check(rec->input_b_offset, input_b_bytes, &span_end))) {
+                fprintf(stderr, "APIC: Error - reduction span overflow at operation %u\n", i);
+                return false;
             }
             break;
         }
@@ -1913,6 +1999,55 @@ static bool apic_cpu_replay_stream(
                     reinterpret_cast<uint64_t>(src), reinterpret_cast<uint64_t>(dst), static_cast<int>(rec->length),
                     rec->in_stride, rec->out_stride, rec->type_len, rec->inclusive != 0
                 );
+            }
+            break;
+        }
+
+        case APIC_OP_REDUCTION: {
+            const APICReductionRecord* rec = reinterpret_cast<const APICReductionRecord*>(ptr);
+            size_t scalar_size = apic_type_size(rec->dtype);
+            size_t input_a_bytes
+                = apic_reduction_input_bytes(rec->count, rec->input_a_stride, rec->type_len, scalar_size);
+            size_t input_b_bytes = rec->kind == APIC_REDUCTION_INNER
+                ? apic_reduction_input_bytes(rec->count, rec->input_b_stride, rec->type_len, scalar_size)
+                : 0;
+            size_t output_bytes
+                = rec->kind == APIC_REDUCTION_SUM ? static_cast<size_t>(rec->type_len) * scalar_size : scalar_size;
+
+            const void* input_a = resolve_ptr(rec->input_a_region_id, rec->input_a_offset, input_a_bytes);
+            const void* input_b = rec->kind == APIC_REDUCTION_INNER
+                ? resolve_ptr(rec->input_b_region_id, rec->input_b_offset, input_b_bytes)
+                : nullptr;
+            void* output = resolve_ptr(rec->output_region_id, rec->output_offset, output_bytes);
+            if (!input_a || !output || (rec->kind == APIC_REDUCTION_INNER && !input_b)) {
+                fprintf(stderr, "APIC: Error - reduction pointer resolution failed at operation %u\n", i);
+                return false;
+            }
+
+            if (rec->kind == APIC_REDUCTION_SUM) {
+                if (rec->dtype == APIC_TYPE_FLOAT32)
+                    wp_array_sum_float_host(
+                        reinterpret_cast<uint64_t>(input_a), reinterpret_cast<uint64_t>(output),
+                        static_cast<int>(rec->count), rec->input_a_stride, rec->type_len
+                    );
+                else
+                    wp_array_sum_double_host(
+                        reinterpret_cast<uint64_t>(input_a), reinterpret_cast<uint64_t>(output),
+                        static_cast<int>(rec->count), rec->input_a_stride, rec->type_len
+                    );
+            } else {
+                if (rec->dtype == APIC_TYPE_FLOAT32)
+                    wp_array_inner_float_host(
+                        reinterpret_cast<uint64_t>(input_a), reinterpret_cast<uint64_t>(input_b),
+                        reinterpret_cast<uint64_t>(output), static_cast<int>(rec->count), rec->input_a_stride,
+                        rec->input_b_stride, rec->type_len
+                    );
+                else
+                    wp_array_inner_double_host(
+                        reinterpret_cast<uint64_t>(input_a), reinterpret_cast<uint64_t>(input_b),
+                        reinterpret_cast<uint64_t>(output), static_cast<int>(rec->count), rec->input_a_stride,
+                        rec->input_b_stride, rec->type_len
+                    );
             }
             break;
         }

--- a/warp/native/apic.cu
+++ b/warp/native/apic.cu
@@ -580,6 +580,58 @@ static bool apic_replay_ops_into_cuda_capture(
             break;
         }
 
+        case APIC_OP_REDUCTION: {
+            const APICReductionRecord* rec = reinterpret_cast<const APICReductionRecord*>(ptr);
+            size_t scalar_size = apic_type_size(rec->dtype);
+            size_t input_a_bytes
+                = apic_reduction_input_bytes(rec->count, rec->input_a_stride, rec->type_len, scalar_size);
+            size_t input_b_bytes = rec->kind == APIC_REDUCTION_INNER
+                ? apic_reduction_input_bytes(rec->count, rec->input_b_stride, rec->type_len, scalar_size)
+                : 0;
+            size_t output_bytes
+                = rec->kind == APIC_REDUCTION_SUM ? static_cast<size_t>(rec->type_len) * scalar_size : scalar_size;
+
+            void* input_a = apic_resolve_region_ptr(graph, rec->input_a_region_id, rec->input_a_offset, input_a_bytes);
+            void* input_b = rec->kind == APIC_REDUCTION_INNER
+                ? apic_resolve_region_ptr(graph, rec->input_b_region_id, rec->input_b_offset, input_b_bytes)
+                : nullptr;
+            void* output = apic_resolve_region_ptr(graph, rec->output_region_id, rec->output_offset, output_bytes);
+            if (!input_a || !output || (rec->kind == APIC_REDUCTION_INNER && !input_b)) {
+                wp::set_error_string("APIC reduction: failed to resolve region (op %u)", i);
+                success = false;
+                break;
+            }
+
+            // Reissue the CUB entry points while stream capture is active to
+            // record native graph nodes. GPU work runs only at graph launch.
+            if (rec->kind == APIC_REDUCTION_SUM) {
+                if (rec->dtype == APIC_TYPE_FLOAT32)
+                    wp_array_sum_float_device(
+                        reinterpret_cast<uint64_t>(input_a), reinterpret_cast<uint64_t>(output),
+                        static_cast<int>(rec->count), rec->input_a_stride, rec->type_len
+                    );
+                else
+                    wp_array_sum_double_device(
+                        reinterpret_cast<uint64_t>(input_a), reinterpret_cast<uint64_t>(output),
+                        static_cast<int>(rec->count), rec->input_a_stride, rec->type_len
+                    );
+            } else {
+                if (rec->dtype == APIC_TYPE_FLOAT32)
+                    wp_array_inner_float_device(
+                        reinterpret_cast<uint64_t>(input_a), reinterpret_cast<uint64_t>(input_b),
+                        reinterpret_cast<uint64_t>(output), static_cast<int>(rec->count), rec->input_a_stride,
+                        rec->input_b_stride, rec->type_len
+                    );
+                else
+                    wp_array_inner_double_device(
+                        reinterpret_cast<uint64_t>(input_a), reinterpret_cast<uint64_t>(input_b),
+                        reinterpret_cast<uint64_t>(output), static_cast<int>(rec->count), rec->input_a_stride,
+                        rec->input_b_stride, rec->type_len
+                    );
+            }
+            break;
+        }
+
         case APIC_OP_SEGMENTED_SORT: {
             const APICSegmentedSortRecord* rec = reinterpret_cast<const APICSegmentedSortRecord*>(ptr);
             size_t key_size = (rec->dtype == APIC_TYPE_INT32 ? sizeof(int32_t) : sizeof(float));
@@ -898,7 +950,7 @@ static bool apic_rebuild_cuda_graph(APICGraph* graph, CUstream stream)
         return false;
 
     // Use Warp's capture management (not a raw cudaStreamBeginCapture) so the
-    // allocator knows a capture is active. Extended ops (scan/sort/bsr) allocate
+    // allocator knows a capture is active. Extended ops (reduction/scan/sort/bsr) allocate
     // CUB scratch during capture; the allocator only routes those allocs/frees
     // to graph memory nodes when it sees an active Warp capture, otherwise it
     // would cudaFreeAsync on the null stream and invalidate the capture.
@@ -906,7 +958,7 @@ static bool apic_rebuild_cuda_graph(APICGraph* graph, CUstream stream)
         return false;
     }
 
-    // Extended ops (SCAN/SORT/RUNLENGTH/BSR/MEMTILE) issue their kernels on the
+    // Extended ops (REDUCTION/SCAN/SORT/RUNLENGTH/BSR/MEMTILE) issue their kernels on the
     // context's current stream rather than the passed stream. Point the current
     // stream at the capture stream so they are recorded into the graph, then
     // restore it after the replay loop.

--- a/warp/native/apic_internal.h
+++ b/warp/native/apic_internal.h
@@ -55,6 +55,47 @@ inline size_t apic_strided_access_bytes(uint32_t length, int32_t stride, int32_t
     return static_cast<size_t>(length - 1) * static_cast<size_t>(stride) + static_cast<size_t>(type_len) * scalar_size;
 }
 
+inline size_t apic_reduction_input_bytes(uint32_t count, int32_t stride, int32_t type_len, size_t scalar_size)
+{
+    if (count == 0 || stride < 0 || type_len <= 0 || scalar_size == 0)
+        return 0;
+
+    size_t count_minus_one = static_cast<size_t>(count - 1);
+    size_t byte_stride = static_cast<size_t>(stride);
+    size_t lanes = static_cast<size_t>(type_len);
+    if ((byte_stride != 0 && count_minus_one > SIZE_MAX / byte_stride) || lanes > SIZE_MAX / scalar_size)
+        return 0;
+
+    size_t strided_bytes = count_minus_one * byte_stride;
+    size_t value_bytes = lanes * scalar_size;
+    if (strided_bytes > SIZE_MAX - value_bytes)
+        return 0;
+    return strided_bytes + value_bytes;
+}
+
+inline bool apic_reduction_metadata_valid(
+    uint64_t input_a,
+    uint64_t input_b,
+    uint64_t output,
+    int32_t count,
+    int32_t input_a_stride,
+    int32_t input_b_stride,
+    int32_t type_len,
+    uint8_t kind,
+    uint8_t dtype
+)
+{
+    bool is_sum = kind == APIC_REDUCTION_SUM;
+    bool is_inner = kind == APIC_REDUCTION_INNER;
+    size_t scalar_size = apic_type_size(dtype);
+    return (is_sum || is_inner) && scalar_size > 0 && count > 0 && type_len > 0 && input_a != 0 && output != 0
+        && input_a_stride >= 0 && input_a % scalar_size == 0 && output % scalar_size == 0
+        && input_a_stride % scalar_size == 0
+        && ((is_sum && input_b == 0 && input_b_stride == 0)
+            || (is_inner && input_b != 0 && input_b_stride >= 0 && input_b % scalar_size == 0
+                && input_b_stride % scalar_size == 0));
+}
+
 namespace apic_detail {
 
 constexpr size_t launch_bounds_align8(size_t offset) { return (offset + 7) & ~size_t(7); }
@@ -300,6 +341,22 @@ void apic_record_scan(
     int32_t type_len,
     uint8_t dtype,
     uint8_t inclusive
+);
+
+void apic_record_reduction(
+    APICState* state,
+    int32_t input_a_region_id,
+    uint64_t input_a_offset,
+    int32_t input_b_region_id,
+    uint64_t input_b_offset,
+    int32_t output_region_id,
+    uint64_t output_offset,
+    uint32_t count,
+    int32_t input_a_stride,
+    int32_t input_b_stride,
+    int32_t type_len,
+    uint8_t kind,
+    uint8_t dtype
 );
 
 // Records a wp.utils.segmented_sort_pairs() call. dtype is the key

--- a/warp/native/apic_types.h
+++ b/warp/native/apic_types.h
@@ -10,7 +10,7 @@
 // APIC Format Constants
 // =============================================================================
 
-#define APIC_FORMAT_VERSION 14
+#define APIC_FORMAT_VERSION 15
 #define APIC_MIN_SUPPORTED_FORMAT_VERSION 13
 #define APIC_MAGIC "WRP1"
 #define APIC_MAGIC_VALUE 0x31505257  // "WRP1" as little-endian uint32
@@ -42,6 +42,12 @@ enum APICOpType : uint32_t {
     APIC_OP_RUNLENGTH_ENCODE = 13,  // wp.utils.runlength_encode
     APIC_OP_BSR_FROM_TRIPLETS = 14,  // wp_bsr_matrix_from_triplets_host
     APIC_OP_BSR_TRANSPOSE = 15,  // wp_bsr_transpose_host
+    APIC_OP_REDUCTION = 16,
+};
+
+enum APICReductionKind : uint8_t {
+    APIC_REDUCTION_SUM = 1,
+    APIC_REDUCTION_INNER = 2,
 };
 
 // Scalar element types
@@ -303,6 +309,24 @@ struct APICScanRecord {
     uint8_t inclusive;  // 1 = inclusive, 0 = exclusive
     uint8_t _pad[2];
 };
+
+struct APICReductionRecord {
+    APICOpHeader header;  // op_type = APIC_OP_REDUCTION
+    int32_t input_a_region_id;
+    int32_t input_b_region_id;  // -1 for APIC_REDUCTION_SUM
+    int32_t output_region_id;
+    uint32_t count;
+    uint64_t input_a_offset;
+    uint64_t input_b_offset;
+    uint64_t output_offset;
+    int32_t input_a_stride;
+    int32_t input_b_stride;  // 0 for APIC_REDUCTION_SUM
+    int32_t type_len;
+    uint8_t kind;  // APICReductionKind
+    uint8_t dtype;  // APICType: FLOAT32 or FLOAT64
+    uint8_t _pad[2];
+};  // 64 bytes
+static_assert(sizeof(APICReductionRecord) == 64, "APICReductionRecord must remain 64 bytes");
 
 // Segmented-sort op (fixed size). Records a wp.utils.segmented_sort_pairs()
 // call so replay re-sorts the current (replay-time) keys/values instead of

--- a/warp/native/reduce.cpp
+++ b/warp/native/reduce.cpp
@@ -3,6 +3,9 @@
 
 #include "warp.h"
 
+#include "apic.h"
+#include "apic_internal.h"
+
 namespace {
 
 // Specialized accumulation functions for common type sizes
@@ -32,6 +35,59 @@ template <typename T> void dyn_len_inner(const T* a, const T* b, T* dot, int val
     for (int i = 0; i < value_size; ++i, ++a, ++b) {
         *dot += *a * *b;
     }
+}
+
+static bool apic_capture_reduction_host(
+    uint64_t input_a,
+    uint64_t input_b,
+    uint64_t output,
+    int count,
+    int input_a_stride,
+    int input_b_stride,
+    int type_len,
+    uint8_t kind,
+    uint8_t dtype
+)
+{
+    APICState* state = wp_apic_get_recording_state();
+    if (!state)
+        return false;
+
+    if (!apic_reduction_metadata_valid(
+            input_a, input_b, output, count, input_a_stride, input_b_stride, type_len, kind, dtype
+        )) {
+        // Poison the byte stream so capture validation fails closed. Returning
+        // false here would execute the malformed reduction eagerly.
+        apic_record_reduction(
+            state, -1, 0, -1, 0, -1, 0, static_cast<uint32_t>(count), input_a_stride, input_b_stride, type_len, kind,
+            dtype
+        );
+        return true;
+    }
+
+    size_t scalar_size = apic_type_size(dtype);
+    size_t input_a_bytes = apic_reduction_input_bytes(count, input_a_stride, type_len, scalar_size);
+    size_t input_b_bytes
+        = kind == APIC_REDUCTION_INNER ? apic_reduction_input_bytes(count, input_b_stride, type_len, scalar_size) : 0;
+    size_t output_bytes = kind == APIC_REDUCTION_SUM ? static_cast<size_t>(type_len) * scalar_size : scalar_size;
+    if (input_a_bytes == 0 || output_bytes == 0 || (kind == APIC_REDUCTION_INNER && input_b_bytes == 0)) {
+        apic_record_reduction(
+            state, -1, 0, -1, 0, -1, 0, static_cast<uint32_t>(count), input_a_stride, input_b_stride, type_len, kind,
+            dtype
+        );
+        return true;
+    }
+
+    APICAddress input_a_addr = apic_resolve_host_ptr(state, input_a, input_a_bytes);
+    APICAddress input_b_addr
+        = kind == APIC_REDUCTION_INNER ? apic_resolve_host_ptr(state, input_b, input_b_bytes) : APICAddress { -1, 0 };
+    APICAddress output_addr = apic_resolve_host_ptr(state, output, output_bytes);
+    apic_record_reduction(
+        state, input_a_addr.region_id, input_a_addr.offset, input_b_addr.region_id, input_b_addr.offset,
+        output_addr.region_id, output_addr.offset, static_cast<uint32_t>(count), input_a_stride, input_b_stride,
+        type_len, kind, dtype
+    );
+    return true;
 }
 
 }  // namespace
@@ -102,6 +158,11 @@ void wp_array_inner_float_host(
     uint64_t a, uint64_t b, uint64_t out, int count, int byte_stride_a, int byte_stride_b, int type_length
 )
 {
+    if (apic_capture_reduction_host(
+            a, b, out, count, byte_stride_a, byte_stride_b, type_length, APIC_REDUCTION_INNER, APIC_TYPE_FLOAT32
+        ))
+        return;
+
     const float* ptr_a = (const float*)(a);
     const float* ptr_b = (const float*)(b);
     float* ptr_out = (float*)(out);
@@ -113,6 +174,11 @@ void wp_array_inner_double_host(
     uint64_t a, uint64_t b, uint64_t out, int count, int byte_stride_a, int byte_stride_b, int type_length
 )
 {
+    if (apic_capture_reduction_host(
+            a, b, out, count, byte_stride_a, byte_stride_b, type_length, APIC_REDUCTION_INNER, APIC_TYPE_FLOAT64
+        ))
+        return;
+
     const double* ptr_a = (const double*)(a);
     const double* ptr_b = (const double*)(b);
     double* ptr_out = (double*)(out);
@@ -122,6 +188,11 @@ void wp_array_inner_double_host(
 
 void wp_array_sum_float_host(uint64_t a, uint64_t out, int count, int byte_stride_a, int type_length)
 {
+    if (apic_capture_reduction_host(
+            a, 0, out, count, byte_stride_a, 0, type_length, APIC_REDUCTION_SUM, APIC_TYPE_FLOAT32
+        ))
+        return;
+
     const float* ptr_a = (const float*)(a);
     float* ptr_out = (float*)(out);
     array_sum_host(ptr_a, ptr_out, count, byte_stride_a, type_length);
@@ -129,6 +200,11 @@ void wp_array_sum_float_host(uint64_t a, uint64_t out, int count, int byte_strid
 
 void wp_array_sum_double_host(uint64_t a, uint64_t out, int count, int byte_stride_a, int type_length)
 {
+    if (apic_capture_reduction_host(
+            a, 0, out, count, byte_stride_a, 0, type_length, APIC_REDUCTION_SUM, APIC_TYPE_FLOAT64
+        ))
+        return;
+
     const double* ptr_a = (const double*)(a);
     double* ptr_out = (double*)(out);
     array_sum_host(ptr_a, ptr_out, count, byte_stride_a, type_length);

--- a/warp/native/reduce.cu
+++ b/warp/native/reduce.cu
@@ -3,6 +3,8 @@
 
 #include "warp.h"
 
+#include "apic.h"
+#include "apic_internal.h"
 #include "cuda_util.h"
 #include "temp_buffer.h"
 
@@ -274,10 +276,68 @@ void array_inner_device_dispatch(
 
 }  // anonymous namespace
 
+// Record metadata, then continue through CUB so its CUDA operations become
+// native graph nodes. Stream capture defers device execution until graph launch.
+static void apic_capture_reduction_device(
+    uint64_t input_a,
+    uint64_t input_b,
+    uint64_t output,
+    int count,
+    int input_a_stride,
+    int input_b_stride,
+    int type_len,
+    uint8_t kind,
+    uint8_t dtype
+)
+{
+    APICState* state = wp_apic_get_cuda_recording_state();
+    if (!state)
+        return;
+
+    if (!apic_reduction_metadata_valid(
+            input_a, input_b, output, count, input_a_stride, input_b_stride, type_len, kind, dtype
+        )) {
+        // Keep the native CUDA capture path running, but poison the APIC byte
+        // stream so malformed metadata cannot produce a loadable graph.
+        apic_record_reduction(
+            state, -1, 0, -1, 0, -1, 0, static_cast<uint32_t>(count), input_a_stride, input_b_stride, type_len, kind,
+            dtype
+        );
+        return;
+    }
+
+    size_t scalar_size = apic_type_size(dtype);
+    size_t input_a_bytes = apic_reduction_input_bytes(count, input_a_stride, type_len, scalar_size);
+    size_t input_b_bytes
+        = kind == APIC_REDUCTION_INNER ? apic_reduction_input_bytes(count, input_b_stride, type_len, scalar_size) : 0;
+    size_t output_bytes = kind == APIC_REDUCTION_SUM ? static_cast<size_t>(type_len) * scalar_size : scalar_size;
+    if (input_a_bytes == 0 || output_bytes == 0 || (kind == APIC_REDUCTION_INNER && input_b_bytes == 0)) {
+        apic_record_reduction(
+            state, -1, 0, -1, 0, -1, 0, static_cast<uint32_t>(count), input_a_stride, input_b_stride, type_len, kind,
+            dtype
+        );
+        return;
+    }
+
+    APICAddress input_a_addr = apic_resolve_live_ptr(state, input_a, input_a_bytes);
+    APICAddress input_b_addr
+        = kind == APIC_REDUCTION_INNER ? apic_resolve_live_ptr(state, input_b, input_b_bytes) : APICAddress { -1, 0 };
+    APICAddress output_addr = apic_resolve_live_ptr(state, output, output_bytes);
+    apic_record_reduction(
+        state, input_a_addr.region_id, input_a_addr.offset, input_b_addr.region_id, input_b_addr.offset,
+        output_addr.region_id, output_addr.offset, static_cast<uint32_t>(count), input_a_stride, input_b_stride,
+        type_len, kind, dtype
+    );
+}
+
 void wp_array_inner_float_device(
     uint64_t a, uint64_t b, uint64_t out, int count, int byte_stride_a, int byte_stride_b, int type_len
 )
 {
+    apic_capture_reduction_device(
+        a, b, out, count, byte_stride_a, byte_stride_b, type_len, APIC_REDUCTION_INNER, APIC_TYPE_FLOAT32
+    );
+
     void* context = wp_cuda_context_get_current();
 
     const float* ptr_a = (const float*)(a);
@@ -291,6 +351,10 @@ void wp_array_inner_double_device(
     uint64_t a, uint64_t b, uint64_t out, int count, int byte_stride_a, int byte_stride_b, int type_len
 )
 {
+    apic_capture_reduction_device(
+        a, b, out, count, byte_stride_a, byte_stride_b, type_len, APIC_REDUCTION_INNER, APIC_TYPE_FLOAT64
+    );
+
     const double* ptr_a = (const double*)(a);
     const double* ptr_b = (const double*)(b);
     double* ptr_out = (double*)(out);
@@ -300,6 +364,8 @@ void wp_array_inner_double_device(
 
 void wp_array_sum_float_device(uint64_t a, uint64_t out, int count, int byte_stride, int type_length)
 {
+    apic_capture_reduction_device(a, 0, out, count, byte_stride, 0, type_length, APIC_REDUCTION_SUM, APIC_TYPE_FLOAT32);
+
     const float* ptr_a = (const float*)(a);
     float* ptr_out = (float*)(out);
     array_sum_device_dispatch(ptr_a, ptr_out, count, byte_stride, type_length);
@@ -307,6 +373,8 @@ void wp_array_sum_float_device(uint64_t a, uint64_t out, int count, int byte_str
 
 void wp_array_sum_double_device(uint64_t a, uint64_t out, int count, int byte_stride, int type_length)
 {
+    apic_capture_reduction_device(a, 0, out, count, byte_stride, 0, type_length, APIC_REDUCTION_SUM, APIC_TYPE_FLOAT64);
+
     const double* ptr_a = (const double*)(a);
     double* ptr_out = (double*)(out);
     array_sum_device_dispatch(ptr_a, ptr_out, count, byte_stride, type_length);

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -58,6 +58,13 @@ def fill_runs_kernel(values: wp.array(dtype=wp.int32)):
     values[i] = i // 3
 
 
+@wp.kernel
+def fill_reduction_inputs_kernel(a: wp.array[wp.float32], b: wp.array[wp.float32]):
+    i = wp.tid()
+    a[i] = float(i + 1)
+    b[i] = float(2 * i + 1)
+
+
 class TestApic(unittest.TestCase):
     pass
 
@@ -1566,6 +1573,89 @@ def test_capture_with_array_scan(test, device):
     np.testing.assert_allclose(dst_ex.numpy(), np.arange(0, n, dtype=np.int32))
 
 
+def test_capture_with_array_reductions(test, device):
+    """Replay captured array reductions."""
+    n = 8
+    a = wp.zeros(n, dtype=wp.float32, device=device)
+    b = wp.zeros(n, dtype=wp.float32, device=device)
+    sum_out = wp.full(1, -1.0, dtype=wp.float32, device=device)
+    inner_out = wp.full(1, -1.0, dtype=wp.float32, device=device)
+
+    wp.load_module(device=device)
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        wp.launch(fill_reduction_inputs_kernel, dim=n, inputs=[a, b], device=device)
+        wp.utils.array_sum(a, out=sum_out)
+        wp.utils.array_inner(a, b, out=inner_out)
+
+    np.testing.assert_array_equal(sum_out.numpy(), np.array([-1.0], dtype=np.float32))
+    np.testing.assert_array_equal(inner_out.numpy(), np.array([-1.0], dtype=np.float32))
+
+    wp.capture_launch(capture.graph)
+
+    expected_a = np.arange(1, n + 1, dtype=np.float32)
+    expected_b = np.arange(1, 2 * n, 2, dtype=np.float32)
+    np.testing.assert_allclose(sum_out.numpy(), np.array([expected_a.sum()], dtype=np.float32))
+    np.testing.assert_allclose(inner_out.numpy(), np.array([expected_a @ expected_b], dtype=np.float32))
+
+
+def test_array_reduction_capture_errors(test, device):
+    """Reject unsupported array reductions during capture."""
+    values = wp.array([1.0, 2.0, 3.0], dtype=wp.float32, device=device)
+    reversed_values = wp.array(
+        ptr=values.ptr + 2 * values.strides[0],
+        dtype=values.dtype,
+        shape=values.shape,
+        strides=(-values.strides[0],),
+        capacity=values.capacity,
+        device=device,
+    )
+    reversed_values._ref = values
+    out = wp.zeros(1, dtype=wp.float32, device=device)
+
+    wp.load_module(device=device)
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False):
+        out.zero_()
+        with test.assertRaisesRegex(NotImplementedError, r"array_sum\(\).*explicit out"):
+            wp.utils.array_sum(values)
+        with test.assertRaisesRegex(NotImplementedError, r"array_inner\(\).*explicit out"):
+            wp.utils.array_inner(values, values)
+        with test.assertRaisesRegex(NotImplementedError, r"array_sum\(\).*negative strides"):
+            wp.utils.array_sum(reversed_values, out=out, axis=0)
+        with test.assertRaisesRegex(NotImplementedError, r"array_inner\(\).*negative strides"):
+            wp.utils.array_inner(reversed_values, reversed_values, out=out, axis=0)
+        with test.assertRaisesRegex(RuntimeError, r"array_sum\(\).*negative count"):
+            wp.utils.array_sum(values, out=out, value_count=-1)
+        with test.assertRaisesRegex(RuntimeError, r"array_inner\(\).*negative count"):
+            wp.utils.array_inner(values, values, out=out, count=-1)
+
+
+def test_empty_array_reductions_during_capture(test, device):
+    """Preserve empty array-reduction behavior during capture."""
+    empty_vector = wp.empty(0, dtype=wp.vec2, device=device)
+    empty_matrix = wp.empty((0, 3), dtype=wp.float32, device=device)
+    seed = wp.zeros(1, dtype=wp.float32, device=device)
+
+    wp.load_module(device=device)
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False):
+        seed.zero_()
+        operation_count = wp_context.runtime._apic_capture.operation_count
+
+        sum_result = wp.utils.array_sum(empty_vector)
+        inner_result = wp.utils.array_inner(empty_vector, empty_vector)
+        axis_sum = wp.utils.array_sum(empty_matrix, axis=1)
+        axis_inner = wp.utils.array_inner(empty_matrix, empty_matrix, axis=1)
+
+        test.assertEqual(wp_context.runtime._apic_capture.operation_count, operation_count)
+
+    np.testing.assert_array_equal(sum_result, np.zeros(2, dtype=np.float32))
+    test.assertEqual(inner_result, 0.0)
+    for result in (axis_sum, axis_inner):
+        test.assertEqual(result.shape, (0, 1))
+        test.assertEqual(result.dtype, wp.float32)
+        test.assertEqual(result.device, device)
+        np.testing.assert_array_equal(result.numpy(), np.empty((0, 1), dtype=np.float32))
+
+
 def test_cpu_helper_not_recorded_during_cuda_capture(test, device):
     """A CPU host helper invoked during a CUDA APIC capture must execute live,
     not record into the CUDA byte stream. The native host hooks are gated on the
@@ -1585,6 +1675,25 @@ def test_cpu_helper_not_recorded_during_cuda_capture(test, device):
     # If the CPU scan had been recorded (and thus deferred) into the CUDA capture
     # instead of executing live, dst would still be all zeros here.
     np.testing.assert_allclose(dst.numpy(), np.arange(1, n + 1, dtype=np.int32))
+
+
+def test_array_reduction_cpu_not_recorded_during_cuda_capture(test, device):
+    """Execute CPU array reductions during CUDA capture."""
+    a_np = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    b_np = np.array([4.0, 5.0, 6.0], dtype=np.float32)
+    a = wp.array(a_np, dtype=wp.float32, device="cpu")
+    b = wp.array(b_np, dtype=wp.float32, device="cpu")
+    sum_out = wp.full(1, -1.0, dtype=wp.float32, device="cpu")
+    inner_out = wp.full(1, -1.0, dtype=wp.float32, device="cpu")
+    cuda_marker = wp.zeros(1, dtype=wp.float32, device=device)
+
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False):
+        cuda_marker.fill_(1.0)
+        wp.utils.array_sum(a, out=sum_out)
+        wp.utils.array_inner(a, b, out=inner_out)
+
+    np.testing.assert_allclose(sum_out.numpy(), np.array([a_np.sum()], dtype=np.float32))
+    np.testing.assert_allclose(inner_out.numpy(), np.array([a_np @ b_np], dtype=np.float32))
 
 
 def test_capture_pause_resume_allows_unrecorded_allocation(test, device):
@@ -1705,6 +1814,110 @@ def test_bsr_status_sync_during_cpu_apic_capture_rejected(test, device):
     with test.assertRaisesRegex(NotImplementedError, "CPU APIC graph capture"):
         with wp.ScopedCapture(device=device, apic=True, force_module_load=False):
             bsr.status_sync()
+
+
+def test_save_load_array_reductions(test, device):
+    """Replay saved array reductions with updated inputs."""
+    original_a = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    original_b = np.array([2.0, 4.0, 6.0, 8.0], dtype=np.float32)
+    updated_a = np.array([5.0, 1.0, 4.0, 2.0], dtype=np.float32)
+    updated_b = np.array([3.0, 7.0, 2.0, 6.0], dtype=np.float32)
+
+    a = wp.array(original_a, dtype=wp.float32, device=device)
+    b = wp.array(original_b, dtype=wp.float32, device=device)
+    sum_out = wp.zeros(1, dtype=wp.float32, device=device)
+    inner_out = wp.zeros(1, dtype=wp.float32, device=device)
+
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        wp.utils.array_sum(a, out=sum_out)
+        wp.utils.array_inner(a, b, out=inner_out)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "array_reductions")
+        wp.capture_save(
+            capture.graph,
+            path,
+            inputs={"a": a, "b": b},
+            outputs={"sum_out": sum_out, "inner_out": inner_out},
+        )
+
+        loaded = wp.capture_load(path, device=device)
+        loaded.set_param("a", wp.array(updated_a, dtype=wp.float32, device=device))
+        loaded.set_param("b", wp.array(updated_b, dtype=wp.float32, device=device))
+        wp.capture_launch(loaded)
+
+        loaded_sum = wp.zeros_like(sum_out)
+        loaded_inner = wp.zeros_like(inner_out)
+        loaded.get_param("sum_out", loaded_sum)
+        loaded.get_param("inner_out", loaded_inner)
+
+    np.testing.assert_allclose(loaded_sum.numpy(), np.array([updated_a.sum()], dtype=np.float32))
+    np.testing.assert_allclose(loaded_inner.numpy(), np.array([updated_a @ updated_b], dtype=np.float32))
+
+
+def test_save_load_array_reduction_metadata(test, device):
+    """Preserve array-reduction metadata through save and load."""
+    base_np = np.arange(1.0, 13.0, dtype=np.float64)
+    other_np = np.arange(13.0, 25.0, dtype=np.float64)
+    updated_base_np = np.arange(101.0, 113.0, dtype=np.float64)
+    updated_other_np = np.arange(211.0, 223.0, dtype=np.float64)
+    base = wp.array(base_np, dtype=wp.float64, device=device)
+    other = wp.array(other_np, dtype=wp.float64, device=device)
+    strided = base[1::2]
+    other_strided = other[1::2]
+
+    vec_np = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float64)
+    updated_vec_np = np.array([[7.0, 1.0, 2.0], [3.0, 4.0, 5.0]], dtype=np.float64)
+    vec = wp.array(vec_np, dtype=wp.vec3d, device=device)
+    matrix_np = np.arange(1.0, 7.0, dtype=np.float32).reshape(2, 3)
+    updated_matrix_np = np.array([[9.0, 8.0, 7.0], [6.0, 5.0, 4.0]], dtype=np.float32)
+    matrix = wp.array(matrix_np, shape=(2, 3), dtype=wp.float32, device=device)
+
+    outputs = {
+        "strided_sum": wp.zeros(1, dtype=wp.float64, device=device),
+        "strided_inner": wp.zeros(1, dtype=wp.float64, device=device),
+        "vec_sum": wp.zeros(1, dtype=wp.vec3d, device=device),
+        "vec_inner": wp.zeros(1, dtype=wp.float64, device=device),
+        "axis_sum": wp.zeros((2, 1), dtype=wp.float32, device=device),
+        "axis_inner": wp.zeros((2, 1), dtype=wp.float32, device=device),
+    }
+
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        wp.utils.array_sum(strided, out=outputs["strided_sum"], value_count=3, axis=0)
+        wp.utils.array_inner(strided, other_strided, out=outputs["strided_inner"], count=3, axis=0)
+        wp.utils.array_sum(vec, out=outputs["vec_sum"])
+        wp.utils.array_inner(vec, vec, out=outputs["vec_inner"])
+        wp.utils.array_sum(matrix, out=outputs["axis_sum"], axis=1)
+        wp.utils.array_inner(matrix, matrix, out=outputs["axis_inner"], axis=1)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "array_reduction_metadata")
+        wp.capture_save(
+            capture.graph,
+            path,
+            inputs={"base": base, "other": other, "vec": vec, "matrix": matrix},
+            outputs=outputs,
+        )
+        loaded = wp.capture_load(path, device=device)
+        loaded.set_param("base", wp.array(updated_base_np, dtype=wp.float64, device=device))
+        loaded.set_param("other", wp.array(updated_other_np, dtype=wp.float64, device=device))
+        loaded.set_param("vec", wp.array(updated_vec_np, dtype=wp.vec3d, device=device))
+        loaded.set_param("matrix", wp.array(updated_matrix_np, shape=(2, 3), dtype=wp.float32, device=device))
+        wp.capture_launch(loaded)
+
+        results = {}
+        for name, output in outputs.items():
+            results[name] = wp.empty_like(output)
+            loaded.get_param(name, results[name])
+
+    np.testing.assert_allclose(results["strided_sum"].numpy(), [updated_base_np[1::2][:3].sum()])
+    np.testing.assert_allclose(
+        results["strided_inner"].numpy(), [updated_base_np[1::2][:3] @ updated_other_np[1::2][:3]]
+    )
+    np.testing.assert_allclose(results["vec_sum"].numpy(), updated_vec_np.sum(axis=0, keepdims=True))
+    np.testing.assert_allclose(results["vec_inner"].numpy(), [np.square(updated_vec_np).sum()])
+    np.testing.assert_allclose(results["axis_sum"].numpy()[:, 0], updated_matrix_np.sum(axis=1))
+    np.testing.assert_allclose(results["axis_inner"].numpy()[:, 0], np.square(updated_matrix_np).sum(axis=1))
 
 
 def test_save_load_array_scan_replay_with_updated_input(test, device):
@@ -2886,8 +3099,32 @@ add_function_test(
 add_function_test(TestApic, "test_capture_with_array_scan", test_capture_with_array_scan, devices=devices)
 add_function_test(
     TestApic,
+    "test_capture_with_array_reductions",
+    test_capture_with_array_reductions,
+    devices=devices_with_graph_capture_allocation_and_cuda_graph_module_load,
+)
+add_function_test(
+    TestApic,
+    "test_array_reduction_capture_errors",
+    test_array_reduction_capture_errors,
+    devices=devices_with_graph_capture_allocation_and_cuda_graph_module_load,
+)
+add_function_test(
+    TestApic,
+    "test_empty_array_reductions_during_capture",
+    test_empty_array_reductions_during_capture,
+    devices=devices_with_graph_capture_allocation_and_cuda_graph_module_load,
+)
+add_function_test(
+    TestApic,
     "test_cpu_helper_not_recorded_during_cuda_capture",
     test_cpu_helper_not_recorded_during_cuda_capture,
+    devices=get_cuda_test_devices(),
+)
+add_function_test(
+    TestApic,
+    "test_array_reduction_cpu_not_recorded_during_cuda_capture",
+    test_array_reduction_cpu_not_recorded_during_cuda_capture,
     devices=get_cuda_test_devices(),
 )
 add_function_test(
@@ -3057,6 +3294,18 @@ add_function_test(
     "test_apic_capture_resume_rejects_finished_graph",
     test_apic_capture_resume_rejects_finished_graph,
     devices=[d for d in devices if d.is_cpu],
+)
+add_function_test(
+    TestApic,
+    "test_save_load_array_reductions",
+    test_save_load_array_reductions,
+    devices=devices_with_graph_capture_allocation,
+)
+add_function_test(
+    TestApic,
+    "test_save_load_array_reduction_metadata",
+    test_save_load_array_reduction_metadata,
+    devices=devices_with_graph_capture_allocation,
 )
 add_function_test(
     TestApic,


### PR DESCRIPTION
## Description

Closes #1663.

Record `wp.utils.array_sum()` and `wp.utils.array_inner()` in APIC graphs so CPU graph replay and CPU/CUDA save/load recompute reductions from current inputs. Previously, the native reduction helpers did not append replayable operation metadata, so captured graphs could omit the reduction or retain capture-time results.

## Changes

- Record array reduction metadata and bindings in APIC streams, then reconstruct the operations for CPU replay and CUDA graph loading.
- Support whole-array reductions, explicit counts, composite data types, and positive-stride axis reductions.
- Reject unsupported counts, negative strides, unaligned layouts, and non-empty captures without an explicit output array.
- Bump the APIC writer format to version 15 while retaining reader compatibility with versions 13 through 15.
- Document the supported reduction contract and add CPU/CUDA capture, replay, save/load, metadata, empty-input, and validation coverage.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/latest/project/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

Built the release native libraries with CUDA 13.0 on driver 13.0, verifying that the C++ and CUDA additions compile and link.

Ran `WARP_CACHE_PATH=/tmp/warp-cache-warp-worktree-4 uv run warp/tests/test_apic.py`; all 216 tests passed on CPU and two CUDA devices, including the new array reduction capture, replay, save/load, metadata, and error-handling cases.

Ran pre-commit on all changed files; every applicable hook passed.

Built the HTML documentation successfully with no build errors.

## Bug fix

```python
import numpy as np

import warp as wp


with wp.ScopedDevice("cpu"):
    a = wp.array([1.0, 2.0], dtype=wp.float32)
    eager_out = wp.zeros(1, dtype=wp.float32)
    captured_out = wp.zeros(1, dtype=wp.float32)

    wp.utils.array_inner(a, a, out=eager_out)

    with wp.ScopedCapture() as capture:
        wp.utils.array_inner(a, a, out=captured_out)

    captured_out.zero_()
    wp.capture_launch(capture.graph)

    np.testing.assert_allclose(captured_out.numpy(), eager_out.numpy())
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental APIC reduction capture/replay for `wp.utils.array_sum()` and `wp.utils.array_inner()` (CPU and CUDA), with correct save/load persistence and parameter updates.
  * APIC graph format update for reduction ops (writer emits a newer version; reader remains backward-compatible).
* **Bug Fixes**
  * Captured reductions no longer recompute on replay; improved handling for empty/zero-count cases and stricter validation of counts, strides, and required `out`.
  * CUDA capture behavior clarified so reduction work is deferred appropriately.
* **Documentation**
  * Updated runtime guidance for APIC CPU/GPU reduction limitations and save/load version compatibility.
* **Tests**
  * Added new correctness, error-handling, empty-input, and save/load metadata coverage for these reductions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->