### PR TITLE
Fix autograd Jacobian plotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,9 @@
   Warp function targets during argument type inference ([GH-1648](https://github.com/NVIDIA/warp/issues/1648)).
 - Fix freeing arrays allocated during graph capture while a `wp.capture_if()` or `wp.capture_while()` body graph is being captured
   ([GH-1641](https://github.com/NVIDIA/warp/issues/1641)).
+- Fix Jacobian plotting for Python functions and typed Warp kernels in `wp.autograd.jacobian()`,
+  `wp.autograd.jacobian_fd()`, and `wp.autograd.gradcheck()`
+  ([GH-1672](https://github.com/NVIDIA/warp/issues/1672)).
 
 ### Documentation
 

--- a/warp/_src/autograd.py
+++ b/warp/_src/autograd.py
@@ -198,16 +198,12 @@ def gradcheck(
         jacobian_plot(
             relative_error_jacs,
             metadata,
-            inputs,
-            outputs,
             title=f"{metadata.key} kernel Jacobian relative error",
         )
     if plot_absolute_error:
         jacobian_plot(
             absolute_error_jacs,
             metadata,
-            inputs,
-            outputs,
             title=f"{metadata.key} kernel Jacobian absolute error",
         )
 
@@ -375,10 +371,10 @@ class FunctionMetadata:
         return self.key is None
 
     def input_is_array(self, i: int):
-        return self.input_strides[i] is not None
+        return self.input_dtypes[i] is not None
 
     def output_is_array(self, i: int):
-        return self.output_strides[i] is not None
+        return self.output_dtypes[i] is not None
 
     def update_from_kernel(self, kernel: wp.Kernel, inputs: Sequence):
         self.key = kernel.key
@@ -388,16 +384,16 @@ class FunctionMetadata:
         self.output_strides = []
         self.input_dtypes = []
         self.output_dtypes = []
-        for arg in kernel.adj.args[: len(inputs)]:
-            if arg.type is wp.array:
-                self.input_strides.append(arg.type.strides)
-                self.input_dtypes.append(arg.type.dtype)
+        for arg, value in zip(kernel.adj.args[: len(inputs)], inputs, strict=True):
+            if wp._src.types.matches_array_class(arg.type, wp.array):
+                self.input_strides.append(getattr(value, "strides", getattr(arg.type, "strides", None)))
+                self.input_dtypes.append(getattr(value, "dtype", arg.type.dtype))
             else:
                 self.input_strides.append(None)
                 self.input_dtypes.append(None)
         for arg in kernel.adj.args[len(inputs) :]:
-            if arg.type is wp.array:
-                self.output_strides.append(arg.type.strides)
+            if wp._src.types.matches_array_class(arg.type, wp.array):
+                self.output_strides.append(getattr(arg.type, "strides", None))
                 self.output_dtypes.append(arg.type.dtype)
             else:
                 self.output_strides.append(None)
@@ -478,52 +474,62 @@ def jacobian_plot(
     jacobians = sorted(jacobians.items(), key=lambda x: (x[0][1], x[0][0]))
     jacobians = dict(jacobians)
 
-    input_to_ax = {}
-    output_to_ax = {}
-    ax_to_input = {}
-    ax_to_output = {}
-    for i, j in jacobians.keys():
-        if i not in input_to_ax:
-            input_to_ax[i] = len(input_to_ax)
-            ax_to_input[input_to_ax[i]] = i
-        if j not in output_to_ax:
-            output_to_ax[j] = len(output_to_ax)
-            ax_to_output[output_to_ax[j]] = j
+    input_indices = sorted({input_i for input_i, _ in jacobians})
+    output_indices = sorted({output_i for _, output_i in jacobians})
+    input_to_ax = {input_i: ax_j for ax_j, input_i in enumerate(input_indices)}
+    output_to_ax = {output_i: ax_i for ax_i, output_i in enumerate(output_indices)}
+    ax_to_input = dict(enumerate(input_indices))
+    ax_to_output = dict(enumerate(output_indices))
 
     num_rows = len(output_to_ax)
     num_cols = len(input_to_ax)
     if num_rows == 0 or num_cols == 0:
         return
 
-    # determine the width and height ratios for the subplots based on the
-    # dimensions of the Jacobians
-    width_ratios = []
-    height_ratios = []
-    for i in range(len(metadata.input_labels)):
-        if not metadata.input_is_array(i):
-            continue
-        input_stride = metadata.input_strides[i][0]
-        for j in range(len(metadata.output_labels)):
-            if (i, j) not in jacobians:
-                continue
-            jac_wp = jacobians[(i, j)]
-            width_ratios.append(jac_wp.shape[1] * input_stride)
-            break
+    input_component_counts = {}
+    for input_i in input_to_ax:
+        input_count = len(metadata.input_labels or [])
+        if input_i < 0 or input_i >= input_count:
+            raise ValueError(f"Invalid Jacobian input index {input_i}: plotting metadata defines {input_count} inputs")
+        if metadata.input_labels[input_i] is None:
+            raise ValueError(f"Invalid plotting metadata for Jacobian input index {input_i}: missing label")
+        dtype_count = len(metadata.input_dtypes or [])
+        if input_i < 0 or input_i >= dtype_count or metadata.input_dtypes[input_i] is None:
+            raise ValueError(f"Invalid plotting metadata for Jacobian input index {input_i}: missing array dtype")
+        component_count = getattr(metadata.input_dtypes[input_i], "_length_", None)
+        if component_count is None:
+            raise ValueError(
+                f"Invalid plotting metadata for Jacobian input index {input_i}: array dtype has no component count"
+            )
+        input_component_counts[input_i] = component_count
 
-    for i in range(len(metadata.output_labels)):
-        if not metadata.output_is_array(i):
-            continue
-        for j in range(len(inputs)):
-            if (j, i) not in jacobians:
-                continue
-            jac_wp = jacobians[(j, i)]
-            height_ratios.append(jac_wp.shape[0])
-            break
+    for output_i in output_to_ax:
+        output_count = len(metadata.output_labels or [])
+        if output_i < 0 or output_i >= output_count:
+            raise ValueError(
+                f"Invalid Jacobian output index {output_i}: plotting metadata defines {output_count} outputs"
+            )
+        if metadata.output_labels[output_i] is None:
+            raise ValueError(f"Invalid plotting metadata for Jacobian output index {output_i}: missing label")
+
+    width_ratios = []
+    for ax_j in range(num_cols):
+        input_i = ax_to_input[ax_j]
+        jac_wp = next(jac for (jac_input_i, _), jac in jacobians.items() if jac_input_i == input_i)
+        input_component_count = input_component_counts[input_i]
+        width_ratios.append(jac_wp.shape[1] * input_component_count)
+
+    height_ratios = []
+    for ax_i in range(num_rows):
+        output_i = ax_to_output[ax_i]
+        jac_wp = next(jac for (_, jac_output_i), jac in jacobians.items() if jac_output_i == output_i)
+        height_ratios.append(jac_wp.shape[0])
 
     fig, axs = plt.subplots(
         ncols=num_cols,
         nrows=num_rows,
         figsize=(7, 7),
+        layout="constrained",
         sharex="col",
         sharey="row",
         gridspec_kw={
@@ -536,7 +542,7 @@ def jacobian_plot(
         squeeze=False,
     )
     if title is None:
-        key = kernel.key if isinstance(kernel, wp.Kernel) else kernel.get("key", "unknown")
+        key = metadata.key or "unknown"
         title = f"{key} kernel Jacobian"
     fig.suptitle(title)
     fig.canvas.manager.set_window_title(title)
@@ -570,12 +576,12 @@ def jacobian_plot(
         ax.tick_params(which="major", width=1, length=7)
         ax.tick_params(which="minor", width=1, length=4, color="gray")
 
-        input_stride = metadata.input_dtypes[input_i]._length_
+        input_component_count = input_component_counts[input_i]
         # output_stride = metadata.output_dtypes[output_i]._length_
 
         jac = jac_wp.numpy()
         # Jacobian matrix has output stride already multiplied to first dimension
-        jac = jac.reshape(jac_wp.shape[0], jac_wp.shape[1] * input_stride)
+        jac = jac.reshape(jac_wp.shape[0], jac_wp.shape[1] * input_component_count)
 
         ax.xaxis.set_major_locator(MaxNLocator(integer=True))
         ax.yaxis.set_major_locator(MaxNLocator(integer=True))
@@ -613,7 +619,6 @@ def jacobian_plot(
         m.set_clim(vmin, vmax)
         plt.colorbar(m, ax=axs, orientation="vertical", pad=0.02)
 
-    plt.tight_layout()
     if show_plot:
         plt.show()
     return fig
@@ -780,12 +785,7 @@ def jacobian(
         jacobians[input_i, output_i] = jacobian
 
     if plot_jacobians:
-        jacobian_plot(
-            jacobians,
-            metadata,
-            inputs,
-            outputs,
-        )
+        jacobian_plot(jacobians, metadata)
 
     return jacobians
 
@@ -984,12 +984,7 @@ def jacobian_fd(
         jacobians[input_i, output_i] = jacobian
 
     if plot_jacobians:
-        jacobian_plot(
-            jacobians,
-            metadata,
-            inputs,
-            outputs,
-        )
+        jacobian_plot(jacobians, metadata)
 
     return jacobians
 

--- a/warp/tests/test_grad_debug.py
+++ b/warp/tests/test_grad_debug.py
@@ -2,14 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+import warnings
 from typing import Any
+from unittest.mock import patch
 
 import warp as wp
+from warp._src.autograd import FunctionMetadata
 from warp.autograd import (
     gradcheck,
     gradcheck_tape,
     jacobian,
     jacobian_fd,
+    jacobian_plot,
 )
 from warp.tests.unittest_utils import *
 
@@ -96,6 +100,33 @@ def transform_point_kernel(
 ):
     tid = wp.tid()
     out[tid] = wp.transform_point(transforms[tid], points[tid])
+
+
+@wp.kernel
+def jacobian_plot_scale_kernel(a: wp.array[float], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = 2.0 * a[tid]
+
+
+def jacobian_plot_pipeline(a):
+    out = wp.zeros_like(a, requires_grad=True)
+    wp.launch(
+        jacobian_plot_scale_kernel,
+        dim=len(a),
+        inputs=[a],
+        outputs=[out],
+        device=a.device,
+    )
+    return out
+
+
+def _get_test_pyplot():
+    import matplotlib  # noqa: PLC0415
+
+    matplotlib.use("Agg", force=True)
+    import matplotlib.pyplot as plt  # noqa: PLC0415
+
+    return plt
 
 
 def test_gradcheck_3d(test, device, dtype):
@@ -239,7 +270,261 @@ devices = get_test_devices()
 
 
 class TestGradDebug(unittest.TestCase):
-    pass
+    def test_jacobian_plot_function(self):
+        """Verify Jacobian plotting supports Python function pipelines."""
+        plt = _get_test_pyplot()
+        self.addCleanup(plt.close, "all")
+
+        for jacobian_function in (jacobian, jacobian_fd):
+            with self.subTest(jacobian_function=jacobian_function.__name__):
+                plt.close("all")
+                a = wp.array([1.0, 2.0], dtype=wp.float32, requires_grad=True, device="cpu")
+
+                with patch.object(plt, "show") as show:
+                    jacobians = jacobian_function(
+                        jacobian_plot_pipeline,
+                        inputs=[a],
+                        plot_jacobians=True,
+                    )
+
+                np.testing.assert_allclose(
+                    jacobians[(0, 0)].numpy(),
+                    np.eye(2, dtype=np.float32) * 2.0,
+                    atol=1.0e-3,
+                    rtol=1.0e-3,
+                )
+                figure = plt.gcf()
+                self.assertEqual(figure.get_suptitle(), "jacobian_plot_pipeline kernel Jacobian")
+                self.assertEqual(figure.axes[0].get_xlabel(), "a")
+                self.assertEqual(figure.axes[0].get_ylabel(), "output_0")
+                show.assert_called_once_with()
+
+    def test_jacobian_plot_kernel(self):
+        """Verify Jacobian plotting uses typed kernel metadata."""
+        plt = _get_test_pyplot()
+        self.addCleanup(plt.close, "all")
+
+        for jacobian_function in (jacobian, jacobian_fd):
+            with self.subTest(jacobian_function=jacobian_function.__name__):
+                plt.close("all")
+                a = wp.array([2.0, -1.0], dtype=wp.float32, requires_grad=True, device="cpu")
+                b = wp.array(
+                    [wp.vec3(3.0, 1.0, 2.0), wp.vec3(-4.0, -1.0, 0.0)],
+                    dtype=wp.vec3,
+                    requires_grad=True,
+                    device="cpu",
+                )
+                out1 = wp.zeros(2, dtype=wp.vec2, requires_grad=True, device="cpu")
+                out2 = wp.zeros(2, dtype=wp.quat, requires_grad=True, device="cpu")
+
+                with patch.object(plt, "show") as show:
+                    jacobians = jacobian_function(
+                        kernel_mixed,
+                        dim=len(a),
+                        inputs=[a, b],
+                        outputs=[out1, out2],
+                        input_output_mask=[("b", "out1"), ("a", "out2")],
+                        plot_jacobians=True,
+                    )
+
+                self.assertEqual(sorted(jacobians), [(0, 1), (1, 0)])
+                figure = plt.gcf()
+                self.assertEqual(figure.get_suptitle(), "kernel_mixed kernel Jacobian")
+                self.assertEqual(len(figure.axes), 5)
+                axes = figure.axes[:4]
+                self.assertFalse(axes[0].axison)
+                self.assertTrue(axes[1].axison)
+                self.assertEqual(axes[1].get_xlabel(), "b")
+                self.assertEqual(axes[1].get_ylabel(), "out1")
+                self.assertTrue(axes[2].axison)
+                self.assertEqual(axes[2].get_xlabel(), "a")
+                self.assertEqual(axes[2].get_ylabel(), "out2")
+                self.assertFalse(axes[3].axison)
+                self.assertEqual(axes[0].get_gridspec().get_width_ratios(), [2, 6])
+                self.assertEqual(axes[0].get_gridspec().get_height_ratios(), [4, 8])
+                show.assert_called_once_with()
+
+    def test_gradcheck_plotting(self):
+        """Verify gradient checks render both error matrices without layout warnings."""
+        plt = _get_test_pyplot()
+        self.addCleanup(plt.close, "all")
+
+        a = wp.array([1.0, 2.0], dtype=wp.float32, requires_grad=True, device="cpu")
+        out = wp.zeros_like(a, requires_grad=True)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            with patch.object(plt, "show") as show:
+                passed = gradcheck(
+                    jacobian_plot_scale_kernel,
+                    dim=len(a),
+                    inputs=[a],
+                    outputs=[out],
+                    plot_relative_error=True,
+                    plot_absolute_error=True,
+                    show_summary=False,
+                )
+            figures = [plt.figure(number) for number in plt.get_fignums()]
+            for figure in figures:
+                figure.canvas.draw()
+
+        self.assertTrue(passed)
+        self.assertEqual(
+            [figure.get_suptitle() for figure in figures],
+            [
+                "jacobian_plot_scale_kernel kernel Jacobian relative error",
+                "jacobian_plot_scale_kernel kernel Jacobian absolute error",
+            ],
+        )
+        self.assertEqual(show.call_count, 2)
+
+    def test_jacobian_plot_direct_kernel(self):
+        """Verify direct kernel plotting preserves its public contract."""
+        plt = _get_test_pyplot()
+        self.addCleanup(plt.close, "all")
+
+        inputs = [wp.zeros((1, 1, 1), dtype=wp.float32, requires_grad=True, device="cpu") for _ in range(3)]
+        jacobian_matrix = wp.array([[1.0]], dtype=wp.float32, device="cpu")
+
+        with patch.object(plt, "show") as show:
+            figure = jacobian_plot(
+                {(0, 0): jacobian_matrix},
+                kernel_3d,
+                inputs=inputs,
+                show_plot=False,
+                show_colorbar=False,
+            )
+
+        self.assertEqual(figure.get_suptitle(), "kernel_3d kernel Jacobian")
+        self.assertEqual(figure.axes[0].get_xlabel(), "a")
+        self.assertEqual(figure.axes[0].get_ylabel(), "out1")
+        self.assertEqual(figure.axes[0].get_gridspec().get_width_ratios(), [1])
+        show.assert_not_called()
+
+    def test_jacobian_plot_validation(self):
+        """Reject incomplete metadata before constructing Jacobian figures.
+
+        A displayed Jacobian key must resolve to an input label, input array
+        dtype, and output label in the normalized metadata.
+        """
+        plt = _get_test_pyplot()
+        self.addCleanup(plt.close, "all")
+
+        with self.assertRaisesRegex(ValueError, "inputs must be provided"):
+            jacobian_plot({}, jacobian_plot_scale_kernel)
+
+        empty_metadata = FunctionMetadata(
+            key="empty",
+            input_labels=[],
+            output_labels=[],
+            input_strides=[],
+            output_strides=[],
+            input_dtypes=[],
+            output_dtypes=[],
+        )
+        self.assertIsNone(jacobian_plot({}, empty_metadata, show_plot=False))
+
+        anonymous_metadata = FunctionMetadata(
+            input_labels=["a"],
+            output_labels=["output_0"],
+            input_strides=[None],
+            output_strides=[None],
+            input_dtypes=[wp.float32],
+            output_dtypes=[wp.float32],
+        )
+        jacobian_matrix = wp.array([[1.0]], dtype=wp.float32, device="cpu")
+        figure = jacobian_plot(
+            {(0, 0): jacobian_matrix},
+            anonymous_metadata,
+            show_plot=False,
+            show_colorbar=False,
+        )
+        self.assertEqual(figure.get_suptitle(), "unknown kernel Jacobian")
+
+        invalid_cases = [
+            (
+                "missing input label",
+                FunctionMetadata(
+                    key="malformed",
+                    input_labels=[],
+                    output_labels=["output_0"],
+                    input_strides=[],
+                    output_strides=[None],
+                    input_dtypes=[],
+                    output_dtypes=[wp.float32],
+                ),
+                "Jacobian input index 0",
+            ),
+            (
+                "null input label",
+                FunctionMetadata(
+                    key="malformed",
+                    input_labels=[None],
+                    output_labels=["output_0"],
+                    input_strides=[None],
+                    output_strides=[None],
+                    input_dtypes=[wp.float32],
+                    output_dtypes=[wp.float32],
+                ),
+                "Jacobian input index 0: missing label",
+            ),
+            (
+                "missing input dtype",
+                FunctionMetadata(
+                    key="malformed",
+                    input_labels=["a"],
+                    output_labels=["output_0"],
+                    input_strides=[None],
+                    output_strides=[None],
+                    input_dtypes=[None],
+                    output_dtypes=[wp.float32],
+                ),
+                "missing array dtype",
+            ),
+            (
+                "generic input dtype",
+                FunctionMetadata(
+                    key="malformed",
+                    input_labels=["a"],
+                    output_labels=["output_0"],
+                    input_strides=[None],
+                    output_strides=[None],
+                    input_dtypes=[Any],
+                    output_dtypes=[wp.float32],
+                ),
+                "component count",
+            ),
+            (
+                "missing output label",
+                FunctionMetadata(
+                    key="malformed",
+                    input_labels=["a"],
+                    output_labels=[],
+                    input_strides=[None],
+                    output_strides=[],
+                    input_dtypes=[wp.float32],
+                    output_dtypes=[],
+                ),
+                "Jacobian output index 0",
+            ),
+            (
+                "null output label",
+                FunctionMetadata(
+                    key="malformed",
+                    input_labels=["a"],
+                    output_labels=[None],
+                    input_strides=[None],
+                    output_strides=[None],
+                    input_dtypes=[wp.float32],
+                    output_dtypes=[wp.float32],
+                ),
+                "Jacobian output index 0: missing label",
+            ),
+        ]
+        for case, metadata, error in invalid_cases:
+            with self.subTest(case=case):
+                with self.assertRaisesRegex(ValueError, error):
+                    jacobian_plot({(0, 0): jacobian_matrix}, metadata, show_plot=False)
 
 
 for dtype in [wp.float32, wp.float64]:


### PR DESCRIPTION
## Description

Fix Jacobian plotting for Python function pipelines and typed Warp kernels. The plotting path now reads normalized metadata consistently, derives subplot topology and component ratios from that metadata, validates displayed indices before constructing figures, sorts sparse-mask axes deterministically, and uses Matplotlib constrained layout for warning-free shared colorbars. Closes #1672.

## Changes

- Support Python functions and direct or typed Warp kernel annotations through one normalized metadata path.
- Derive sparse subplot topology, labels, and component ratios from validated metadata.
- Use constrained layout for Jacobian and gradient-check figures.
- Add regression coverage for Python functions, typed kernels, sparse masks, invalid metadata, direct-kernel behavior, and warning-free gradient-check plots.
- Add an `Unreleased` changelog entry.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/latest/project/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Verified the layout-warning regression fails against the previous `tight_layout()` implementation and passes after switching to constrained layout.
- Ran `warp/tests/test_grad_debug.py` on CPU and both available CUDA devices; all 29 tests passed.
- Ran pre-commit hooks on all three changed files; all applicable hooks passed.

## Bug fix

```python
import warp as wp
from warp.autograd import jacobian

@wp.kernel
def scale(a: wp.array[float], out: wp.array[float]):
    tid = wp.tid()
    out[tid] = 2.0 * a[tid]

def pipeline(a):
    out = wp.zeros_like(a, requires_grad=True)
    wp.launch(scale, dim=len(a), inputs=[a], outputs=[out], device=a.device)
    return out

a = wp.array([1.0, 2.0], dtype=wp.float32, requires_grad=True)
jacobian(pipeline, inputs=[a], plot_jacobians=True)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Jacobian plotting in `wp.autograd.jacobian()`, `wp.autograd.jacobian_fd()`, and `wp.autograd.gradcheck()` for both Python functions and typed Warp kernels (GH-1672).
  - Improved Jacobian/gradcheck plot layout, labels, and metadata handling for more reliable, consistent figures.

- **Tests**
  - Added/expanded automated coverage for Jacobian plotting and gradcheck figure behavior across Python and typed-kernel workflows, including validations and `show` behavior.

- **Documentation**
  - Updated the unreleased changelog with the Jacobian plotting fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->