### PR TITLE
Add ARM64 L4 GPU CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,27 +466,40 @@ jobs:
           - runner-label: linux-amd64-gpu-h100-latest-1
             gpu-name: h100
             artifact-name: build-artifact-ubuntu-x86_64-cuda13
+            python-version: "3.12"
             torch-extra: torch-cu13
             jax-extra: jax[cuda13]
             rmm-args: ""
           - runner-label: linux-amd64-gpu-rtxpro6000-latest-1
             gpu-name: rtxpro6000
             artifact-name: build-artifact-ubuntu-x86_64-cuda13
+            python-version: "3.12"
             torch-extra: torch-cu13
             jax-extra: jax[cuda13]
             rmm-args: ""
           - runner-label: linux-amd64-gpu-l4-earliest-1
             gpu-name: l4
             artifact-name: build-artifact-ubuntu-x86_64-cuda12
+            python-version: "3.12"
             torch-extra: torch-cu12
             jax-extra: jax[cuda12]
             rmm-args: --with rmm-cu12
+          - runner-label: linux-arm64-gpu-l4-latest-1
+            gpu-name: l4-arm64
+            artifact-name: build-artifact-ubuntu-aarch64-cuda13
+            python-version: "3.14"
+            torch-extra: torch-cu13
+            jax-extra: jax[cuda13]
+            rmm-args: --with rmm-cu13
     container:
       image: ubuntu:24.04
       options: -u root --security-opt seccomp=unconfined --shm-size 16g
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     timeout-minutes: 45
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+      WARP_CACHE_PATH: /tmp/warp-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.gpu-name }}
     steps:
       - name: Display GPU information
         run: nvidia-smi
@@ -502,6 +515,10 @@ jobs:
           apt-get update
           apt-get install -y git git-lfs curl gpg
           git lfs install
+
+      - name: Install Python 3.14 build dependencies
+        if: matrix.python-version == '3.14'
+        run: apt-get install -y build-essential
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -522,6 +539,12 @@ jobs:
         with:
           name: ${{ matrix.artifact-name }}
           path: warp/bin/
+
+      - name: Report Warp diagnostics
+        # Warp counterpart to nvidia-smi: dump the build, CUDA, driver, and device
+        # snapshot into the log, then fail loudly if Warp enumerated no GPU (otherwise
+        # the test suite silently falls back to CPU-only and still passes green).
+        run: uv run --extra dev --extra ${{ matrix.torch-extra }} --with "${{ matrix.jax-extra }}" ${{ matrix.rmm-args }} python -c "import warp as wp; wp.print_diagnostics(); assert wp.get_cuda_devices(), 'No CUDA device visible to Warp'"
 
       - name: Run Tests
         run: uv run --extra dev --extra ${{ matrix.torch-extra }} --with "${{ matrix.jax-extra }}" ${{ matrix.rmm-args }} -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
@@ -602,6 +625,10 @@ jobs:
         with:
           name: build-artifact-ubuntu-aarch64-cuda13
           path: warp/bin/
+
+      - name: Report Warp diagnostics
+        # See the note in test-warp-gpu-linux; the Warp counterpart to nvidia-smi.
+        run: uv run --extra dev --with "jax[cuda13]" python -c "import warp as wp; wp.print_diagnostics(); assert wp.get_cuda_devices(), 'No CUDA device visible to Warp'"
 
       - name: Run Tests
         run: uv run --extra dev --with "jax[cuda13]" -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
@@ -696,6 +723,10 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --python 3.14t --extra dev --no-install-package usd-core --no-install-package blosc
 
+      - name: Report Warp diagnostics
+        # See the note in test-warp-gpu-linux; the Warp counterpart to nvidia-smi.
+        run: uv run --python 3.14t --no-sync python -c "import warp as wp; wp.print_diagnostics(); assert wp.get_cuda_devices(), 'No CUDA device visible to Warp'"
+
       - name: Run Tests
         run: uv run --python 3.14t --no-sync -m warp.tests --junit-report-xml rspec.xml -s autodetect --failfast
 
@@ -727,6 +758,7 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     env:
       UV_PYTHON: "3.10"
+      WARP_CACHE_PATH: /tmp/warp-cache-${{ github.run_id }}-${{ github.run_attempt }}-mgpu-python310
     timeout-minutes: 60
     steps:
       - name: Display GPU information
@@ -764,8 +796,14 @@ jobs:
           name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
 
+      - name: Report Warp diagnostics
+        # See the note in test-warp-gpu-linux; the Warp counterpart to nvidia-smi.
+        run: uv run --extra dev python -c "import warp as wp; wp.print_diagnostics(); assert wp.get_cuda_devices(), 'No CUDA device visible to Warp'"
+
       - name: Run Tests
-        run: uv run --extra dev --extra torch-cu13 --with "jax[cuda13]" -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
+        # Keep this minimum-Python lane focused on core Warp multi-GPU coverage;
+        # current JAX and PyTorch interoperability is covered by the standard Python GPU jobs.
+        run: uv run --extra dev -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
 
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
@@ -833,6 +871,10 @@ jobs:
         with:
           name: build-artifact-windows-cuda13
           path: warp/bin/
+
+      - name: Report Warp diagnostics
+        # See the note in test-warp-gpu-linux; the Warp counterpart to nvidia-smi.
+        run: uv run --extra dev --extra torch-cu13 --with usd-core==25.5.1 python -c "import warp as wp; wp.print_diagnostics(); assert wp.get_cuda_devices(), 'No CUDA device visible to Warp'"
 
       - name: Run Tests
         # Pin usd-core to 25.5.1 to work around a frequent loading crash on Windows.
@@ -931,6 +973,10 @@ jobs:
         with:
           name: build-artifact-ubuntu-x86_64-cuda13
           path: warp/bin/
+
+      - name: Report Warp diagnostics
+        # See the note in test-warp-gpu-linux; the Warp counterpart to nvidia-smi.
+        run: uv run --extra docs python -c "import warp as wp; wp.print_diagnostics(); assert wp.get_cuda_devices(), 'No CUDA device visible to Warp'"
 
       - name: Run doctest
         run: uv run --extra docs build_docs.py --doctest --no-html --warnings-as-errors

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -828,7 +828,7 @@ linux-x86_64 python matrix test:
     - !reference [.snippets, move-linux-x86_64-binaries]
     - !reference [.snippets, section-end-install-deps]
   script:
-    - uv run --extra dev --with "rmm-cu12 ; python_version < '3.14'" -m warp.tests --junit-report-xml rspec.xml -s autodetect --failfast
+    - uv run --extra dev --with rmm-cu12 -m warp.tests --junit-report-xml rspec.xml -s autodetect --failfast
 
 # Ensure cpp examples compile and run
 linux-x86_64 cpp examples test:


### PR DESCRIPTION
## Description

Add one R595 L4 ARM64 GPU lane to the pull request and main GitHub Actions workflows. The lane uses regular Python 3.14 with the CUDA 13 ARM64 artifact and current JAX, PyTorch, and RMM integrations. The GB300 ARM64 job remains nightly-only.

This also removes unsupported current-framework requests from the Python 3.10 CUDA 13 multi-GPU lane and enables current RMM wheels throughout the GitLab Python matrix, including Python 3.14.

## Changes

- Add `linux-arm64-gpu-l4-latest-1` as the only ARM64 GPU lane on pull request and main runs.
- Exercise CUDA 13, JAX, PyTorch, RMM, and Warp GPU discovery on regular Python 3.14.
- Keep the Python 3.10 multi-GPU lane focused on core Warp coverage.
- Install RMM on Python 3.14 in the GitLab Python matrix.
- Keep the existing GB300 ARM64 lane restricted to scheduled nightly runs.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/latest/project/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes (no documentation changes are needed).
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section (not user-facing).

## Validation summary

- The first [ARM64 L4 PR job](https://github.com/NVIDIA/warp/actions/runs/30048863526/job/89346432322) passed on Python 3.14 with JAX 0.11.0, RMM 26.06.00, and PyTorch 2.13.0+cu130; all 8,454 Warp tests passed with 80 skips.
- Verified the CI structure assertions fail before the changes and pass after them.
- Parsed both workflow files and asserted the new ARM64 matrix row, Python selection, Python 3.10 dependency cleanup, and GitLab RMM command.
- Resolved the full Linux ARM64/Python 3.14 dependency set with JAX 0.11.0, PyTorch 2.13.0+cu130, and RMM 26.6.0.
- Ran the Python 3.10 core Warp version tests successfully on CUDA devices without JAX or PyTorch.
- Imported current RMM successfully under Python 3.14.
- Ran `actionlint`, `git diff --check`, and the repository pre-commit hooks for both changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded GPU test coverage with per-GPU configuration and isolated cache paths for more reliable CI runs.
  * Added early CUDA visibility diagnostics before executing GPU and documentation doctests.
  * Simplified multi-GPU test invocation and strengthened consistency across GPU job variants.

* **Chores**
  * Improved Python 3.14 CI dependency handling.
  * Updated CI test commands to consistently include the required RMM CUDA support (Linux).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->