### PR TITLE
Support CPU HashGrid graph replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   that restricts traversal to points sharing the requested group id. Use
   `wp.HashGrid.reserve(num_points, with_groups=True)` to record grouped rebuilds inside a CUDA graph without a
   warm-up build ([GH-1579](https://github.com/NVIDIA/warp/issues/1579)).
+- Add live CPU graph capture and replay support for `wp.HashGrid.build()`. Each replay rebuilds the grid from current
+  point and optional group data. Saveable captures remain unsupported until `wp.HashGrid` resources can be serialized
+  ([GH-1664](https://github.com/NVIDIA/warp/issues/1664)).
 - Add `wp.cuda_profiler_start()`, `wp.cuda_profiler_stop()`, and the `wp.ScopedCudaProfiler` context manager to
   control CUDA profiler data collection from Python (equivalent to `cuProfilerStart`/`cuProfilerStop`) for an
   external profiler's capture range. They accept an optional `device` argument and act on that device's current CUDA

--- a/docs/user_guide/runtime.rst
+++ b/docs/user_guide/runtime.rst
@@ -1876,6 +1876,10 @@ The operations recorded on CPU now cover most of the CUDA path:
   :meth:`wp.Bvh.rebuild() <warp.Bvh.rebuild>`), re-run on replay against the
   current ``lowers`` / ``uppers`` so a captured graph queries the updated tree.
   These make the graph replay-only (see the limitations below).
+- Live CPU graphs record :meth:`HashGrid.build() <warp.HashGrid.build>` in
+  operation order. Each replay reads the current contents of the normalized
+  point and optional group arrays, and the first replay may allocate or grow
+  the grid buffers.
 - Conditional graph nodes (:func:`wp.capture_if() <warp.capture_if>` and
   :func:`wp.capture_while() <warp.capture_while>`). The condition is re-evaluated
   on every replay, so a captured ``while`` loop can iterate a different number
@@ -2006,6 +2010,9 @@ A few operations cannot be captured for save/load on CUDA and raise
 :exc:`NotImplementedError` during an ``apic=True`` capture; build these outside the captured
 region:
 
+- :meth:`HashGrid.build() <warp.HashGrid.build>`, because ``HashGrid``
+  resources and their process-local IDs cannot yet be serialized. Use
+  ``apic=False`` for live CUDA graph capture.
 - :func:`wp.sparse.bsr_set_from_triplets() <warp.sparse.bsr_set_from_triplets>` (and the
   ``warp.sparse`` matrix products that build topology with it), because it reads the resulting
   ``nnz`` back to the host after its own kernels, which a captured graph cannot reproduce.
@@ -2282,6 +2289,12 @@ Current limitations of API Capture:
 - Only :class:`wp.Mesh <warp.Mesh>` object handles are serialized.
   :class:`wp.Volume <warp.Volume>` and :class:`wp.Bvh <warp.Bvh>` handles are not
   yet supported.
+- ``HashGrid.build()`` is supported by live CPU graphs captured with
+  ``apic=False``. It is not supported by saveable captures because ``HashGrid``
+  resources and their process-local IDs cannot yet be serialized. Calling
+  ``HashGrid.build()`` with ``apic=True`` raises :class:`NotImplementedError`.
+  Call ``HashGrid.reserve()`` before CPU graph capture; reserve calls inside a
+  capture are rejected.
 - ``.wrp`` files are not portable across CUDA compute architectures unless the
   capture was built with PTX output (set ``warp.config.cuda_output = "ptx"``
   before capture). Multi-GPU and cross-architecture loading are not yet
@@ -2833,6 +2846,12 @@ undefined behavior when the kernel tries to access the freed memory.
 Always maintain references to spatial computing primitive objects
 (like :class:`wp.HashGrid <warp.HashGrid>`, :class:`wp.Bvh <warp.Bvh>`, etc.) rather than just their ID values.
 This is especially important in loops, functions, and temporary variables where object scope might be unclear.
+
+When a graph captures a :class:`wp.HashGrid <warp.HashGrid>` ID, the caller must
+keep the ``HashGrid`` alive until every graph that captures its ID is destroyed.
+This caller-ownership contract is the same for live CPU and CUDA graphs. The
+graph retains the array inputs captured by ``HashGrid.build()``, including
+normalized views and their backing allocations.
 
 Marching Cubes
 --------------

--- a/warp/_src/apic/types.py
+++ b/warp/_src/apic/types.py
@@ -28,6 +28,7 @@ APIC_OP_BSR_TRANSPOSE = 15
 APIC_OP_REDUCTION = 16
 APIC_OP_BVH_REFIT = 17
 APIC_OP_BVH_REBUILD = 18
+APIC_OP_HASH_GRID_UPDATE = 19
 
 
 # Scalar element types (must match APICType in apic_types.h).

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -7768,50 +7768,67 @@ class HashGrid:
                 interact, even when their coordinates overlap. Omitting the group argument in
                 :func:`warp.hash_grid_query` preserves the all-points traversal behavior.
                 Group ids may be arbitrary ``int32`` values and are consumed on-device, so group assignments may
-                change between rebuilds, including during CUDA graph replay.
+                change between rebuilds, including during CPU and CUDA graph replay.
         """
         if not types_equal(points.dtype, self._vec_type):
             raise TypeError(f"Hash grid points should have type {self._vec_type.__name__}, got {points.dtype}")
-
         if radius <= 0.0:
             raise ValueError(f"Hash grid cell width must be positive, got {radius}")
-
-        if points.ndim > 1:
-            points = points.contiguous().flatten()
         if points.device != self.device:
             raise RuntimeError("points must live on the same device as this HashGrid")
 
-        groups_arg = None
         if groups is not None:
             if groups.dtype != int32:
                 raise RuntimeError("groups should be an array of type wp.int32")
             if groups.device != self.device:
                 raise RuntimeError("groups must live on the same device as this HashGrid")
+            if groups.size != points.size:
+                raise RuntimeError("groups must have the same length as points")
+
+        apic_capture = warp._src.context._get_apic_capture_for_device(self.device)
+        if apic_capture is not None and apic_capture.apic_savable:
+            raise NotImplementedError(
+                "HashGrid.build() cannot be used in a saveable APIC capture because "
+                "HashGrid serialization is not yet supported; use apic=False or build outside capture"
+            )
+
+        if points.ndim > 1:
+            points = points.contiguous().flatten()
+
+        groups_arg = None
+        if groups is not None:
             if groups.ndim > 1:
                 groups = groups.contiguous().flatten()
             elif not groups.is_contiguous:
                 groups = groups.contiguous()
-            if len(groups) != len(points):
-                raise RuntimeError("groups must have the same length as points")
-
             groups_arg = ctypes.byref(groups.__ctype__())
 
-        self.groups = groups
+        if apic_capture is not None:
+            apic_capture.track_array(points)
+            apic_capture.track_array(groups)
 
+        self.groups = groups
         self._native_func("update")(self.id, self._type_id, radius, ctypes.byref(points.__ctype__()), groups_arg)
         self.reserved = True
 
     def reserve(self, num_points, with_groups=False):
         """Reserve enough memory to build the grid for the given number of points.
 
-        Reserving ahead of CUDA graph capture makes subsequent :meth:`build` calls of up to
-        ``num_points`` points allocation-free, without requiring a warm-up build before capture.
+        Reserving ahead of CPU or CUDA graph capture makes subsequent :meth:`build` calls of up to
+        ``num_points`` points allocation-free, without requiring a warm-up build before capture. CPU live replay can
+        allocate on the first replayed build, so pre-reserving is optional. :meth:`reserve` cannot be called during CPU
+        graph capture.
 
         Args:
             num_points (int): Number of points the grid should accommodate.
             with_groups (bool): Also reserve the buffers used by grouped builds, so that a
                 grouped :meth:`build` (with ``groups``) is allocation-free as well.
         """
+        if self.device.is_cpu and warp._src.context._get_apic_capture_for_device(self.device) is not None:
+            raise NotImplementedError(
+                "HashGrid.reserve() cannot be called during CPU graph capture; reserve before capture"
+            )
+
         self._native_func("reserve")(self.id, self._type_id, num_points, with_groups)
         self.reserved = True
 

--- a/warp/native/apic.cpp
+++ b/warp/native/apic.cpp
@@ -19,17 +19,49 @@
 #include "apic.h"
 #include "apic_internal.h"
 #include "error.h"
+#include "hashgrid.h"
 #include "mesh.h"
 
 #include <algorithm>
 #include <cassert>
 #include <climits>
+#include <cmath>
 #include <cstddef>  // offsetof
 #include <cstdint>  // SIZE_MAX
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
+
+// Convert a strided view into its lowest touched byte and full backing span,
+// including negative strides whose logical first element is not the base.
+static bool apic_compute_strided_span(
+    int32_t count,
+    int32_t stride,
+    uint64_t element_size,
+    uint64_t logical_offset,
+    uint64_t* low_offset,
+    uint64_t* span_size
+)
+{
+    if (count < 0 || element_size == 0)
+        return false;
+    if (count == 0) {
+        *low_offset = logical_offset;
+        *span_size = 0;
+        return true;
+    }
+
+    const int64_t last_delta = static_cast<int64_t>(count - 1) * static_cast<int64_t>(stride);
+    const uint64_t before = last_delta < 0 ? static_cast<uint64_t>(-last_delta) : 0;
+    const uint64_t after = last_delta > 0 ? static_cast<uint64_t>(last_delta) : 0;
+    if (logical_offset < before || after > UINT64_MAX - element_size || before > UINT64_MAX - after - element_size)
+        return false;
+
+    *low_offset = logical_offset - before;
+    *span_size = before + after + element_size;
+    return true;
+}
 
 // ============================================================================
 // Thread-local Recording State
@@ -760,21 +792,10 @@ static void apic_record_bvh_op(APICState* state, APICOpType op_type, uint64_t bv
     state->append_bytes(&rec, sizeof(rec));
     state->operation_count++;
     // The record replays by re-invoking the host function on this raw,
-    // process-local BVH handle, so the stream can no longer be serialized.
-    // Mark it nonportable so wp_apic_state_save() refuses it up front; keep the
-    // first offending op's name for the error in a mixed refit/rebuild graph.
-    //
-    // KNOWN LIMITATION: this marker is set eagerly at record time and is NOT
-    // rolled back with branch capture. If a BVH op is recorded inside a
-    // capture_if/capture_while body that then raises, wp_apic_end_branch()
-    // discards the op from the operation stream but leaves this marker set -- so
-    // a caller that recovers from the exception and reuses the finalized graph
-    // gets a spurious capture_save() rejection for a graph with no BVH op left.
-    // Fail-safe (over-rejects; never writes a bad .wrp) and needs unusual error
-    // recovery, so it is left as-is; the planned fix derives nonportability
-    // from the finalized stream at save time instead of here.
-    if (!state->nonportable_reason)
-        state->nonportable_reason = (op_type == APIC_OP_BVH_REBUILD) ? "wp.Bvh.rebuild()" : "wp.Bvh.refit()";
+    // process-local BVH handle, so the stream cannot be serialized. That is
+    // enforced at save time by scanning the finalized operation stream (see
+    // apic_stream_first_nonserializable_op), which correctly ignores ops that a
+    // branch body discards when it unwinds -- rather than by a flag set here.
 }
 
 void apic_record_bvh_refit(APICState* state, uint64_t bvh_id)
@@ -785,6 +806,80 @@ void apic_record_bvh_refit(APICState* state, uint64_t bvh_id)
 void apic_record_bvh_rebuild(APICState* state, uint64_t bvh_id, int32_t constructor_type)
 {
     apic_record_bvh_op(state, APIC_OP_BVH_REBUILD, bvh_id, constructor_type);
+}
+
+void apic_record_hash_grid_update(
+    APICState* state,
+    uint64_t grid_id,
+    uint8_t grid_type,
+    double cell_width,
+    const void* points_data,
+    int32_t point_count,
+    int32_t points_stride,
+    const void* groups_data,
+    int32_t groups_stride,
+    uint8_t has_groups
+)
+{
+    if (!state)
+        return;
+
+    uint64_t point_element_size = 0;
+    switch (grid_type) {
+    case wp::HASH_GRID_TYPE_FLOAT16:
+        point_element_size = sizeof(wp::vec3h);
+        break;
+    case wp::HASH_GRID_TYPE_FLOAT32:
+        point_element_size = sizeof(wp::vec3f);
+        break;
+    case wp::HASH_GRID_TYPE_FLOAT64:
+        point_element_size = sizeof(wp::vec3d);
+        break;
+    }
+
+    // HashGrid updates are live-only, so retain region IDs without snapshotting
+    // potentially large backing allocations into the serialized memory table.
+    APICAddress points_address;
+    APICAddress groups_address;
+    if (point_count > 0 && points_data && point_element_size > 0) {
+        const uint64_t logical_address = reinterpret_cast<uint64_t>(points_data);
+        uint64_t low_address;
+        uint64_t span_size;
+        if (apic_compute_strided_span(
+                point_count, points_stride, point_element_size, logical_address, &low_address, &span_size
+            )) {
+            points_address = apic_resolve_live_ptr(state, low_address, span_size);
+            points_address.offset += logical_address - low_address;
+        }
+    }
+    if (has_groups && point_count > 0 && groups_data) {
+        const uint64_t logical_address = reinterpret_cast<uint64_t>(groups_data);
+        uint64_t low_address;
+        uint64_t span_size;
+        if (apic_compute_strided_span(
+                point_count, groups_stride, sizeof(int32_t), logical_address, &low_address, &span_size
+            )) {
+            groups_address = apic_resolve_live_ptr(state, low_address, span_size);
+            groups_address.offset += logical_address - low_address;
+        }
+    }
+
+    APICHashGridUpdateRecord rec = {};
+    rec.header.op_type = APIC_OP_HASH_GRID_UPDATE;
+    rec.header.total_size = sizeof(rec);
+    rec.grid_id = grid_id;
+    rec.cell_width = cell_width;
+    rec.points_region_id = points_address.region_id;
+    rec.groups_region_id = has_groups ? groups_address.region_id : -1;
+    rec.points_offset = points_address.offset;
+    rec.groups_offset = has_groups ? groups_address.offset : 0;
+    rec.point_count = point_count;
+    rec.points_stride = points_stride;
+    rec.groups_stride = has_groups ? groups_stride : 0;
+    rec.grid_type = grid_type;
+    rec.has_groups = has_groups;
+    state->append_bytes(&rec, sizeof(rec));
+    state->operation_count++;
 }
 
 // ============================================================================
@@ -1683,6 +1778,66 @@ bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t o
                 return false;
             }
             break;
+        case APIC_OP_HASH_GRID_UPDATE: {
+            if (header->total_size != sizeof(APICHashGridUpdateRecord)) {
+                fprintf(stderr, "APIC: Error - invalid HashGrid update record size at operation %u\n", i);
+                return false;
+            }
+            const auto* rec = reinterpret_cast<const APICHashGridUpdateRecord*>(ptr);
+            if (rec->grid_id == 0 || !std::isfinite(rec->cell_width) || rec->cell_width <= 0.0 || rec->point_count < 0
+                || rec->has_groups > 1 || rec->grid_type > wp::HASH_GRID_TYPE_FLOAT64) {
+                fprintf(stderr, "APIC: Error - invalid HashGrid update metadata at operation %u\n", i);
+                return false;
+            }
+
+            uint64_t point_element_size;
+            switch (rec->grid_type) {
+            case wp::HASH_GRID_TYPE_FLOAT16:
+                point_element_size = sizeof(wp::vec3h);
+                break;
+            case wp::HASH_GRID_TYPE_FLOAT32:
+                point_element_size = sizeof(wp::vec3f);
+                break;
+            default:
+                point_element_size = sizeof(wp::vec3d);
+                break;
+            }
+
+            if (rec->points_region_id == 0 || rec->points_region_id < -1 || rec->groups_region_id == 0
+                || rec->groups_region_id < -1) {
+                fprintf(stderr, "APIC: Error - invalid HashGrid update region id at operation %u\n", i);
+                return false;
+            }
+
+            uint64_t low_offset;
+            uint64_t span_size;
+            if ((rec->point_count > 0 && rec->points_region_id < 1)
+                || (rec->points_region_id == -1 && rec->points_offset != 0)
+                || !apic_compute_strided_span(
+                    rec->point_count, rec->points_stride, point_element_size, rec->points_offset, &low_offset,
+                    &span_size
+                )) {
+                fprintf(stderr, "APIC: Error - invalid HashGrid update points span at operation %u\n", i);
+                return false;
+            }
+
+            if (!rec->has_groups) {
+                if (rec->groups_region_id != -1 || rec->groups_offset != 0 || rec->groups_stride != 0) {
+                    fprintf(stderr, "APIC: Error - invalid HashGrid update groups sentinel at operation %u\n", i);
+                    return false;
+                }
+            } else if (
+                (rec->point_count > 0 && rec->groups_region_id < 1)
+                || (rec->groups_region_id == -1 && rec->groups_offset != 0)
+                || !apic_compute_strided_span(
+                    rec->point_count, rec->groups_stride, sizeof(int32_t), rec->groups_offset, &low_offset, &span_size
+                )
+            ) {
+                fprintf(stderr, "APIC: Error - invalid HashGrid update groups span at operation %u\n", i);
+                return false;
+            }
+            break;
+        }
         case APIC_OP_IF:
         case APIC_OP_WHILE: {
             if (op_end < op_start + sizeof(APICCondRecord)) {
@@ -1693,6 +1848,13 @@ bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t o
             if (sizeof(APICCondRecord) + (uint64_t)rec->branch_a_size + (uint64_t)rec->branch_b_size
                 > header->total_size) {
                 fprintf(stderr, "APIC: Error - cond branch sizes overflow at operation %u\n", i);
+                return false;
+            }
+            // Nested stream scans trust these counts, so an empty byte range
+            // must also declare zero operations.
+            if ((rec->branch_a_size == 0) != (rec->branch_a_op_count == 0)
+                || (rec->branch_b_size == 0) != (rec->branch_b_op_count == 0)) {
+                fprintf(stderr, "APIC: Error - cond branch size/count mismatch at operation %u\n", i);
                 return false;
             }
             const uint8_t* branch_a = op_start + sizeof(APICCondRecord);
@@ -1727,6 +1889,59 @@ bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t o
     }
 
     return true;
+}
+
+// Human-facing name for a BVH op type (nullptr for any non-BVH op). BVH refit /
+// rebuild replay by re-invoking a host function on a process-local BVH handle,
+// so a stream that records one cannot cross a save/load boundary; naming the op
+// makes the rejection actionable.
+static const char* apic_bvh_op_name(uint32_t op_type)
+{
+    switch (op_type) {
+    case APIC_OP_BVH_REFIT:
+        return "wp.Bvh.refit()";
+    case APIC_OP_BVH_REBUILD:
+        return "wp.Bvh.rebuild()";
+    default:
+        return nullptr;
+    }
+}
+
+// Returns the op_type of the first operation in `data` whose replay depends on a
+// process-local handle -- BVH refit/rebuild (a live BVH pointer) or a HashGrid
+// update (a live grid_id) -- or 0 if the stream is fully serializable. Recurses
+// into capture_if / capture_while branch bodies. Deriving non-serializability
+// from the finalized stream, rather than from a flag set eagerly when an op is
+// recorded, means an op that a branch body discards when it unwinds no longer
+// blocks a later save. Callers validate the stream first, so record sizes and
+// nested operation counts are trusted here.
+static uint32_t apic_stream_first_nonserializable_op(const uint8_t* data, uint32_t operation_count)
+{
+    const uint8_t* ptr = data;
+    for (uint32_t i = 0; i < operation_count; ++i) {
+        const auto* header = reinterpret_cast<const APICOpHeader*>(ptr);
+        switch (header->op_type) {
+        case APIC_OP_BVH_REFIT:
+        case APIC_OP_BVH_REBUILD:
+        case APIC_OP_HASH_GRID_UPDATE:
+            return header->op_type;
+        case APIC_OP_IF:
+        case APIC_OP_WHILE: {
+            const auto* rec = reinterpret_cast<const APICCondRecord*>(ptr);
+            const uint8_t* branch_a = ptr + sizeof(APICCondRecord);
+            const uint8_t* branch_b = branch_a + rec->branch_a_size;
+            if (uint32_t op = apic_stream_first_nonserializable_op(branch_a, rec->branch_a_op_count))
+                return op;
+            if (uint32_t op = apic_stream_first_nonserializable_op(branch_b, rec->branch_b_op_count))
+                return op;
+            break;
+        }
+        default:
+            break;
+        }
+        ptr += header->total_size;
+    }
+    return 0;
 }
 
 // ============================================================================
@@ -1823,6 +2038,28 @@ static size_t apic_args_buf_size(const APICLaunchParamRecord* bindings, uint16_t
         total += binding->value_size;
     }
     return total;
+}
+
+template <typename VecType>
+static void apic_execute_hash_grid_update(const APICHashGridUpdateRecord* rec, void* points_data, void* groups_data)
+{
+    // Recreate transient descriptors around replay-resolved data because the
+    // captured array descriptors contain process-local pointers.
+    wp::array_t<VecType> points = {};
+    points.data = static_cast<VecType*>(points_data);
+    points.ndim = 1;
+    points.shape[0] = rec->point_count;
+    points.strides[0] = rec->points_stride;
+
+    wp::array_t<int> groups = {};
+    groups.data = static_cast<int*>(groups_data);
+    groups.ndim = 1;
+    groups.shape[0] = rec->point_count;
+    groups.strides[0] = rec->groups_stride;
+
+    wp_hash_grid_update_host(
+        rec->grid_id, rec->grid_type, rec->cell_width, &points, rec->has_groups ? &groups : nullptr
+    );
 }
 
 // Walk an APIC byte stream and execute CPU operations. Assumes the stream
@@ -2359,6 +2596,76 @@ static bool apic_cpu_replay_stream(
             break;
         }
 
+        case APIC_OP_HASH_GRID_UPDATE: {
+            const auto* rec = reinterpret_cast<const APICHashGridUpdateRecord*>(ptr);
+            uint64_t point_element_size;
+            switch (rec->grid_type) {
+            case wp::HASH_GRID_TYPE_FLOAT16:
+                point_element_size = sizeof(wp::vec3h);
+                break;
+            case wp::HASH_GRID_TYPE_FLOAT32:
+                point_element_size = sizeof(wp::vec3f);
+                break;
+            default:
+                point_element_size = sizeof(wp::vec3d);
+                break;
+            }
+
+            void* points_data = nullptr;
+            if (rec->point_count > 0) {
+                uint64_t low_offset;
+                uint64_t span_size;
+                if (!apic_compute_strided_span(
+                        rec->point_count, rec->points_stride, point_element_size, rec->points_offset, &low_offset,
+                        &span_size
+                    )) {
+                    fprintf(stderr, "APIC: Error - HashGrid points span invalid at operation %u\n", i);
+                    return false;
+                }
+                void* low_data = resolve_ptr(rec->points_region_id, low_offset, span_size);
+                if (!low_data) {
+                    fprintf(stderr, "APIC: Error - HashGrid points resolution failed at operation %u\n", i);
+                    return false;
+                }
+                points_data = static_cast<uint8_t*>(low_data) + (rec->points_offset - low_offset);
+            }
+
+            void* groups_data = nullptr;
+            if (rec->has_groups && rec->point_count > 0) {
+                uint64_t low_offset;
+                uint64_t span_size;
+                if (!apic_compute_strided_span(
+                        rec->point_count, rec->groups_stride, sizeof(int32_t), rec->groups_offset, &low_offset,
+                        &span_size
+                    )) {
+                    fprintf(stderr, "APIC: Error - HashGrid groups span invalid at operation %u\n", i);
+                    return false;
+                }
+                void* low_data = resolve_ptr(rec->groups_region_id, low_offset, span_size);
+                if (!low_data) {
+                    fprintf(stderr, "APIC: Error - HashGrid groups resolution failed at operation %u\n", i);
+                    return false;
+                }
+                groups_data = static_cast<uint8_t*>(low_data) + (rec->groups_offset - low_offset);
+            }
+
+            switch (rec->grid_type) {
+            case wp::HASH_GRID_TYPE_FLOAT16:
+                apic_execute_hash_grid_update<wp::vec3h>(rec, points_data, groups_data);
+                break;
+            case wp::HASH_GRID_TYPE_FLOAT32:
+                apic_execute_hash_grid_update<wp::vec3f>(rec, points_data, groups_data);
+                break;
+            case wp::HASH_GRID_TYPE_FLOAT64:
+                apic_execute_hash_grid_update<wp::vec3d>(rec, points_data, groups_data);
+                break;
+            default:
+                fprintf(stderr, "APIC: Error - unsupported HashGrid type at operation %u\n", i);
+                return false;
+            }
+            break;
+        }
+
         case APIC_OP_IF: {
             const APICCondRecord* rec = reinterpret_cast<const APICCondRecord*>(ptr);
             const uint8_t* branch_a = ptr + sizeof(APICCondRecord);
@@ -2522,16 +2829,31 @@ bool wp_apic_state_save(APICState* state, const char* path, int target_arch, voi
         return false;
     }
 
+    if (!apic_validate_operation_stream(
+            state->operation_stream.data(), state->operation_stream.size(), state->operation_count
+        )) {
+        wp::set_error_string("APIC operation stream failed validation");
+        return false;
+    }
+
     // Refuse to serialize a stream whose replay depends on a process-local
-    // handle (e.g. wp.Bvh.refit()/rebuild()). The recorded handle would dangle
-    // when the graph is loaded in another process; fail with an actionable
-    // error instead of writing a .wrp that crashes at replay.
-    if (state->nonportable_reason) {
+    // handle (a live BVH pointer or HashGrid grid_id). Such a handle would
+    // dangle when the graph is loaded in another process, so fail with an
+    // actionable error instead of writing a .wrp that crashes at replay. The
+    // check scans the finalized stream, so ops discarded by branch-capture
+    // unwinding do not count.
+    const uint32_t nonserializable_op
+        = apic_stream_first_nonserializable_op(state->operation_stream.data(), state->operation_count);
+    if (const char* bvh_op = apic_bvh_op_name(nonserializable_op)) {
         wp::set_error_string(
             "Cannot serialize a captured graph that records %s: the BVH handle is process-local and cannot be "
             "saved to a .wrp. Replay the captured graph in-process instead of saving it.",
-            state->nonportable_reason
+            bvh_op
         );
+        return false;
+    }
+    if (nonserializable_op == APIC_OP_HASH_GRID_UPDATE) {
+        wp::set_error_string("HashGrid serialization is not yet supported in APIC graphs");
         return false;
     }
 
@@ -2910,12 +3232,6 @@ APICGraph* wp_apic_load_graph(void* context, const char* path, int device_type)
         return nullptr;
     }
 
-    APICGraph* graph = new APICGraph();
-    graph->cuda_context = context;
-    graph->target_arch = header->target_arch;
-    graph->device_type = static_cast<APICDeviceType>(device_type);
-    graph->base_path = base_name;
-
     const APICSectionEntry* sections
         = reinterpret_cast<const APICSectionEntry*>(file_data.data() + header->section_table_offset);
 
@@ -2938,6 +3254,47 @@ APICGraph* wp_apic_load_graph(void* context, const char* path, int device_type)
             operations_size = sections[i].size;
         }
     }
+
+    // Validate operations before allocating or reconstructing graph resources.
+    // The later recursive scan relies on validation for safe traversal.
+    uint32_t operation_count = 0;
+    const uint8_t* operation_stream = nullptr;
+    size_t operation_stream_size = 0;
+    if (operations_ptr) {
+        if (operations_size < sizeof(operation_count)) {
+            wp::set_error_string("Failed to parse operations");
+            return nullptr;
+        }
+        memcpy(&operation_count, operations_ptr, sizeof(operation_count));
+        operation_stream = operations_ptr + sizeof(operation_count);
+        operation_stream_size = operations_size - sizeof(operation_count);
+        if (!apic_validate_operation_stream(operation_stream, operation_stream_size, operation_count)) {
+            wp::set_error_string("APIC operation stream failed validation");
+            return nullptr;
+        }
+        // A well-formed .wrp never records a process-local handle (wp_apic_state_save
+        // refuses one); reject defensively in case of a hand-crafted or corrupt file,
+        // since a loaded graph cannot reconstruct the live BVH pointer or grid_id.
+        const uint32_t nonserializable_op = apic_stream_first_nonserializable_op(operation_stream, operation_count);
+        if (const char* bvh_op = apic_bvh_op_name(nonserializable_op)) {
+            wp::set_error_string(
+                "Cannot load a captured graph that records %s: the BVH handle is process-local and cannot be "
+                "reconstructed from a .wrp.",
+                bvh_op
+            );
+            return nullptr;
+        }
+        if (nonserializable_op == APIC_OP_HASH_GRID_UPDATE) {
+            wp::set_error_string("HashGrid serialization is not yet supported in APIC graphs");
+            return nullptr;
+        }
+    }
+
+    APICGraph* graph = new APICGraph();
+    graph->cuda_context = context;
+    graph->target_arch = header->target_arch;
+    graph->device_type = static_cast<APICDeviceType>(device_type);
+    graph->base_path = base_name;
 
     if (metadata_ptr && metadata_size > 0) {
         if (!apic_parse_metadata(metadata_ptr, metadata_size, graph)) {
@@ -2985,17 +3342,8 @@ APICGraph* wp_apic_load_graph(void* context, const char* path, int device_type)
         return nullptr;
     }
 
-    // Validate the operation byte stream once, before any replay/rebuild consumes it.
-    // Downstream paths (apic_rebuild_cuda_graph, wp_apic_cpu_replay_graph) gate on
-    // graph->operations_validated and skip per-op bounds checks.
-    graph->operations_validated = apic_validate_operation_stream(
-        graph->operation_stream.data(), graph->operation_stream.size(), graph->operation_count
-    );
-    if (!graph->operations_validated) {
-        wp::set_error_string("APIC operation stream failed validation");
-        delete graph;
-        return nullptr;
-    }
+    // The raw operation section was validated before graph resources were built.
+    graph->operations_validated = true;
 
     return graph;
 }

--- a/warp/native/apic_internal.h
+++ b/warp/native/apic_internal.h
@@ -224,14 +224,6 @@ struct APICState {
     // Replay paths require it; see apic_validate_operation_stream.
     bool operations_validated = false;
 
-    // Names the recorded operation, if any, whose replay depends on a
-    // process-local handle that cannot be serialized (e.g. wp.Bvh.refit() /
-    // rebuild(), which reference a live BVH pointer). Such a stream is valid for
-    // in-process replay but not portable, so wp_apic_state_save() refuses it
-    // with this name in the error rather than emitting a .wrp that would dangle
-    // when loaded in another process. nullptr means the stream is serializable.
-    const char* nonportable_reason = nullptr;
-
     // Contiguous operation byte stream (serializable)
     std::vector<uint8_t> operation_stream;
     uint32_t operation_count = 0;
@@ -482,6 +474,19 @@ void apic_record_bvh_refit(APICState* state, uint64_t bvh_id);
 // Records a wp_bvh_rebuild_host() call. ``constructor_type`` is the rebuild
 // construction algorithm (a BVH_CONSTRUCTOR_* value).
 void apic_record_bvh_rebuild(APICState* state, uint64_t bvh_id, int32_t constructor_type);
+
+void apic_record_hash_grid_update(
+    APICState* state,
+    uint64_t grid_id,
+    uint8_t grid_type,
+    double cell_width,
+    const void* points_data,
+    int32_t point_count,
+    int32_t points_stride,
+    const void* groups_data,
+    int32_t groups_stride,
+    uint8_t has_groups
+);
 
 // ----- Pointer resolution (for memcpy/memset hooks that receive raw pointers) -----
 

--- a/warp/native/apic_types.h
+++ b/warp/native/apic_types.h
@@ -45,6 +45,7 @@ enum APICOpType : uint32_t {
     APIC_OP_REDUCTION = 16,
     APIC_OP_BVH_REFIT = 17,  // wp_bvh_refit_host
     APIC_OP_BVH_REBUILD = 18,  // wp_bvh_rebuild_host
+    APIC_OP_HASH_GRID_UPDATE = 19,  // wp_hash_grid_update_host
 };
 
 enum APICReductionKind : uint8_t {
@@ -488,6 +489,24 @@ struct APICBvhRecord {
     int32_t constructor_type;  // rebuild constructor; -1 for refit
     uint32_t _pad;
 };  // 24 bytes
+
+struct APICHashGridUpdateRecord {
+    APICOpHeader header;
+    uint64_t grid_id;
+    double cell_width;
+    int32_t points_region_id;
+    int32_t groups_region_id;
+    uint64_t points_offset;
+    uint64_t groups_offset;
+    int32_t point_count;
+    int32_t points_stride;
+    int32_t groups_stride;
+    uint8_t grid_type;
+    uint8_t has_groups;
+    uint8_t _pad[2];
+};  // 64 bytes
+
+static_assert(sizeof(APICHashGridUpdateRecord) == 64, "APIC HashGrid update record must remain 64 bytes");
 
 // Conditional / loop op (variable: trailing per-branch op-stream blocks).
 // Used by both APIC_OP_IF (then + else branches) and APIC_OP_WHILE

--- a/warp/native/hashgrid.cpp
+++ b/warp/native/hashgrid.cpp
@@ -3,6 +3,8 @@
 
 #include "warp.h"
 
+#include "apic.h"
+#include "apic_internal.h"
 #include "cuda_util.h"
 #include "hashgrid.h"
 #include "sort.h"
@@ -361,11 +363,28 @@ void hash_grid_update_device_impl(
 // Exported API
 // =============================================================================
 
-enum HashGridTypeId {
-    HASH_GRID_TYPE_FLOAT16 = 0,
-    HASH_GRID_TYPE_FLOAT32 = 1,
-    HASH_GRID_TYPE_FLOAT64 = 2,
-};
+// CPU capture is record-only: returning true makes the caller skip the eager
+// rebuild so replay performs it in operation-stream order.
+template <typename Type>
+static bool hash_grid_record_update_host(
+    APICState* state,
+    uint64_t id,
+    int grid_type,
+    double cell_width,
+    const wp::array_t<vec_t<3, Type>>* points,
+    const wp::array_t<int>* groups
+)
+{
+    if (!state)
+        return false;
+
+    apic_record_hash_grid_update(
+        state, id, static_cast<uint8_t>(grid_type), cell_width, points ? points->data : nullptr,
+        points ? points->shape[0] : -1, points ? points->strides[0] : 0, groups ? groups->data : nullptr,
+        groups ? groups->strides[0] : 0, groups ? 1 : 0
+    );
+    return true;
+}
 
 uint64_t wp_hash_grid_create_host(int type, int dim_x, int dim_y, int dim_z)
 {
@@ -402,21 +421,30 @@ void wp_hash_grid_destroy_host(uint64_t id, int type)
 void wp_hash_grid_update_host(uint64_t id, int type, double cell_width, const void* points, const void* groups)
 {
     switch (type) {
-    case HASH_GRID_TYPE_FLOAT16:
-        hash_grid_update_host_impl<half>(
-            id, half(cell_width), (const wp::array_t<wp::vec3h>*)points, (const wp::array_t<int>*)groups
-        );
+    case HASH_GRID_TYPE_FLOAT16: {
+        const auto* points_desc = static_cast<const wp::array_t<wp::vec3h>*>(points);
+        const auto* groups_desc = static_cast<const wp::array_t<int>*>(groups);
+        if (hash_grid_record_update_host(wp_apic_get_recording_state(), id, type, cell_width, points_desc, groups_desc))
+            break;
+        hash_grid_update_host_impl<half>(id, half(cell_width), points_desc, groups_desc);
         break;
-    case HASH_GRID_TYPE_FLOAT32:
-        hash_grid_update_host_impl<float>(
-            id, float(cell_width), (const wp::array_t<wp::vec3f>*)points, (const wp::array_t<int>*)groups
-        );
+    }
+    case HASH_GRID_TYPE_FLOAT32: {
+        const auto* points_desc = static_cast<const wp::array_t<wp::vec3f>*>(points);
+        const auto* groups_desc = static_cast<const wp::array_t<int>*>(groups);
+        if (hash_grid_record_update_host(wp_apic_get_recording_state(), id, type, cell_width, points_desc, groups_desc))
+            break;
+        hash_grid_update_host_impl<float>(id, float(cell_width), points_desc, groups_desc);
         break;
-    case HASH_GRID_TYPE_FLOAT64:
-        hash_grid_update_host_impl<double>(
-            id, cell_width, (const wp::array_t<wp::vec3d>*)points, (const wp::array_t<int>*)groups
-        );
+    }
+    case HASH_GRID_TYPE_FLOAT64: {
+        const auto* points_desc = static_cast<const wp::array_t<wp::vec3d>*>(points);
+        const auto* groups_desc = static_cast<const wp::array_t<int>*>(groups);
+        if (hash_grid_record_update_host(wp_apic_get_recording_state(), id, type, cell_width, points_desc, groups_desc))
+            break;
+        hash_grid_update_host_impl<double>(id, cell_width, points_desc, groups_desc);
         break;
+    }
     default:
         fprintf(stderr, "Warp error: Invalid hash grid type %d\n", type);
     }

--- a/warp/native/hashgrid.h
+++ b/warp/native/hashgrid.h
@@ -5,6 +5,12 @@
 
 namespace wp {
 
+enum HashGridTypeId {
+    HASH_GRID_TYPE_FLOAT16 = 0,
+    HASH_GRID_TYPE_FLOAT32 = 1,
+    HASH_GRID_TYPE_FLOAT64 = 2,
+};
+
 // Note: Field order is important! Type-independent fields come first so that
 // point_ids is at a consistent offset regardless of Type. This allows
 // hash_grid_point_id to work without knowing the grid's scalar type.

--- a/warp/tests/geometry/test_hash_grid.py
+++ b/warp/tests/geometry/test_hash_grid.py
@@ -616,6 +616,16 @@ def test_hashgrid_grouped_many_groups(test, device):
     assert_np_equal(counts.numpy(), np.ones(num_points, dtype=np.int32))
 
 
+def test_hashgrid_saveable_capture_unsupported(test, device):
+    """Report saveable capture as unsupported pending HashGrid serialization."""
+    points = wp.array([[0.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
+    grid = wp.HashGrid(16, 16, 16, device=device)
+
+    with test.assertRaisesRegex(NotImplementedError, "HashGrid serialization is not yet supported"):
+        with wp.ScopedCapture(device=device, apic=True, force_module_load=False):
+            grid.build(points, 1.0)
+
+
 def test_hashgrid_grouped_graph_capture_changing_group_ids(test, device):
     """Group values written by captured work are honored on replay, including unseen group ids."""
     points = np.array(
@@ -1020,6 +1030,179 @@ class TestHashGrid(unittest.TestCase):
         self.assertIn("HashGridQueryD", output)
         self.assertIn("warp.hash_grid_query()", output)
 
+    def test_hashgrid_graph_rebuilds_current_points(self):
+        """Rebuild a CPU HashGrid from a current strided point view on every replay."""
+        device = "cpu"
+        radius = 0.25
+        point_buffer = wp.array(
+            [[0.0, 0.0, 0.0], [20.0, 0.0, 0.0], [0.1, 0.0, 0.0], [30.0, 0.0, 0.0]],
+            dtype=wp.vec3,
+            device=device,
+        )
+        points = point_buffer[::2]
+        source = wp.array(
+            [[2.0, 0.0, 0.0], [20.0, 0.0, 0.0], [6.0, 0.0, 0.0], [30.0, 0.0, 0.0]],
+            dtype=wp.vec3,
+            device=device,
+        )
+        counts = wp.zeros(2, dtype=int, device=device)
+        grid = wp.HashGrid(16, 16, 16, device=device)
+        grid.build(points, radius)
+
+        wp.load_module(device=device)
+        with wp.ScopedCapture(device=device, apic=False, force_module_load=False) as capture:
+            wp.copy(point_buffer, source)
+            grid.build(points, radius)
+            wp.launch(
+                count_neighbors_f32,
+                dim=2,
+                inputs=[wp.uint64(grid.id), wp.float32(radius), points, counts],
+                device=device,
+            )
+
+        wp.capture_launch(capture.graph)
+        assert_np_equal(counts.numpy(), np.array([1, 1], dtype=np.int32))
+
+        source.assign([[2.0, 0.0, 0.0], [20.0, 0.0, 0.0], [2.1, 0.0, 0.0], [30.0, 0.0, 0.0]])
+        wp.capture_launch(capture.graph)
+        assert_np_equal(counts.numpy(), np.array([2, 2], dtype=np.int32))
+
+    def test_hashgrid_graph_first_build_all_precisions(self):
+        """Allocate and rebuild every supported CPU HashGrid precision on first replay."""
+        device = "cpu"
+        precision_types = (
+            (wp.float16, wp.vec3h, count_neighbors_f16),
+            (wp.float32, wp.vec3f, count_neighbors_f32),
+            (wp.float64, wp.vec3d, count_neighbors_f64),
+        )
+
+        for scalar_dtype, vector_dtype, kernel in precision_types:
+            with self.subTest(dtype=scalar_dtype.__name__):
+                points = wp.zeros(2, dtype=vector_dtype, device=device)
+                source = wp.array([[3.0, 0.0, 0.0], [3.1, 0.0, 0.0]], dtype=vector_dtype, device=device)
+                counts = wp.zeros(2, dtype=int, device=device)
+                grid = wp.HashGrid(16, 16, 16, device=device, dtype=scalar_dtype)
+
+                wp.load_module(device=device)
+                with wp.ScopedCapture(device=device, apic=False, force_module_load=False) as capture:
+                    wp.copy(points, source)
+                    grid.build(points, 0.25)
+                    wp.launch(
+                        kernel,
+                        dim=2,
+                        inputs=[wp.uint64(grid.id), scalar_dtype(0.25), points, counts],
+                        device=device,
+                    )
+
+                wp.capture_launch(capture.graph)
+                assert_np_equal(counts.numpy(), np.array([2, 2], dtype=np.int32))
+
+    def test_hashgrid_grouped_graph_first_build(self):
+        """Allocate a grouped CPU HashGrid on first replay and rebuild from current groups."""
+        device = "cpu"
+        radius = 0.25
+        points = wp.array(
+            [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.0], [0.1, 0.0, 0.0]],
+            dtype=wp.vec3,
+            device=device,
+        )
+        groups = wp.array([0, 0, 1, 1], dtype=int, device=device)
+        counts = wp.zeros(4, dtype=int, device=device)
+        grid = wp.HashGrid(16, 16, 16, device=device)
+
+        wp.load_module(device=device)
+        with wp.ScopedCapture(device=device, apic=False, force_module_load=False) as capture:
+            grid.build(points, radius, groups=groups)
+            wp.launch(
+                count_neighbors_grouped,
+                dim=4,
+                inputs=[wp.uint64(grid.id), radius, points, groups, counts],
+                device=device,
+            )
+
+        wp.capture_launch(capture.graph)
+        assert_np_equal(counts.numpy(), np.array([2, 2, 2, 2], dtype=np.int32))
+
+        groups.assign([3, 3, 3, 3])
+        wp.capture_launch(capture.graph)
+        assert_np_equal(counts.numpy(), np.array([4, 4, 4, 4], dtype=np.int32))
+
+    def test_hashgrid_graph_empty_build(self):
+        """Clear prior grouped CPU HashGrid contents when an empty build replays."""
+        device = "cpu"
+        radius = 1.0
+        query_points = wp.array([[0.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
+        warm_groups = wp.array([7], dtype=int, device=device)
+        empty_points = wp.empty(0, dtype=wp.vec3, device=device)
+        empty_groups = wp.empty(0, dtype=int, device=device)
+        counts = wp.zeros(1, dtype=int, device=device)
+        grid = wp.HashGrid(16, 16, 16, device=device)
+        grid.build(query_points, radius, groups=warm_groups)
+
+        wp.load_module(device=device)
+        with wp.ScopedCapture(device=device, apic=False, force_module_load=False) as capture:
+            grid.build(empty_points, radius, groups=empty_groups)
+            wp.launch(
+                count_neighbors_fixed_group,
+                dim=1,
+                inputs=[wp.uint64(grid.id), radius, 7, query_points, counts],
+                device=device,
+            )
+
+        wp.capture_launch(capture.graph)
+        assert_np_equal(counts.numpy(), np.array([0], dtype=np.int32))
+
+    def test_hashgrid_graph_multidimensional_inputs(self):
+        """Replay builds from current two-dimensional point and group arrays."""
+        device = "cpu"
+        radius = 0.25
+        clustered_points = np.array(
+            [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.0, 0.0, 0.0], [0.1, 0.0, 0.0]],
+            dtype=np.float32,
+        )
+        separated_points = np.array(
+            [[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], [4.0, 0.0, 0.0], [6.0, 0.0, 0.0]],
+            dtype=np.float32,
+        )
+        initial_groups = np.array([0, 0, 1, 1], dtype=np.int32)
+        updated_groups = np.array([3, 3, 3, 3], dtype=np.int32)
+
+        shape = (2, 2)
+        points = wp.array(clustered_points.reshape((*shape, 3)), dtype=wp.vec3, device=device)
+        groups = wp.array(initial_groups.reshape(shape), dtype=int, device=device)
+        points_flat = points.flatten()
+        groups_flat = groups.flatten()
+        counts = wp.zeros(4, dtype=int, device=device)
+        grid = wp.HashGrid(16, 16, 16, device=device)
+
+        wp.load_module(device=device)
+        with wp.ScopedCapture(device=device, apic=False, force_module_load=False) as capture:
+            grid.build(points, radius, groups=groups)
+            wp.launch(
+                count_neighbors_grouped,
+                dim=4,
+                inputs=[wp.uint64(grid.id), radius, points_flat, groups_flat, counts],
+                device=device,
+            )
+
+        wp.capture_launch(capture.graph)
+        assert_np_equal(counts.numpy(), np.array([2, 2, 2, 2], dtype=np.int32))
+
+        points.assign(separated_points.reshape((*shape, 3)))
+        groups.assign(updated_groups.reshape(shape))
+        wp.capture_launch(capture.graph)
+        assert_np_equal(counts.numpy(), np.array([1, 1, 1, 1], dtype=np.int32))
+
+    def test_hashgrid_reserve_during_capture_unsupported(self):
+        """Report reserve as unsupported while a live CPU graph capture is active."""
+        device = "cpu"
+        grid = wp.HashGrid(16, 16, 16, device=device)
+        grid.reserve(4)
+
+        with self.assertRaisesRegex(NotImplementedError, "reserve before capture"):
+            with wp.ScopedCapture(device=device, apic=False, force_module_load=False):
+                grid.reserve(8)
+
 
 add_function_test(TestHashGrid, "test_hashgrid_query", test_hashgrid_query, devices=devices)
 add_function_test(TestHashGrid, "test_hashgrid_inputs", test_hashgrid_inputs, devices=devices)
@@ -1041,15 +1224,21 @@ add_function_test(
 add_function_test(TestHashGrid, "test_hashgrid_grouped_many_groups", test_hashgrid_grouped_many_groups, devices=devices)
 add_function_test(
     TestHashGrid,
+    "test_hashgrid_saveable_capture_unsupported",
+    test_hashgrid_saveable_capture_unsupported,
+    devices=devices,
+)
+add_function_test(
+    TestHashGrid,
     "test_hashgrid_grouped_graph_capture_changing_group_ids",
     test_hashgrid_grouped_graph_capture_changing_group_ids,
-    devices=cuda_devices,
+    devices=devices,
 )
 add_function_test(
     TestHashGrid,
     "test_hashgrid_grouped_graph_capture_after_reserve",
     test_hashgrid_grouped_graph_capture_after_reserve,
-    devices=cuda_devices,
+    devices=devices,
 )
 add_function_test(TestHashGrid, "test_hashgrid_device_validation", test_hashgrid_device_validation, devices=devices)
 add_function_test(

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -6,9 +6,11 @@
 import ctypes
 import gc
 import os
+import struct
 import tempfile
 import unittest
 import weakref
+from functools import partial
 from unittest import mock
 
 import numpy as np
@@ -64,6 +66,72 @@ class TestApic(unittest.TestCase):
     pass
 
 
+# Must match APICSectionType in warp/native/apic_types.h.
+_APIC_SECTION_MEMORY = 2
+_APIC_SECTION_OPERATIONS = 3
+
+# These layouts mirror the packed structs in warp/native/apic_types.h. "<"
+# selects little-endian standard sizes without implicit alignment; "4s", "i",
+# "I", and "Q" mean four raw bytes, int32_t, uint32_t, and uint64_t.
+
+# APICFileHeader prefix: magic, version, flags, section count, section-table offset.
+_APIC_FILE_HEADER_PREFIX = struct.Struct("<4sIIIQ")
+
+# APICSectionEntry: type, flags, offset, stored size, uncompressed size.
+_APIC_SECTION_ENTRY = struct.Struct("<IIQQQ")
+
+# APICCondRecord: operation type/size, condition region/padding/offset, then each
+# branch's byte size and operation count.
+_APIC_COND_RECORD = struct.Struct("<IIiIQIIII")
+_APIC_UINT32 = struct.Struct("<I")  # One serialized uint32_t.
+
+
+def _find_apic_section(wrp_data, requested_section_type):
+    """Return the byte offset and size of one WRP section."""
+    magic, _, _, section_count, section_table_offset = _APIC_FILE_HEADER_PREFIX.unpack_from(wrp_data)
+    if magic != b"WRP1":
+        raise ValueError("Not a WRP file")
+
+    matching_sections = []
+    for section_index in range(section_count):
+        entry = _APIC_SECTION_ENTRY.unpack_from(
+            wrp_data, section_table_offset + _APIC_SECTION_ENTRY.size * section_index
+        )
+        section_type, _, section_offset, section_size, _ = entry
+        if section_type == requested_section_type:
+            matching_sections.append((section_offset, section_size))
+
+    if len(matching_sections) != 1:
+        raise ValueError(f"Expected one WRP section of type {requested_section_type}")
+    return matching_sections[0]
+
+
+def _corrupt_apic_empty_branch_count(path, branch_name):
+    """Make one empty conditional branch declare an operation."""
+    branch_fields = {"branch_a": (5, 6), "branch_b": (7, 8)}
+    branch_size_index, branch_count_index = branch_fields[branch_name]
+
+    with open(path, "r+b") as wrp_file:
+        wrp_data = wrp_file.read()
+        section_offset, section_size = _find_apic_section(wrp_data, _APIC_SECTION_OPERATIONS)
+
+        if section_size < _APIC_UINT32.size + _APIC_COND_RECORD.size:
+            raise ValueError("WRP operations section has no conditional record")
+
+        operation_count = _APIC_UINT32.unpack_from(wrp_data, section_offset)[0]
+        if operation_count != 1:
+            raise ValueError("Expected exactly one operation")
+
+        conditional_offset = section_offset + _APIC_UINT32.size
+        conditional = list(_APIC_COND_RECORD.unpack_from(wrp_data, conditional_offset))
+        if conditional[branch_size_index] != 0 or conditional[branch_count_index] != 0:
+            raise ValueError(f"Expected an empty {branch_name}")
+
+        conditional[branch_count_index] = 1
+        wrp_file.seek(conditional_offset)
+        wrp_file.write(_APIC_COND_RECORD.pack(*conditional))
+
+
 def test_save_apic_false_error(test, device):
     """capture_save() should raise when apic=False."""
     n = 64
@@ -77,6 +145,102 @@ def test_save_apic_false_error(test, device):
     with tempfile.TemporaryDirectory() as tmpdir:
         with test.assertRaises(RuntimeError):
             wp.capture_save(capture.graph, os.path.join(tmpdir, "should_not_exist"))
+
+
+def test_apic_native_save_reports_hashgrid_serialization_unsupported(test, device):
+    """Report HashGrid serialization as unsupported pending grid-handle remapping."""
+    points = wp.array([[0.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
+    condition = wp.array([1], dtype=wp.int32, device=device)
+
+    for nested in (False, True):
+        with test.subTest(nested=nested):
+            grid = wp.HashGrid(16, 16, 16, device=device)
+
+            with wp.ScopedCapture(device=device, apic=False, force_module_load=False) as capture:
+                if nested:
+                    wp.capture_if(condition, on_true=partial(grid.build, points, 1.0))
+                else:
+                    grid.build(points, 1.0)
+
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = os.path.join(tmpdir, "hashgrid.wrp")
+                saved_error_output_enabled = wp_context.runtime.core.wp_is_error_output_enabled()
+                try:
+                    wp_context.runtime.core.wp_set_error_output_enabled(False)
+                    result = wp_context.runtime.core.wp_apic_state_save(
+                        capture.graph.apic_state,
+                        path.encode("utf-8"),
+                        0,
+                        None,
+                    )
+                    test.assertFalse(result)
+                    test.assertIn(
+                        "HashGrid serialization is not yet supported in APIC graphs",
+                        wp_context.runtime.get_error_string(),
+                    )
+                    test.assertFalse(os.path.exists(path))
+                finally:
+                    wp_context.runtime.core.wp_set_error_output_enabled(saved_error_output_enabled)
+
+
+def test_capture_load_rejects_empty_conditional_branches_with_operations(test, device):
+    """Reject conditional branches that declare operations without bytes."""
+    condition = wp.array([1], dtype=wp.int32, device=device)
+
+    def empty_branch():
+        """Record an intentionally empty conditional branch."""
+
+    for branch_name in ("branch_a", "branch_b"):
+        with test.subTest(branch=branch_name), tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, f"{branch_name}.wrp")
+            with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+                if branch_name == "branch_a":
+                    wp.capture_if(condition, on_true=empty_branch)
+                else:
+                    wp.capture_if(condition, on_false=empty_branch)
+            wp.capture_save(capture.graph, path)
+            _corrupt_apic_empty_branch_count(path, branch_name)
+
+            saved_error_output_enabled = wp_context.runtime.core.wp_is_error_output_enabled()
+            try:
+                wp_context.runtime.core.wp_set_error_output_enabled(False)
+                with test.assertRaisesRegex(RuntimeError, "operation stream failed validation"):
+                    wp.capture_load(path, device=device)
+            finally:
+                wp_context.runtime.core.wp_set_error_output_enabled(saved_error_output_enabled)
+
+
+def test_live_hashgrid_capture_does_not_snapshot_inputs(test, device):
+    """Keep live-only HashGrid input regions out of serialized snapshots."""
+    base = wp.zeros(4096, dtype=wp.vec3, device=device)
+    points = base[:1]
+    grid = wp.HashGrid(16, 16, 16, device=device)
+
+    with wp.ScopedCapture(device=device, apic=False, force_module_load=False) as capture:
+        apic_capture = wp_context.runtime._apic_capture
+        branch_start = wp_context.runtime.core.wp_apic_begin_branch(apic_capture.apic_state)
+        try:
+            grid.build(points, 1.0)
+        finally:
+            branch_body = wp_context.runtime.core.wp_apic_end_branch(apic_capture.apic_state, branch_start)
+            wp_context.runtime.core.wp_apic_free_branch_body(branch_body)
+
+    test.assertEqual(capture.graph._apic_capture.operation_count, 0)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "live_hashgrid_inputs.wrp")
+        result = wp_context.runtime.core.wp_apic_state_save(
+            capture.graph.apic_state,
+            path.encode("utf-8"),
+            0,
+            None,
+        )
+        test.assertTrue(result, wp_context.runtime.get_error_string())
+
+        with open(path, "rb") as wrp_file:
+            wrp_data = wrp_file.read()
+        memory_offset, memory_size = _find_apic_section(wrp_data, _APIC_SECTION_MEMORY)
+        test.assertEqual(memory_size, 4)
+        test.assertEqual(_APIC_UINT32.unpack_from(wrp_data, memory_offset)[0], 0)
 
 
 def test_save_single_kernel(test, device):
@@ -2765,6 +2929,42 @@ def test_capture_with_bvh_rebuild_save_rejected(test, device):
         test.assertFalse(os.path.exists(path + ".wrp"))
 
 
+def test_discarded_bvh_op_does_not_block_save(test, device):
+    """A BVH op discarded when a branch body unwinds must not block a later save.
+
+    Non-serializability is derived from the finalized operation stream, not from
+    a flag set when the op is recorded. So recording a BVH refit inside a branch
+    that is then discarded (as capture_if/capture_while do when a body raises)
+    leaves the finalized stream serializable, and capture_save() must accept it.
+    """
+    lowers = wp.array([(0.0, 0.0, 0.0)], dtype=wp.vec3, device=device)
+    uppers = wp.array([(1.0, 1.0, 1.0)], dtype=wp.vec3, device=device)
+    bvh = wp.Bvh(lowers, uppers)
+
+    wp.load_module(device=device)
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        apic_capture = wp_context.runtime._apic_capture
+        branch_start = wp_context.runtime.core.wp_apic_begin_branch(apic_capture.apic_state)
+        try:
+            bvh.refit()
+        finally:
+            branch_body = wp_context.runtime.core.wp_apic_end_branch(apic_capture.apic_state, branch_start)
+            wp_context.runtime.core.wp_apic_free_branch_body(branch_body)
+
+    # The refit was discarded with the branch, so nothing non-serializable remains.
+    test.assertEqual(capture.graph._apic_capture.operation_count, 0)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "discarded_bvh_refit.wrp")
+        result = wp_context.runtime.core.wp_apic_state_save(
+            capture.graph.apic_state,
+            path.encode("utf-8"),
+            0,
+            None,
+        )
+        test.assertTrue(result, wp_context.runtime.get_error_string())
+        test.assertTrue(os.path.exists(path))
+
+
 devices = get_test_devices()
 devices_with_graph_capture_allocation = get_test_devices_with_graph_capture_allocation()
 devices_with_cuda_graph_module_load = get_test_devices_with_cuda_graph_module_load()
@@ -2798,9 +2998,33 @@ add_function_test(
 )
 add_function_test(
     TestApic,
+    "test_discarded_bvh_op_does_not_block_save",
+    test_discarded_bvh_op_does_not_block_save,
+    devices=[d for d in devices if d.is_cpu],
+)
+add_function_test(
+    TestApic,
     "test_save_apic_false_error",
     test_save_apic_false_error,
     devices=devices_with_cuda_graph_module_load,
+)
+add_function_test(
+    TestApic,
+    "test_apic_native_save_reports_hashgrid_serialization_unsupported",
+    test_apic_native_save_reports_hashgrid_serialization_unsupported,
+    devices=[d for d in devices if d.is_cpu],
+)
+add_function_test(
+    TestApic,
+    "test_capture_load_rejects_empty_conditional_branches_with_operations",
+    test_capture_load_rejects_empty_conditional_branches_with_operations,
+    devices=[d for d in devices if d.is_cpu],
+)
+add_function_test(
+    TestApic,
+    "test_live_hashgrid_capture_does_not_snapshot_inputs",
+    test_live_hashgrid_capture_does_not_snapshot_inputs,
+    devices=[d for d in devices if d.is_cpu],
 )
 add_function_test(
     TestApic,


### PR DESCRIPTION
## Description

Add live CPU graph capture and replay support for `wp.HashGrid.build()`. CPU APIC capture previously did not record HashGrid builds, so replayed queries could use stale buckets after point or group data changed. Captured graphs now rebuild the caller-owned grid in operation order from current inputs on every replay.

Saveable APIC capture still cannot serialize process-local HashGrid handles. Matching-device `apic=True` capture therefore rejects `HashGrid.build()` on both CPU and CUDA until handle remapping is supported, while `apic=False` remains available for live graphs.

Closes #1664.

## Changes

- Record CPU HashGrid builds with grouped, strided, multidimensional, empty, and all supported precision inputs.
- Retain graph input lifetimes without snapshotting potentially large backing allocations.
- Reject HashGrid serialization during saveable CPU and CUDA capture and in native save/load paths.
- Harden conditional-operation validation so malformed captures cannot trigger unbounded reads.
- Document live CPU graph ownership, reserve requirements, and unsupported CUDA saveable-capture operations.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/latest/project/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Rebuilt the native library successfully after the C++ changes.
- Verified CPU replay rebuilds HashGrid data from current point and group inputs, including strided and multidimensional arrays, empty builds, and all supported precisions.
- Verified the saveable-capture rejection test on CPU and both CUDA devices, including red/green coverage for the CUDA rejection.
- Verified malformed conditional branch records are rejected instead of allowing unbounded reads.
- Passed all 66 HashGrid tests and all 219 APIC tests.
- Passed the affected pre-commit hooks and built the documentation without warnings.

## New feature / enhancement

```python
import warp as wp

device = "cpu"
radius = 0.25
points = wp.array([[0.0, 0.0, 0.0], [0.1, 0.0, 0.0]], dtype=wp.vec3, device=device)
grid = wp.HashGrid(16, 16, 16, device=device)

with wp.ScopedCapture(device=device, apic=False) as capture:
    grid.build(points, radius)

points.assign([[2.0, 0.0, 0.0], [2.1, 0.0, 0.0]])
wp.capture_launch(capture.graph)  # Rebuilds the grid from the updated points.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live CPU graph capture and replay support for `HashGrid.build()`, rebuilding neighbor results from the current point data on every replay (including strided, grouped, empty-build, and multidimensional inputs across float16/32/64).

- **Limitations**
  - Saveable graph capture/APIC serialization does not support `HashGrid.build()`.
  - During live CPU graph capture, `HashGrid.build()` requires capture mode with `apic=False` (with `apic=True` raising `NotImplementedError`), and `HashGrid.reserve()` is not allowed during capture.

- **Documentation & Tests**
  - Updated runtime guidance and added CPU graph-replay and APIC validation regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->