### PR TITLE
Fix/hip mempool enable for graph capture

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,6 +321,7 @@ autosummary_filename_map = {
 }
 
 AUTOSUMMARY_ANNOTATION_OVERRIDES = {
+    "warp.config.enable_mempools_at_init": ": bool = True",
     "warp.config.launch_array_access_mode": (
         ": warp.config.LaunchArrayAccessMode = warp.config.LaunchArrayAccessMode.RELAXED"
     ),

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -5550,7 +5550,6 @@ class Device:
                 # enable if supported
                 self.is_mempool_enabled = self.is_mempool_supported
             else:
-                # disable by default
                 self.is_mempool_enabled = False
 
             uuid_buffer = (ctypes.c_char * 16)()

--- a/warp/_src/tape.py
+++ b/warp/_src/tape.py
@@ -1149,7 +1149,7 @@ def visit_tape(
         for id, x in enumerate(launch.inputs):
             name = kernel.adj.args[id].label
             if isinstance(x, wp.array):
-                if x.ptr is None:
+                if x.size == 0:  # skip zero-size arrays (ptr may be non-None on HIP)
                     continue
                 # if x.ptr in array_to_launch and len(array_to_launch[x.ptr]) > 1:
                 #     launch_arg_i = array_to_launch[x.ptr]
@@ -1166,6 +1166,8 @@ def visit_tape(
             elif wp._src.types.is_struct(x):
                 for varname, var in get_struct_vars(x).items():
                     if isinstance(var, wp.array):
+                        if var.size == 0:  # skip zero-size nested arrays (ptr may be non-None on HIP)
+                            continue
                         if not hide_readonly_arrays or var.ptr in computed_nodes or var.ptr in input_output_ptr:
                             add_array_node(var, f"{name}.{varname}", active_scope_stack)
                             input_arrays.append(var.ptr)
@@ -1176,7 +1178,7 @@ def visit_tape(
         output_arrays = []
         for id, x in enumerate(launch.outputs):
             name = kernel.adj.args[id + len(launch.inputs)].label
-            if isinstance(x, wp.array) and x.ptr is not None:
+            if isinstance(x, wp.array) and x.size > 0:  # skip zero-size arrays
                 add_array_node(x, name, active_scope_stack)
                 output_arrays.append(x.ptr)
                 computed_nodes.add(x.ptr)
@@ -1184,6 +1186,8 @@ def visit_tape(
             elif wp._src.types.is_struct(x):
                 for varname, var in get_struct_vars(x).items():
                     if isinstance(var, wp.array):
+                        if var.size == 0:  # skip zero-size nested arrays (ptr may be non-None on HIP)
+                            continue
                         add_array_node(var, f"{name}.{varname}", active_scope_stack)
                         output_arrays.append(var.ptr)
                         computed_nodes.add(var.ptr)

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -4358,6 +4358,13 @@ class array(Array[DType, NDim]):
 
     def zero_(self):
         """Zero out the array entries."""
+        if self.size == 0:
+            # Skip the zero-byte memset, but still record the initialization:
+            # otherwise verify_autograd_array_access keeps a stale "read" mark
+            # on the empty array and a later guarded write reports a false
+            # write-after-read.
+            self.mark_init()
+            return
         self._apic_ensure_tracked()
         if self.is_contiguous:
             # simple memset is usually faster than generic fill

--- a/warp/config.py
+++ b/warp/config.py
@@ -14,6 +14,7 @@ setting documentation for details.
 For information on module-level and kernel-level settings, see :doc:`/user_guide/configuration`.
 """
 
+import os as _os
 import sys as _sys
 import types as _types
 from enum import IntEnum as _IntEnum
@@ -386,8 +387,13 @@ enable_graph_capture_module_load_by_default: bool = True
 Only affects systems with CUDA driver versions below 12.3.
 """
 
-enable_mempools_at_init: bool = True
-"""Enable CUDA memory pools during device initialization when supported."""
+enable_mempools_at_init: bool = _os.environ.get("WARP_ENABLE_MEMPOOLS_AT_INIT", "1").lower() not in ("0", "false", "no")
+"""Enable CUDA memory pools during device initialization when supported.
+
+Set ``WARP_ENABLE_MEMPOOLS_AT_INIT`` to ``0``, ``false``, or ``no`` before
+importing Warp to disable automatic memory pool initialization (e.g. when
+sharing the process with a framework that owns its own GPU allocator).
+"""
 
 track_memory: bool = False
 """Enable tracking of memory allocations at initialization.


### PR DESCRIPTION


## Description

Three bug fixes in warp/_src/types.py and warp/_src/context.py required for correct GPU graph capture on AMD ROCm (HIP) devices. These make the standard upstream graph capture pattern work on AMD MI300X/MI325X (ROCm 7.x) without affecting NVIDIA CUDA behavior.
Tested on AMD MI325X (gfx942), ROCm 7.2 with mujoco_warp + PyTorch-ROCm.
Companion PR: google-deepmind/mujoco_warp#1556

Fix 1 — types.py: hipMalloc(0) returns nullptr on ROCm
Unlike CUDA where cudaMalloc(0) returns a unique non-null pointer, hipMalloc(0) on ROCm returns nullptr. For zero-capacity arrays (e.g. models with no tendons, no welds), downstream code that uses the pointer causes GPU page faults.
python# Before: hipMalloc(0) → nullptr → GPU page fault
ptr = allocator.allocate(capacity)

# After: 1-byte minimum on HIP, behavior unchanged on CUDA
alloc_size = 1 if (device.is_cuda and getattr(device, "is_hip", False) and capacity == 0) else capacity
if alloc_size > 0:
    ptr = allocator.allocate(alloc_size)

Fix 2 — types.py: zero_() raises hipErrorInvalidValue on zero-size arrays
hipMemsetAsync(ptr, 0, 0) returns hipErrorInvalidValue on ROCm 7.x. CUDA silently ignores size=0. Added early return after the docstring to match CUDA no-op behavior:
pythondef zero_(self):
    """Zero out the array entries."""
    if self.size == 0:   # hipMemsetAsync(size=0) errors on ROCm; no-op matches CUDA
        return
    ...

Fix 3 — context.py: Opt-out for mempool conflict with PyTorch ROCm allocator
On AMD ROCm, Warp auto-enabling the HIP memory pool at device init conflicts with PyTorch's ROCm allocator when both run in the same process (e.g. physics simulation + RL policy training on the same GPU). This causes null pointer faults during wp.array() allocation.
New environment variable WARP_DISABLE_MEMPOOLS_FOR_TORCH=1 allows users to opt out:
python# NVIDIA CUDA: env var not set → behavior unchanged (is_mempool_enabled = is_mempool_supported)
# AMD ROCm: set WARP_DISABLE_MEMPOOLS_FOR_TORCH=1 → mempool disabled
if os.environ.get("WARP_DISABLE_MEMPOOLS_FOR_TORCH") == "1":
    self.is_mempool_enabled = False
else:
    self.is_mempool_enabled = self.is_mempool_supported
This approach requires no HIP-specific device attribute detection and preserves NVIDIA CUDA behavior exactly.


<!--
Explain what changed, why it matters, and reference issues with "closes #1234"
when applicable.
-->

## Changes

<!--
List the main changes grouped by behavior or subsystem. Keep this high-level;
avoid repeating the diff.
-->

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/latest/project/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

<!--
Explain what was verified and why it is sufficient for review. Write a short
step-by-step validation narrative, not a command dump. Prefer test names plus
behavior summaries.

For test-driven changes, include red/green evidence when applicable, e.g.:
- Verified the new test fails on the target branch without this change.
- Verified the new test passes on this branch with the fix.

If testing was not run, say so and explain the risk or blocker. Include
commands only when they help reproduce the validation.
-->

## Bug fix

<!-- If this is a bug fix, provide a minimal code example that reproduces
     the issue WITHOUT this PR applied. Delete this section if not applicable. -->

```python
import warp as wp
# Code that demonstrates the bug
```

## New feature / enhancement

<!-- If this is a new feature or enhancement, provide a code example showing
     what this PR enables. Delete this section if not applicable. -->

```python
import warp as wp
# Code that demonstrates the new capability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of zero-capacity arrays on HIP/ROCm to prevent invalid allocation behavior.
  * Made zeroing zero-size arrays on HIP/ROCm a safe no-op (matching CUDA behavior).
  * Updated graph capture to ignore zero-size input/output arrays, avoiding unnecessary nodes and edges.
* **Behavior Changes**
  * CUDA memory-pool auto-enablement on HIP/ROCm is now opt-in only to prevent allocator conflicts.
* **Tests**
  * Adjusted assertions for empty array capture to validate `size == 0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->