### PR TITLE
Add NumPy-style tile slicing and fancy indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,9 @@
 - Add an optional `block_dim` argument to `wp.jax_kernel()` for selecting the CUDA thread-block size, including for
   tile kernels and their generated adjoint launches ([GH-1436](https://github.com/NVIDIA/warp/issues/1436)).
 - Add NumPy-style slicing for tiles, including strided and reversed slices (`t[2:6, :]`, `t[:, ::2]`, `t[::-1, :]`),
-  dimension-collapsing integer indices with negative-index support (`t[5, :]`, `t[-1, :]`), slice assignment
-  (`t[0:4, :] = src`), and fancy indexing that gathers rows selected by a 1D integer index tile (`t[indices, :]`)
-  ([GH-1176](https://github.com/NVIDIA/warp/issues/1176)).
+  dimension-collapsing integer indices with negative-index support (`t[5, :]`, `t[-1, :]`), and slice assignment
+  (`t[0:4, :] = src`). Also add `wp.tile_slice_indexed()`, which gathers elements along a single axis using a
+  1D integer index tile (`t[indices, :]`) ([GH-1176](https://github.com/NVIDIA/warp/issues/1176)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,9 +142,6 @@
   instead of node coordinates in Warp FEM kernels ([GH-1685](https://github.com/NVIDIA/warp/issues/1685)).
 - Reject malformed APIC `.wrp` memory sections containing duplicate region IDs
   or out-of-bounds initial data during graph loading.
-- Fix `wp.tile_reshape()` silently reading incorrect elements (or out of bounds) for non-contiguous tile views;
-  reshaping a strided or reversed tile view now raises an error instead.
-- Fix `wp.tile_view()` silently truncating non-integer offsets; a non-integer offset entry now raises an error.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@
   the BVH handle cannot be serialized ([GH-1665](https://github.com/NVIDIA/warp/issues/1665)).
 - Add an optional `block_dim` argument to `wp.jax_kernel()` for selecting the CUDA thread-block size, including for
   tile kernels and their generated adjoint launches ([GH-1436](https://github.com/NVIDIA/warp/issues/1436)).
+- Add NumPy-style slicing for tiles, including strided and reversed slices (`t[2:6, :]`, `t[:, ::2]`, `t[::-1, :]`),
+  dimension-collapsing integer indices with negative-index support (`t[5, :]`, `t[-1, :]`), slice assignment
+  (`t[0:4, :] = src`), and fancy indexing that gathers rows selected by a 1D integer index tile (`t[indices, :]`)
+  ([GH-1176](https://github.com/NVIDIA/warp/issues/1176)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,9 @@
   instead of node coordinates in Warp FEM kernels ([GH-1685](https://github.com/NVIDIA/warp/issues/1685)).
 - Reject malformed APIC `.wrp` memory sections containing duplicate region IDs
   or out-of-bounds initial data during graph loading.
+- Fix `wp.tile_reshape()` silently reading incorrect elements (or out of bounds) for non-contiguous tile views;
+  reshaping a strided or reversed tile view now raises an error instead.
+- Fix `wp.tile_view()` silently truncating non-integer offsets; a non-integer offset entry now raises an error.
 
 ### Documentation
 

--- a/docs/language_reference/builtins.rst
+++ b/docs/language_reference/builtins.rst
@@ -223,6 +223,7 @@ Tile Primitives
    tile_scan_min_inclusive
    tile_scatter_add
    tile_scatter_masked
+   tile_slice_indexed
    tile_sort
    tile_squeeze
    tile_stack

--- a/docs/user_guide/programming_model/tiles.rst
+++ b/docs/user_guide/programming_model/tiles.rst
@@ -263,6 +263,54 @@ Load/Store
 * :func:`tile_scatter_add <warp._src.lang.tile_scatter_add>`
 * :func:`tile_scatter_masked <warp._src.lang.tile_scatter_masked>`
 
+Indexing and Slicing
+^^^^^^^^^^^^^^^^^^^^^
+
+Tiles support NumPy-style indexing and slicing. Slice bounds must be compile-time
+constants so the resulting tile shape is known during code generation.
+
+.. code-block:: python
+
+    @wp.kernel
+    def process(data: wp.array2d(dtype=float)):
+        t = wp.tile_load(data, shape=(64, 64))
+
+        row = t[5, :]           # a single row, shape (64,)
+        block = t[10:20, :]     # rows 10..19, shape (10, 64)
+        cols = t[:, 0:32]       # first 32 columns, shape (64, 32)
+        strided = t[::2, ::2]   # every other element, shape (32, 32)
+        reversed = t[::-1, :]   # rows in reverse order, shape (64, 64)
+
+        # slice assignment writes a source tile into a sub-range in place
+        t[0:8, :] = wp.tile_ones(shape=(8, 64), dtype=float)
+
+Basic slicing produces a view that aliases the source tile's memory (compiling down
+to :func:`tile_view <warp._src.lang.tile_view>`), so an integer index collapses that
+dimension just as it does in NumPy. Slicing is fully differentiable.
+
+Negative indices are wrapped like NumPy (``t[-1, :]`` is the last row) only when the
+index is a compile-time constant. A runtime integer index (e.g. one computed from
+``wp.tid()``) must be non-negative and in bounds; like other tile operations, a
+runtime index is bounds-checked only in debug builds.
+
+Fancy indexing gathers elements along a single axis using a 1D integer index tile,
+returning a new (non-aliasing) register tile:
+
+.. code-block:: python
+
+    @wp.kernel
+    def gather(data: wp.array2d(dtype=float)):
+        t = wp.tile_load(data, shape=(64, 64))
+
+        indices = wp.tile_arange(0, 8, dtype=int) * 8   # [0, 8, 16, ..., 56]
+        selected_rows = t[indices, :]                   # shape (8, 64)
+
+Index values must be within bounds for the gathered axis: like other tile
+operations, the gather (and its gradient scatter) validates indices only in debug
+builds, so an out-of-range value reads or writes out of bounds in release builds.
+Duplicate indices are supported and accumulate their gradients atomically on the
+backward pass.
+
 Maps/Reductions
 ^^^^^^^^^^^^^^^
 

--- a/docs/user_guide/programming_model/tiles.rst
+++ b/docs/user_guide/programming_model/tiles.rst
@@ -288,10 +288,13 @@ Basic slicing produces a view that aliases the source tile's memory (compiling d
 to :func:`tile_view <warp._src.lang.tile_view>`), so an integer index collapses that
 dimension just as it does in NumPy. Slicing is fully differentiable.
 
-Negative indices are wrapped like NumPy (``t[-1, :]`` is the last row) only when the
-index is a compile-time constant. A runtime integer index (e.g. one computed from
-``wp.tid()``) must be non-negative and in bounds; like other tile operations, a
-runtime index is bounds-checked only in debug builds.
+.. caution::
+
+    Negative indices are wrapped like NumPy (``t[-1, :]`` is the last row) only when
+    the index is a compile-time constant. A runtime integer index (e.g. one computed
+    from ``wp.tid()``) must be non-negative and in bounds; like other tile
+    operations, a runtime index is bounds-checked only in debug builds, so an
+    out-of-range value reads out of bounds in release builds.
 
 Fancy indexing gathers elements along a single axis using a 1D integer index tile,
 returning a new (non-aliasing) register tile:
@@ -305,9 +308,13 @@ returning a new (non-aliasing) register tile:
         indices = wp.tile_arange(0, 8, dtype=int) * 8   # [0, 8, 16, ..., 56]
         selected_rows = t[indices, :]                   # shape (8, 64)
 
-Index values must be within bounds for the gathered axis: like other tile
-operations, the gather (and its gradient scatter) validates indices only in debug
-builds, so an out-of-range value reads or writes out of bounds in release builds.
+.. caution::
+
+    Index values must be within bounds for the gathered axis: like other tile
+    operations, the gather (and its gradient scatter) validates indices only in
+    debug builds, so an out-of-range value reads or writes out of bounds in
+    release builds.
+
 Duplicate indices are supported and accumulate their gradients atomically on the
 backward pass.
 

--- a/docs/user_guide/programming_model/tiles.rst
+++ b/docs/user_guide/programming_model/tiles.rst
@@ -290,6 +290,13 @@ dimension just as it does in NumPy. Slicing is fully differentiable. Negative in
 are wrapped like NumPy (``t[-1, :]`` is the last row) for both compile-time-constant
 and runtime integer indices.
 
+:func:`tile_view <warp._src.lang.tile_view>` can also be called directly with
+``slice`` objects in ``offset``; for example, ``wp.tile_view(t, offset=(slice(0, -1,
+1),))`` selects the same elements as ``t[0:-1]``. When any ``offset`` entry is a
+slice, ``shape`` must be omitted because the view shape is inferred from the slice
+bounds. Slice bounds must be compile-time constants, and slices that produce a
+zero-length tile dimension are rejected.
+
 Advanced indexing gathers elements along a single axis using a 1D integer index tile,
 returning a new (non-aliasing) register tile:
 

--- a/docs/user_guide/programming_model/tiles.rst
+++ b/docs/user_guide/programming_model/tiles.rst
@@ -272,7 +272,7 @@ constants so the resulting tile shape is known during code generation.
 .. code-block:: python
 
     @wp.kernel
-    def process(data: wp.array2d(dtype=float)):
+    def process(data: wp.array2d[float]):
         t = wp.tile_load(data, shape=(64, 64))
 
         row = t[5, :]           # a single row, shape (64,)
@@ -286,37 +286,31 @@ constants so the resulting tile shape is known during code generation.
 
 Basic slicing produces a view that aliases the source tile's memory (compiling down
 to :func:`tile_view <warp._src.lang.tile_view>`), so an integer index collapses that
-dimension just as it does in NumPy. Slicing is fully differentiable.
+dimension just as it does in NumPy. Slicing is fully differentiable. Negative indices
+are wrapped like NumPy (``t[-1, :]`` is the last row) for both compile-time-constant
+and runtime integer indices.
 
-.. caution::
-
-    Negative indices are wrapped like NumPy (``t[-1, :]`` is the last row) only when
-    the index is a compile-time constant. A runtime integer index (e.g. one computed
-    from ``wp.tid()``) must be non-negative and in bounds; like other tile
-    operations, a runtime index is bounds-checked only in debug builds, so an
-    out-of-range value reads out of bounds in release builds.
-
-Fancy indexing gathers elements along a single axis using a 1D integer index tile,
+Advanced indexing gathers elements along a single axis using a 1D integer index tile,
 returning a new (non-aliasing) register tile:
 
 .. code-block:: python
 
     @wp.kernel
-    def gather(data: wp.array2d(dtype=float)):
+    def gather(data: wp.array2d[float]):
         t = wp.tile_load(data, shape=(64, 64))
 
         indices = wp.tile_arange(0, 8, dtype=int) * 8   # [0, 8, 16, ..., 56]
         selected_rows = t[indices, :]                   # shape (8, 64)
 
+Negative index values wrap like NumPy, and duplicate indices are supported and
+accumulate their gradients atomically on the backward pass.
+
 .. caution::
 
-    Index values must be within bounds for the gathered axis: like other tile
-    operations, the gather (and its gradient scatter) validates indices only in
-    debug builds, so an out-of-range value reads or writes out of bounds in
-    release builds.
-
-Duplicate indices are supported and accumulate their gradients atomically on the
-backward pass.
+    Index values must be within bounds for the indexed axis. Like other tile
+    operations, both a runtime scalar index and an index-tile gather (including its
+    gradient scatter) are bounds-checked only in debug builds, so an out-of-range
+    value reads or writes out of bounds in release builds.
 
 Maps/Reductions
 ^^^^^^^^^^^^^^^

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -3197,15 +3197,21 @@ def tile_atomic_add_indexed(
     ...
 
 def tile_view(t: Tile[Any, tuple[int, ...]], offset: tuple, shape: tuple[int, ...]) -> Tile[Any, tuple[int, ...]]:
-    """Extract a slice of a given tile [offset, offset+shape], if shape is not specified it will be inferred from the unspecified offset dimensions.
+    """Extract a view of a tile.
+
+    ``offset`` may contain integer coordinates, in which case ``shape`` gives the
+    returned tile shape. ``offset`` may also contain ``slice`` objects, in which
+    case the returned shape is inferred from the slice bounds and ``shape`` must
+    not be specified.
 
     Args:
         t: Input tile to extract a subrange from
-        offset: Offset in the source tile
-        shape: Shape of the returned slice
+        offset: Integer offsets or slices in the source tile
+        shape: Shape of the returned view for integer-only offsets
 
     Returns:
-        A tile with dimensions given by the specified shape or the remaining source tile dimensions."""
+        A tile view with dimensions given by ``shape``, the remaining source tile
+        dimensions, or the inferred slice extents."""
     ...
 
 def tile_slice_indexed(t: Tile[Any, tuple[int, ...]], indices: tuple) -> Tile[Any, tuple[int, ...]]:

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -3196,11 +3196,7 @@ def tile_atomic_add_indexed(
                 [20. 22. 24. 26.]]"""
     ...
 
-def tile_view(
-    t: Tile[Any, tuple[int, ...]],
-    offset: tuple[int, ...],
-    shape: tuple[int, ...],
-) -> Tile[Any, tuple[int, ...]]:
+def tile_view(t: Tile[Any, tuple[int, ...]], offset: tuple, shape: tuple[int, ...]) -> Tile[Any, tuple[int, ...]]:
     """Extract a slice of a given tile [offset, offset+shape], if shape is not specified it will be inferred from the unspecified offset dimensions.
 
     Args:
@@ -3210,6 +3206,20 @@ def tile_view(
 
     Returns:
         A tile with dimensions given by the specified shape or the remaining source tile dimensions."""
+    ...
+
+def tile_slice_indexed(t: Tile[Any, tuple[int, ...]], indices: tuple) -> Tile[Any, tuple[int, ...]]:
+    """Gather elements of a tile along a single axis using a 1D tile of integer indices.
+
+    This lowers the fancy-indexing syntax ``t[indices, :]``, selecting rows (or planes)
+    of ``t`` given by ``indices`` along one axis. All other axes must be selected in full.
+
+    Args:
+        t: Input tile to gather from
+        indices: A 1D tile of integer indices selecting elements along one axis
+
+    Returns:
+        A register tile whose extent along the indexed axis equals the number of indices."""
     ...
 
 def tile_squeeze(t: Tile[Any, tuple[int, ...]], axis: tuple[int, ...]) -> Tile[Any, tuple[int, ...]]:

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -3211,8 +3211,8 @@ def tile_view(t: Tile[Any, tuple[int, ...]], offset: tuple, shape: tuple[int, ..
 def tile_slice_indexed(t: Tile[Any, tuple[int, ...]], indices: tuple) -> Tile[Any, tuple[int, ...]]:
     """Gather elements of a tile along a single axis using a 1D tile of integer indices.
 
-    This lowers the fancy-indexing syntax ``t[indices, :]``, selecting rows (or planes)
-    of ``t`` given by ``indices`` along one axis. All other axes must be selected in full.
+    This lowers the advanced-indexing syntax ``t[indices, :]``, gathering elements of
+    ``t`` along one axis given by ``indices``. All other axes must be selected in full.
 
     Args:
         t: Input tile to gather from

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -4093,10 +4093,25 @@ def tile_view_value_func(arg_types, arg_values):
     index_types = [_tile_slice_index_type(v) for v in offset]
     has_slice = any(is_slice(t) for t in index_types)
 
+    for idx_type in index_types:
+        # Each offset entry must be an integer (a Warp integer Var or a plain
+        # Python constant) or a slice; the native tile_coord() would otherwise
+        # silently truncate e.g. a float offset to int.
+        if is_slice(idx_type) or isinstance(idx_type, int) or type_is_int(idx_type):
+            continue
+        raise ValueError(f"tile_view() offset entries must be integers or slices, got {type_repr(idx_type)}")
+
     # force source tile to shared memory
     tile_type.storage = "shared"
 
     if has_slice:
+        if arg_values.get("shape") is not None:
+            # The view shape is inferred from the slice bounds; accepting an
+            # explicit shape here would silently ignore it.
+            raise ValueError(
+                "tile_view() does not support specifying 'shape' together with a slice-containing "
+                "'offset'; the view shape is inferred from the slice bounds."
+            )
         # slice syntax path, e.g.: t[a:b, :], t[::2, :], t[5, :]. Slices produce a
         # (possibly strided or reversed) sub-range; integer indices collapse their
         # dimension (NumPy semantics). Unspecified trailing dimensions are kept in full.
@@ -4385,6 +4400,18 @@ def tile_reshape_value_func(arg_types, arg_values):
         return tile(dtype=Any, shape=tuple[int, ...])
 
     tile_type = arg_types["t"]
+
+    # Reshape aliases the source pointer with dense strides, so the source
+    # layout must itself be dense (in its own layout order). A strided or
+    # reversed view (e.g. t[::2, :] or t[::-1, :]) would silently reinterpret
+    # unrelated elements, or read outside the allocation entirely.
+    dense_type = tile(dtype=tile_type.dtype, shape=tile_type.shape, layout=tile_type.layout)
+    if tuple(tile_type.strides) != tuple(dense_type.strides):
+        raise ValueError(
+            f"tile_reshape() requires a contiguous tile; a tile view with shape {tuple(tile_type.shape)} and "
+            f"strides {tuple(tile_type.strides)} cannot be reshaped in place. Copy the view into a new tile "
+            f"first, e.g. with wp.tile_assign()."
+        )
 
     # calculate total size of tile_type
     size = 1

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -4058,40 +4058,98 @@ add_builtin(
 )
 
 
+def _tile_slice_length(start, stop, step):
+    """Number of elements produced by a slice with already-resolved bounds.
+
+    ``start``/``stop`` are expected to be the concrete (non-sentinel) values
+    produced by ``Adjoint.eval_const_slice``, so no additional index wrapping is
+    performed here. Supports negative steps (reversed views).
+    """
+    if step > 0:
+        return max(0, (stop - start + step - 1) // step)
+    return max(0, (start - stop + (-step) - 1) // (-step))
+
+
+def _tile_slice_index_type(v):
+    """Return the Warp type of a tile-view index (int or ``slice_t``)."""
+    return v.type if isinstance(v, Var) else v
+
+
 def tile_view_value_func(arg_types, arg_values):
     # return generic type (for doc builds)
     if arg_types is None:
         return tile(dtype=Any, shape=tuple[int, ...])
 
     tile_type = arg_types["t"]
+    parent_shape = tile_type.shape
+    parent_strides = tile_type.strides
+    ndim = len(parent_shape)
+
     offset = extract_tuple(arg_values["offset"])
 
-    if len(offset) > len(tile_type.shape):
-        raise ValueError(f"tile_view() specified too many offset coordinates {len(offset)} > {len(tile_type.shape)}")
+    if len(offset) > ndim:
+        raise ValueError(f"tile_view() specified too many indices {len(offset)} > {ndim}")
 
-    if "shape" in arg_values:
-        # if shape is specified take it directly, e.g.:
-        # tile_view(t, offset=(i,j), shape=(m,n))
-        shape = extract_tuple(arg_values["shape"], as_constant=True)
-        strides = tile_type.strides
-
-        if len(shape) != len(tile_type.shape):
-            raise ValueError(
-                f"tile_view() if shape is specified it must have same number of dimensions as source tile, expected {len(tile_type.shape)}, got {len(shape)}"
-            )
-    else:
-        # if not specified, then take output shape from unspecified src dimensions
-        # e.g.: tile[i] will return a whole row of a 2D tile
-        shape = tile_type.shape[len(offset) :]
-        strides = tile_type.strides[len(offset) :]
-
-    assert len(shape) == len(strides)
+    index_types = [_tile_slice_index_type(v) for v in offset]
+    has_slice = any(is_slice(t) for t in index_types)
 
     # force source tile to shared memory
     tile_type.storage = "shared"
 
+    if has_slice:
+        # slice syntax path, e.g.: t[a:b, :], t[::2, :], t[5, :]. Slices produce a
+        # (possibly strided or reversed) sub-range; integer indices collapse their
+        # dimension (NumPy semantics). Unspecified trailing dimensions are kept in full.
+        shape = []
+        strides = []
+        for dim in range(ndim):
+            if dim < len(index_types):
+                idx_type = index_types[dim]
+                if is_slice(idx_type):
+                    length = _tile_slice_length(idx_type.start, idx_type.stop, idx_type.step)
+                    shape.append(length)
+                    strides.append(parent_strides[dim] * idx_type.step)
+                # integer index: collapse this dimension (contributes only an offset)
+            else:
+                shape.append(parent_shape[dim])
+                strides.append(parent_strides[dim])
+
+        if len(shape) == 0:
+            raise ValueError("tile_view() slice resulted in a scalar; use tile_extract() for element access")
+
+        if any(dim_len == 0 for dim_len in shape):
+            # A zero-length axis (e.g. t[4:4, :] or an out-of-range slice clamped
+            # to empty) cannot be instantiated as a native tile type; reject it
+            # here with a clear message instead of a cryptic build failure.
+            raise ValueError(
+                f"tile_view() slice produced an empty tile with shape {tuple(shape)}; "
+                f"zero-length tile dimensions are not supported."
+            )
+    elif "shape" in arg_values:
+        # if shape is specified take it directly, e.g.:
+        # tile_view(t, offset=(i,j), shape=(m,n))
+        shape = extract_tuple(arg_values["shape"], as_constant=True)
+        strides = parent_strides
+
+        if len(shape) != ndim:
+            raise ValueError(
+                f"tile_view() if shape is specified it must have same number of dimensions as source tile, expected {ndim}, got {len(shape)}"
+            )
+    else:
+        # if not specified, then take output shape from unspecified src dimensions
+        # e.g.: tile[i] will return a whole row of a 2D tile
+        shape = parent_shape[len(offset) :]
+        strides = parent_strides[len(offset) :]
+
+    assert len(shape) == len(strides)
+
     output = tile(
-        dtype=tile_type.dtype, shape=shape, strides=strides, layout=tile_type.layout, storage="shared", owner=False
+        dtype=tile_type.dtype,
+        shape=tuple(shape),
+        strides=tuple(strides),
+        layout=tile_type.layout,
+        storage="shared",
+        owner=False,
     )
     return output
 
@@ -4100,10 +4158,16 @@ def tile_view_dispatch_func(arg_types: Mapping[str, type], return_type: Any, arg
     tile = arg_values["t"]
     coord = extract_tuple(arg_values["offset"])
 
-    # zero-pad coord to match source array
+    # Build the source-space coordinate of the view origin. Slices contribute
+    # their (compile-time constant) start; integer indices contribute their value
+    # (which may be a runtime variable); unspecified dimensions default to 0.
     view_coord = [0] * len(tile.type.shape)
-    for i in range(len(coord)):
-        view_coord[i] = coord[i]
+    for i, idx in enumerate(coord):
+        idx_type = _tile_slice_index_type(idx)
+        if is_slice(idx_type):
+            view_coord[i] = Var(None, type=int, constant=idx_type.start)
+        else:
+            view_coord[i] = idx
 
     func_args = (tile, *view_coord)
     template_args = (return_type,)
@@ -4113,7 +4177,9 @@ def tile_view_dispatch_func(arg_types: Mapping[str, type], return_type: Any, arg
 
 add_builtin(
     "tile_view",
-    input_types={"t": tile(dtype=Any, shape=tuple[int, ...]), "offset": tuple[int, ...], "shape": tuple[int, ...]},
+    # `offset` is a bare tuple so it can carry either integer offsets (explicit API)
+    # or a mix of integers and slices (subscript syntax lowered by the code generator).
+    input_types={"t": tile(dtype=Any, shape=tuple[int, ...]), "offset": tuple, "shape": tuple[int, ...]},
     value_func=tile_view_value_func,
     dispatch_func=tile_view_dispatch_func,
     defaults={"shape": None},
@@ -4129,6 +4195,110 @@ add_builtin(
         A tile with dimensions given by the specified shape or the remaining source tile dimensions.""",
     group="Tile Primitives",
     is_differentiable=False,
+    export=False,
+)
+
+
+def _tile_slice_indexed_axis(indices, parent_shape):
+    """Resolve the gather axis and index tile from a tile fancy-index expression.
+
+    ``indices`` is the tuple of subscript indices; exactly one must be a 1D integer
+    index tile (the gather axis) and every other entry must be a full ``:`` slice.
+    Returns ``(axis, index_tile_var)``.
+    """
+    axis = None
+    index_tile = None
+    for dim, v in enumerate(indices):
+        idx_type = _tile_slice_index_type(v)
+        if is_tile(idx_type):
+            if axis is not None:
+                raise ValueError("Tile fancy indexing supports only a single index tile.")
+            if len(idx_type.shape) != 1:
+                raise ValueError(
+                    f"Tile fancy indexing requires a 1D integer index tile, got {len(idx_type.shape)} dimensions."
+                )
+            if not type_is_int(idx_type.dtype):
+                raise ValueError(
+                    f"Tile fancy indexing requires an integer index tile, got dtype {idx_type.dtype.__name__}."
+                )
+            axis = dim
+            index_tile = v
+        elif is_slice(idx_type):
+            length = _tile_slice_length(idx_type.start, idx_type.stop, idx_type.step)
+            if not (idx_type.start == 0 and idx_type.step == 1 and length == parent_shape[dim]):
+                raise ValueError(
+                    "Tile fancy indexing only supports full slices ':' on non-indexed axes, e.g. `t[indices, :]`."
+                )
+        else:
+            raise ValueError("Tile fancy indexing indices must be a 1D integer index tile or full slices ':'.")
+
+    if axis is None:
+        raise ValueError("Tile fancy indexing requires an integer index tile.")
+
+    return axis, index_tile
+
+
+def tile_slice_indexed_value_func(arg_types, arg_values):
+    # return generic type (for doc builds)
+    if arg_types is None:
+        return tile(dtype=Any, shape=tuple[int, ...])
+
+    tile_type = arg_types["t"]
+    parent_shape = tile_type.shape
+
+    indices = extract_tuple(arg_values["indices"])
+    if len(indices) > len(parent_shape):
+        raise ValueError(f"tile fancy indexing specified too many indices {len(indices)} > {len(parent_shape)}")
+
+    axis, index_tile = _tile_slice_indexed_axis(indices, parent_shape)
+    index_tile_type = _tile_slice_index_type(index_tile)
+
+    # gather reads from the source tile in shared memory, and the index tile is
+    # addressed via shared linear indexing
+    tile_type.storage = "shared"
+    index_tile_type.storage = "shared"
+
+    if index_tile_type.shape[0] == 0:
+        # An empty index tile would produce a zero-length axis, which cannot be
+        # instantiated as a native tile type; reject it with a clear message
+        # instead of a cryptic build failure (mirrors tile_view()).
+        raise ValueError("tile fancy indexing requires a non-empty index tile.")
+
+    shape = list(parent_shape)
+    shape[axis] = index_tile_type.shape[0]
+
+    return tile(dtype=tile_type.dtype, shape=tuple(shape), storage="register")
+
+
+def tile_slice_indexed_dispatch_func(arg_types: Mapping[str, type], return_type: Any, arg_values: Mapping[str, Var]):
+    src = arg_values["t"]
+    indices = extract_tuple(arg_values["indices"])
+    axis, index_tile = _tile_slice_indexed_axis(indices, src.type.shape)
+
+    func_args = (src, index_tile, Var(None, type=int, constant=axis))
+    template_args = return_type.shape
+
+    return (func_args, template_args)
+
+
+add_builtin(
+    "tile_slice_indexed",
+    input_types={"t": tile(dtype=Any, shape=tuple[int, ...]), "indices": tuple},
+    value_func=tile_slice_indexed_value_func,
+    dispatch_func=tile_slice_indexed_dispatch_func,
+    variadic=False,
+    doc="""Gather elements of a tile along a single axis using a 1D tile of integer indices.
+
+    This lowers the fancy-indexing syntax ``t[indices, :]``, selecting rows (or planes)
+    of ``t`` given by ``indices`` along one axis. All other axes must be selected in full.
+
+    Args:
+        t: Input tile to gather from
+        indices: A 1D tile of integer indices selecting elements along one axis
+
+    Returns:
+        A register tile whose extent along the indexed axis equals the number of indices.""",
+    group="Tile Primitives",
     export=False,
 )
 
@@ -4345,6 +4515,18 @@ def tile_assign_value_func(arg_types, arg_values):
                 f"tile_assign() destination and source tiles must have the same rank, "
                 f"got {len(dst_type.shape)} and {len(src_type.shape)}"
             )
+
+        # When no offset is given the source is written at the origin, so it must
+        # fit within the destination along every axis. With an explicit (possibly
+        # runtime) offset the fit cannot be verified here and is a caller
+        # precondition (checked only in debug builds).
+        if "offset" not in arg_values or arg_values["offset"] is None:
+            for dim in range(len(dst_type.shape)):
+                if src_type.shape[dim] > dst_type.shape[dim]:
+                    raise ValueError(
+                        f"tile_assign() source tile of shape {tuple(src_type.shape)} does not fit "
+                        f"within destination tile of shape {tuple(dst_type.shape)}"
+                    )
 
     # force the destination tile to shared memory
     dst_type.storage = "shared"

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -4087,15 +4087,16 @@ def _tile_slice_bound(v):
     return v
 
 
-def _normalize_tile_slice(start, stop, step, length):
+def _normalize_tile_slice(start, stop, step, length, start_omitted=False, stop_omitted=False):
     """Resolve raw slice bounds against ``length`` following CPython ``slice.indices``.
 
-    ``start``/``stop`` may be ``SLICE_BEGIN``/``SLICE_END`` sentinels (open bounds) or
-    raw integers (possibly negative or out of range). Returns concrete, clamped
-    ``(start, stop, step)`` matching NumPy for both positive and negative steps, so
-    subscript syntax (``t[0:-1]``) and explicit ``wp.tile_view()`` slice offsets
-    (``wp.tile_view(t, offset=(slice(0, -1, 1),))``) normalize identically. This
-    mirrors ``Adjoint.eval_const_slice`` in the code generator.
+    ``start_omitted``/``stop_omitted`` preserve whether a subscript left the bound
+    open, so explicit bounds equal to ``SLICE_BEGIN``/``SLICE_END`` remain ordinary
+    integer bounds. Returns concrete, clamped ``(start, stop, step)`` matching NumPy
+    for both positive and negative steps, so subscript syntax (``t[0:-1]``) and
+    explicit ``wp.tile_view()`` slice offsets (``wp.tile_view(t, offset=(slice(0,
+    -1, 1),))``) normalize identically. This mirrors ``Adjoint.eval_const_slice`` in
+    the code generator.
     """
     start, stop, step = _tile_slice_bound(start), _tile_slice_bound(stop), _tile_slice_bound(step)
 
@@ -4106,16 +4107,27 @@ def _normalize_tile_slice(start, stop, step, length):
     # [-1, length-1] for a negative step (so a reversed slice can reach index 0).
     lower, upper = (0, length) if step > 0 else (-1, length - 1)
 
-    def resolve(value, default):
-        if value == SLICE_BEGIN or value == SLICE_END:
+    def resolve(value, default, omitted):
+        if omitted:
             return default
         if value < 0:
             return max(value + length, lower)
         return min(value, upper)
 
-    start = resolve(start, lower if step > 0 else upper)
-    stop = resolve(stop, upper if step > 0 else lower)
+    start = resolve(start, lower if step > 0 else upper, start_omitted)
+    stop = resolve(stop, upper if step > 0 else lower, stop_omitted)
     return (start, stop, step)
+
+
+def _normalize_tile_slice_type(slice_type, length):
+    return _normalize_tile_slice(
+        slice_type.start,
+        slice_type.stop,
+        slice_type.step,
+        length,
+        getattr(slice_type, "start_omitted", False),
+        getattr(slice_type, "stop_omitted", False),
+    )
 
 
 def _tile_slice_index_type(v):
@@ -4189,9 +4201,7 @@ def tile_view_value_func(arg_types, arg_values):
             if dim < len(index_types):
                 idx_type = index_types[dim]
                 if is_slice(idx_type):
-                    n_start, n_stop, n_step = _normalize_tile_slice(
-                        idx_type.start, idx_type.stop, idx_type.step, parent_shape[dim]
-                    )
+                    n_start, n_stop, n_step = _normalize_tile_slice_type(idx_type, parent_shape[dim])
                     length = _tile_slice_length(n_start, n_stop, n_step)
                     shape.append(length)
                     strides.append(parent_strides[dim] * n_step)
@@ -4251,7 +4261,7 @@ def tile_view_dispatch_func(arg_types: Mapping[str, type], return_type: Any, arg
     for i, idx in enumerate(coord):
         idx_type = _tile_slice_index_type(idx)
         if is_slice(idx_type):
-            n_start, _, _ = _normalize_tile_slice(idx_type.start, idx_type.stop, idx_type.step, tile.type.shape[i])
+            n_start, _, _ = _normalize_tile_slice_type(idx_type, tile.type.shape[i])
             view_coord[i] = Var(None, type=int, constant=n_start)
         else:
             view_coord[i] = idx
@@ -4271,15 +4281,21 @@ add_builtin(
     dispatch_func=tile_view_dispatch_func,
     defaults={"shape": None},
     variadic=False,
-    doc="""Extract a slice of a given tile [offset, offset+shape], if shape is not specified it will be inferred from the unspecified offset dimensions.
+    doc="""Extract a view of a tile.
+
+    ``offset`` may contain integer coordinates, in which case ``shape`` gives the
+    returned tile shape. ``offset`` may also contain ``slice`` objects, in which
+    case the returned shape is inferred from the slice bounds and ``shape`` must
+    not be specified.
 
     Args:
         t: Input tile to extract a subrange from
-        offset: Offset in the source tile
-        shape: Shape of the returned slice
+        offset: Integer offsets or slices in the source tile
+        shape: Shape of the returned view for integer-only offsets
 
     Returns:
-        A tile with dimensions given by the specified shape or the remaining source tile dimensions.""",
+        A tile view with dimensions given by ``shape``, the remaining source tile
+        dimensions, or the inferred slice extents.""",
     group="Tile Primitives",
     is_differentiable=False,
     export=False,
@@ -4309,9 +4325,7 @@ def _tile_slice_indexed_axis(indices, parent_shape):
             axis = dim
             index_tile = v
         elif is_slice(idx_type):
-            n_start, n_stop, n_step = _normalize_tile_slice(
-                idx_type.start, idx_type.stop, idx_type.step, parent_shape[dim]
-            )
+            n_start, n_stop, n_step = _normalize_tile_slice_type(idx_type, parent_shape[dim])
             length = _tile_slice_length(n_start, n_stop, n_step)
             if not (n_start == 0 and n_step == 1 and length == parent_shape[dim]):
                 raise ValueError(

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -4062,7 +4062,7 @@ def _tile_slice_length(start, stop, step):
     """Number of elements produced by a slice with already-resolved bounds.
 
     ``start``/``stop`` are expected to be the concrete (non-sentinel) values
-    produced by ``Adjoint.eval_const_slice``, so no additional index wrapping is
+    produced by ``_normalize_tile_slice``, so no additional index wrapping is
     performed here. Supports negative steps (reversed views).
     """
     if step > 0:
@@ -4070,9 +4070,63 @@ def _tile_slice_length(start, stop, step):
     return max(0, (start - stop + (-step) - 1) // (-step))
 
 
+def _tile_slice_bound(v):
+    """Resolve a slice bound to a Python int, requiring a compile-time constant.
+
+    Bounds may be plain ints (subscript lowering, ``SLICE_BEGIN``/``SLICE_END``
+    sentinels) or constant ``Var``s (an explicit ``wp.tile_view(t, offset=(slice(n
+    - 1, ...),))`` where the bound is a constant expression). A runtime (non-constant)
+    bound cannot be used because the view shape must be known at code-gen time.
+    """
+    if isinstance(v, Var):
+        if v.constant is None:
+            raise ValueError("tile_view() slice bounds must be compile-time constants.")
+        v = v.constant
+    if not isinstance(v, int):
+        raise ValueError(f"tile_view() slice bounds must be integers, got {type_repr(v)}.")
+    return v
+
+
+def _normalize_tile_slice(start, stop, step, length):
+    """Resolve raw slice bounds against ``length`` following CPython ``slice.indices``.
+
+    ``start``/``stop`` may be ``SLICE_BEGIN``/``SLICE_END`` sentinels (open bounds) or
+    raw integers (possibly negative or out of range). Returns concrete, clamped
+    ``(start, stop, step)`` matching NumPy for both positive and negative steps, so
+    subscript syntax (``t[0:-1]``) and explicit ``wp.tile_view()`` slice offsets
+    (``wp.tile_view(t, offset=(slice(0, -1, 1),))``) normalize identically. This
+    mirrors ``Adjoint.eval_const_slice`` in the code generator.
+    """
+    start, stop, step = _tile_slice_bound(start), _tile_slice_bound(stop), _tile_slice_bound(step)
+
+    if step == 0:
+        raise ValueError("tile_view() slice step cannot be zero.")
+
+    # CPython slice.indices() clamp bounds: [0, length] for a positive step,
+    # [-1, length-1] for a negative step (so a reversed slice can reach index 0).
+    lower, upper = (0, length) if step > 0 else (-1, length - 1)
+
+    def resolve(value, default):
+        if value == SLICE_BEGIN or value == SLICE_END:
+            return default
+        if value < 0:
+            return max(value + length, lower)
+        return min(value, upper)
+
+    start = resolve(start, lower if step > 0 else upper)
+    stop = resolve(stop, upper if step > 0 else lower)
+    return (start, stop, step)
+
+
 def _tile_slice_index_type(v):
-    """Return the Warp type of a tile-view index (int or ``slice_t``)."""
-    return v.type if isinstance(v, Var) else v
+    """Return the Warp type of a tile-view index (int or ``slice_t``).
+
+    References are stripped so a runtime index loaded from an array (e.g.
+    ``t[indices[0], :]``, represented as ``wp.ref[int32]`` during code generation)
+    validates and dispatches like a plain integer; the dispatched reference is
+    loaded to its value at the call site.
+    """
+    return strip_reference(v.type) if isinstance(v, Var) else v
 
 
 def tile_view_value_func(arg_types, arg_values):
@@ -4093,11 +4147,25 @@ def tile_view_value_func(arg_types, arg_values):
     index_types = [_tile_slice_index_type(v) for v in offset]
     has_slice = any(is_slice(t) for t in index_types)
 
-    for idx_type in index_types:
+    for dim, (entry, idx_type) in enumerate(zip(offset, index_types, strict=True)):
         # Each offset entry must be an integer (a Warp integer Var or a plain
         # Python constant) or a slice; the native tile_coord() would otherwise
         # silently truncate e.g. a float offset to int.
         if is_slice(idx_type) or isinstance(idx_type, int) or type_is_int(idx_type):
+            # An explicit tile_view() offset is a raw source coordinate, so a
+            # constant that lands outside the parent axis would read out of bounds.
+            # Unlike subscript indexing (which wraps negatives, e.g. t[-1], and
+            # rejects out-of-range constants), the explicit offset is not wrapped,
+            # so range-check the constant case here for parity instead of silently
+            # reading out of bounds. Runtime offsets fall through to the debug-only
+            # bounds check (they cannot be validated at code-gen time).
+            const = entry.constant if isinstance(entry, Var) else entry
+            if isinstance(const, int) and not (0 <= const < parent_shape[dim]):
+                raise ValueError(
+                    f"tile_view() integer offset {const} is out of bounds for axis {dim} with size "
+                    f"{parent_shape[dim]}; negative offsets are only wrapped for subscript indexing "
+                    f"(e.g. t[-1, :]), not explicit tile_view() calls."
+                )
             continue
         raise ValueError(f"tile_view() offset entries must be integers or slices, got {type_repr(idx_type)}")
 
@@ -4121,9 +4189,12 @@ def tile_view_value_func(arg_types, arg_values):
             if dim < len(index_types):
                 idx_type = index_types[dim]
                 if is_slice(idx_type):
-                    length = _tile_slice_length(idx_type.start, idx_type.stop, idx_type.step)
+                    n_start, n_stop, n_step = _normalize_tile_slice(
+                        idx_type.start, idx_type.stop, idx_type.step, parent_shape[dim]
+                    )
+                    length = _tile_slice_length(n_start, n_stop, n_step)
                     shape.append(length)
-                    strides.append(parent_strides[dim] * idx_type.step)
+                    strides.append(parent_strides[dim] * n_step)
                 # integer index: collapse this dimension (contributes only an offset)
             else:
                 shape.append(parent_shape[dim])
@@ -4180,7 +4251,8 @@ def tile_view_dispatch_func(arg_types: Mapping[str, type], return_type: Any, arg
     for i, idx in enumerate(coord):
         idx_type = _tile_slice_index_type(idx)
         if is_slice(idx_type):
-            view_coord[i] = Var(None, type=int, constant=idx_type.start)
+            n_start, _, _ = _normalize_tile_slice(idx_type.start, idx_type.stop, idx_type.step, tile.type.shape[i])
+            view_coord[i] = Var(None, type=int, constant=n_start)
         else:
             view_coord[i] = idx
 
@@ -4215,7 +4287,7 @@ add_builtin(
 
 
 def _tile_slice_indexed_axis(indices, parent_shape):
-    """Resolve the gather axis and index tile from a tile fancy-index expression.
+    """Resolve the gather axis and index tile from an advanced-index expression.
 
     ``indices`` is the tuple of subscript indices; exactly one must be a 1D integer
     index tile (the gather axis) and every other entry must be a full ``:`` slice.
@@ -4227,28 +4299,29 @@ def _tile_slice_indexed_axis(indices, parent_shape):
         idx_type = _tile_slice_index_type(v)
         if is_tile(idx_type):
             if axis is not None:
-                raise ValueError("Tile fancy indexing supports only a single index tile.")
+                raise ValueError("Tile indexing supports exactly one 1D integer index tile.")
             if len(idx_type.shape) != 1:
                 raise ValueError(
-                    f"Tile fancy indexing requires a 1D integer index tile, got {len(idx_type.shape)} dimensions."
+                    f"Tile indexing requires a 1D integer index tile, got {len(idx_type.shape)} dimensions."
                 )
             if not type_is_int(idx_type.dtype):
-                raise ValueError(
-                    f"Tile fancy indexing requires an integer index tile, got dtype {idx_type.dtype.__name__}."
-                )
+                raise ValueError(f"Tile indexing requires an integer index tile, got dtype {idx_type.dtype.__name__}.")
             axis = dim
             index_tile = v
         elif is_slice(idx_type):
-            length = _tile_slice_length(idx_type.start, idx_type.stop, idx_type.step)
-            if not (idx_type.start == 0 and idx_type.step == 1 and length == parent_shape[dim]):
+            n_start, n_stop, n_step = _normalize_tile_slice(
+                idx_type.start, idx_type.stop, idx_type.step, parent_shape[dim]
+            )
+            length = _tile_slice_length(n_start, n_stop, n_step)
+            if not (n_start == 0 and n_step == 1 and length == parent_shape[dim]):
                 raise ValueError(
-                    "Tile fancy indexing only supports full slices ':' on non-indexed axes, e.g. `t[indices, :]`."
+                    "Tile indexing with an integer index tile requires ':' on all other axes, e.g. `t[indices, :]`."
                 )
         else:
-            raise ValueError("Tile fancy indexing indices must be a 1D integer index tile or full slices ':'.")
+            raise ValueError("Tile indexing entries must be a 1D integer index tile or full slices ':'.")
 
     if axis is None:
-        raise ValueError("Tile fancy indexing requires an integer index tile.")
+        raise ValueError("Tile indexing requires an integer index tile.")
 
     return axis, index_tile
 
@@ -4263,7 +4336,7 @@ def tile_slice_indexed_value_func(arg_types, arg_values):
 
     indices = extract_tuple(arg_values["indices"])
     if len(indices) > len(parent_shape):
-        raise ValueError(f"tile fancy indexing specified too many indices {len(indices)} > {len(parent_shape)}")
+        raise ValueError(f"tile indexing specified too many indices {len(indices)} > {len(parent_shape)}")
 
     axis, index_tile = _tile_slice_indexed_axis(indices, parent_shape)
     index_tile_type = _tile_slice_index_type(index_tile)
@@ -4277,7 +4350,7 @@ def tile_slice_indexed_value_func(arg_types, arg_values):
         # An empty index tile would produce a zero-length axis, which cannot be
         # instantiated as a native tile type; reject it with a clear message
         # instead of a cryptic build failure (mirrors tile_view()).
-        raise ValueError("tile fancy indexing requires a non-empty index tile.")
+        raise ValueError("tile indexing requires a non-empty index tile.")
 
     shape = list(parent_shape)
     shape[axis] = index_tile_type.shape[0]
@@ -4304,8 +4377,8 @@ add_builtin(
     variadic=False,
     doc="""Gather elements of a tile along a single axis using a 1D tile of integer indices.
 
-    This lowers the fancy-indexing syntax ``t[indices, :]``, selecting rows (or planes)
-    of ``t`` given by ``indices`` along one axis. All other axes must be selected in full.
+    This lowers the advanced-indexing syntax ``t[indices, :]``, gathering elements of
+    ``t`` along one axis given by ``indices``. All other axes must be selected in full.
 
     Args:
         t: Input tile to gather from

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -3930,10 +3930,16 @@ class Adjoint:
             raise WarpCodegenValueError("Slice step cannot be zero.")
 
         if length is None:
-            start = adj.eval_const_slice_component(node.lower) if node.lower is not None else (0 if step > 0 else None)
-            stop = (
-                adj.eval_const_slice_component(node.upper) if node.upper is not None else (length if step > 0 else -1)
-            )
+            if step < 0 and (node.lower is None or node.upper is None):
+                # There is no integer that can stand in for an open bound of a
+                # reverse slice without a known length, and callers treat the
+                # returned bounds as integers.
+                raise WarpCodegenValueError(
+                    "Reverse slices require explicit start and stop bounds when the sequence length "
+                    "is not known at compile time (e.g. slicing an array)."
+                )
+            start = adj.eval_const_slice_component(node.lower) if node.lower is not None else 0
+            stop = adj.eval_const_slice_component(node.upper) if node.upper is not None else None
             return (start, stop, step)
 
         # CPython slice.indices() clamp bounds: [0, length] for a positive step,
@@ -4235,13 +4241,19 @@ class Adjoint:
         against the axis length, and out-of-range constant indices are rejected
         at code-gen time. Runtime (non-constant) indices and index tiles pass
         through unchanged (runtime bounds are only checked in debug builds).
+        Non-integer scalar indices (e.g. floats) are rejected.
         """
+        if not isinstance(idx, Var):
+            return idx
         idx_type = strip_reference(idx.type)
-        if not isinstance(idx, Var) or idx.constant is None:
+        if is_tile(idx_type):
+            # index tiles (fancy indexing) are resolved by tile_slice_indexed
             return idx
         if not warp._src.types.type_is_int(idx_type):
-            return idx
-        if dim >= len(shape):
+            # The native tile_coord() would silently truncate a float index to
+            # int; reject it like NumPy does instead.
+            raise WarpCodegenTypeError(f"Tile indices must be integers or slices, got {type_repr(idx_type)}.")
+        if idx.constant is None or dim >= len(shape):
             return idx
 
         length = shape[dim]
@@ -4932,7 +4944,7 @@ class Adjoint:
                     # slice is not supported.
                     raise WarpCodegenError(
                         f"Tile slice assignment requires a tile of matching shape on the right-hand side "
-                        f"(e.g. `t[a:b, :] = src`), but got a value of type {rhs_type.__name__}."
+                        f"(e.g. `t[a:b, :] = src`), but got a value of type {type_repr(rhs_type)}."
                     )
                 view = adj.add_builtin_call("tile_view", [target, indices])
                 view_type = strip_reference(view.type)

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -4475,15 +4475,237 @@ class Adjoint:
         target = adj.eval(node)
         return target, indices
 
+    def _tile_type_probe_value(adj, node):
+        try:
+            value = ast.literal_eval(node)
+        except (ValueError, TypeError):
+            pass
+        else:
+            if isinstance(value, (tuple, list)):
+                return tuple(Var(None, type=get_arg_type(x), constant=x) for x in value)
+            return Var(None, type=get_arg_type(value), constant=value)
+
+        if isinstance(node, ast.Name):
+            if node.id in adj.symbols:
+                return adj.symbols[node.id]
+
+            expr, _ = adj.resolve_static_expression(node)
+            if expr is None:
+                return None
+            if isinstance(expr, (type, Struct, Var, warp._src.context.Function, str)):
+                return expr
+            if isinstance(expr, (enum.IntEnum, enum.IntFlag)):
+                expr = int(expr)
+            return Var(None, type=get_arg_type(expr), constant=expr)
+
+        if isinstance(node, ast.Attribute):
+            expr, _ = adj.resolve_static_expression(node)
+            if expr is None:
+                return None
+            if isinstance(expr, (type, Struct, Var, warp._src.context.Function, str)):
+                return expr
+            if isinstance(expr, (enum.IntEnum, enum.IntFlag)):
+                expr = int(expr)
+            return Var(None, type=get_arg_type(expr), constant=expr)
+
+        if isinstance(node, ast.Tuple):
+            values = tuple(adj._tile_type_probe_value(x) for x in node.elts)
+            if any(x is None for x in values):
+                return None
+            return values
+
+        if isinstance(node, ast.UnaryOp | ast.BinOp | ast.Call | ast.Subscript):
+            node_type = adj._tile_type_probe(node)
+            if node_type is not None:
+                return Var(None, type=node_type)
+
+        return None
+
+    def _tile_resolve_call_for_type_probe(adj, node):
+        if hasattr(node.func, "warp_func"):
+            return node.func.warp_func, {}
+
+        func, path = adj.resolve_static_expression(node.func, eval_types=False)
+        if func is None:
+            return None, {}
+
+        type_args = {}
+
+        if len(path) > 0 and not isinstance(func, warp._src.context.Function):
+            attr = path[-1]
+            caller = func
+            func = None
+
+            if isinstance(caller, types.ModuleType):
+                if hasattr(caller, attr):
+                    func = getattr(caller, attr)
+                    if not isinstance(func, warp._src.context.Function):
+                        caller = func
+                        func = None
+                elif caller is warp and attr in warp._src.context.builtin_functions:
+                    func = warp._src.context.builtin_functions[attr]
+                else:
+                    return None, {}
+
+            if func is None and attr in warp._src.context.builtin_functions:
+                func = warp._src.context.builtin_functions[attr]
+
+            if func is None and hasattr(caller, "_wp_generic_type_str_"):
+                func = warp._src.context.builtin_functions.get(caller._wp_constructor_)
+
+            if func is None and hasattr(caller, "__name__") and caller.__name__ in warp._src.context.builtin_functions:
+                func = warp._src.context.builtin_functions.get(caller.__name__)
+
+            if func is None and isinstance(caller, Struct):
+                if node.args or node.keywords:
+                    func = caller.value_constructor
+                else:
+                    func = caller.default_constructor
+
+            if hasattr(caller, "_wp_type_args_"):
+                type_args = caller._wp_type_args_
+
+        if isinstance(func, warp._src.context.Function):
+            return func, type_args
+
+        return None, {}
+
+    def _tile_call_type_probe(adj, node):
+        func, type_args = adj._tile_resolve_call_for_type_probe(node)
+        if func is None or not func.is_builtin():
+            return None
+
+        args = tuple(adj._tile_type_probe_value(x) for x in node.args)
+        if any(x is None for x in args):
+            return None
+
+        kwargs = {x.arg: adj._tile_type_probe_value(x.value) for x in node.keywords}
+        if any(x is None for x in kwargs.values()):
+            return None
+
+        try:
+            func, bound_args, _ = adj.resolve_call(func, args, kwargs, type_args)
+        except Exception:
+            return None
+
+        bound_arg_types = {k: get_arg_type(v) for k, v in bound_args.items()}
+        bound_arg_values = {k: get_arg_value(v) for k, v in bound_args.items()}
+
+        try:
+            return_type = func.value_func(
+                {k: strip_reference(v) for k, v in bound_arg_types.items()},
+                bound_arg_values,
+            )
+        except Exception:
+            return None
+
+        if get_origin(return_type) is tuple:
+            types = get_args(return_type)
+            return warp._src.types.tuple_t(types=types, values=(None,) * len(types))
+
+        if isinstance(return_type, Sequence):
+            return None
+
+        return strip_reference(return_type)
+
+    def _tile_operator_type_probe(adj, op_name, args):
+        func = warp._src.context.builtin_functions[op_name]
+        try:
+            func, bound_args, _ = adj.resolve_call(func, args, {}, {})
+        except Exception:
+            return None
+
+        bound_arg_types = {k: get_arg_type(v) for k, v in bound_args.items()}
+        bound_arg_values = {k: get_arg_value(v) for k, v in bound_args.items()}
+
+        try:
+            return_type = func.value_func(
+                {k: strip_reference(v) for k, v in bound_arg_types.items()},
+                bound_arg_values,
+            )
+        except Exception:
+            return None
+
+        if isinstance(return_type, Sequence):
+            return None
+
+        return strip_reference(return_type)
+
+    def _tile_subscript_type_probe(adj, node):
+        target_type = adj._tile_type_probe(node.value)
+        if target_type is None or not is_tile(target_type):
+            return None
+
+        if isinstance(node.slice, ast.Tuple):
+            index_nodes = node.slice.elts
+        else:
+            index_nodes = [node.slice]
+
+        has_slice = any(isinstance(x, ast.Slice) for x in index_nodes)
+        has_index_tile = False
+        index_count = 0
+
+        for index_node in index_nodes:
+            if isinstance(index_node, ast.Slice):
+                index_count += 1
+                continue
+
+            index_type = adj._tile_type_probe(index_node)
+            if index_type is not None and is_tile(index_type):
+                has_index_tile = True
+            index_count += 1
+
+        if has_slice or has_index_tile or index_count < len(target_type.shape):
+            return tile(dtype=target_type.dtype, shape=tuple[int, ...], storage=target_type.storage)
+
+        return target_type.dtype
+
+    def _tile_type_probe(adj, node):
+        if isinstance(node, ast.Slice):
+            return slice_t
+
+        if isinstance(node, ast.Call):
+            return adj._tile_call_type_probe(node)
+
+        if isinstance(node, ast.UnaryOp):
+            arg = adj._tile_type_probe_value(node.operand)
+            if arg is None:
+                return None
+            op_name = builtin_operators.get(type(node.op))
+            if op_name is None:
+                return None
+            return adj._tile_operator_type_probe(op_name, (arg,))
+
+        if isinstance(node, ast.BinOp):
+            left = adj._tile_type_probe_value(node.left)
+            right = adj._tile_type_probe_value(node.right)
+            if left is None or right is None:
+                return None
+            op_name = builtin_operators.get(type(node.op))
+            if op_name is None:
+                return None
+            return adj._tile_operator_type_probe(op_name, (left, right))
+
+        if isinstance(node, ast.Subscript):
+            return adj._tile_subscript_type_probe(node)
+
+        value = adj._tile_type_probe_value(node)
+        if isinstance(value, Var):
+            return strip_reference(value.type)
+        if value is not None:
+            return get_arg_type(value)
+
+        return None
+
     def _tile_group_produces_view(adj, group):
         """Whether a chained tile subscript group yields a tile the next bracket
-        re-indexes — a slice or a 1D integer index tile — rather than collapsing
+        re-indexes -- a slice or a 1D integer index tile -- rather than collapsing
         the tile to a scalar/element.
 
-        Side-effect-free: only checks for ``ast.Slice`` structurally and looks up
-        already-bound names in ``adj.symbols`` (index tiles are bound to a name), so
-        nothing is emitted here and the flat path can re-evaluate the same nodes
-        without duplicating instructions.
+        Side-effect-free: type probing uses already-bound symbols, static
+        references, and function overload metadata only. It does not evaluate
+        index nodes or emit code, so the accepted path still evaluates each
+        index expression exactly once.
         """
         for n in group:
             if isinstance(n, ast.Slice):
@@ -4492,6 +4714,9 @@ class Adjoint:
                 v = adj.symbols[n.id]
                 if isinstance(v, Var) and is_tile(strip_reference(v.type)):
                     return True
+            n_type = adj._tile_type_probe(n)
+            if n_type is not None and is_tile(strip_reference(n_type)):
+                return True
         return False
 
     def _tile_later_group_produces_view(adj, groups):

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -3959,6 +3959,22 @@ class Adjoint:
 
         return (start, stop, step)
 
+    def eval_raw_const_slice(adj, node) -> tuple[int, int, int]:
+        """Evaluate a slice to constant components without wrapping against a length.
+
+        Open bounds become ``SLICE_BEGIN``/``SLICE_END`` sentinels and provided
+        bounds are returned as-is (possibly negative or out of range). Used for tile
+        slicing so that subscript syntax and explicit ``wp.tile_view()`` slice
+        offsets share a single normalization site (``_normalize_tile_slice``) in the
+        ``tile_view`` builtin, keeping their semantics identical.
+        """
+        step = 1 if node.step is None else adj.eval_const_slice_component(node.step)
+        if step == 0:
+            raise WarpCodegenValueError("Slice step cannot be zero.")
+        start = SLICE_BEGIN if node.lower is None else adj.eval_const_slice_component(node.lower)
+        stop = SLICE_END if node.upper is None else adj.eval_const_slice_component(node.upper)
+        return (start, stop, step)
+
     def unpack_starred(adj, node):
         """Unpack a starred expression into individual elements."""
         value = node.value
@@ -4238,25 +4254,40 @@ class Adjoint:
 
         Integer indices into a tile collapse their dimension and contribute the
         view origin along that axis. NumPy-style negative indices are wrapped
-        against the axis length, and out-of-range constant indices are rejected
-        at code-gen time. Runtime (non-constant) indices and index tiles pass
-        through unchanged (runtime bounds are only checked in debug builds).
-        Non-integer scalar indices (e.g. floats) are rejected.
+        against the axis length for both compile-time-constant and runtime
+        indices, and out-of-range constant indices are rejected at code-gen time.
+        A runtime index is wrapped once (not by modulo), so a value of ``-length``
+        maps to ``0`` while ``-length - 1`` stays negative and reaches the
+        debug-only bounds check. Index tiles pass through unchanged. Non-integer
+        scalar indices (e.g. floats) are rejected.
         """
         if not isinstance(idx, Var):
             return idx
         idx_type = strip_reference(idx.type)
         if is_tile(idx_type):
-            # index tiles (fancy indexing) are resolved by tile_slice_indexed
+            # index tiles (advanced indexing) are resolved by tile_slice_indexed
             return idx
         if not warp._src.types.type_is_int(idx_type):
             # The native tile_coord() would silently truncate a float index to
             # int; reject it like NumPy does instead.
             raise WarpCodegenTypeError(f"Tile indices must be integers or slices, got {type_repr(idx_type)}.")
-        if idx.constant is None or dim >= len(shape):
+        if dim >= len(shape):
+            # No known axis length for this dimension; pass through unchanged.
             return idx
 
         length = shape[dim]
+
+        if idx.constant is None:
+            # Runtime scalar index: wrap negatives against the axis length so a
+            # runtime ``i == -1`` selects the last element just like the constant
+            # ``t[-1]``. Typed constants keep the arithmetic in the index's own
+            # integer type. This lowers to ``i < 0 ? i + length : i``.
+            zero = adj.add_var(type=idx_type, constant=0)
+            length_var = adj.add_var(type=idx_type, constant=length)
+            is_negative = adj.add_comp(["<"], idx, [zero])
+            wrapped_idx = adj.add_builtin_call("add", [idx, length_var])
+            return adj.add_builtin_call("where", [is_negative, wrapped_idx, idx])
+
         value = idx.constant
         wrapped = value + length if value < 0 else value
         if wrapped < 0 or wrapped >= length:
@@ -4286,13 +4317,14 @@ class Adjoint:
             # Tile slicing follows the same compile-time-constant rule as composite
             # types: the resulting view shape must be known at code-gen time so the
             # native tile type can be instantiated. Non-slice indices (integers for
-            # element/row access, or index tiles for fancy indexing) are evaluated
+            # element/row access, or index tiles for advanced indexing) are evaluated
             # normally.
             indices = []
             for dim, node in enumerate(nodes):
                 if isinstance(node, ast.Slice):
-                    length = target_type.shape[dim]
-                    bounds = adj.eval_const_slice(node, length)
+                    # Pass raw bounds through to tile_view, which normalizes them
+                    # against the axis length (shared with explicit slice offsets).
+                    bounds = adj.eval_raw_const_slice(node)
                     slice = adj.add_builtin_call("slice", bounds)
                     indices.append(slice)
                 else:
@@ -4357,7 +4389,7 @@ class Adjoint:
             has_slice, has_index_tile = adj.tile_index_kinds(indices)
 
             if has_index_tile:
-                # fancy indexing, e.g.: t[indices, :] gathers the rows/planes selected
+                # advanced indexing, e.g.: t[indices, :] gathers the elements selected
                 # by an integer index tile along a single axis
                 out = adj.add_builtin_call("tile_slice_indexed", [target, indices])
             elif has_slice:
@@ -4443,9 +4475,42 @@ class Adjoint:
         target = adj.eval(node)
         return target, indices
 
+    def _tile_group_produces_view(adj, group):
+        """Whether a chained tile subscript group yields a tile the next bracket
+        re-indexes — a slice or a 1D integer index tile — rather than collapsing
+        the tile to a scalar/element.
+
+        Side-effect-free: only checks for ``ast.Slice`` structurally and looks up
+        already-bound names in ``adj.symbols`` (index tiles are bound to a name), so
+        nothing is emitted here and the flat path can re-evaluate the same nodes
+        without duplicating instructions.
+        """
+        for n in group:
+            if isinstance(n, ast.Slice):
+                return True
+            if isinstance(n, ast.Name) and n.id in adj.symbols:
+                v = adj.symbols[n.id]
+                if isinstance(v, Var) and is_tile(strip_reference(v.type)):
+                    return True
+        return False
+
     # returns the object being indexed, and the list of indices
     def eval_subscript(adj, node):
         target, indices = adj.recurse_subscript(node, [])
+
+        # Chained tile subscripts (a[X][Y]...) apply each bracket group to the
+        # result of the previous one, innermost group first, for arbitrary depth.
+        # A single flat index list cannot express e.g. a[::-1][::2] (two successive
+        # views), so a group that produces a view/gather is materialized here. Pure
+        # integer groups are left for the flat path so a[i][j] still lowers to one
+        # tile_extract (and a[i][k] into a tile of vectors keeps working) — folding
+        # them here would instead force the source tile to shared via tile_view.
+        while len(indices) > 1 and is_tile(strip_reference(target.type)):
+            if not adj._tile_group_produces_view(indices[0]):
+                break
+            target = adj.emit_indexing(target, indices[0])
+            indices = indices[1:]
+
         flat_indices = [i for ij in indices for i in ij]
         return target, flat_indices
 
@@ -4926,17 +4991,20 @@ class Adjoint:
             has_slice, has_index_tile = adj.tile_index_kinds(indices)
 
             if has_index_tile:
-                # fancy-index assignment (t[indices, :] = src) is not supported: a
+                # advanced-index assignment (t[indices, :] = src) is not supported: a
                 # scatter with duplicate indices is ambiguous. Users should build the
                 # result explicitly instead.
                 raise WarpCodegenError(
-                    "Fancy-index assignment on tiles (e.g. `t[indices, :] = src`) is not supported. "
+                    "Advanced-index assignment on tiles (e.g. `t[indices, :] = src`) is not supported. "
                     "Use slice assignment (`t[a:b, :] = src`) or construct the tile explicitly."
                 )
-            elif has_slice:
-                # slice assignment, e.g.: t[a:b, :] = src. Build a view over the
-                # destination sub-range (handles offsets, strides, and dimension
-                # collapse) and assign the source into it in place.
+            elif has_slice or len(indices) < len(target_type.shape):
+                # view assignment, e.g.: t[a:b, :] = src (slice) or t[0] = row
+                # (partial integer indexing, fewer indices than the tile rank).
+                # Both build a view over the destination sub-range (handling
+                # offsets, strides, and dimension collapse) and assign the source
+                # into it in place. A full-rank integer index (t[i, j] = x) instead
+                # falls through to scalar element assignment below.
                 rhs_type = strip_reference(rhs.type)
                 if not is_tile(rhs_type):
                     # A non-tile rhs (scalar, vector, matrix, ...) would fall through

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -3917,26 +3917,39 @@ class Adjoint:
         return var.constant
 
     def eval_const_slice(adj, node, length) -> tuple[int, int, int]:
-        """Evaluate a slice, returning its constant components."""
+        """Evaluate a slice, returning its constant (start, stop, step) components.
+
+        When ``length`` is known the bounds follow CPython ``slice.indices``
+        semantics exactly (negative-index wrapping and per-step clamping), so
+        downstream shape math matches NumPy for both positive and negative
+        steps. Without a known ``length`` the raw components are returned with
+        the usual open-ended defaults.
+        """
         step = 1 if node.step is None else adj.eval_const_slice_component(node.step)
         if step == 0:
             raise WarpCodegenValueError("Slice step cannot be zero.")
 
-        if node.lower is None:
-            start = length - 1 if step < 0 else 0
-        else:
-            start = adj.eval_const_slice_component(node.lower)
-            if length is not None:
-                start = min(max(start, -length), length)
-                start = start + length if start < 0 else start
+        if length is None:
+            start = adj.eval_const_slice_component(node.lower) if node.lower is not None else (0 if step > 0 else None)
+            stop = (
+                adj.eval_const_slice_component(node.upper) if node.upper is not None else (length if step > 0 else -1)
+            )
+            return (start, stop, step)
 
-        if node.upper is None:
-            stop = -1 if step < 0 else length
-        else:
-            stop = adj.eval_const_slice_component(node.upper)
-            if length is not None:
-                stop = min(max(stop, -length), length)
-                stop = stop + length if stop < 0 else stop
+        # CPython slice.indices() clamp bounds: [0, length] for a positive step,
+        # [-1, length-1] for a negative step (so a reversed slice can reach index 0).
+        lower, upper = (0, length) if step > 0 else (-1, length - 1)
+
+        def resolve(component, default):
+            if component is None:
+                return default
+            value = adj.eval_const_slice_component(component)
+            if value < 0:
+                return max(value + length, lower)
+            return min(value, upper)
+
+        start = resolve(node.lower, lower if step > 0 else upper)
+        stop = resolve(node.upper, upper if step > 0 else lower)
 
         return (start, stop, step)
 
@@ -4202,6 +4215,44 @@ class Adjoint:
 
         return out
 
+    @staticmethod
+    def tile_index_kinds(indices):
+        """Classify evaluated tile subscript ``indices`` for dispatch.
+
+        Returns ``(has_slice, has_index_tile)`` so the read, assign, and
+        augmented-assign paths route tile subscripts identically.
+        """
+        index_types = [strip_reference(x.type) for x in indices]
+        has_slice = any(warp._src.types.is_slice(t) for t in index_types)
+        has_index_tile = any(is_tile(t) for t in index_types)
+        return has_slice, has_index_tile
+
+    def resolve_tile_int_index(adj, idx, shape, dim):
+        """Wrap and bounds-check a compile-time-constant integer tile index.
+
+        Integer indices into a tile collapse their dimension and contribute the
+        view origin along that axis. NumPy-style negative indices are wrapped
+        against the axis length, and out-of-range constant indices are rejected
+        at code-gen time. Runtime (non-constant) indices and index tiles pass
+        through unchanged (runtime bounds are only checked in debug builds).
+        """
+        idx_type = strip_reference(idx.type)
+        if not isinstance(idx, Var) or idx.constant is None:
+            return idx
+        if not warp._src.types.type_is_int(idx_type):
+            return idx
+        if dim >= len(shape):
+            return idx
+
+        length = shape[dim]
+        value = idx.constant
+        wrapped = value + length if value < 0 else value
+        if wrapped < 0 or wrapped >= length:
+            raise WarpCodegenValueError(f"Tile index {value} is out of bounds for axis {dim} with size {length}.")
+        if wrapped == value:
+            return idx
+        return adj.add_constant(wrapped)
+
     def eval_indices(adj, target_type, indices):
         nodes = indices
         if type_is_composite(target_type):
@@ -4217,6 +4268,23 @@ class Adjoint:
                     indices.append(slice)
                 else:
                     indices.append(adj.eval(node))
+
+            return tuple(indices)
+        elif is_tile(target_type):
+            # Tile slicing follows the same compile-time-constant rule as composite
+            # types: the resulting view shape must be known at code-gen time so the
+            # native tile type can be instantiated. Non-slice indices (integers for
+            # element/row access, or index tiles for fancy indexing) are evaluated
+            # normally.
+            indices = []
+            for dim, node in enumerate(nodes):
+                if isinstance(node, ast.Slice):
+                    length = target_type.shape[dim]
+                    bounds = adj.eval_const_slice(node, length)
+                    slice = adj.add_builtin_call("slice", bounds)
+                    indices.append(slice)
+                else:
+                    indices.append(adj.resolve_tile_int_index(adj.eval(node), target_type.shape, dim))
 
             return tuple(indices)
         else:
@@ -4274,11 +4342,22 @@ class Adjoint:
                     out.is_write = target.is_write
 
         elif is_tile(target_type):
-            if len(indices) >= len(target_type.shape):  # equality for scalars, inequality for composite types
+            has_slice, has_index_tile = adj.tile_index_kinds(indices)
+
+            if has_index_tile:
+                # fancy indexing, e.g.: t[indices, :] gathers the rows/planes selected
+                # by an integer index tile along a single axis
+                out = adj.add_builtin_call("tile_slice_indexed", [target, indices])
+            elif has_slice:
+                # slice syntax, e.g.: t[a:b, :] / t[::2, :] / t[5, :]. Integer indices
+                # that co-occur with a slice collapse their dimension (NumPy semantics)
+                # and are handled inside tile_view.
+                out = adj.add_builtin_call("tile_view", [target, indices])
+            elif len(indices) >= len(target_type.shape):  # equality for scalars, inequality for composite types
                 # handles extracting a single element from a tile
                 out = adj.add_builtin_call("tile_extract", [target, *indices])
             elif len(indices) < len(target_type.shape):
-                # handles tile views
+                # handles tile views (fewer integer indices than dimensions)
                 out = adj.add_builtin_call("tile_view", [target, indices])
             else:
                 raise RuntimeError(
@@ -4832,7 +4911,42 @@ class Adjoint:
             adj._mark_array_write(target)
 
         elif is_tile(target_type):
-            adj.add_builtin_call("assign", [target, *indices, rhs])
+            has_slice, has_index_tile = adj.tile_index_kinds(indices)
+
+            if has_index_tile:
+                # fancy-index assignment (t[indices, :] = src) is not supported: a
+                # scatter with duplicate indices is ambiguous. Users should build the
+                # result explicitly instead.
+                raise WarpCodegenError(
+                    "Fancy-index assignment on tiles (e.g. `t[indices, :] = src`) is not supported. "
+                    "Use slice assignment (`t[a:b, :] = src`) or construct the tile explicitly."
+                )
+            elif has_slice:
+                # slice assignment, e.g.: t[a:b, :] = src. Build a view over the
+                # destination sub-range (handles offsets, strides, and dimension
+                # collapse) and assign the source into it in place.
+                rhs_type = strip_reference(rhs.type)
+                if not is_tile(rhs_type):
+                    # A non-tile rhs (scalar, vector, matrix, ...) would fall through
+                    # to tile_assign with no matching overload; broadcasting into a
+                    # slice is not supported.
+                    raise WarpCodegenError(
+                        f"Tile slice assignment requires a tile of matching shape on the right-hand side "
+                        f"(e.g. `t[a:b, :] = src`), but got a value of type {rhs_type.__name__}."
+                    )
+                view = adj.add_builtin_call("tile_view", [target, indices])
+                view_type = strip_reference(view.type)
+                if tuple(view_type.shape) != tuple(rhs_type.shape):
+                    # NumPy requires the assigned value to match the destination
+                    # slice exactly; a mismatched source would otherwise write
+                    # outside the slice (silent corruption or out-of-bounds).
+                    raise WarpCodegenError(
+                        f"Tile slice assignment shape mismatch: destination slice has shape "
+                        f"{tuple(view_type.shape)} but source has shape {tuple(rhs_type.shape)}."
+                    )
+                adj.add_builtin_call("tile_assign", [view, rhs])
+            else:
+                adj.add_builtin_call("assign", [target, *indices, rhs])
 
         elif (
             type_is_vector(target_type)
@@ -5237,6 +5351,17 @@ class Adjoint:
                     return
 
             elif is_tile(target.type):
+                has_slice, has_index_tile = adj.tile_index_kinds(indices)
+                # In-place tile ops operate element-wise on whole-tile coordinates,
+                # so any subscript that produces a view — a slice, an index tile, or
+                # fewer integer indices than dimensions (e.g. a row) — has no in-place
+                # read path. Reject it with a clear message instead of an opaque
+                # overload error.
+                if has_slice or has_index_tile or len(indices) < len(target.type.shape):
+                    raise WarpCodegenError(
+                        "Compound assignment to a tile view (e.g. `t[a:b, :] += x` or `t[i] += x`) is not "
+                        "supported. Read the view, update it, and assign it back explicitly."
+                    )
                 if isinstance(node.op, ast.Add):
                     adj.add_builtin_call("tile_add_inplace", [target, *indices, rhs])
                 elif isinstance(node.op, ast.Sub):

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -4477,6 +4477,25 @@ class Adjoint:
         target = adj.eval(node)
         return target, indices
 
+    def _tile_type_probe_copy_type(adj, arg_type):
+        if is_tile(arg_type) or is_tile_stack(arg_type):
+            return shallowcopy(arg_type)
+        if is_reference(arg_type):
+            copied_type = shallowcopy(arg_type)
+            copied_type.value_type = adj._tile_type_probe_copy_type(arg_type.value_type)
+            return copied_type
+        if is_tuple(arg_type):
+            return tuple_t(
+                types=tuple(adj._tile_type_probe_copy_type(t) for t in arg_type.types),
+                values=arg_type.values,
+            )
+        return arg_type
+
+    def _tile_type_probe_copy_var(adj, var):
+        probe_var = shallowcopy(var)
+        probe_var.type = adj._tile_type_probe_copy_type(var.type)
+        return probe_var
+
     def _tile_type_probe_value(adj, node):
         try:
             value = ast.literal_eval(node)
@@ -4489,12 +4508,14 @@ class Adjoint:
 
         if isinstance(node, ast.Name):
             if node.id in adj.symbols:
-                return adj.symbols[node.id]
+                return adj._tile_type_probe_copy_var(adj.symbols[node.id])
 
             expr, _ = adj.resolve_static_expression(node)
             if expr is None:
                 return None
-            if isinstance(expr, (type, Struct, Var, warp._src.context.Function, str)):
+            if isinstance(expr, Var):
+                return adj._tile_type_probe_copy_var(expr)
+            if isinstance(expr, (type, Struct, warp._src.context.Function, str)):
                 return expr
             if isinstance(expr, (enum.IntEnum, enum.IntFlag)):
                 expr = int(expr)
@@ -4504,7 +4525,9 @@ class Adjoint:
             expr, _ = adj.resolve_static_expression(node)
             if expr is None:
                 return None
-            if isinstance(expr, (type, Struct, Var, warp._src.context.Function, str)):
+            if isinstance(expr, Var):
+                return adj._tile_type_probe_copy_var(expr)
+            if isinstance(expr, (type, Struct, warp._src.context.Function, str)):
                 return expr
             if isinstance(expr, (enum.IntEnum, enum.IntFlag)):
                 expr = int(expr)

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -4250,7 +4250,7 @@ class Adjoint:
         return has_slice, has_index_tile
 
     def resolve_tile_int_index(adj, idx, shape, dim):
-        """Wrap and bounds-check a compile-time-constant integer tile index.
+        """Wrap and bounds-check an integer tile index.
 
         Integer indices into a tile collapse their dimension and contribute the
         view origin along that axis. NumPy-style negative indices are wrapped
@@ -4265,7 +4265,7 @@ class Adjoint:
             return idx
         idx_type = strip_reference(idx.type)
         if is_tile(idx_type):
-            # index tiles (advanced indexing) are resolved by tile_slice_indexed
+            # index tiles are resolved by tile_slice_indexed
             return idx
         if not warp._src.types.type_is_int(idx_type):
             # The native tile_coord() would silently truncate a float index to
@@ -4326,6 +4326,8 @@ class Adjoint:
                     # against the axis length (shared with explicit slice offsets).
                     bounds = adj.eval_raw_const_slice(node)
                     slice = adj.add_builtin_call("slice", bounds)
+                    slice.type.start_omitted = node.lower is None
+                    slice.type.stop_omitted = node.upper is None
                     indices.append(slice)
                 else:
                     indices.append(adj.resolve_tile_int_index(adj.eval(node), target_type.shape, dim))
@@ -4572,7 +4574,7 @@ class Adjoint:
 
     def _tile_call_type_probe(adj, node):
         func, type_args = adj._tile_resolve_call_for_type_probe(node)
-        if func is None or not func.is_builtin():
+        if func is None:
             return None
 
         args = tuple(adj._tile_type_probe_value(x) for x in node.args)
@@ -4588,16 +4590,45 @@ class Adjoint:
         except Exception:
             return None
 
-        bound_arg_types = {k: get_arg_type(v) for k, v in bound_args.items()}
-        bound_arg_values = {k: get_arg_value(v) for k, v in bound_args.items()}
+        if not func.is_builtin() and func.value_func is None:
+            try:
+                probe_adj = Adjoint(
+                    func.func,
+                    overload_annotations=func.input_types,
+                    is_user_function=True,
+                    skip_forward_codegen=func.adj.skip_forward_codegen,
+                    skip_reverse_codegen=func.adj.skip_reverse_codegen,
+                    custom_reverse_mode=func.adj.custom_reverse_mode,
+                    custom_reverse_num_input_args=func.adj.custom_reverse_num_input_args,
+                    transformers=func.adj.transformers,
+                    source=func.adj.source,
+                )
+                probe_adj.used_by_backward_kernel = func.adj.used_by_backward_kernel
+                probe_adj.force_adjoint_codegen = func.adj.force_adjoint_codegen
+                probe_adj.build(None, adj.builder_options)
+            except Exception:
+                return None
 
-        try:
-            return_type = func.value_func(
-                {k: strip_reference(v) for k, v in bound_arg_types.items()},
-                bound_arg_values,
-            )
-        except Exception:
-            return None
+            if probe_adj.return_var is None or len(probe_adj.return_var) == 0:
+                return None
+            if len(probe_adj.return_var) == 1:
+                return_type = probe_adj.return_var[0].type
+            else:
+                return_type = [v.type for v in probe_adj.return_var]
+        else:
+            if func.value_func is None:
+                return None
+
+            bound_arg_types = {k: get_arg_type(v) for k, v in bound_args.items()}
+            bound_arg_values = {k: get_arg_value(v) for k, v in bound_args.items()}
+
+            try:
+                return_type = func.value_func(
+                    {k: strip_reference(v) for k, v in bound_arg_types.items()},
+                    bound_arg_values,
+                )
+            except Exception:
+                return None
 
         if get_origin(return_type) is tuple:
             types = get_args(return_type)
@@ -4636,28 +4667,35 @@ class Adjoint:
         if target_type is None or not is_tile(target_type):
             return None
 
+        target_shape = target_type.shape
+        if not isinstance(target_shape, (tuple, list)):
+            return None
+
         if isinstance(node.slice, ast.Tuple):
             index_nodes = node.slice.elts
         else:
             index_nodes = [node.slice]
 
-        has_slice = any(isinstance(x, ast.Slice) for x in index_nodes)
-        has_index_tile = False
-        index_count = 0
+        result_shape = []
 
-        for index_node in index_nodes:
+        for dim, index_node in enumerate(index_nodes):
+            if dim >= len(target_shape):
+                return None
             if isinstance(index_node, ast.Slice):
-                index_count += 1
+                result_shape.append(1)
                 continue
 
             index_type = adj._tile_type_probe(index_node)
             if index_type is not None and is_tile(index_type):
-                has_index_tile = True
-            index_count += 1
+                index_shape = index_type.shape if isinstance(index_type.shape, (tuple, list)) else (1,)
+                if len(index_shape) != 1:
+                    return None
+                result_shape.append(index_shape[0])
 
-        if has_slice or has_index_tile or index_count < len(target_type.shape):
-            return tile(dtype=target_type.dtype, shape=tuple[int, ...], storage=target_type.storage)
+        result_shape.extend(target_shape[len(index_nodes) :])
 
+        if result_shape:
+            return tile(dtype=target_type.dtype, shape=tuple(result_shape), storage=target_type.storage)
         return target_type.dtype
 
     def _tile_type_probe(adj, node):
@@ -5252,19 +5290,19 @@ class Adjoint:
                 if not is_tile(rhs_type):
                     # A non-tile rhs (scalar, vector, matrix, ...) would fall through
                     # to tile_assign with no matching overload; broadcasting into a
-                    # slice is not supported.
+                    # view is not supported.
                     raise WarpCodegenError(
-                        f"Tile slice assignment requires a tile of matching shape on the right-hand side "
-                        f"(e.g. `t[a:b, :] = src`), but got a value of type {type_repr(rhs_type)}."
+                        f"Tile view assignment requires a tile of matching shape on the right-hand side "
+                        f"(e.g. `t[a:b, :] = src` or `t[0] = row`), but got a value of type {type_repr(rhs_type)}."
                     )
                 view = adj.add_builtin_call("tile_view", [target, indices])
                 view_type = strip_reference(view.type)
                 if tuple(view_type.shape) != tuple(rhs_type.shape):
                     # NumPy requires the assigned value to match the destination
-                    # slice exactly; a mismatched source would otherwise write
-                    # outside the slice (silent corruption or out-of-bounds).
+                    # view exactly; a mismatched source would otherwise write
+                    # outside the view (silent corruption or out-of-bounds).
                     raise WarpCodegenError(
-                        f"Tile slice assignment shape mismatch: destination slice has shape "
+                        f"Tile view assignment shape mismatch: destination view has shape "
                         f"{tuple(view_type.shape)} but source has shape {tuple(rhs_type.shape)}."
                     )
                 adj.add_builtin_call("tile_assign", [view, rhs])

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -4508,7 +4508,10 @@ class Adjoint:
 
         if isinstance(node, ast.Name):
             if node.id in adj.symbols:
-                return adj._tile_type_probe_copy_var(adj.symbols[node.id])
+                symbol = adj.symbols[node.id]
+                if isinstance(symbol, Var):
+                    return adj._tile_type_probe_copy_var(symbol)
+                return symbol
 
             expr, _ = adj.resolve_static_expression(node)
             if expr is None:

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -4494,6 +4494,15 @@ class Adjoint:
                     return True
         return False
 
+    def _tile_later_group_produces_view(adj, groups):
+        """Whether any later chained tile subscript group is known to need a view.
+
+        Used to decide when a partial integer-only prefix such as ``t[2]`` must
+        be emitted before applying a later slice/gather, e.g. ``t[2][idx]``.
+        Pure integer chains such as ``t[2][3]`` stay flattened.
+        """
+        return any(adj._tile_group_produces_view(group) for group in groups)
+
     # returns the object being indexed, and the list of indices
     def eval_subscript(adj, node):
         target, indices = adj.recurse_subscript(node, [])
@@ -4501,14 +4510,23 @@ class Adjoint:
         # Chained tile subscripts (a[X][Y]...) apply each bracket group to the
         # result of the previous one, innermost group first, for arbitrary depth.
         # A single flat index list cannot express e.g. a[::-1][::2] (two successive
-        # views), so a group that produces a view/gather is materialized here. Pure
-        # integer groups are left for the flat path so a[i][j] still lowers to one
-        # tile_extract (and a[i][k] into a tile of vectors keeps working) — folding
-        # them here would instead force the source tile to shared via tile_view.
+        # views), so a group that produces a view/gather is materialized here.
+        # Pure integer groups are left for the flat path so a[i][j] still lowers
+        # to one tile_extract (and a[i][k] into a tile of vectors keeps working),
+        # unless that integer group is a partial index whose resulting row/slice
+        # is then re-indexed by a later slice/gather, e.g. t[2][idx].
         while len(indices) > 1 and is_tile(strip_reference(target.type)):
-            if not adj._tile_group_produces_view(indices[0]):
+            target_type = strip_reference(target.type)
+            group = indices[0]
+            group_produces_view = adj._tile_group_produces_view(group)
+            partial_integer_view_before_later_view = (
+                not group_produces_view
+                and len(group) < len(target_type.shape)
+                and adj._tile_later_group_produces_view(indices[1:])
+            )
+            if not (group_produces_view or partial_integer_view_before_later_view):
                 break
-            target = adj.emit_indexing(target, indices[0])
+            target = adj.emit_indexing(target, group)
             indices = indices[1:]
 
         flat_indices = [i for ij in indices for i in ij]

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -2278,6 +2278,8 @@ class slice_t:
         self.start = start
         self.stop = stop
         self.step = step
+        self.start_omitted = False
+        self.stop_omitted = False
 
     def get_length(self, parent_length, wrap=False):
         if any(isinstance(x, warp._src.codegen.Var) for x in (self.start, self.stop, self.step)):

--- a/warp/native/tile.h
+++ b/warp/native/tile.h
@@ -5361,11 +5361,16 @@ template <unsigned... Shape, typename Tile, typename IndicesTile>
 inline CUDA_CALLABLE auto tile_slice_indexed(Tile& src, IndicesTile& indices, int axis)
 {
     using T = typename Tile::Type;
+    using SrcShape = typename Tile::Layout::Shape;
     auto out = tile_register_t<T, tile_layout_register_t<tile_shape_t<Shape...>>>();
 
     out.apply([&](int reg, auto c) {
         auto sc = c;
-        sc.indices[axis] = indices.data(c[axis]);
+        // wrap negative indices against the source axis length (NumPy semantics)
+        int idx = indices.data(c[axis]);
+        if (idx < 0)
+            idx += SrcShape::dim(axis);
+        sc.indices[axis] = idx;
         out.data[reg] = src.data(sc);
     });
 
@@ -5383,11 +5388,16 @@ inline CUDA_CALLABLE void adj_tile_slice_indexed(
     if (src.grad.ptr == nullptr)
         return;
 
+    using SrcShape = typename Tile::Layout::Shape;
     auto adj_ret_reg = adj_ret.grad_to_register();
 
     adj_ret_reg.apply([&](int reg, auto c) {
         auto sc = c;
-        sc.indices[axis] = indices.data(c[axis]);
+        // wrap negative indices to match the forward gather
+        int idx = indices.data(c[axis]);
+        if (idx < 0)
+            idx += SrcShape::dim(axis);
+        sc.indices[axis] = idx;
         tile_adj_atomic_add_value(&src.grad(sc), adj_ret_reg.data[reg]);
     });
 

--- a/warp/native/tile.h
+++ b/warp/native/tile.h
@@ -5776,15 +5776,16 @@ inline CUDA_CALLABLE void adj_assign(
 template <typename TileA, typename TileB, int N>
 inline CUDA_CALLABLE void tile_assign(TileA& dest, TileB& src, const tile_coord_t<N>& offset)
 {
-    using Layout = typename TileB::Layout;
+    // Snapshot the source into registers before any thread writes the
+    // destination: dest may be a view overlapping src (e.g. t[1:] = t[:-1]),
+    // and NumPy assignment semantics require every read to observe the
+    // pre-assignment source values.
+    auto staged = src.copy_to_register();
 
-    WP_PRAGMA_UNROLL
-    for (int t = WP_TILE_THREAD_IDX; t < Layout::Size; t += WP_TILE_BLOCK_DIM) {
-        auto c = Layout::coord_from_linear(t);
-        dest.data(c + offset) = src.data(c);
-    }
-
+    // ensure all reads complete before any writes to (potentially aliasing) dest
     WP_TILE_SYNC();
+
+    tile_assign(dest, staged, offset);
 }
 
 template <typename TileA, typename T, typename Layout, int N>
@@ -5824,13 +5825,40 @@ inline CUDA_CALLABLE void adj_tile_assign(
         return;
     }
 
+    // Stage the incoming gradients in registers before mutating anything:
+    // src may be a view overlapping dest (e.g. t[1:] = t[:-1]), so the reads,
+    // the zeroing, and the accumulation must not interleave.
+    using GradLayout = tile_layout_register_t<typename Layout::Shape>;
+    tile_register_t<typename TileA::Type, GradLayout> staged;
+
+    WP_PRAGMA_UNROLL
+    for (int reg = 0; reg < GradLayout::NumRegs; ++reg) {
+        int linear = GradLayout::linear_from_register(reg);
+        if (!GradLayout::valid(linear)) {
+            break;
+        }
+        staged.data[reg] = dest.grad(GradLayout::coord_from_linear(linear) + offset);
+    }
+
+    // all gradient reads must complete before the destination gradients are zeroed
+    WP_TILE_SYNC();
+
+    // Overwritten destinations do not contribute to the pre-assignment dest value.
     WP_PRAGMA_UNROLL
     for (int t = WP_TILE_THREAD_IDX; t < Layout::Size; t += WP_TILE_BLOCK_DIM) {
-        auto c = Layout::coord_from_linear(t);
-        auto dst_c = c + offset;
-        src.grad(c) += dest.grad(dst_c);
-        // Overwritten destinations do not contribute to the pre-assignment dest value.
-        dest.grad(dst_c) = typename TileA::Type {};
+        dest.grad(Layout::coord_from_linear(t) + offset) = typename TileA::Type {};
+    }
+
+    // zeroing must complete before accumulating into (potentially aliasing) src gradients
+    WP_TILE_SYNC();
+
+    WP_PRAGMA_UNROLL
+    for (int reg = 0; reg < GradLayout::NumRegs; ++reg) {
+        int linear = GradLayout::linear_from_register(reg);
+        if (!GradLayout::valid(linear)) {
+            break;
+        }
+        src.grad(GradLayout::coord_from_linear(linear)) += staged.data[reg];
     }
 
     WP_TILE_SYNC();

--- a/warp/native/tile.h
+++ b/warp/native/tile.h
@@ -5838,9 +5838,14 @@ inline CUDA_CALLABLE void adj_tile_assign(
     // Stage the incoming gradients in registers before mutating anything:
     // src may be a view overlapping dest (e.g. t[1:] = t[:-1]), so the reads,
     // the zeroing, and the accumulation must not interleave.
+    // GradLayout covers the same source-view coordinates as Layout; it just
+    // iterates them in register order so staged values match accumulation.
     using GradLayout = tile_layout_register_t<typename Layout::Shape>;
     tile_register_t<typename TileA::Type, GradLayout> staged;
 
+    // linear_from_register() is monotone, so after the first invalid
+    // register slot all later slots are invalid too. The accumulation loop
+    // uses the same guard before reading staged.data[reg].
     WP_PRAGMA_UNROLL
     for (int reg = 0; reg < GradLayout::NumRegs; ++reg) {
         int linear = GradLayout::linear_from_register(reg);
@@ -5854,6 +5859,8 @@ inline CUDA_CALLABLE void adj_tile_assign(
     WP_TILE_SYNC();
 
     // Overwritten destinations do not contribute to the pre-assignment dest value.
+    // This Layout loop zeroes the same coordinate set staged above, only in
+    // the source tile layout order instead of register order.
     WP_PRAGMA_UNROLL
     for (int t = WP_TILE_THREAD_IDX; t < Layout::Size; t += WP_TILE_BLOCK_DIM) {
         dest.grad(Layout::coord_from_linear(t) + offset) = typename TileA::Type {};

--- a/warp/native/tile.h
+++ b/warp/native/tile.h
@@ -5354,6 +5354,47 @@ inline CUDA_CALLABLE auto tile_view(Tile& t, Indices... indices)
 }
 
 
+// Gather along a single axis: out[..., k, ...] = src[..., indices[k], ...].
+// `indices` is a 1D tile of integers whose length equals the output extent along
+// `axis`. The result is a register tile (a fresh copy, not an alias of `src`).
+template <unsigned... Shape, typename Tile, typename IndicesTile>
+inline CUDA_CALLABLE auto tile_slice_indexed(Tile& src, IndicesTile& indices, int axis)
+{
+    using T = typename Tile::Type;
+    auto out = tile_register_t<T, tile_layout_register_t<tile_shape_t<Shape...>>>();
+
+    out.apply([&](int reg, auto c) {
+        auto sc = c;
+        sc.indices[axis] = indices.data(c[axis]);
+        out.data[reg] = src.data(sc);
+    });
+
+    return out;
+}
+
+template <unsigned... Shape, typename Tile, typename IndicesTile, typename AdjTile>
+inline CUDA_CALLABLE void adj_tile_slice_indexed(
+    Tile& src, IndicesTile& indices, int axis, Tile& adj_src, IndicesTile& adj_indices, int adj_axis, AdjTile& adj_ret
+)
+{
+    // scatter gradients from the gathered result back onto the selected source
+    // rows; multiple output rows may map to the same source row (duplicate
+    // indices) so the accumulation must be atomic
+    if (src.grad.ptr == nullptr)
+        return;
+
+    auto adj_ret_reg = adj_ret.grad_to_register();
+
+    adj_ret_reg.apply([&](int reg, auto c) {
+        auto sc = c;
+        sc.indices[axis] = indices.data(c[axis]);
+        tile_adj_atomic_add_value(&src.grad(sc), adj_ret_reg.data[reg]);
+    });
+
+    WP_TILE_SYNC();
+}
+
+
 template <typename ReturnTile, typename Tile> inline CUDA_CALLABLE auto tile_squeeze(Tile& t)
 {
     // ReturnTile layout is set in builtins.py

--- a/warp/tests/tile/test_tile_view.py
+++ b/warp/tests/tile/test_tile_view.py
@@ -664,6 +664,29 @@ def test_tile_view_shape_with_slice_rejected(test, device):
         wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
+def test_tile_slice_sentinel_bounds_empty_rejected(test, device):
+    # Explicit bounds equal to the old omitted-bound sentinels must remain
+    # ordinary integer bounds and produce an empty tile, matching Python slices.
+    src = wp.array(np.arange(8, dtype=np.float32), dtype=float, device=device)
+    dst = wp.zeros(8, dtype=float, device=device)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def max_start_kernel(src: wp.array1d[float], dst: wp.array1d[float]):
+        t = wp.tile_load(src, shape=(8,))
+        wp.tile_store(dst, t[2147483647:])
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"empty tile|zero-length"):
+        wp.launch_tiled(max_start_kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def min_stop_kernel(src: wp.array1d[float], dst: wp.array1d[float]):
+        t = wp.tile_load(src, shape=(8,))
+        wp.tile_store(dst, t[:-2147483648])
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"empty tile|zero-length"):
+        wp.launch_tiled(min_stop_kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+
+
 # ---------------------------------------------------------------------------
 # Runtime and negative index handling, chained subscripts, explicit slices
 # ---------------------------------------------------------------------------
@@ -856,6 +879,60 @@ def test_tile_chained_partial_int_subscript(test, device):
     assert_np_equal(dst_slice.numpy(), src_np[2][1:9:2], tol=1e-6)
 
 
+@wp.kernel(enable_backward=False)
+def tile_inline_index_expression_kernel(src: wp.array2d[float], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(8, 8))
+    wp.tile_store(dst, t[wp.tile_arange(0, 8, dtype=int)[::2][0]][:])
+
+
+@wp.kernel(enable_backward=False)
+def tile_local_index_expression_kernel(src: wp.array2d[float], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(8, 8))
+    indices = wp.tile_arange(0, 8, dtype=int)
+    even_indices = indices[::2]
+    row_index = even_indices[0]
+    row = t[row_index]
+    wp.tile_store(dst, row[:])
+
+
+def test_tile_inline_index_expression(test, device):
+    src_np = np.arange(64, dtype=np.float32).reshape(8, 8)
+    src = wp.array(src_np, dtype=float, device=device)
+
+    for kernel in (tile_inline_index_expression_kernel, tile_local_index_expression_kernel):
+        dst = wp.zeros(8, dtype=float, device=device)
+        wp.launch_tiled(kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+        assert_np_equal(dst.numpy(), src_np[0], tol=1e-6)
+
+
+def test_tile_inline_user_function_index(test, device):
+    @wp.func
+    def index_passthrough(indices: wp.tile[int, 8]) -> wp.tile[int, 8]:
+        return indices[:]
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def inline_kernel(src: wp.array2d[float], dst: wp.array1d[float]):
+        t = wp.tile_load(src, shape=(8, 8))
+        indices = wp.tile_arange(0, 8, dtype=int, storage="shared")
+        wp.tile_store(dst, t[index_passthrough(indices)][0])
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def local_kernel(src: wp.array2d[float], dst: wp.array1d[float]):
+        t = wp.tile_load(src, shape=(8, 8))
+        indices = wp.tile_arange(0, 8, dtype=int, storage="shared")
+        resolved_indices = index_passthrough(indices)
+        gathered = t[resolved_indices]
+        wp.tile_store(dst, gathered[0])
+
+    src_np = np.arange(64, dtype=np.float32).reshape(8, 8)
+    src = wp.array(src_np, dtype=float, device=device)
+
+    for kernel in (inline_kernel, local_kernel):
+        dst = wp.zeros(8, dtype=float, device=device)
+        wp.launch_tiled(kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+        assert_np_equal(dst.numpy(), src_np[0], tol=1e-6)
+
+
 @wp.kernel
 def tile_view_explicit_slice_kernel(src: wp.array1d[float], dst: wp.array1d[float]):
     t = wp.tile_load(src, shape=(TILE_DIM,))
@@ -1046,12 +1123,22 @@ add_function_test(
 add_function_test(
     TestTileView, "test_tile_view_shape_with_slice_rejected", test_tile_view_shape_with_slice_rejected, devices=devices
 )
+add_function_test(
+    TestTileView,
+    "test_tile_slice_sentinel_bounds_empty_rejected",
+    test_tile_slice_sentinel_bounds_empty_rejected,
+    devices=devices,
+)
 add_function_test(TestTileView, "test_tile_runtime_ref_index", test_tile_runtime_ref_index, devices=devices)
 add_function_test(TestTileView, "test_tile_runtime_neg_index", test_tile_runtime_neg_index, devices=devices)
 add_function_test(TestTileView, "test_tile_gather_neg_index", test_tile_gather_neg_index, devices=devices)
 add_function_test(TestTileView, "test_tile_chained_subscript", test_tile_chained_subscript, devices=devices)
 add_function_test(
     TestTileView, "test_tile_chained_partial_int_subscript", test_tile_chained_partial_int_subscript, devices=devices
+)
+add_function_test(TestTileView, "test_tile_inline_index_expression", test_tile_inline_index_expression, devices=devices)
+add_function_test(
+    TestTileView, "test_tile_inline_user_function_index", test_tile_inline_user_function_index, devices=devices
 )
 add_function_test(TestTileView, "test_tile_view_explicit_slice", test_tile_view_explicit_slice, devices=devices)
 add_function_test(TestTileView, "test_tile_row_assign", test_tile_row_assign, devices=devices)

--- a/warp/tests/tile/test_tile_view.py
+++ b/warp/tests/tile/test_tile_view.py
@@ -534,6 +534,17 @@ def test_tile_advanced_index_float_rejected(test, device):
         wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
+def test_tile_advanced_index_non_full_slice_rejected(test, device):
+    @wp.kernel(module="unique", enable_backward=False)
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        idx = wp.tile_arange(0, 4, dtype=int)
+        rows = t[idx, 1:5]
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"requires ':' on all other axes"):
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
+
+
 def test_tile_slice_scalar_assign_rejected(test, device):
     @wp.kernel(module="unique", enable_backward=False)
     def kernel_fn():
@@ -1102,6 +1113,12 @@ add_function_test(TestTileView, "test_tile_slice_empty_rejected", test_tile_slic
 add_function_test(TestTileView, "test_tile_slice_neg_stop", test_tile_slice_neg_stop, devices=devices)
 add_function_test(
     TestTileView, "test_tile_advanced_index_float_rejected", test_tile_advanced_index_float_rejected, devices=devices
+)
+add_function_test(
+    TestTileView,
+    "test_tile_advanced_index_non_full_slice_rejected",
+    test_tile_advanced_index_non_full_slice_rejected,
+    devices=devices,
 )
 add_function_test(
     TestTileView, "test_tile_slice_scalar_assign_rejected", test_tile_slice_scalar_assign_rejected, devices=devices

--- a/warp/tests/tile/test_tile_view.py
+++ b/warp/tests/tile/test_tile_view.py
@@ -286,6 +286,301 @@ def test_tile_view_non_dense_store(test, device):
     assert_np_equal(dst.numpy(), expected)
 
 
+# ---------------------------------------------------------------------------
+# NumPy-style slicing (GH-1176)
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def tile_slice_rows_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[4:12, :])
+
+
+@wp.kernel
+def tile_slice_cols_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[:, 8:24])
+
+
+@wp.kernel
+def tile_slice_strided_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[::2, ::2])
+
+
+@wp.kernel
+def tile_slice_reverse_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[::-1, :])
+
+
+@wp.kernel
+def tile_slice_row_collapse_kernel(src: wp.array2d(dtype=float), dst: wp.array1d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[5, :])
+
+
+@wp.kernel
+def tile_slice_assign_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    ones = wp.tile_ones(shape=(4, TILE_N), dtype=float)
+    t[0:4, :] = ones
+    wp.tile_store(dst, t)
+
+
+@wp.kernel
+def tile_fancy_index_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    idx = wp.tile_arange(0, 8, dtype=int) * 2  # [0, 2, 4, ..., 14]
+    wp.tile_store(dst, t[idx, :])
+
+
+@wp.kernel
+def tile_fancy_index_dup_kernel(src: wp.array2d(dtype=float), idx: wp.array1d(dtype=int), dst: wp.array2d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    i = wp.tile_load(idx, shape=8)
+    wp.tile_store(dst, t[i, :])
+
+
+@wp.kernel
+def tile_slice_assign_grad_kernel(
+    src: wp.array2d(dtype=float), val: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)
+):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    v = wp.tile_load(val, shape=(4, TILE_N))
+    t[0:4, :] = v
+    wp.tile_store(dst, t)
+
+
+@wp.kernel
+def tile_slice_neg_index_kernel(src: wp.array2d(dtype=float), dst: wp.array1d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[-1, :])  # NumPy negative index: last row
+
+
+@wp.kernel
+def tile_slice_neg_step_oob_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[100::-1, :])  # out-of-range start clamps to the full reverse
+
+
+@wp.kernel
+def tile_slice_neg_stop_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[7:-100:-1, :])  # out-of-range negative stop must still include row 0
+
+
+def _check_slice(test, device, kernel, np_index, out_shape, check_grad=True):
+    """Launch ``kernel`` (which slices a (TILE_M, TILE_N) tile with ``np_index``)
+    and compare against NumPy, including a gradient check by default."""
+    rng = np.random.default_rng(42)
+    src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+
+    src = wp.array(src_np, dtype=float, requires_grad=True, device=device)
+    dst = wp.zeros(out_shape, dtype=float, requires_grad=True, device=device)
+
+    with wp.Tape() as tape:
+        wp.launch_tiled(kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+
+    assert_np_equal(dst.numpy(), src_np[np_index], tol=1e-6)
+
+    if not check_grad:
+        return
+
+    adj_np = rng.random(out_shape, dtype=np.float32)
+    dst.grad = wp.array(adj_np, dtype=float, device=device)
+    tape.backward()
+
+    expected_grad = np.zeros_like(src_np)
+    expected_grad[np_index] = adj_np
+    assert_np_equal(src.grad.numpy(), expected_grad, tol=1e-6)
+
+
+def test_tile_slice_rows(test, device):
+    _check_slice(test, device, tile_slice_rows_kernel, np.s_[4:12, :], (8, TILE_N))
+
+
+def test_tile_slice_cols(test, device):
+    _check_slice(test, device, tile_slice_cols_kernel, np.s_[:, 8:24], (TILE_M, 16))
+
+
+def test_tile_slice_strided(test, device):
+    _check_slice(test, device, tile_slice_strided_kernel, np.s_[::2, ::2], (TILE_M // 2, TILE_N // 2))
+
+
+def test_tile_slice_reverse(test, device):
+    _check_slice(test, device, tile_slice_reverse_kernel, np.s_[::-1, :], (TILE_M, TILE_N))
+
+
+def test_tile_slice_row_collapse(test, device):
+    _check_slice(test, device, tile_slice_row_collapse_kernel, np.s_[5, :], (TILE_N,))
+
+
+def test_tile_slice_assign(test, device):
+    rng = np.random.default_rng(42)
+    src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+
+    src = wp.array(src_np, dtype=float, device=device)
+    dst = wp.zeros((TILE_M, TILE_N), dtype=float, device=device)
+
+    wp.launch_tiled(tile_slice_assign_kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+
+    expected = src_np.copy()
+    expected[0:4, :] = 1.0
+    assert_np_equal(dst.numpy(), expected, tol=1e-6)
+
+
+def test_tile_fancy_index(test, device):
+    idx = np.arange(0, 8) * 2
+    _check_slice(test, device, tile_fancy_index_kernel, np.s_[idx, :], (8, TILE_N))
+
+
+def test_tile_fancy_index_duplicate_grad(test, device):
+    # Duplicate indices must accumulate their gradients (atomic scatter). The
+    # generic _check_slice reference assigns rather than accumulates, so this
+    # case needs an np.add.at reference of its own.
+    rng = np.random.default_rng(42)
+    src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+    idx_np = np.array([0, 0, 3, 3, 5, 5, 7, 7], dtype=np.int32)
+
+    src = wp.array(src_np, dtype=float, requires_grad=True, device=device)
+    idx = wp.array(idx_np, dtype=int, device=device)
+    dst = wp.zeros((8, TILE_N), dtype=float, requires_grad=True, device=device)
+
+    with wp.Tape() as tape:
+        wp.launch_tiled(tile_fancy_index_dup_kernel, dim=[1], inputs=[src, idx, dst], block_dim=32, device=device)
+
+    assert_np_equal(dst.numpy(), src_np[idx_np], tol=1e-6)
+
+    adj_np = rng.random((8, TILE_N), dtype=np.float32)
+    dst.grad = wp.array(adj_np, dtype=float, device=device)
+    tape.backward()
+
+    expected_grad = np.zeros_like(src_np)
+    np.add.at(expected_grad, idx_np, adj_np)  # accumulate contributions from repeated rows
+    assert_np_equal(src.grad.numpy(), expected_grad, tol=1e-6)
+
+
+def test_tile_slice_assign_grad(test, device):
+    # Slice assignment must route gradients correctly: the overwritten region flows
+    # to the assigned source, and the untouched region passes through to the base.
+    rng = np.random.default_rng(42)
+    src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+    val_np = rng.random((4, TILE_N), dtype=np.float32)
+
+    src = wp.array(src_np, dtype=float, requires_grad=True, device=device)
+    val = wp.array(val_np, dtype=float, requires_grad=True, device=device)
+    dst = wp.zeros((TILE_M, TILE_N), dtype=float, requires_grad=True, device=device)
+
+    with wp.Tape() as tape:
+        wp.launch_tiled(tile_slice_assign_grad_kernel, dim=[1], inputs=[src, val, dst], block_dim=32, device=device)
+
+    expected = src_np.copy()
+    expected[0:4, :] = val_np
+    assert_np_equal(dst.numpy(), expected, tol=1e-6)
+
+    adj_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+    dst.grad = wp.array(adj_np, dtype=float, device=device)
+    tape.backward()
+
+    # rows 0:4 are overwritten by val, so they contribute no gradient to src
+    expected_src_grad = adj_np.copy()
+    expected_src_grad[0:4, :] = 0.0
+    assert_np_equal(src.grad.numpy(), expected_src_grad, tol=1e-6)
+    assert_np_equal(val.grad.numpy(), adj_np[0:4, :], tol=1e-6)
+
+
+def test_tile_slice_neg_index(test, device):
+    # A negative integer index must wrap like NumPy (last row), not read out of bounds.
+    _check_slice(test, device, tile_slice_neg_index_kernel, np.s_[-1, :], (TILE_N,))
+
+
+def test_tile_slice_neg_step_oob_start(test, device):
+    # An out-of-range start with a negative step clamps to length-1 (full reverse).
+    _check_slice(test, device, tile_slice_neg_step_oob_kernel, np.s_[100::-1, :], (TILE_M, TILE_N))
+
+
+def test_tile_slice_neg_stop(test, device):
+    # An out-of-range negative stop with a negative step must still reach row 0.
+    _check_slice(test, device, tile_slice_neg_stop_kernel, np.s_[7:-100:-1, :], (8, TILE_N))
+
+
+def test_tile_fancy_index_float_rejected(test, device):
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        idx = wp.tile_arange(0.0, 8.0, 1.0, dtype=float)  # non-integer index tile
+        rows = t[idx, :]
+
+    kernel = wp.Kernel(func=kernel_fn)
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"integer index tile"):
+        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_slice_scalar_assign_rejected(test, device):
+    def kernel_fn():
+        t = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=float)
+        t[0:4, :] = 1.0  # scalar broadcast into a slice is not supported
+
+    kernel = wp.Kernel(func=kernel_fn)
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"requires a tile of matching shape"):
+        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_slice_augassign_rejected(test, device):
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        v = wp.tile_ones(shape=(4, TILE_N), dtype=float)
+        t[0:4, :] += v  # compound assignment to a slice is not supported
+
+    kernel = wp.Kernel(func=kernel_fn)
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"Compound assignment to a tile view"):
+        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_row_augassign_rejected(test, device):
+    # A partial integer index (a row view) has no in-place path either.
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        v = wp.tile_ones(shape=(TILE_N,), dtype=float)
+        t[0] += v  # compound assignment to a row view is not supported
+
+    kernel = wp.Kernel(func=kernel_fn)
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"Compound assignment to a tile view"):
+        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_slice_assign_shape_mismatch(test, device):
+    def kernel_fn():
+        t = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=float)
+        src = wp.tile_ones(shape=(5, TILE_N), dtype=float)  # 5 rows into a 4-row slice
+        t[0:4, :] = src
+
+    kernel = wp.Kernel(func=kernel_fn)
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"shape mismatch|does not fit"):
+        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_index_out_of_bounds(test, device):
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        row = t[100, :]  # constant out-of-range integer index
+
+    kernel = wp.Kernel(func=kernel_fn)
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"out of bounds"):
+        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_slice_empty_rejected(test, device):
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        empty = t[4:4, :]  # zero-length axis
+
+    kernel = wp.Kernel(func=kernel_fn)
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"empty tile|zero-length"):
+        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+
 devices = get_test_devices()
 
 
@@ -316,6 +611,37 @@ add_function_test(
     test_tile_view_non_dense_store,
     devices=devices,
 )
+add_function_test(TestTileView, "test_tile_slice_rows", test_tile_slice_rows, devices=devices)
+add_function_test(TestTileView, "test_tile_slice_cols", test_tile_slice_cols, devices=devices)
+add_function_test(TestTileView, "test_tile_slice_strided", test_tile_slice_strided, devices=devices)
+add_function_test(TestTileView, "test_tile_slice_reverse", test_tile_slice_reverse, devices=devices)
+add_function_test(TestTileView, "test_tile_slice_row_collapse", test_tile_slice_row_collapse, devices=devices)
+add_function_test(TestTileView, "test_tile_slice_assign", test_tile_slice_assign, devices=devices)
+add_function_test(TestTileView, "test_tile_fancy_index", test_tile_fancy_index, devices=devices)
+add_function_test(
+    TestTileView, "test_tile_fancy_index_duplicate_grad", test_tile_fancy_index_duplicate_grad, devices=devices
+)
+add_function_test(TestTileView, "test_tile_slice_assign_grad", test_tile_slice_assign_grad, devices=devices)
+add_function_test(TestTileView, "test_tile_slice_neg_index", test_tile_slice_neg_index, devices=devices)
+add_function_test(
+    TestTileView, "test_tile_slice_neg_step_oob_start", test_tile_slice_neg_step_oob_start, devices=devices
+)
+add_function_test(
+    TestTileView, "test_tile_slice_assign_shape_mismatch", test_tile_slice_assign_shape_mismatch, devices=devices
+)
+add_function_test(TestTileView, "test_tile_index_out_of_bounds", test_tile_index_out_of_bounds, devices=devices)
+add_function_test(TestTileView, "test_tile_slice_empty_rejected", test_tile_slice_empty_rejected, devices=devices)
+add_function_test(TestTileView, "test_tile_slice_neg_stop", test_tile_slice_neg_stop, devices=devices)
+add_function_test(
+    TestTileView, "test_tile_fancy_index_float_rejected", test_tile_fancy_index_float_rejected, devices=devices
+)
+add_function_test(
+    TestTileView, "test_tile_slice_scalar_assign_rejected", test_tile_slice_scalar_assign_rejected, devices=devices
+)
+add_function_test(
+    TestTileView, "test_tile_slice_augassign_rejected", test_tile_slice_augassign_rejected, devices=devices
+)
+add_function_test(TestTileView, "test_tile_row_augassign_rejected", test_tile_row_augassign_rejected, devices=devices)
 
 
 if __name__ == "__main__":

--- a/warp/tests/tile/test_tile_view.py
+++ b/warp/tests/tile/test_tile_view.py
@@ -292,37 +292,37 @@ def test_tile_view_non_dense_store(test, device):
 
 
 @wp.kernel
-def tile_slice_rows_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+def tile_slice_rows_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     wp.tile_store(dst, t[4:12, :])
 
 
 @wp.kernel
-def tile_slice_cols_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+def tile_slice_cols_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     wp.tile_store(dst, t[:, 8:24])
 
 
 @wp.kernel
-def tile_slice_strided_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+def tile_slice_strided_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     wp.tile_store(dst, t[::2, ::2])
 
 
 @wp.kernel
-def tile_slice_reverse_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+def tile_slice_reverse_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     wp.tile_store(dst, t[::-1, :])
 
 
 @wp.kernel
-def tile_slice_row_collapse_kernel(src: wp.array2d(dtype=float), dst: wp.array1d(dtype=float)):
+def tile_slice_row_collapse_kernel(src: wp.array2d[float], dst: wp.array1d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     wp.tile_store(dst, t[5, :])
 
 
 @wp.kernel
-def tile_slice_assign_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+def tile_slice_assign_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     ones = wp.tile_ones(shape=(4, TILE_N), dtype=float)
     t[0:4, :] = ones
@@ -330,23 +330,21 @@ def tile_slice_assign_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype
 
 
 @wp.kernel
-def tile_fancy_index_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+def tile_fancy_index_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     idx = wp.tile_arange(0, 8, dtype=int) * 2  # [0, 2, 4, ..., 14]
     wp.tile_store(dst, t[idx, :])
 
 
 @wp.kernel
-def tile_fancy_index_dup_kernel(src: wp.array2d(dtype=float), idx: wp.array1d(dtype=int), dst: wp.array2d(dtype=float)):
+def tile_fancy_index_dup_kernel(src: wp.array2d[float], idx: wp.array1d[int], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     i = wp.tile_load(idx, shape=8)
     wp.tile_store(dst, t[i, :])
 
 
 @wp.kernel
-def tile_slice_assign_grad_kernel(
-    src: wp.array2d(dtype=float), val: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)
-):
+def tile_slice_assign_grad_kernel(src: wp.array2d[float], val: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     v = wp.tile_load(val, shape=(4, TILE_N))
     t[0:4, :] = v
@@ -354,26 +352,35 @@ def tile_slice_assign_grad_kernel(
 
 
 @wp.kernel
-def tile_slice_neg_index_kernel(src: wp.array2d(dtype=float), dst: wp.array1d(dtype=float)):
+def tile_slice_neg_index_kernel(src: wp.array2d[float], dst: wp.array1d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     wp.tile_store(dst, t[-1, :])  # NumPy negative index: last row
 
 
 @wp.kernel
-def tile_slice_neg_step_oob_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+def tile_slice_neg_step_oob_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     wp.tile_store(dst, t[100::-1, :])  # out-of-range start clamps to the full reverse
 
 
 @wp.kernel
-def tile_slice_neg_stop_kernel(src: wp.array2d(dtype=float), dst: wp.array2d(dtype=float)):
+def tile_slice_neg_stop_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     wp.tile_store(dst, t[7:-100:-1, :])  # out-of-range negative stop must still include row 0
 
 
 def _check_slice(test, device, kernel, np_index, out_shape, check_grad=True):
-    """Launch ``kernel`` (which slices a (TILE_M, TILE_N) tile with ``np_index``)
-    and compare against NumPy, including a gradient check by default."""
+    """Check a tile-slicing kernel against the equivalent NumPy indexing expression.
+
+    Args:
+        test: Test case instance.
+        device: Device to launch on.
+        kernel: Kernel that slices a ``(TILE_M, TILE_N)`` tile with ``np_index``.
+        np_index: NumPy index expression matching the kernel's subscript.
+        out_shape: Shape of the sliced result.
+        check_grad: Whether to also verify the backward pass scatters gradients
+            back to the sliced source elements.
+    """
     rng = np.random.default_rng(42)
     src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
 
@@ -507,78 +514,144 @@ def test_tile_slice_neg_stop(test, device):
 
 
 def test_tile_fancy_index_float_rejected(test, device):
+    @wp.kernel(module="unique", enable_backward=False)
     def kernel_fn():
         t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
         idx = wp.tile_arange(0.0, 8.0, 1.0, dtype=float)  # non-integer index tile
         rows = t[idx, :]
 
-    kernel = wp.Kernel(func=kernel_fn)
     with test.assertRaisesRegex((RuntimeError, ValueError), r"integer index tile"):
-        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
 def test_tile_slice_scalar_assign_rejected(test, device):
+    @wp.kernel(module="unique", enable_backward=False)
     def kernel_fn():
         t = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=float)
         t[0:4, :] = 1.0  # scalar broadcast into a slice is not supported
 
-    kernel = wp.Kernel(func=kernel_fn)
     with test.assertRaisesRegex((RuntimeError, ValueError), r"requires a tile of matching shape"):
-        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
 def test_tile_slice_augassign_rejected(test, device):
+    @wp.kernel(module="unique", enable_backward=False)
     def kernel_fn():
         t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
         v = wp.tile_ones(shape=(4, TILE_N), dtype=float)
         t[0:4, :] += v  # compound assignment to a slice is not supported
 
-    kernel = wp.Kernel(func=kernel_fn)
     with test.assertRaisesRegex((RuntimeError, ValueError), r"Compound assignment to a tile view"):
-        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
 def test_tile_row_augassign_rejected(test, device):
     # A partial integer index (a row view) has no in-place path either.
+    @wp.kernel(module="unique", enable_backward=False)
     def kernel_fn():
         t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
         v = wp.tile_ones(shape=(TILE_N,), dtype=float)
         t[0] += v  # compound assignment to a row view is not supported
 
-    kernel = wp.Kernel(func=kernel_fn)
     with test.assertRaisesRegex((RuntimeError, ValueError), r"Compound assignment to a tile view"):
-        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
 def test_tile_slice_assign_shape_mismatch(test, device):
+    @wp.kernel(module="unique", enable_backward=False)
     def kernel_fn():
         t = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=float)
         src = wp.tile_ones(shape=(5, TILE_N), dtype=float)  # 5 rows into a 4-row slice
         t[0:4, :] = src
 
-    kernel = wp.Kernel(func=kernel_fn)
     with test.assertRaisesRegex((RuntimeError, ValueError), r"shape mismatch|does not fit"):
-        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
 def test_tile_index_out_of_bounds(test, device):
+    @wp.kernel(module="unique", enable_backward=False)
     def kernel_fn():
         t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
         row = t[100, :]  # constant out-of-range integer index
 
-    kernel = wp.Kernel(func=kernel_fn)
     with test.assertRaisesRegex((RuntimeError, ValueError), r"out of bounds"):
-        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
 def test_tile_slice_empty_rejected(test, device):
+    @wp.kernel(module="unique", enable_backward=False)
     def kernel_fn():
         t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
         empty = t[4:4, :]  # zero-length axis
 
-    kernel = wp.Kernel(func=kernel_fn)
     with test.assertRaisesRegex((RuntimeError, ValueError), r"empty tile|zero-length"):
-        wp.launch_tiled(kernel, dim=[1], inputs=[], block_dim=32, device=device)
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+@wp.kernel(enable_backward=False)
+def tile_slice_assign_overlap_kernel(src: wp.array1d[wp.int32], dst: wp.array1d[wp.int32]):
+    t = wp.tile_load(src, shape=(TILE_DIM,))
+    t[1:] = t[:-1]  # source and destination views alias the same tile
+    wp.tile_store(dst, t)
+
+
+def test_tile_slice_assign_overlap(test, device):
+    # Overlapping slice assignment must read the pre-assignment source values
+    # (NumPy semantics): the copy is staged through registers, not interleaved.
+    src_np = np.arange(TILE_DIM, dtype=np.int32)
+    src = wp.array(src_np, device=device)
+    dst = wp.zeros(TILE_DIM, dtype=wp.int32, device=device)
+
+    wp.launch_tiled(tile_slice_assign_overlap_kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+
+    expected = src_np.copy()
+    expected[1:] = src_np[:-1]
+    assert_np_equal(dst.numpy(), expected)
+
+
+def test_tile_slice_float_index_rejected(test, device):
+    @wp.kernel(module="unique", enable_backward=False)
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        row = t[1.5, :]  # non-integer scalar index
+
+    with test.assertRaisesRegex((RuntimeError, TypeError), r"must be integers or slices"):
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_view_float_offset_rejected(test, device):
+    # The explicit tile_view() API must reject non-integer offsets as well.
+    @wp.kernel(module="unique", enable_backward=False)
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        row = wp.tile_view(t, offset=(1.5,))
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"must be integers or slices"):
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_reshape_strided_view_rejected(test, device):
+    # Reshape aliases the source pointer with dense strides, so a strided or
+    # reversed view would silently read the wrong elements (or out of bounds).
+    @wp.kernel(module="unique", enable_backward=False)
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        flat = wp.tile_reshape(t[::2, ::2], shape=((TILE_M // 2) * (TILE_N // 2),))
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"requires a contiguous tile"):
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_view_shape_with_slice_rejected(test, device):
+    # Passing an explicit shape alongside a slice-containing offset would
+    # silently drop the shape, so it must be rejected.
+    @wp.kernel(module="unique", enable_backward=False)
+    def kernel_fn():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        v = wp.tile_view(t, offset=(slice(0, 2, 1), slice(0, 3, 1)), shape=(2, 3))
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"'shape' together with a slice"):
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
 devices = get_test_devices()
@@ -642,6 +715,19 @@ add_function_test(
     TestTileView, "test_tile_slice_augassign_rejected", test_tile_slice_augassign_rejected, devices=devices
 )
 add_function_test(TestTileView, "test_tile_row_augassign_rejected", test_tile_row_augassign_rejected, devices=devices)
+add_function_test(TestTileView, "test_tile_slice_assign_overlap", test_tile_slice_assign_overlap, devices=devices)
+add_function_test(
+    TestTileView, "test_tile_slice_float_index_rejected", test_tile_slice_float_index_rejected, devices=devices
+)
+add_function_test(
+    TestTileView, "test_tile_view_float_offset_rejected", test_tile_view_float_offset_rejected, devices=devices
+)
+add_function_test(
+    TestTileView, "test_tile_reshape_strided_view_rejected", test_tile_reshape_strided_view_rejected, devices=devices
+)
+add_function_test(
+    TestTileView, "test_tile_view_shape_with_slice_rejected", test_tile_view_shape_with_slice_rejected, devices=devices
+)
 
 
 if __name__ == "__main__":

--- a/warp/tests/tile/test_tile_view.py
+++ b/warp/tests/tile/test_tile_view.py
@@ -337,6 +337,12 @@ def tile_advanced_index_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
 
 
 @wp.kernel
+def tile_advanced_inline_index_chain_kernel(src: wp.array2d[float], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[wp.tile_arange(0, 8, dtype=int) * 2][3])
+
+
+@wp.kernel
 def tile_advanced_index_dup_kernel(src: wp.array2d[float], idx: wp.array1d[int], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     i = wp.tile_load(idx, shape=8)
@@ -441,6 +447,10 @@ def test_tile_slice_assign(test, device):
 def test_tile_advanced_index(test, device):
     idx = np.arange(0, 8) * 2
     _check_slice(test, device, tile_advanced_index_kernel, np.s_[idx, :], (8, TILE_N))
+
+
+def test_tile_advanced_inline_index_chain(test, device):
+    _check_slice(test, device, tile_advanced_inline_index_chain_kernel, np.s_[6, :], (TILE_N,))
 
 
 def test_tile_advanced_index_duplicate_grad(test, device):
@@ -996,6 +1006,9 @@ add_function_test(TestTileView, "test_tile_slice_reverse", test_tile_slice_rever
 add_function_test(TestTileView, "test_tile_slice_row_collapse", test_tile_slice_row_collapse, devices=devices)
 add_function_test(TestTileView, "test_tile_slice_assign", test_tile_slice_assign, devices=devices)
 add_function_test(TestTileView, "test_tile_advanced_index", test_tile_advanced_index, devices=devices)
+add_function_test(
+    TestTileView, "test_tile_advanced_inline_index_chain", test_tile_advanced_inline_index_chain, devices=devices
+)
 add_function_test(
     TestTileView, "test_tile_advanced_index_duplicate_grad", test_tile_advanced_index_duplicate_grad, devices=devices
 )

--- a/warp/tests/tile/test_tile_view.py
+++ b/warp/tests/tile/test_tile_view.py
@@ -287,7 +287,7 @@ def test_tile_view_non_dense_store(test, device):
 
 
 # ---------------------------------------------------------------------------
-# NumPy-style slicing (GH-1176)
+# NumPy-style slicing
 # ---------------------------------------------------------------------------
 
 
@@ -330,14 +330,14 @@ def tile_slice_assign_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
 
 
 @wp.kernel
-def tile_fancy_index_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
+def tile_advanced_index_kernel(src: wp.array2d[float], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     idx = wp.tile_arange(0, 8, dtype=int) * 2  # [0, 2, 4, ..., 14]
     wp.tile_store(dst, t[idx, :])
 
 
 @wp.kernel
-def tile_fancy_index_dup_kernel(src: wp.array2d[float], idx: wp.array1d[int], dst: wp.array2d[float]):
+def tile_advanced_index_dup_kernel(src: wp.array2d[float], idx: wp.array1d[int], dst: wp.array2d[float]):
     t = wp.tile_load(src, shape=(TILE_M, TILE_N))
     i = wp.tile_load(idx, shape=8)
     wp.tile_store(dst, t[i, :])
@@ -438,12 +438,12 @@ def test_tile_slice_assign(test, device):
     assert_np_equal(dst.numpy(), expected, tol=1e-6)
 
 
-def test_tile_fancy_index(test, device):
+def test_tile_advanced_index(test, device):
     idx = np.arange(0, 8) * 2
-    _check_slice(test, device, tile_fancy_index_kernel, np.s_[idx, :], (8, TILE_N))
+    _check_slice(test, device, tile_advanced_index_kernel, np.s_[idx, :], (8, TILE_N))
 
 
-def test_tile_fancy_index_duplicate_grad(test, device):
+def test_tile_advanced_index_duplicate_grad(test, device):
     # Duplicate indices must accumulate their gradients (atomic scatter). The
     # generic _check_slice reference assigns rather than accumulates, so this
     # case needs an np.add.at reference of its own.
@@ -456,7 +456,7 @@ def test_tile_fancy_index_duplicate_grad(test, device):
     dst = wp.zeros((8, TILE_N), dtype=float, requires_grad=True, device=device)
 
     with wp.Tape() as tape:
-        wp.launch_tiled(tile_fancy_index_dup_kernel, dim=[1], inputs=[src, idx, dst], block_dim=32, device=device)
+        wp.launch_tiled(tile_advanced_index_dup_kernel, dim=[1], inputs=[src, idx, dst], block_dim=32, device=device)
 
     assert_np_equal(dst.numpy(), src_np[idx_np], tol=1e-6)
 
@@ -513,7 +513,7 @@ def test_tile_slice_neg_stop(test, device):
     _check_slice(test, device, tile_slice_neg_stop_kernel, np.s_[7:-100:-1, :], (8, TILE_N))
 
 
-def test_tile_fancy_index_float_rejected(test, device):
+def test_tile_advanced_index_float_rejected(test, device):
     @wp.kernel(module="unique", enable_backward=False)
     def kernel_fn():
         t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
@@ -654,6 +654,269 @@ def test_tile_view_shape_with_slice_rejected(test, device):
         wp.launch_tiled(kernel_fn, dim=[1], inputs=[], block_dim=32, device=device)
 
 
+# ---------------------------------------------------------------------------
+# Runtime and negative index handling, chained subscripts, explicit slices
+# ---------------------------------------------------------------------------
+
+
+@wp.kernel
+def tile_runtime_ref_partial_kernel(src: wp.array2d[float], indices: wp.array1d[int], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[indices[0], :])
+
+
+@wp.kernel
+def tile_runtime_ref_bare_kernel(src: wp.array2d[float], indices: wp.array1d[int], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[indices[0]])
+
+
+@wp.kernel
+def tile_runtime_ref_explicit_kernel(src: wp.array2d[float], indices: wp.array1d[int], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, wp.tile_view(t, offset=(indices[0],)))
+
+
+def test_tile_runtime_ref_index(test, device):
+    # A runtime integer index loaded from an array (a wp.ref[int32] during code
+    # generation) must be accepted by the subscript, bare-index, and explicit
+    # tile_view() routes; the referenced value is loaded at the call site.
+    rng = np.random.default_rng(42)
+    src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+    src = wp.array(src_np, dtype=float, device=device)
+    indices = wp.array(np.array([5], dtype=np.int32), dtype=int, device=device)
+
+    for kernel in (
+        tile_runtime_ref_partial_kernel,
+        tile_runtime_ref_bare_kernel,
+        tile_runtime_ref_explicit_kernel,
+    ):
+        dst = wp.zeros(TILE_N, dtype=float, device=device)
+        wp.launch_tiled(kernel, dim=[1], inputs=[src, indices, dst], block_dim=32, device=device)
+        assert_np_equal(dst.numpy(), src_np[5], tol=1e-6)
+
+
+@wp.kernel
+def tile_runtime_neg_index_kernel(src: wp.array2d[float], offset: int, dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    i = offset  # runtime (non-constant) index
+    wp.tile_store(dst, t[i, :])
+
+
+def test_tile_runtime_neg_index(test, device):
+    # A runtime (non-constant) negative index must wrap like NumPy, matching the
+    # compile-time-constant t[-1]. -TILE_M wraps to row 0.
+    rng = np.random.default_rng(42)
+    src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+    src = wp.array(src_np, dtype=float, device=device)
+    for offset in (-1, -TILE_M):
+        dst = wp.zeros(TILE_N, dtype=float, device=device)
+        wp.launch_tiled(tile_runtime_neg_index_kernel, dim=[1], inputs=[src, offset, dst], block_dim=32, device=device)
+        assert_np_equal(dst.numpy(), src_np[offset], tol=1e-6)
+
+
+@wp.kernel
+def tile_gather_neg_index_kernel(src: wp.array2d[float], idx: wp.array1d[int], dst: wp.array2d[float]):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    i = wp.tile_load(idx, shape=4)
+    wp.tile_store(dst, t[i, :])
+
+
+def test_tile_gather_neg_index(test, device):
+    # Negative values in an integer index tile must wrap against the gathered axis
+    # (NumPy semantics) on both the forward gather and the backward scatter.
+    rng = np.random.default_rng(42)
+    src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+    idx_np = np.array([-1, 0, -TILE_M, 3], dtype=np.int32)  # wraps to [TILE_M-1, 0, 0, 3]
+
+    src = wp.array(src_np, dtype=float, requires_grad=True, device=device)
+    idx = wp.array(idx_np, dtype=int, device=device)
+    dst = wp.zeros((4, TILE_N), dtype=float, requires_grad=True, device=device)
+
+    with wp.Tape() as tape:
+        wp.launch_tiled(tile_gather_neg_index_kernel, dim=[1], inputs=[src, idx, dst], block_dim=32, device=device)
+
+    assert_np_equal(dst.numpy(), src_np[idx_np], tol=1e-6)
+
+    adj_np = rng.random((4, TILE_N), dtype=np.float32)
+    dst.grad = wp.array(adj_np, dtype=float, device=device)
+    tape.backward()
+
+    expected_grad = np.zeros_like(src_np)
+    np.add.at(expected_grad, idx_np % TILE_M, adj_np)  # wrapped rows; duplicate wraps accumulate
+    assert_np_equal(src.grad.numpy(), expected_grad, tol=1e-6)
+
+
+@wp.kernel
+def tile_chain_slice_kernel(src: wp.array1d[float], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_DIM,))
+    wp.tile_store(dst, t[::-1][::2])
+
+
+@wp.kernel
+def tile_chain_three_kernel(src: wp.array1d[float], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_DIM,))
+    wp.tile_store(dst, t[::-1][1:][::2])
+
+
+@wp.kernel
+def tile_chain_slice_gather_kernel(src: wp.array1d[float], idx: wp.array1d[int], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_DIM,))
+    i = wp.tile_load(idx, shape=4)
+    wp.tile_store(dst, t[::2][i])
+
+
+@wp.kernel
+def tile_chain_gather_slice_kernel(src: wp.array1d[float], idx: wp.array1d[int], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_DIM,))
+    i = wp.tile_load(idx, shape=4)
+    wp.tile_store(dst, t[i][::-1])
+
+
+def test_tile_chained_subscript(test, device):
+    # Chained tile subscripts (a[X][Y]...) apply each bracket to the previous
+    # result: slice/slice, three-deep, slice/gather, and gather/slice.
+    a = np.arange(TILE_DIM, dtype=np.float32)
+    src = wp.array(a, dtype=float, requires_grad=True, device=device)
+
+    def check(kernel, expected, extra_inputs=()):
+        dst = wp.zeros(len(expected), dtype=float, device=device)
+        wp.launch_tiled(kernel, dim=[1], inputs=[src, *extra_inputs, dst], block_dim=32, device=device)
+        assert_np_equal(dst.numpy(), np.asarray(expected, dtype=np.float32), tol=1e-6)
+
+    check(tile_chain_slice_kernel, a[::-1][::2])
+    check(tile_chain_three_kernel, a[::-1][1:][::2])
+
+    idx_np = np.array([0, 5, 5, 9], dtype=np.int32)
+    idx = wp.array(idx_np, dtype=int, device=device)
+    check(tile_chain_slice_gather_kernel, a[::2][idx_np], extra_inputs=(idx,))
+    check(tile_chain_gather_slice_kernel, a[idx_np][::-1], extra_inputs=(idx,))
+
+    # gradient through the slice/slice chain scatters back to the selected elements
+    dst = wp.zeros(TILE_DIM // 2, dtype=float, requires_grad=True, device=device)
+    with wp.Tape() as tape:
+        wp.launch_tiled(tile_chain_slice_kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+    adj_np = np.arange(1, TILE_DIM // 2 + 1, dtype=np.float32)
+    dst.grad = wp.array(adj_np, dtype=float, device=device)
+    tape.backward()
+    expected_grad = np.zeros_like(a)
+    expected_grad[::-1][::2] = adj_np
+    assert_np_equal(src.grad.numpy(), expected_grad, tol=1e-6)
+
+
+@wp.kernel
+def tile_view_explicit_slice_kernel(src: wp.array1d[float], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_DIM,))
+    wp.tile_store(dst, wp.tile_view(t, offset=(slice(0, -1, 1),)))
+
+
+@wp.kernel
+def tile_view_explicit_slice_neg_start_kernel(src: wp.array1d[float], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_DIM,))
+    wp.tile_store(dst, wp.tile_view(t, offset=(slice(-3, TILE_DIM, 1),)))
+
+
+def test_tile_view_explicit_slice(test, device):
+    # An explicit slice offset must normalize its bounds against the parent shape,
+    # matching the equivalent subscript syntax (t[0:-1], t[-3:]).
+    a = np.arange(TILE_DIM, dtype=np.float32)
+    src = wp.array(a, dtype=float, device=device)
+
+    dst = wp.zeros(TILE_DIM - 1, dtype=float, device=device)
+    wp.launch_tiled(tile_view_explicit_slice_kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+    assert_np_equal(dst.numpy(), a[0:-1], tol=1e-6)
+
+    dst2 = wp.zeros(3, dtype=float, device=device)
+    wp.launch_tiled(tile_view_explicit_slice_neg_start_kernel, dim=[1], inputs=[src, dst2], block_dim=32, device=device)
+    assert_np_equal(dst2.numpy(), a[-3:], tol=1e-6)
+
+
+@wp.kernel
+def tile_row_assign_kernel(src: wp.array2d[float], row_src: wp.array1d[float], dst: wp.array2d[float]):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    r = wp.tile_load(row_src, shape=(TILE_N,))
+    t[0] = r  # partial integer index assignment (fewer indices than the tile rank)
+    wp.tile_store(dst, t)
+
+
+def test_tile_row_assign(test, device):
+    # Partial integer index assignment (t[0] = row) must build a row view and assign
+    # in place, matching t[0, :] = row, including gradient routing.
+    rng = np.random.default_rng(42)
+    src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+    row_np = rng.random(TILE_N, dtype=np.float32)
+
+    src = wp.array(src_np, dtype=float, requires_grad=True, device=device)
+    row = wp.array(row_np, dtype=float, requires_grad=True, device=device)
+    dst = wp.zeros((TILE_M, TILE_N), dtype=float, requires_grad=True, device=device)
+
+    with wp.Tape() as tape:
+        wp.launch_tiled(tile_row_assign_kernel, dim=[1], inputs=[src, row, dst], block_dim=32, device=device)
+
+    expected = src_np.copy()
+    expected[0] = row_np
+    assert_np_equal(dst.numpy(), expected, tol=1e-6)
+
+    adj_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+    dst.grad = wp.array(adj_np, dtype=float, device=device)
+    tape.backward()
+
+    expected_src_grad = adj_np.copy()
+    expected_src_grad[0] = 0.0  # row 0 is overwritten, so it contributes no gradient to src
+    assert_np_equal(src.grad.numpy(), expected_src_grad, tol=1e-6)
+    assert_np_equal(row.grad.numpy(), adj_np[0], tol=1e-6)
+
+
+@wp.kernel
+def tile_chain_int_element_kernel(src: wp.array2d[float], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(5, 7))  # register tile
+    dst[0] = t[3][4]  # chained integer subscripts collapse to a single element
+
+
+def test_tile_chain_int_element(test, device):
+    # t[i][j] with all-integer brackets must resolve to the same element as t[i, j]
+    # without going through the slice/view path (which would force shared storage).
+    rng = np.random.default_rng(42)
+    src_np = rng.random((5, 7), dtype=np.float32)
+    src = wp.array(src_np, dtype=float, device=device)
+    dst = wp.zeros(1, dtype=float, device=device)
+    wp.launch_tiled(tile_chain_int_element_kernel, dim=[1], inputs=[src, dst], block_dim=32, device=device)
+    assert_np_equal(dst.numpy(), src_np[3, 4:5], tol=1e-6)
+
+
+def test_tile_view_offset_oob_rejected(test, device):
+    # An explicit tile_view() offset is a raw coordinate, so an out-of-range constant
+    # (negative or too large) must be rejected rather than silently read out of
+    # bounds, matching the subscript path.
+    @wp.kernel(module="unique", enable_backward=False)
+    def neg_kernel():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        row = wp.tile_view(t, offset=(-1,))  # negative constant offset
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"out of bounds"):
+        wp.launch_tiled(neg_kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def pos_kernel():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        row = wp.tile_view(t, offset=(TILE_M,))  # one past the last valid row
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"out of bounds"):
+        wp.launch_tiled(pos_kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+
+def test_tile_view_runtime_slice_bound_rejected(test, device):
+    # An explicit slice offset with a runtime bound cannot infer the view shape at
+    # code-gen time, so it must be rejected with a clear message (not crash).
+    @wp.kernel(module="unique", enable_backward=False)
+    def kernel_fn(n: int):
+        t = wp.tile_ones(shape=(TILE_N,), dtype=float)
+        v = wp.tile_view(t, offset=(slice(0, n, 1),))  # runtime stop bound
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"compile-time constant"):
+        wp.launch_tiled(kernel_fn, dim=[1], inputs=[4], block_dim=32, device=device)
+
+
 devices = get_test_devices()
 
 
@@ -690,9 +953,9 @@ add_function_test(TestTileView, "test_tile_slice_strided", test_tile_slice_strid
 add_function_test(TestTileView, "test_tile_slice_reverse", test_tile_slice_reverse, devices=devices)
 add_function_test(TestTileView, "test_tile_slice_row_collapse", test_tile_slice_row_collapse, devices=devices)
 add_function_test(TestTileView, "test_tile_slice_assign", test_tile_slice_assign, devices=devices)
-add_function_test(TestTileView, "test_tile_fancy_index", test_tile_fancy_index, devices=devices)
+add_function_test(TestTileView, "test_tile_advanced_index", test_tile_advanced_index, devices=devices)
 add_function_test(
-    TestTileView, "test_tile_fancy_index_duplicate_grad", test_tile_fancy_index_duplicate_grad, devices=devices
+    TestTileView, "test_tile_advanced_index_duplicate_grad", test_tile_advanced_index_duplicate_grad, devices=devices
 )
 add_function_test(TestTileView, "test_tile_slice_assign_grad", test_tile_slice_assign_grad, devices=devices)
 add_function_test(TestTileView, "test_tile_slice_neg_index", test_tile_slice_neg_index, devices=devices)
@@ -706,7 +969,7 @@ add_function_test(TestTileView, "test_tile_index_out_of_bounds", test_tile_index
 add_function_test(TestTileView, "test_tile_slice_empty_rejected", test_tile_slice_empty_rejected, devices=devices)
 add_function_test(TestTileView, "test_tile_slice_neg_stop", test_tile_slice_neg_stop, devices=devices)
 add_function_test(
-    TestTileView, "test_tile_fancy_index_float_rejected", test_tile_fancy_index_float_rejected, devices=devices
+    TestTileView, "test_tile_advanced_index_float_rejected", test_tile_advanced_index_float_rejected, devices=devices
 )
 add_function_test(
     TestTileView, "test_tile_slice_scalar_assign_rejected", test_tile_slice_scalar_assign_rejected, devices=devices
@@ -727,6 +990,22 @@ add_function_test(
 )
 add_function_test(
     TestTileView, "test_tile_view_shape_with_slice_rejected", test_tile_view_shape_with_slice_rejected, devices=devices
+)
+add_function_test(TestTileView, "test_tile_runtime_ref_index", test_tile_runtime_ref_index, devices=devices)
+add_function_test(TestTileView, "test_tile_runtime_neg_index", test_tile_runtime_neg_index, devices=devices)
+add_function_test(TestTileView, "test_tile_gather_neg_index", test_tile_gather_neg_index, devices=devices)
+add_function_test(TestTileView, "test_tile_chained_subscript", test_tile_chained_subscript, devices=devices)
+add_function_test(TestTileView, "test_tile_view_explicit_slice", test_tile_view_explicit_slice, devices=devices)
+add_function_test(TestTileView, "test_tile_row_assign", test_tile_row_assign, devices=devices)
+add_function_test(TestTileView, "test_tile_chain_int_element", test_tile_chain_int_element, devices=devices)
+add_function_test(
+    TestTileView, "test_tile_view_offset_oob_rejected", test_tile_view_offset_oob_rejected, devices=devices
+)
+add_function_test(
+    TestTileView,
+    "test_tile_view_runtime_slice_bound_rejected",
+    test_tile_view_runtime_slice_bound_rejected,
+    devices=devices,
 )
 
 

--- a/warp/tests/tile/test_tile_view.py
+++ b/warp/tests/tile/test_tile_view.py
@@ -773,6 +773,19 @@ def tile_chain_gather_slice_kernel(src: wp.array1d[float], idx: wp.array1d[int],
     wp.tile_store(dst, t[i][::-1])
 
 
+@wp.kernel
+def tile_chain_row_gather_kernel(src: wp.array2d[float], idx: wp.array1d[int], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    i = wp.tile_load(idx, shape=4)
+    wp.tile_store(dst, t[2][i])
+
+
+@wp.kernel
+def tile_chain_row_slice_kernel(src: wp.array2d[float], dst: wp.array1d[float]):
+    t = wp.tile_load(src, shape=(TILE_M, TILE_N))
+    wp.tile_store(dst, t[2][1:9:2])
+
+
 def test_tile_chained_subscript(test, device):
     # Chained tile subscripts (a[X][Y]...) apply each bracket to the previous
     # result: slice/slice, three-deep, slice/gather, and gather/slice.
@@ -802,6 +815,35 @@ def test_tile_chained_subscript(test, device):
     expected_grad = np.zeros_like(a)
     expected_grad[::-1][::2] = adj_np
     assert_np_equal(src.grad.numpy(), expected_grad, tol=1e-6)
+
+
+def test_tile_chained_partial_int_subscript(test, device):
+    # A partial integer prefix followed by a slice/gather must apply the later
+    # bracket to the row view, while pure integer chains still use tile_extract.
+    rng = np.random.default_rng(42)
+    src_np = rng.random((TILE_M, TILE_N), dtype=np.float32)
+    idx_np = np.array([1, 3, 3, -1], dtype=np.int32)
+
+    src = wp.array(src_np, dtype=float, requires_grad=True, device=device)
+    idx = wp.array(idx_np, dtype=int, device=device)
+    dst = wp.zeros(4, dtype=float, requires_grad=True, device=device)
+
+    with wp.Tape() as tape:
+        wp.launch_tiled(tile_chain_row_gather_kernel, dim=[1], inputs=[src, idx, dst], block_dim=32, device=device)
+
+    assert_np_equal(dst.numpy(), src_np[2][idx_np], tol=1e-6)
+
+    adj_np = rng.random(4, dtype=np.float32)
+    dst.grad = wp.array(adj_np, dtype=float, device=device)
+    tape.backward()
+
+    expected_grad = np.zeros_like(src_np)
+    np.add.at(expected_grad[2], idx_np % TILE_N, adj_np)
+    assert_np_equal(src.grad.numpy(), expected_grad, tol=1e-6)
+
+    dst_slice = wp.zeros(4, dtype=float, device=device)
+    wp.launch_tiled(tile_chain_row_slice_kernel, dim=[1], inputs=[src, dst_slice], block_dim=32, device=device)
+    assert_np_equal(dst_slice.numpy(), src_np[2][1:9:2], tol=1e-6)
 
 
 @wp.kernel
@@ -995,6 +1037,9 @@ add_function_test(TestTileView, "test_tile_runtime_ref_index", test_tile_runtime
 add_function_test(TestTileView, "test_tile_runtime_neg_index", test_tile_runtime_neg_index, devices=devices)
 add_function_test(TestTileView, "test_tile_gather_neg_index", test_tile_gather_neg_index, devices=devices)
 add_function_test(TestTileView, "test_tile_chained_subscript", test_tile_chained_subscript, devices=devices)
+add_function_test(
+    TestTileView, "test_tile_chained_partial_int_subscript", test_tile_chained_partial_int_subscript, devices=devices
+)
 add_function_test(TestTileView, "test_tile_view_explicit_slice", test_tile_view_explicit_slice, devices=devices)
 add_function_test(TestTileView, "test_tile_row_assign", test_tile_row_assign, devices=devices)
 add_function_test(TestTileView, "test_tile_chain_int_element", test_tile_chain_int_element, devices=devices)


### PR DESCRIPTION
## Description

Add NumPy-style tile slicing and fancy indexing support, including chained tile views and inline advanced index expressions.

Related to #1176.

## Changes

- Add tile view, slice, and advanced indexing support for tile values.
- Add code generation support for chained tile indexing and inline index expressions.
- Add native tile helpers and generated type stubs for the new tile slicing surface.
- Add user guide documentation and unit test coverage for tile slicing, fancy indexing, assignment, gradients, and inline index chains.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/stable/user_guide/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Verified the focused inline index-chain coverage passes on CPU and CUDA with `test_tile_advanced_inline_index_chain_cpu` and `test_tile_advanced_inline_index_chain_cuda_0`.
- Ran file-scoped pre-commit checks for `warp/_src/codegen.py` and `warp/tests/tile/test_tile_view.py`; the commit hook also passed while creating the final commit.

## Bug fix

Before this PR, chained indexing through an inline advanced index expression could be treated as scalar indexing rather than a tile view.

```python
import warp as wp

@wp.kernel
def kernel(src: wp.array2d[float], dst: wp.array1d[float]):
    t = wp.tile_load(src, shape=(16, 8))
    wp.tile_store(dst, t[wp.tile_arange(0, 8, dtype=int) * 2][3])
```

## New feature / enhancement

This PR enables NumPy-style tile slicing and fancy indexing for tile values.

```python
import warp as wp

@wp.kernel
def kernel(src: wp.array2d[float], dst: wp.array2d[float]):
    t = wp.tile_load(src, shape=(16, 8))
    rows = wp.tile_arange(0, 8, dtype=int) * 2
    wp.tile_store(dst, t[rows, :])
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added NumPy-style tile slicing (strides, reverse slices, negative indices) with dimension-collapsing integer indexing and slice assignment.
  - Added advanced single-axis gather indexing via 1D integer index tiles, including duplicate-index gradient accumulation.
  - Extended tile views to support slice-based offsets with inferred output shapes.

- **Bug Fixes**
  - Improved alias-safety for overlapping tile assignments and enhanced validation for invalid indexing/reshape cases.

- **Documentation**
  - Updated tile programming model docs and public helper references for the new indexing/slicing capabilities.

- **Tests**
  - Added extensive tile slicing/indexing regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->