### PR TITLE
Add configurable JAX kernel block dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   called during a capture are recorded and replayed against the current bounds, instead of running once at capture
   time and leaving replay to query a stale BVH. Such captures are replay-only; `capture_save()` rejects them because
   the BVH handle cannot be serialized ([GH-1665](https://github.com/NVIDIA/warp/issues/1665)).
+- Add an optional `block_dim` argument to `wp.jax_kernel()` for selecting the CUDA thread-block size, including for
+  tile kernels and their generated adjoint launches ([GH-1436](https://github.com/NVIDIA/warp/issues/1436)).
 
 ### Removed
 

--- a/docs/user_guide/interoperability/jax.rst
+++ b/docs/user_guide/interoperability/jax.rst
@@ -329,6 +329,52 @@ On the other hand, JAX dimensions are also accepted to allow passing shapes dire
 
 See `example_jax_kernel.py <https://github.com/NVIDIA/warp/blob/main/warp/examples/interop/example_jax_kernel.py>`_ for examples.
 
+CUDA Block Dimensions and Tile Kernels
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, :func:`jax_kernel() <warp.jax_kernel>` uses 256 threads per
+block on CUDA. Pass ``block_dim`` when a kernel needs another CUDA execution
+width, including SIMT kernels that use block-cooperative tile operations. The
+value is fixed when the wrapper is constructed. CPU execution continues to
+use one thread per block. See :doc:`Warp's tile programming model
+<../programming_model/tiles>` for an introduction to tile operations and their
+execution model.
+
+This example uses 64 CUDA threads to reduce each of four rows containing 256
+values::
+
+    ROW_COUNT = 4
+    TILE_SIZE = 256
+    TILE_THREADS = 64
+
+    @wp.kernel
+    def row_sum(values: wp.array2d[float], output: wp.array[float]):
+        row = wp.tid()
+        tile = wp.tile_load(values[row], shape=TILE_SIZE)
+        wp.tile_store(output[row], wp.tile_sum(tile))
+
+    jax_row_sum = wp.jax_kernel(
+        row_sum,
+        launch_dims=(ROW_COUNT, TILE_THREADS),
+        output_dims=(ROW_COUNT,),
+        block_dim=TILE_THREADS,
+    )
+
+    values = jnp.arange(ROW_COUNT * TILE_SIZE, dtype=jnp.float32)
+    values = values.reshape(ROW_COUNT, TILE_SIZE)
+    (output,) = jax.jit(jax_row_sum)(values)
+
+The launch dimensions follow :func:`wp.launch() <warp.launch>` semantics. A
+regular SIMT kernel passes its logical thread dimensions directly.
+:func:`wp.launch_tiled() <warp.launch_tiled>` normally appends ``block_dim``
+to those dimensions. Because :func:`jax_kernel() <warp.jax_kernel>` has no
+tiled-launch wrapper, include that execution width as the trailing launch
+dimension, as in ``launch_dims=(ROW_COUNT, TILE_THREADS)`` above.
+
+Keep ``output_dims`` equal to the logical output shape. When it is omitted,
+:func:`jax_kernel() <warp.jax_kernel>` defaults it to ``launch_dims``, so this
+example would allocate an output with shape ``(4, 64)`` instead of ``(4,)``.
+
 .. _jax-vmap:
 
 VMAP Support

--- a/warp/_src/jax/ffi.py
+++ b/warp/_src/jax/ffi.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import collections
 import ctypes
 import inspect
+import operator
 import threading
 import traceback
 from collections.abc import Callable
@@ -140,12 +141,16 @@ class JaxModulePreloadMode(IntEnum):
 ModulePreloadMode = JaxModulePreloadMode
 
 
-def _get_ffi_block_dim(device):
-    return 1 if device.is_cpu else 256
+def _get_ffi_block_dim(device, block_dim=None):
+    """Resolve the FFI block dimension for ``device``."""
+    if device.is_cpu:
+        # Remove this override if CPU launches gain configurable block dimensions.
+        return 1
+    return 256 if block_dim is None else block_dim
 
 
-def _load_ffi_module(module, device):
-    module_exec = module.load(device, _get_ffi_block_dim(device))
+def _load_ffi_module(module, device, block_dim=None):
+    module_exec = module.load(device, _get_ffi_block_dim(device, block_dim))
     if module_exec is None:
         raise RuntimeError(
             f"Failed to load Warp module '{module.name}' on device '{device}' after a previous build failure"
@@ -153,7 +158,7 @@ def _load_ffi_module(module, device):
     return module_exec
 
 
-def _preload_ffi_module(module, mode):
+def _preload_ffi_module(module, mode, block_dim=None):
     if mode == JaxModulePreloadMode.NONE:
         return
 
@@ -163,7 +168,7 @@ def _preload_ffi_module(module, mode):
             device = wp.device_from_jax(jax_device)
         except (IndexError, RuntimeError):
             return
-        _load_ffi_module(module, device)
+        _load_ffi_module(module, device, block_dim)
         return
 
     if mode == JaxModulePreloadMode.ALL_DEVICES:
@@ -189,7 +194,7 @@ def _preload_ffi_module(module, mode):
                 devices.append(device)
 
         for device in devices:
-            _load_ffi_module(module, device)
+            _load_ffi_module(module, device, block_dim)
         return
 
     raise ValueError(f"Unsupported JAX module preload mode '{mode}'")
@@ -239,6 +244,7 @@ class FfiKernel:
         num_outputs,
         vmap_method,
         launch_dims,
+        block_dim,
         output_dims,
         in_out_argnames,
         module_preload_mode,
@@ -249,6 +255,7 @@ class FfiKernel:
         self.num_outputs = num_outputs
         self.vmap_method = vmap_method
         self.launch_dims = launch_dims
+        self.block_dim = block_dim
         self.output_dims = output_dims
         self.module_preload_mode = module_preload_mode
         self.has_side_effect = has_side_effect
@@ -403,7 +410,7 @@ class FfiKernel:
             has_side_effect=self.has_side_effect,
         )
 
-        _preload_ffi_module(self.kernel.module, self.module_preload_mode)
+        _preload_ffi_module(self.kernel.module, self.module_preload_mode, self.block_dim)
 
         # save launch data to be retrieved by callback
         launch_id = self.launch_id
@@ -518,7 +525,7 @@ class FfiKernel:
 
                 # Preloading is best-effort, so the callback's actual device must
                 # load the module before reading code-generation metadata.
-                module_exec = _load_ffi_module(self.kernel.module, device)
+                module_exec = _load_ffi_module(self.kernel.module, device, self.block_dim)
                 block_dim = module_exec.block_dim
 
                 # determine launch bounds
@@ -553,7 +560,7 @@ class FfiKernel:
                     raise RuntimeError("Failed to find CUDA kernel entry point")
 
                 # reject non-cluster-aligned grids with a clear Python error instead
-                # of a cryptic native CUDA error (block_dim=256, max_blocks=0 below)
+                # of a cryptic native CUDA error (configured block_dim, max_blocks=0 below)
                 _validate_cluster_launch(hooks.cluster_dim, launch_bounds.size, block_dim, 0)
 
                 # launch the kernel (cluster_dim is cached on the hooks at load time)
@@ -1290,6 +1297,7 @@ def jax_kernel(
     module_preload_mode=JaxModulePreloadMode.CURRENT_DEVICE,
     enable_backward: bool = False,
     has_side_effect: bool = False,
+    block_dim: int | None = None,
 ):
     """Create a JAX callback from a Warp kernel.
 
@@ -1324,6 +1332,11 @@ def jax_kernel(
         enable_backward: Enable automatic differentiation for this kernel.
         has_side_effect: Whether the custom call has side effects. When True,
             the FFI call will be executed even when the outputs are not used.
+        block_dim: Specify the number of threads per block for CUDA execution.
+            When ``None``, CUDA uses 256 threads per block. CPU execution always
+            uses one thread per block. The value is fixed when the wrapper is
+            constructed and is shared by forward and adjoint launches when
+            ``enable_backward=True``.
 
     Limitations:
         - All kernel arguments must be contiguous arrays or scalars.
@@ -1337,6 +1350,16 @@ def jax_kernel(
 
     check_jax_version()
     jax = _get_jax()
+
+    if block_dim is not None:
+        if isinstance(block_dim, bool):
+            raise TypeError("jax_kernel(): block_dim must be an integer or None.")
+        try:
+            block_dim = operator.index(block_dim)
+        except TypeError:
+            raise TypeError("jax_kernel(): block_dim must be an integer or None.") from None
+        if block_dim <= 0:
+            raise ValueError("jax_kernel(): block_dim must be positive.")
 
     if isinstance(output_dims, dict):
         hashable_output_dims = tuple(sorted(output_dims.items()))
@@ -1360,6 +1383,7 @@ def jax_kernel(
             hashable_output_dims,
             module_preload_mode,
             has_side_effect,
+            block_dim,
         )
 
         with _FFI_REGISTRY_LOCK:
@@ -1369,6 +1393,7 @@ def jax_kernel(
                     num_outputs,
                     vmap_method,
                     launch_dims,
+                    block_dim,
                     output_dims,
                     in_out_argnames,
                     module_preload_mode,
@@ -1414,6 +1439,7 @@ def jax_kernel(
     # Reuse `hashable_launch_dims` (computed above for the cache key path)
     # so 1-D integer and sequence forms are normalized identically.
     _user_launch_dims = hashable_launch_dims if launch_dims is not None else None
+    _launch_block_dim = 256 if block_dim is None else block_dim
 
     def _resolve_launch_dims(call_args):
         if _user_launch_dims is not None:
@@ -1434,7 +1460,13 @@ def jax_kernel(
 
     # Forward kernel wrapper: simply launches the kernel
     def fwd_kernel_wrapper(*args):
-        wp.launch(kernel, dim=_resolve_launch_dims(args), inputs=args[:num_inputs], outputs=args[num_inputs:])
+        wp.launch(
+            kernel,
+            dim=_resolve_launch_dims(args),
+            inputs=args[:num_inputs],
+            outputs=args[num_inputs:],
+            block_dim=_launch_block_dim,
+        )
 
     # update forward signature and annotations so jax_callable() sees a fully annotated function
     fwd_kernel_wrapper.__signature__ = signature
@@ -1487,6 +1519,7 @@ def jax_kernel(
             adj_inputs=grad_in,
             adj_outputs=grad_out,
             adjoint=True,
+            block_dim=_launch_block_dim,
         )
 
     # Build the backward wrapper signature expected by jax_callable
@@ -1617,6 +1650,7 @@ def jax_kernel(
         # Reusing _user_launch_dims ensures int and 1-tuple forms of the same
         # value map to the same key.
         _user_launch_dims,
+        block_dim,
     )
 
     if static_args:
@@ -1657,6 +1691,7 @@ def jax_kernel(
             )
         return cached(*args)
 
+    _checked_wrapper.block_dim = block_dim
     return _checked_wrapper
 
 

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -27,6 +27,7 @@ os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
 # default array size for tests
 ARRAY_SIZE = 1024 * 1024
 TILE_STORE_SIZE = 64
+JAX_TILE_BLOCK_DIM = 64
 
 
 # basic kernel with one input and output
@@ -66,6 +67,15 @@ def inc_2d_kernel(x: wp.array2d[float], y: wp.array2d[float]):
 def shaped_tile_store_kernel(output: wp.array[float]):
     tile = wp.tile_ones(dtype=float, shape=TILE_STORE_SIZE)
     wp.tile_store(output, tile)
+
+
+@wp.kernel
+def ffi_tile_block_sum_kernel(output: wp.array[int]):
+    i = wp.tid()
+    output[i] = 0
+    values = wp.tile(i)
+    block_sum = wp.tile_sum(values)
+    wp.tile_store(output, block_sum, offset=i)
 
 
 # kernel with multiple inputs and outputs
@@ -127,11 +137,13 @@ class _RecordingFfiModule:
     def __init__(self, load_error=None, load_result=mock.sentinel.module_exec):
         self.name = "recording_module"
         self.loaded_devices = []
+        self.load_calls = []
         self.load_error = load_error
         self.load_result = load_result
 
-    def load(self, device, _block_dim=None):
+    def load(self, device, block_dim=None):
         self.loaded_devices.append(device)
+        self.load_calls.append((device, block_dim))
         if self.load_error is not None:
             raise self.load_error
         return self.load_result
@@ -601,6 +613,12 @@ def scale_sum_square_kernel(a: wp.array[float], b: wp.array[float], s: float, c:
     c[tid] = (a[tid] * s + b[tid]) ** 2.0
 
 
+@wp.kernel
+def block_dim_scale_kernel(a: wp.array[float], b: wp.array[float]):
+    tid = wp.tid()
+    b[tid] = a[tid] * float(wp.block_dim())
+
+
 # Kernels using subscript-style type hints (wp.array[dtype] syntax)
 @wp.kernel
 def add_kernel_subscript(a: wp.array[float], b: wp.array[float], output: wp.array[float]):
@@ -889,6 +907,31 @@ def test_ffi_jax_kernel_launch_dims_custom(test, device):
     test.assertEqual(result2.shape, expected2.shape)
     assert_np_equal(result1, expected1)
     assert_np_equal(result2, expected2)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+def test_ffi_jax_kernel_block_dim_tile(test, device):
+    jax = _import_jax()
+    test.assertTrue(device.is_cuda)
+
+    thread_count = 256
+    for block_dim in (JAX_TILE_BLOCK_DIM, 2 * JAX_TILE_BLOCK_DIM):
+        with test.subTest(block_dim=block_dim):
+            jax_block_sum = wp.jax_kernel(
+                ffi_tile_block_sum_kernel,
+                launch_dims=thread_count,
+                output_dims=thread_count,
+                block_dim=block_dim,
+            )
+
+            with jax.default_device(wp.device_to_jax(device)):
+                (result,) = jax.jit(jax_block_sum)()
+
+            jax.block_until_ready(result)
+            expected = np.zeros(thread_count, dtype=np.int32)
+            for offset in range(0, thread_count, block_dim):
+                expected[offset] = np.arange(offset, offset + block_dim, dtype=np.int32).sum()
+            assert_np_equal(np.asarray(result), expected)
 
 
 @unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
@@ -1438,6 +1481,37 @@ def test_ffi_jax_kernel_autodiff_simple(test, device):
 
     assert_np_equal(np.asarray(da), ref_da)
     assert_np_equal(np.asarray(db), ref_db)
+
+
+@unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+def test_ffi_jax_kernel_block_dim_autodiff(test, device):
+    jax = _import_jax()
+    jnp = _import_jax_numpy()
+
+    thread_count = 256
+    input_data = np.arange(thread_count, dtype=np.float32)
+
+    with jax.default_device(wp.device_to_jax(device)):
+        for block_dim in (64, 128):
+            with test.subTest(block_dim=block_dim):
+                wrapper = wp.jax_kernel(
+                    block_dim_scale_kernel,
+                    num_outputs=1,
+                    block_dim=block_dim,
+                    enable_backward=True,
+                )
+
+                values = jnp.asarray(input_data)
+                output = wrapper(values)[0]
+                gradient = jax.grad(lambda x, wrapper=wrapper: jnp.sum(wrapper(x)[0]))(values)
+                jax.block_until_ready((output, gradient))
+
+                multiplier = 1.0 if device.is_cpu else float(block_dim)
+                np.testing.assert_allclose(np.asarray(output), input_data * multiplier)
+                np.testing.assert_allclose(
+                    np.asarray(gradient),
+                    np.full(thread_count, multiplier, dtype=np.float32),
+                )
 
 
 @unittest.skipUnless(_jax_version() >= (0, 5, 0), "Jax version too old")
@@ -2344,6 +2418,32 @@ class TestJax(unittest.TestCase):
             self.skipTest(f"JAX CPU backend is unavailable: {e}")
 
     @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_jax_kernel_block_dim_validation(self):
+        for block_dim in (0, -1):
+            with self.subTest(block_dim=block_dim), self.assertRaisesRegex(ValueError, "block_dim must be positive"):
+                wp.jax_kernel(triple_kernel, block_dim=block_dim)
+
+        for block_dim in (True, False, 1.5):
+            with (
+                self.subTest(block_dim=block_dim),
+                self.assertRaisesRegex(TypeError, "block_dim must be an integer or None"),
+            ):
+                wp.jax_kernel(triple_kernel, block_dim=block_dim)
+
+        jax_kernel_64 = wp.jax_kernel(triple_kernel, block_dim=np.int64(64))
+        jax_kernel_128 = wp.jax_kernel(triple_kernel, block_dim=128)
+        jax_kernel_default = wp.jax_kernel(triple_kernel)
+        jax_kernel_256 = wp.jax_kernel(triple_kernel, block_dim=256)
+        jax_kernel_autodiff_64 = wp.jax_kernel(triple_kernel, block_dim=64, enable_backward=True)
+        jax_kernel_autodiff_default = wp.jax_kernel(triple_kernel, enable_backward=True)
+        self.assertEqual(jax_kernel_64.block_dim, 64)
+        self.assertEqual(jax_kernel_128.block_dim, 128)
+        self.assertIsNone(jax_kernel_default.block_dim)
+        self.assertEqual(jax_kernel_256.block_dim, 256)
+        self.assertEqual(jax_kernel_autodiff_64.block_dim, 64)
+        self.assertIsNone(jax_kernel_autodiff_default.block_dim)
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
     def test_ffi_jax_kernel_cpu_shaped_tile_store(self):
         """Test jax_kernel on CPU with a kernel that stores a fixed-shape tile."""
         jax = _import_jax()
@@ -2523,6 +2623,41 @@ class TestJax(unittest.TestCase):
             self.assertIn("cuda", requested_backends)
 
     @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
+    def test_ffi_module_preload_all_devices_block_dim(self):
+        """Keep CPU preloads at one thread and pass the configured block width to CUDA."""
+        from warp._src.jax import ffi as ffi_module  # noqa: PLC0415
+
+        jax_cpu = object()
+        jax_cuda = object()
+        warp_cpu = mock.Mock(is_cpu=True)
+        warp_cuda = mock.Mock(is_cpu=False)
+        jax_devices_by_backend = {"cpu": [jax_cpu], "cuda": [jax_cuda]}
+        warp_devices_by_jax_device = {jax_cpu: warp_cpu, jax_cuda: warp_cuda}
+
+        fake_jax = mock.Mock()
+        fake_jax.local_devices.side_effect = lambda *, backend: jax_devices_by_backend[backend]
+
+        module = _RecordingFfiModule()
+        with (
+            mock.patch.object(ffi_module, "_get_jax", return_value=fake_jax),
+            mock.patch.object(
+                ffi_module.wp,
+                "device_from_jax",
+                side_effect=warp_devices_by_jax_device.__getitem__,
+            ),
+        ):
+            ffi_module._preload_ffi_module(
+                module,
+                wp.JaxModulePreloadMode.ALL_DEVICES,
+                block_dim=JAX_TILE_BLOCK_DIM,
+            )
+
+        self.assertEqual(
+            module.load_calls,
+            [(warp_cpu, 1), (warp_cuda, JAX_TILE_BLOCK_DIM)],
+        )
+
+    @unittest.skipUnless(_jax_version() >= (0, 5, 0), "JAX version too old")
     def test_ffi_module_preload_load_error(self):
         """Test that module preloading propagates load errors and reports previously failed builds.
 
@@ -2680,6 +2815,7 @@ else:
                 test_ffi_jax_callable_in_out,
                 # autodiff and subscript annotations
                 test_ffi_jax_kernel_autodiff_simple,
+                test_ffi_jax_kernel_block_dim_autodiff,
                 test_ffi_jax_kernel_autodiff_jit_of_grad_simple,
                 test_ffi_jax_kernel_autodiff_multi_output,
                 test_ffi_jax_kernel_autodiff_jit_of_grad_multi_output,
@@ -2774,6 +2910,7 @@ else:
                 test_ffi_jax_callable_graph_cache,
                 test_ffi_jax_callable_graph_replay_skips_module_load,
                 test_ffi_jax_cuda_requires_cuda_support,
+                test_ffi_jax_kernel_block_dim_tile,
                 test_ffi_callback,
             )
             for test_func in cuda_only_jax_tests:


### PR DESCRIPTION
## Description

`wp.jax_kernel()` currently fixes CUDA launches at 256 threads per block, preventing block-size tuning and excluding tile kernels that require another cooperative width. This change adds a construction-time `block_dim` argument and consistently applies it to module preloading, direct FFI callbacks, forward launches, and generated adjoint launches. CPU execution continues to use one thread per block.

Closes #1436.

## Changes

- Add and validate the `block_dim` argument on `wp.jax_kernel()`.
- Include the selected block dimension in direct and differentiable wrapper cache identities.
- Load and launch the matching CUDA module variant while preserving the CPU block dimension of one.
- Apply the configured block dimension to both forward and adjoint launches when automatic differentiation is enabled.
- Document CUDA block dimensions, tile-kernel launch mapping, and output-dimension behavior.
- Add user-facing changelog coverage.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/latest/project/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Verified argument validation and normalization through `test_ffi_jax_kernel_block_dim_validation`.
- Verified direct JAX FFI tile reductions with 64- and 128-thread CUDA blocks on both available CUDA devices.
- Mutation-checked the direct-wrapper cache coverage by removing `block_dim` from the cache key, observing the expected 128-thread failures, restoring the key, and confirming the tests pass.
- Verified forward and adjoint block-dimension propagation on CPU and both available CUDA devices through `test_ffi_jax_kernel_block_dim_autodiff`.
- Ran the repository pre-commit hooks for the changed test module.

## New feature / enhancement

```python
import jax
import warp as wp

TILE_THREADS = 64

@wp.kernel
def block_sum(output: wp.array[int]):
    i = wp.tid()
    output[i] = 0
    values = wp.tile(i)
    sums = wp.tile_sum(values)
    wp.tile_store(output, sums, offset=i)

jax_block_sum = wp.jax_kernel(
    block_sum,
    launch_dims=256,
    output_dims=256,
    block_dim=TILE_THREADS,
)

(output,) = jax.jit(jax_block_sum)()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `block_dim` to `wp.jax_kernel()` to control CUDA thread-block size, including tile-kernel execution.
  * `block_dim` is applied to both forward execution and autodiff/adjoint launches; different values use separate cached wrappers.
  * The returned wrapper exposes `block_dim`, with defaults matching existing CUDA behavior.
* **Documentation**
  * Updated the JAX interoperability guide with “CUDA Block Dimensions and Tile Kernels,” including launch/output-shape conventions.
* **Tests**
  * Added end-to-end JAX FFI tests for `block_dim` (tiled behavior, gradients, validation, and CPU/CUDA preload rules).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->