### PR TITLE
feat: Warp builtin to normalize quaternion of transform

### DIFF
--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -2440,6 +2440,10 @@ def transform_inverse(xform: Transformation[Float]) -> Transformation[Float]:
     """Compute the inverse of the transformation ``xform``."""
     ...
 
+def transform_normalize(xform: Transformation[Float]) -> Transformation[Float]:
+    """Normalize the rotational part of the transformation ``xform``, leaving its translation unchanged."""
+    ...
+
 @over
 def spatial_vector(dtype: Float) -> Vector[Float, Literal[6]]:
     """Construct a 6D screw vector.

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -2144,6 +2144,13 @@ add_builtin(
     group="Transformations",
     doc="Compute the inverse of the transformation ``xform``.",
 )
+add_builtin(
+    "transform_normalize",
+    input_types={"xform": transformation(dtype=Float)},
+    value_func=sametypes_create_value_func(transformation(dtype=Float)),
+    group="Transformations",
+    doc="Normalize the rotational part of the transformation ``xform``, leaving its translation unchanged.",
+)
 # ---------------------------------
 # Spatial Math
 

--- a/warp/native/exports.h
+++ b/warp/native/exports.h
@@ -975,6 +975,9 @@ WP_API void wp_builtin_transform_vector_mat44d_vec3d(mat44d& mat, vec3d& vec, ve
 WP_API void wp_builtin_transform_inverse_transformh(transformh& xform, transformh* ret) { *ret = wp::transform_inverse(xform); }
 WP_API void wp_builtin_transform_inverse_transformf(transformf& xform, transformf* ret) { *ret = wp::transform_inverse(xform); }
 WP_API void wp_builtin_transform_inverse_transformd(transformd& xform, transformd* ret) { *ret = wp::transform_inverse(xform); }
+WP_API void wp_builtin_transform_normalize_transformh(transformh& xform, transformh* ret) { *ret = wp::transform_normalize(xform); }
+WP_API void wp_builtin_transform_normalize_transformf(transformf& xform, transformf* ret) { *ret = wp::transform_normalize(xform); }
+WP_API void wp_builtin_transform_normalize_transformd(transformd& xform, transformd* ret) { *ret = wp::transform_normalize(xform); }
 WP_API void wp_builtin_spatial_dot_spatial_vectorh_spatial_vectorh(spatial_vectorh& a, spatial_vectorh& b, float16* ret) { *ret = wp::spatial_dot(a, b); }
 WP_API void wp_builtin_spatial_dot_spatial_vectorf_spatial_vectorf(spatial_vectorf& a, spatial_vectorf& b, float32* ret) { *ret = wp::spatial_dot(a, b); }
 WP_API void wp_builtin_spatial_dot_spatial_vectord_spatial_vectord(spatial_vectord& a, spatial_vectord& b, float64* ret) { *ret = wp::spatial_dot(a, b); }

--- a/warp/native/spatial.h
+++ b/warp/native/spatial.h
@@ -352,6 +352,12 @@ template <typename Type> CUDA_CALLABLE inline transform_t<Type> transform_invers
 }
 
 
+template <typename Type> CUDA_CALLABLE inline transform_t<Type> transform_normalize(const transform_t<Type>& t)
+{
+    return transform_t<Type>(t.p, normalize(t.q));
+}
+
+
 template <typename Type>
 CUDA_CALLABLE inline vec_t<3, Type> transform_vector(const transform_t<Type>& t, const vec_t<3, Type>& x)
 {
@@ -1008,6 +1014,14 @@ adj_transform_inverse(const transform_t<Type>& t, transform_t<Type>& adj_t, cons
     adj_p = -adj_np;
     adj_quat_rotate(q_inv, t.p, adj_q_inv, adj_t.p, adj_p);
     adj_quat_inverse(t.q, adj_t.q, adj_q_inv);
+}
+
+template <typename Type>
+CUDA_CALLABLE inline void
+adj_transform_normalize(const transform_t<Type>& t, transform_t<Type>& adj_t, const transform_t<Type>& adj_ret)
+{
+    adj_t.p += adj_ret.p;
+    adj_normalize(t.q, adj_t.q, adj_ret.q);
 }
 
 template <typename Type>

--- a/warp/tests/test_spatial.py
+++ b/warp/tests/test_spatial.py
@@ -1117,6 +1117,92 @@ def test_transform_inverse(test, device, dtype, register_kernels=False):
         assert_np_equal(qgrads, qgrads_manual, tol=tol)
 
 
+def test_transform_normalize(test, device, dtype, register_kernels=False):
+    tol = {
+        np.float16: 1.0e-2,
+        np.float32: 1.0e-6,
+        np.float64: 1.0e-8,
+    }.get(dtype, 0)
+
+    wptype = wp.dtype_from_numpy(np.dtype(dtype))
+    transform = wp.types.transformation(dtype=wptype)
+
+    def check_transform_normalize(
+        a: wp.array[transform],
+        outputs: wp.array[wptype],
+        outputs_manual: wp.array[wptype],
+    ):
+        result = wp.transform_normalize(a[0])
+
+        # normalize the quaternion manually and compare value/gradients:
+        atrans = wp.transform_get_translation(a[0])
+        arot = wp.transform_get_rotation(a[0])
+        result_manual = transform(atrans, wp.normalize(arot))
+
+        for i in range(7):
+            outputs[i] = wptype(2) * result[i]
+            outputs_manual[i] = wptype(2) * result_manual[i]
+
+    kernel = getkernel(check_transform_normalize, suffix=dtype.__name__)
+    output_select_kernel = get_select_kernel(wptype)
+
+    if register_kernels:
+        return
+
+    rng = np.random.default_rng(123)
+
+    # deliberately use an unnormalized quaternion for the input:
+    q = rng.standard_normal(size=7)
+
+    q = wp.array(q.astype(dtype), dtype=transform, requires_grad=True, device=device)
+    outputs = wp.zeros(7, dtype=wptype, requires_grad=True, device=device)
+    outputs_manual = wp.zeros(7, dtype=wptype, requires_grad=True, device=device)
+
+    wp.launch(
+        kernel,
+        dim=1,
+        inputs=[
+            q,
+        ],
+        outputs=[outputs, outputs_manual],
+        device=device,
+    )
+
+    # translation is unchanged and the rotation is normalized to unit length:
+    out = outputs.numpy() / 2
+    assert_np_equal(out[:3], q.numpy()[0][:3], tol=tol)
+    assert_np_equal(np.array([np.linalg.norm(out[3:])]), np.array([1.0]), tol=tol)
+
+    # same as manual result:
+    assert_np_equal(outputs.numpy(), outputs_manual.numpy(), tol=tol)
+
+    for i in range(7):
+        cmp = wp.zeros(1, dtype=wptype, requires_grad=True, device=device)
+        cmp_manual = wp.zeros(1, dtype=wptype, requires_grad=True, device=device)
+        tape = wp.Tape()
+        with tape:
+            wp.launch(
+                kernel,
+                dim=1,
+                inputs=[
+                    q,
+                ],
+                outputs=[outputs, outputs_manual],
+                device=device,
+            )
+            wp.launch(output_select_kernel, dim=1, inputs=[outputs, i], outputs=[cmp], device=device)
+            wp.launch(output_select_kernel, dim=1, inputs=[outputs_manual, i], outputs=[cmp_manual], device=device)
+        tape.backward(loss=cmp)
+        qgrads = 1.0 * tape.gradients[q].numpy()
+        tape.zero()
+        tape.backward(loss=cmp_manual)
+        qgrads_manual = 1.0 * tape.gradients[q].numpy()
+        tape.zero()
+
+        # check gradients against manual result:
+        assert_np_equal(qgrads, qgrads_manual, tol=tol)
+
+
 def test_transform_point_vector(test, device, dtype, register_kernels=False):
     tol = {
         np.float16: 1.0e-2,
@@ -2760,6 +2846,13 @@ for dtype in np_float_types:
         TestSpatial,
         f"test_transform_inverse_{dtype.__name__}",
         test_transform_inverse,
+        devices=devices,
+        dtype=dtype,
+    )
+    add_function_test_register_kernel(
+        TestSpatial,
+        f"test_transform_normalize_{dtype.__name__}",
+        test_transform_normalize,
         devices=devices,
         dtype=dtype,
     )


### PR DESCRIPTION
## Summary

Fixes #315.

Added a new Warp builtin `wp.transform_normalize(xform)` that returns a copy of a `wp.transform` with its quaternion (rotation) component normalized and its translation left unchanged.

### Changes

1. **`warp/native/spatial.h`** — Added the C++ forward function `transform_normalize` (next to `transform_inverse`) and its adjoint `adj_transform_normalize` for autodiff support. The adjoint passes the translation gradient through unchanged and routes the rotation gradient through the existing `adj_normalize` for quaternions.

2. **`warp/_src/builtins.py`** — Registered the `transform_normalize` builtin in the `Transformations` group, using the same `sametypes_create_value_func(transformation(dtype=Float))` value function as `transform_inverse`.

3. **`warp/native/exports.h`** and **`warp/__init__.pyi`** — Regenerated via the repo's own tooling (`tools/build/generate_exports_header.py` / `tools/pre-commit-hooks/check_generated_files.py`); these auto-generated files gained the host-side wrappers and the type stub. I did not hand-edit them.

4. **`warp/tests/test_spatial.py`** — Added `test_transform_normalize` (registered for float16/32/64), which feeds an intentionally un-normalized quaternion and checks that translation is preserved, the resulting quaternion is unit-length, and both values and gradients match a manual `wp.normalize` reference. Follows the exact structure of the existing `test_transform_inverse`.

### Verification
- Built the CPU native library (`python build_lib.py --no-cuda`).
- `TestSpatial` passes fully: **105 passed** (including the 3 new `transform_normalize` cases across dtypes).
- The `docs/language_reference/builtins.rst` reference is generated from the builtin registry at doc-build time, so it picks up the new function automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `transform_normalize` to normalize a transformation’s rotational component while preserving its translation.
  * Works across all supported floating-point transformation types and supports automatic differentiation.

* **Tests**
  * Added parameterized test coverage to verify quaternion normalization, translation preservation, dtype/device support, and gradient correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->