### PR TITLE
Add restart support to CG and CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@
   dimension-collapsing integer indices with negative-index support (`t[5, :]`, `t[-1, :]`), and slice assignment
   (`t[0:4, :] = src`). Also add `wp.tile_slice_indexed()`, which gathers elements along a single axis using a
   1D integer index tile (`t[indices, :]`) ([GH-1176](https://github.com/NVIDIA/warp/issues/1176)).
-- Add an optional `residual_refresh` interval to `warp.optim.linear.cg()` for recomputing
-  the true residual and restarting the search direction during finite-precision solves
+- Add optional `restart` support to `warp.optim.linear.cg()` and `warp.optim.linear.cr()` for
+  recomputing the true residual and resetting the search direction during finite-precision solves
   ([GH-1708](https://github.com/NVIDIA/warp/issues/1708)).
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   dimension-collapsing integer indices with negative-index support (`t[5, :]`, `t[-1, :]`), and slice assignment
   (`t[0:4, :] = src`). Also add `wp.tile_slice_indexed()`, which gathers elements along a single axis using a
   1D integer index tile (`t[indices, :]`) ([GH-1176](https://github.com/NVIDIA/warp/issues/1176)).
+- Add an optional `residual_refresh` interval to `warp.optim.linear.cg()` for recomputing
+  the true residual and restarting the search direction during finite-precision solves.
 
 ### Removed
 
@@ -145,6 +147,7 @@
   instead of node coordinates in Warp FEM kernels ([GH-1685](https://github.com/NVIDIA/warp/issues/1685)).
 - Reject malformed APIC `.wrp` memory sections containing duplicate region IDs
   or out-of-bounds initial data during graph loading.
+- Fix device-side iteration counts for graph-captured solver cycles that perform more than one iteration.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@
   (`t[0:4, :] = src`). Also add `wp.tile_slice_indexed()`, which gathers elements along a single axis using a
   1D integer index tile (`t[indices, :]`) ([GH-1176](https://github.com/NVIDIA/warp/issues/1176)).
 - Add an optional `residual_refresh` interval to `warp.optim.linear.cg()` for recomputing
-  the true residual and restarting the search direction during finite-precision solves.
+  the true residual and restarting the search direction during finite-precision solves
+  ([GH-1708](https://github.com/NVIDIA/warp/issues/1708)).
 
 ### Removed
 
@@ -147,7 +148,8 @@
   instead of node coordinates in Warp FEM kernels ([GH-1685](https://github.com/NVIDIA/warp/issues/1685)).
 - Reject malformed APIC `.wrp` memory sections containing duplicate region IDs
   or out-of-bounds initial data during graph loading.
-- Fix device-side iteration counts for graph-captured solver cycles that perform more than one iteration.
+- Fix device-side iteration counts for graph-captured solver cycles that perform more than one iteration
+  ([GH-1707](https://github.com/NVIDIA/warp/issues/1707)).
 
 ### Documentation
 

--- a/warp/_src/optim/linear.py
+++ b/warp/_src/optim/linear.py
@@ -840,20 +840,8 @@ class LinearSolverState:
         return self._run(A_op, b_arr, x_arr, M_op)
 
 
-class CG(LinearSolverState):
-    """Pre-allocated state for the Conjugate Gradient solver.
-
-    See :class:`LinearSolverState` for the shared constructor parameters, plus:
-
-    Args:
-        residual_refresh: Optional positive number of iterations between explicit
-            residual computations. Each refresh recomputes ``b - A x`` and restarts
-            the search direction to limit finite-precision drift.
-
-    The preconditioner ``M`` may be freely changed (or toggled between ``None`` and
-    a valid operator) between calls as long as the replacement operands match the
-    construction-time shape, dtype, device, and batch layout.
-    """
+class _RestartableLinearSolverState(LinearSolverState):
+    """Shared optional restart configuration for CG and CR."""
 
     def __init__(
         self,
@@ -868,19 +856,19 @@ class CG(LinearSolverState):
         check_every: int = 10,
         use_cuda_graph: bool = True,
         *,
-        residual_refresh: int | None = None,
+        restart: int | None = None,
     ):
-        if residual_refresh is not None:
-            if isinstance(residual_refresh, bool):
-                raise TypeError("residual_refresh must be an integer or None")
+        if restart is not None:
+            if isinstance(restart, bool):
+                raise TypeError("restart must be an integer or None")
             try:
-                residual_refresh = operator.index(residual_refresh)
+                restart = operator.index(restart)
             except TypeError as error:
-                raise TypeError("residual_refresh must be an integer or None") from error
-            if residual_refresh < 1:
-                raise ValueError("residual_refresh must be positive")
+                raise TypeError("restart must be an integer or None") from error
+            if restart < 1:
+                raise ValueError("restart must be positive")
 
-        self._residual_refresh = residual_refresh
+        self._restart = restart
         super().__init__(
             A,
             b,
@@ -894,6 +882,28 @@ class CG(LinearSolverState):
             use_cuda_graph=use_cuda_graph,
         )
 
+    def _configure_restart(self):
+        if self._restart is not None:
+            self._restart = max(1, min(self._restart, self._maxiter))
+            if self._check_every > 0:
+                self._check_every = max(self._check_every, self._restart)
+
+
+class CG(_RestartableLinearSolverState):
+    """Pre-allocated state for the Conjugate Gradient solver.
+
+    See :class:`LinearSolverState` for the shared constructor parameters, plus:
+
+    Args:
+        restart: Optional positive number of iterations between restarts. Each restart
+            recomputes ``b - A x`` and resets the search direction to limit
+            finite-precision drift.
+
+    The preconditioner ``M`` may be freely changed (or toggled between ``None`` and
+    a valid operator) between calls as long as the replacement operands match the
+    construction-time shape, dtype, device, and batch layout.
+    """
+
     def _allocate(self):
         A = self._A
         b = self._b
@@ -901,10 +911,7 @@ class CG(LinearSolverState):
         scalar_type = self._scalar_type
         batch_count = self._batch_count
 
-        if self._residual_refresh is not None:
-            self._residual_refresh = max(1, min(self._residual_refresh, self._maxiter))
-            if self._check_every > 0:
-                self._check_every = max(self._check_every, self._residual_refresh)
+        self._configure_restart()
 
         # Temp storage, with residuals stored per subproblem
         self._r_and_z_buf = wp.empty((2, b.shape[0]), dtype=b.dtype, device=device)
@@ -991,14 +998,14 @@ class CG(LinearSolverState):
                     inputs=[atol_sq, r_norm_sq, rz_old, rz_new, z, p, batch_offsets, dofs_per_entry],
                 )
 
-        residual_refresh = self._residual_refresh
-        if residual_refresh is None:
+        restart = self._restart
+        if restart is None:
             do_cycle = do_iteration
             cycle_size = 1
         else:
 
-            def do_refresh_cycle():
-                for _ in range(residual_refresh - 1):
+            def do_restart_cycle():
+                for _ in range(restart - 1):
                     do_iteration()
 
                 # The explicit residual replaces the recursive update from the final
@@ -1008,8 +1015,8 @@ class CG(LinearSolverState):
                 update_rr_rz()
                 p.assign(z)
 
-            do_cycle = do_refresh_cycle
-            cycle_size = residual_refresh
+            do_cycle = do_restart_cycle
+            cycle_size = restart
 
         return _run_capturable_loop(
             do_cycle,
@@ -1036,7 +1043,7 @@ def cg(
     use_cuda_graph=True,
     run: bool = True,
     *,
-    residual_refresh: int | None = None,
+    restart: int | None = None,
 ) -> tuple[int, float, float] | tuple[wp.array, wp.array, wp.array] | CG:
     """Compute an approximate solution to a symmetric, positive-definite linear system
     using the Conjugate Gradient algorithm.
@@ -1051,8 +1058,8 @@ def cg(
         tol: relative tolerance for the residual, as a ratio of the right-hand-side norm
         atol: absolute tolerance for the residual
         maxiter: maximum number of iterations to perform before aborting. Defaults to the system size.
-            When ``residual_refresh`` is enabled, CG performs complete refresh cycles and may exceed
-            ``maxiter`` by up to ``residual_refresh - 1`` iterations.
+            When ``restart`` is enabled, CG performs complete restart cycles and may exceed
+            ``maxiter`` by up to ``restart - 1`` iterations.
         M: optional left-preconditioner, ideally chosen such that ``M A`` is close to identity.
         callback: function to be called every `check_every` iteration with the current iteration number, residual and tolerance.
             If `check_every` is 0, the callback should be a Warp kernel.
@@ -1067,30 +1074,30 @@ def cg(
             The functor can be called repeatedly without reallocating temporary buffers when replacement operands match the
             construction-time shape, dtype, device, and batch layout. For batched :class:`LinearOperator` inputs, replacement
             operators must use the same ``batch_offsets`` array and ``max_batch_length`` value.
-        residual_refresh: Optional positive number of iterations between explicit residual computations.
-            Each refresh recomputes ``b - A x`` and restarts the search direction, limiting drift between
-            the recursively updated residual and the true residual. Convergence checks and callbacks occur
-            only at refresh-cycle boundaries. The default ``None`` preserves standard recursive CG.
+        restart: Optional positive number of iterations between restarts. Each restart recomputes
+            ``b - A x`` and resets the search direction, limiting drift between the recursively updated
+            residual and the true residual. Convergence checks and callbacks occur only at restart-cycle
+            boundaries. The default ``None`` preserves standard recursive CG.
 
     Returns:
         If ``run`` is ``True`` and ``check_every`` > 0: Tuple (final_iteration, residual_norm, absolute_tolerance)
             - final_iteration: The number of iterations performed before convergence or reaching maxiter
-            - residual_norm: The recursively updated residual norm. When ``residual_refresh`` is enabled,
-              this is the true residual norm ||b - Ax|| at the final refresh-cycle boundary.
+            - residual_norm: The recursively updated residual norm. When ``restart`` is enabled,
+              this is the true residual norm ||b - Ax|| at the final restart-cycle boundary.
             - absolute_tolerance: The absolute tolerance used for convergence checking
 
         If ``run`` is ``True`` and ``check_every`` is 0: Tuple (final_iteration_array, residual_norm_squared_array, absolute_tolerance_squared_array)
             - final_iteration_array: Device array containing the number of iterations performed
             - residual_norm_squared_array: Device array containing the squared recursively updated residual norm.
-              When ``residual_refresh`` is enabled, this is the squared true residual norm ||b - Ax||² at the
-              final refresh-cycle boundary.
+              When ``restart`` is enabled, this is the squared true residual norm ||b - Ax||² at the
+              final restart-cycle boundary.
             - absolute_tolerance_squared_array: Device array containing the squared absolute tolerance
 
         If ``run`` is ``False``: a :class:`~warp.optim.linear.CG` functor with all temporary buffers pre-allocated.
 
     Raises:
-        TypeError: If ``residual_refresh`` is not an integer or ``None``.
-        ValueError: If a specified ``residual_refresh`` is not positive.
+        TypeError: If ``restart`` is not an integer or ``None``.
+        ValueError: If a specified ``restart`` is not positive.
 
     If both `tol` and `atol` are provided, the absolute tolerance used as the termination criterion for the residual norm is ``max(atol, tol * norm(b))``.
     """
@@ -1105,20 +1112,26 @@ def cg(
         callback=callback,
         check_every=check_every,
         use_cuda_graph=use_cuda_graph,
-        residual_refresh=residual_refresh,
+        restart=restart,
     )
     if run:
         return state()
     return state
 
 
-class CR(LinearSolverState):
+class CR(_RestartableLinearSolverState):
     """Pre-allocated state for the Conjugate Residual solver.
 
-    See :class:`LinearSolverState` for the constructor parameters. The preconditioner
-    ``M`` may be freely changed (or toggled between ``None`` and a valid operator)
-    between calls as long as the replacement operands match the construction-time
-    shape, dtype, device, and batch layout.
+    See :class:`LinearSolverState` for the shared constructor parameters, plus:
+
+    Args:
+        restart: Optional positive number of iterations between restarts. Each restart
+            recomputes ``b - A x`` and resets the search direction to limit
+            finite-precision drift.
+
+    The preconditioner ``M`` may be freely changed (or toggled between ``None`` and
+    a valid operator) between calls as long as the replacement operands match the
+    construction-time shape, dtype, device, and batch layout.
     """
 
     def _allocate(self):
@@ -1127,6 +1140,8 @@ class CR(LinearSolverState):
         device = self._device
         scalar_type = self._scalar_type
         batch_count = self._batch_count
+
+        self._configure_restart()
 
         # Notations follow pseudo-code from https://en.wikipedia.org/wiki/Conjugate_residual_method
         # with z := M^-1 r and y := M^-1 Ap
@@ -1181,22 +1196,25 @@ class CR(LinearSolverState):
         # Not strictly necessary, but makes it more robust to user-provided LinearOperators
         y_and_Ap_buf.zero_()
 
-        # z = M r
-        if M is not None:
-            z.zero_()
-            M.matvec(r, z, z, alpha=1.0, beta=0.0)
+        def update_z():
+            # z = M r
+            if M is not None:
+                M.matvec(r, z, z, alpha=1.0, beta=0.0)
 
         def update_rr_zAz():
             A.matvec(z, Az, Az, alpha=1, beta=0)
             r_copy.assign(r)
             tiled_dot.compute(r_and_z, r_and_Az)
 
+        if M is not None:
+            z.zero_()
+        update_z()
         update_rr_zAz()
 
         p.assign(z)
         Ap.assign(Az)
 
-        def do_iteration():
+        def do_iteration(update_direction=True):
             zAz_old.assign(zAz_new)
 
             if M is not None:
@@ -1221,17 +1239,40 @@ class CR(LinearSolverState):
                     inputs=[atol_sq, r_norm_sq, zAz_old, y_Ap, x, r, z, p, Ap, y, batch_offsets, dofs_per_entry],
                 )
 
-            update_rr_zAz()
-            wp.launch(
-                kernel=_cr_kernel_2,
-                dim=z.shape[0],
-                device=device,
-                inputs=[atol_sq, r_norm_sq, zAz_old, zAz_new, z, p, Az, Ap, batch_offsets, dofs_per_entry],
-            )
+            if update_direction:
+                update_rr_zAz()
+                wp.launch(
+                    kernel=_cr_kernel_2,
+                    dim=z.shape[0],
+                    device=device,
+                    inputs=[atol_sq, r_norm_sq, zAz_old, zAz_new, z, p, Az, Ap, batch_offsets, dofs_per_entry],
+                )
+
+        restart = self._restart
+        if restart is None:
+            do_cycle = do_iteration
+            cycle_size = 1
+        else:
+
+            def do_restart_cycle():
+                for _ in range(restart - 1):
+                    do_iteration()
+
+                # Replace the final recursive residual with the true residual, then
+                # rebuild the preconditioned residual and restart both p and A p.
+                do_iteration(update_direction=False)
+                A.matvec(x, b, r, alpha=-1.0, beta=1.0)
+                update_z()
+                update_rr_zAz()
+                p.assign(z)
+                Ap.assign(Az)
+
+            do_cycle = do_restart_cycle
+            cycle_size = restart
 
         return _run_capturable_loop(
-            do_iteration,
-            cycle_size=1,
+            do_cycle,
+            cycle_size=cycle_size,
             r_norm_sq=r_norm_sq,
             maxiter=self._maxiter,
             atol_sq=atol_sq,
@@ -1253,6 +1294,8 @@ def cr(
     check_every=10,
     use_cuda_graph=True,
     run: bool = True,
+    *,
+    restart: int | None = None,
 ) -> tuple[int, float, float] | tuple[wp.array, wp.array, wp.array] | CR:
     """Compute an approximate solution to a symmetric, positive-definite linear system
     using the Conjugate Residual algorithm.
@@ -1267,7 +1310,8 @@ def cr(
         tol: relative tolerance for the residual, as a ratio of the right-hand-side norm
         atol: absolute tolerance for the residual
         maxiter: maximum number of iterations to perform before aborting. Defaults to the system size.
-            Note that the current implementation always performs iterations in pairs, and as a result may exceed the specified maximum number of iterations by one.
+            When ``restart`` is enabled, CR performs complete restart cycles and may exceed
+            ``maxiter`` by up to ``restart - 1`` iterations.
         M: optional left-preconditioner, ideally chosen such that ``M A`` is close to identity.
         callback: function to be called every `check_every` iteration with the current iteration number, residual and tolerance.
             If `check_every` is 0, the callback should be a Warp kernel.
@@ -1282,19 +1326,30 @@ def cr(
             reallocating temporary buffers when replacement operands match the construction-time shape, dtype, device,
             and batch layout. For batched :class:`LinearOperator` inputs, replacement operators must use the same
             ``batch_offsets`` array and ``max_batch_length`` value.
+        restart: Optional positive number of iterations between restarts. Each restart recomputes
+            ``b - A x`` and resets the search direction, limiting drift between the recursively updated
+            residual and the true residual. Convergence checks and callbacks occur only at restart-cycle
+            boundaries. The default ``None`` preserves standard recursive CR.
 
     Returns:
         If ``run`` is ``True`` and ``check_every`` > 0: Tuple (final_iteration, residual_norm, absolute_tolerance)
             - final_iteration: The number of iterations performed before convergence or reaching maxiter
-            - residual_norm: The final residual norm ||b - Ax||
+            - residual_norm: The recursively updated residual norm. When ``restart`` is enabled,
+              this is the true residual norm ||b - Ax|| at the final restart-cycle boundary.
             - absolute_tolerance: The absolute tolerance used for convergence checking
 
         If ``run`` is ``True`` and ``check_every`` is 0: Tuple (final_iteration_array, residual_norm_squared_array, absolute_tolerance_squared_array)
             - final_iteration_array: Device array containing the number of iterations performed
-            - residual_norm_squared_array: Device array containing the squared residual norm ||b - Ax||²
+            - residual_norm_squared_array: Device array containing the squared recursively updated residual norm.
+              When ``restart`` is enabled, this is the squared true residual norm ||b - Ax||² at the
+              final restart-cycle boundary.
             - absolute_tolerance_squared_array: Device array containing the squared absolute tolerance
 
         If ``run`` is ``False``: a :class:`~warp.optim.linear.CR` functor with all temporary buffers pre-allocated.
+
+    Raises:
+        TypeError: If ``restart`` is not an integer or ``None``.
+        ValueError: If a specified ``restart`` is not positive.
 
     If both `tol` and `atol` are provided, the absolute tolerance used as the termination criterion for the residual norm is ``max(atol, tol * norm(b))``.
     """
@@ -1309,6 +1364,7 @@ def cr(
         callback=callback,
         check_every=check_every,
         use_cuda_graph=use_cuda_graph,
+        restart=restart,
     )
     if run:
         return state()

--- a/warp/_src/optim/linear.py
+++ b/warp/_src/optim/linear.py
@@ -3,6 +3,7 @@
 
 import functools
 import math
+import operator
 from collections.abc import Callable
 from typing import Any
 
@@ -842,11 +843,56 @@ class LinearSolverState:
 class CG(LinearSolverState):
     """Pre-allocated state for the Conjugate Gradient solver.
 
-    See :class:`LinearSolverState` for the constructor parameters. The preconditioner
-    ``M`` may be freely changed (or toggled between ``None`` and a valid operator)
-    between calls as long as the replacement operands match the construction-time
-    shape, dtype, device, and batch layout.
+    See :class:`LinearSolverState` for the shared constructor parameters, plus:
+
+    Args:
+        residual_refresh: Optional positive number of iterations between explicit
+            residual computations. Each refresh recomputes ``b - A x`` and restarts
+            the search direction to limit finite-precision drift.
+
+    The preconditioner ``M`` may be freely changed (or toggled between ``None`` and
+    a valid operator) between calls as long as the replacement operands match the
+    construction-time shape, dtype, device, and batch layout.
     """
+
+    def __init__(
+        self,
+        A: _Matrix,
+        b: wp.array,
+        x: wp.array,
+        tol: float | None = None,
+        atol: float | None = None,
+        maxiter: float | None = 0,
+        M: _Matrix | None = None,
+        callback: Callable | None = None,
+        check_every: int = 10,
+        use_cuda_graph: bool = True,
+        *,
+        residual_refresh: int | None = None,
+    ):
+        if residual_refresh is not None:
+            if isinstance(residual_refresh, bool):
+                raise TypeError("residual_refresh must be an integer or None")
+            try:
+                residual_refresh = operator.index(residual_refresh)
+            except TypeError as error:
+                raise TypeError("residual_refresh must be an integer or None") from error
+            if residual_refresh < 1:
+                raise ValueError("residual_refresh must be positive")
+
+        self._residual_refresh = residual_refresh
+        super().__init__(
+            A,
+            b,
+            x,
+            tol=tol,
+            atol=atol,
+            maxiter=maxiter,
+            M=M,
+            callback=callback,
+            check_every=check_every,
+            use_cuda_graph=use_cuda_graph,
+        )
 
     def _allocate(self):
         A = self._A
@@ -855,7 +901,12 @@ class CG(LinearSolverState):
         scalar_type = self._scalar_type
         batch_count = self._batch_count
 
-        # Temp storage — residuals are per-subproblem
+        if self._residual_refresh is not None:
+            self._residual_refresh = max(1, min(self._residual_refresh, self._maxiter))
+            if self._check_every > 0:
+                self._check_every = max(self._check_every, self._residual_refresh)
+
+        # Temp storage, with residuals stored per subproblem
         self._r_and_z_buf = wp.empty((2, b.shape[0]), dtype=b.dtype, device=device)
         self._p_and_Ap = wp.empty_like(self._r_and_z_buf)
         self._residuals = wp.empty((2, batch_count), dtype=scalar_type, device=device)
@@ -915,10 +966,10 @@ class CG(LinearSolverState):
         update_rr_rz()
         p.assign(z)
 
-        def do_iteration():
+        def do_iteration(update_direction=True):
             rz_old.assign(rz_new)
 
-            # Ap = A * p;
+            # Ap = A * p
             A.matvec(p, Ap, Ap, alpha=1, beta=0)
             tiled_dot.compute(p, Ap, col_offset=1)
             p_Ap = tiled_dot.col(1)
@@ -930,23 +981,45 @@ class CG(LinearSolverState):
                 inputs=[atol_sq, r_norm_sq, rz_old, p_Ap, x, r, p, Ap, batch_offsets, dofs_per_entry],
             )
 
-            update_rr_rz()
+            if update_direction:
+                update_rr_rz()
 
-            wp.launch(
-                kernel=_cg_kernel_2,
-                dim=z.shape[0],
-                device=device,
-                inputs=[atol_sq, r_norm_sq, rz_old, rz_new, z, p, batch_offsets, dofs_per_entry],
-            )
+                wp.launch(
+                    kernel=_cg_kernel_2,
+                    dim=z.shape[0],
+                    device=device,
+                    inputs=[atol_sq, r_norm_sq, rz_old, rz_new, z, p, batch_offsets, dofs_per_entry],
+                )
+
+        residual_refresh = self._residual_refresh
+        if residual_refresh is None:
+            do_cycle = do_iteration
+            cycle_size = 1
+        else:
+
+            def do_refresh_cycle():
+                for _ in range(residual_refresh - 1):
+                    do_iteration()
+
+                # The explicit residual replaces the recursive update from the final
+                # iteration, then the search direction restarts from the corrected value.
+                do_iteration(update_direction=False)
+                A.matvec(x, b, r, alpha=-1.0, beta=1.0)
+                update_rr_rz()
+                p.assign(z)
+
+            do_cycle = do_refresh_cycle
+            cycle_size = residual_refresh
 
         return _run_capturable_loop(
-            do_iteration,
+            do_cycle,
             r_norm_sq,
             self._maxiter,
             atol_sq,
             self._callback,
             self._check_every,
             self._use_cuda_graph,
+            cycle_size=cycle_size,
         )
 
 
@@ -962,6 +1035,8 @@ def cg(
     check_every=10,
     use_cuda_graph=True,
     run: bool = True,
+    *,
+    residual_refresh: int | None = None,
 ) -> tuple[int, float, float] | tuple[wp.array, wp.array, wp.array] | CG:
     """Compute an approximate solution to a symmetric, positive-definite linear system
     using the Conjugate Gradient algorithm.
@@ -976,6 +1051,8 @@ def cg(
         tol: relative tolerance for the residual, as a ratio of the right-hand-side norm
         atol: absolute tolerance for the residual
         maxiter: maximum number of iterations to perform before aborting. Defaults to the system size.
+            When ``residual_refresh`` is enabled, CG performs complete refresh cycles and may exceed
+            ``maxiter`` by up to ``residual_refresh - 1`` iterations.
         M: optional left-preconditioner, ideally chosen such that ``M A`` is close to identity.
         callback: function to be called every `check_every` iteration with the current iteration number, residual and tolerance.
             If `check_every` is 0, the callback should be a Warp kernel.
@@ -990,19 +1067,30 @@ def cg(
             The functor can be called repeatedly without reallocating temporary buffers when replacement operands match the
             construction-time shape, dtype, device, and batch layout. For batched :class:`LinearOperator` inputs, replacement
             operators must use the same ``batch_offsets`` array and ``max_batch_length`` value.
+        residual_refresh: Optional positive number of iterations between explicit residual computations.
+            Each refresh recomputes ``b - A x`` and restarts the search direction, limiting drift between
+            the recursively updated residual and the true residual. Convergence checks and callbacks occur
+            only at refresh-cycle boundaries. The default ``None`` preserves standard recursive CG.
 
     Returns:
         If ``run`` is ``True`` and ``check_every`` > 0: Tuple (final_iteration, residual_norm, absolute_tolerance)
             - final_iteration: The number of iterations performed before convergence or reaching maxiter
-            - residual_norm: The final residual norm ||b - Ax||
+            - residual_norm: The recursively updated residual norm. When ``residual_refresh`` is enabled,
+              this is the true residual norm ||b - Ax|| at the final refresh-cycle boundary.
             - absolute_tolerance: The absolute tolerance used for convergence checking
 
         If ``run`` is ``True`` and ``check_every`` is 0: Tuple (final_iteration_array, residual_norm_squared_array, absolute_tolerance_squared_array)
             - final_iteration_array: Device array containing the number of iterations performed
-            - residual_norm_squared_array: Device array containing the squared residual norm ||b - Ax||²
+            - residual_norm_squared_array: Device array containing the squared recursively updated residual norm.
+              When ``residual_refresh`` is enabled, this is the squared true residual norm ||b - Ax||² at the
+              final refresh-cycle boundary.
             - absolute_tolerance_squared_array: Device array containing the squared absolute tolerance
 
         If ``run`` is ``False``: a :class:`~warp.optim.linear.CG` functor with all temporary buffers pre-allocated.
+
+    Raises:
+        TypeError: If ``residual_refresh`` is not an integer or ``None``.
+        ValueError: If a specified ``residual_refresh`` is not positive.
 
     If both `tol` and `atol` are provided, the absolute tolerance used as the termination criterion for the residual norm is ``max(atol, tol * norm(b))``.
     """
@@ -1017,6 +1105,7 @@ def cg(
         callback=callback,
         check_every=check_every,
         use_cuda_graph=use_cuda_graph,
+        residual_refresh=residual_refresh,
     )
     if run:
         return state()
@@ -1983,7 +2072,7 @@ def _run_capturable_loop(
             do_cycle, cycle_size, r_norm_sq, maxiter, atol_sq, callback, check_every, use_cuda_graph, device
         )
 
-    cur_iter_and_condition = wp.full((2,), value=-1, dtype=int, device=device)
+    cur_iter_and_condition = wp.full((2,), value=-cycle_size, dtype=int, device=device)
     cur_iter = cur_iter_and_condition[0:1]
     condition = cur_iter_and_condition[1:2]
 

--- a/warp/tests/test_linear_solvers.py
+++ b/warp/tests/test_linear_solvers.py
@@ -126,6 +126,228 @@ def test_cg(test, device):
     _check_linear_solve(test, A, b, cg, maxiter=30)
 
 
+def test_cg_residual_refresh(test, device):
+    rng = np.random.default_rng(2027)
+    C = rng.standard_normal((12, 12))
+    A_np = C.T @ C + 4.0 * np.eye(12)
+    b_np = rng.standard_normal(12)
+
+    def make_callback(iterations):
+        def callback(iteration, _residual, _tolerance):
+            iterations.append(iteration)
+
+        return callback
+
+    with wp.ScopedDevice(device):
+        A = wp.array(A_np, dtype=wp.float64, device=device)
+        b = wp.array(b_np, dtype=wp.float64, device=device)
+        M = preconditioner(A, "diag")
+
+        for preconditioner_op in (None, M):
+            callback_iterations = []
+
+            x = wp.zeros_like(b)
+            niter, err, atol = cg(
+                A,
+                b,
+                x,
+                tol=1.0e-10,
+                maxiter=120,
+                M=preconditioner_op,
+                callback=make_callback(callback_iterations),
+                check_every=1,
+                use_cuda_graph=True,
+                residual_refresh=3,
+            )
+
+            test.assertLessEqual(err, atol)
+            test.assertEqual(niter % 3, 0)
+            test.assertEqual(callback_iterations[0], 0)
+            test.assertEqual(callback_iterations[-1], niter)
+            test.assertTrue(all(iteration % 3 == 0 for iteration in callback_iterations))
+
+            true_residual = A_np @ x.numpy() - b_np
+            test.assertLessEqual(np.linalg.norm(true_residual), atol)
+
+
+def _make_cg_residual_drift_system(batch_count):
+    dof_count = 130
+    chain_count = dof_count - 1
+    edge_count = chain_count - 1
+    mass = 3.0 / chain_count
+    edge_weight = 0.18**2 / (3.0 / edge_count)
+
+    A_single = mass * np.eye(dof_count)
+    for edge in range(edge_count):
+        A_single[edge, edge] += edge_weight
+        A_single[edge + 1, edge + 1] += edge_weight
+        A_single[edge, edge + 1] -= edge_weight
+        A_single[edge + 1, edge] -= edge_weight
+
+    fixed = np.arange(0, chain_count, 17)
+    A_single[fixed, :] = 0.0
+    A_single[:, fixed] = 0.0
+    A_single[fixed, fixed] = 1.0
+
+    A = np.kron(np.eye(batch_count), A_single).astype(np.float32)
+    rng = np.random.default_rng(7301)
+    initial = (0.1 * rng.standard_normal((batch_count, dof_count))).astype(np.float32)
+    b = (mass * initial).astype(np.float32)
+    initial[:, fixed] = 0.0
+    b[:, fixed] = 0.0
+
+    return A, b.reshape(-1), initial.reshape(-1)
+
+
+def test_cg_residual_refresh_float32_drift(test, device):
+    interval = 32
+    tolerance = 1.0e-6
+
+    for batch_count in (1, 3):
+        A_np, b_np, initial_np = _make_cg_residual_drift_system(batch_count)
+        dof_count = b_np.shape[0] // batch_count
+
+        with wp.ScopedDevice(device):
+            A = wp.array(A_np, dtype=wp.float32, device=device)
+            b = wp.array(b_np, dtype=wp.float32, device=device)
+            M = preconditioner(A, "diag")
+            offsets = None if batch_count == 1 else _batch_offsets([dof_count] * batch_count, device)
+            A_op = aslinearoperator(A, batch_offsets=offsets)
+
+            for preconditioner_name, preconditioner_op in (("none", None), ("Jacobi", M)):
+                x = wp.array(initial_np, dtype=wp.float32, device=device)
+                niter, err, atol = cg(
+                    A_op,
+                    b,
+                    x,
+                    tol=tolerance,
+                    atol=0.0,
+                    maxiter=512,
+                    M=preconditioner_op,
+                    check_every=interval,
+                    use_cuda_graph=True,
+                    residual_refresh=interval,
+                )
+
+                test.assertLessEqual(err, atol)
+                test.assertEqual(niter % interval, 0)
+                test.assertLessEqual(niter, 512)
+
+                x_np = x.numpy().astype(np.float64)
+                for batch_index in range(batch_count):
+                    start = batch_index * dof_count
+                    end = start + dof_count
+                    A_batch = A_np[start:end, start:end].astype(np.float64)
+                    b_batch = b_np[start:end].astype(np.float64)
+                    residual = A_batch @ x_np[start:end] - b_batch
+                    target = tolerance * np.linalg.norm(b_batch)
+                    test.assertLessEqual(
+                        np.linalg.norm(residual),
+                        target,
+                        msg=(
+                            f"{preconditioner_name} batch {batch_index} did not reach "
+                            "the requested true-residual tolerance"
+                        ),
+                    )
+
+
+def test_cg_residual_refresh_validation(test, device):
+    A, b = _make_identity_system(n=3, seed=123, dtype=wp.float64, device=device)
+    x = wp.zeros_like(b)
+
+    for value in (True, 1.5):
+        with test.assertRaises(TypeError):
+            cg(A, b, x, run=False, residual_refresh=value)
+
+    for value in (0, -1):
+        with test.assertRaises(ValueError):
+            cg(A, b, x, run=False, residual_refresh=value)
+
+    state = cg(A, b, x, run=False, residual_refresh=np.int64(2))
+    test.assertIsInstance(state, CG)
+
+    x.zero_()
+    niter, err, atol = cg(A, b, x, maxiter=0.5, check_every=1, residual_refresh=1)
+    test.assertEqual(niter, 1)
+    test.assertLessEqual(err, atol)
+
+
+def test_cg_residual_refresh_conditional_graph(test, device):
+    if not wp.is_conditional_graph_supported():
+        test.skipTest("conditional CUDA graphs are not supported")
+
+    with wp.ScopedDevice(device):
+        A = wp.array((2.0, 3.0, 4.0), dtype=wp.float32, device=device)
+        b = wp.array((2.0, 6.0, 12.0), dtype=wp.float32, device=device)
+        x = wp.zeros_like(b)
+        state = cg(
+            A,
+            b,
+            x,
+            tol=1.0e-6,
+            maxiter=6,
+            check_every=0,
+            use_cuda_graph=True,
+            run=False,
+            residual_refresh=3,
+        )
+
+        state()
+        x.zero_()
+
+        with wp.ScopedCapture() as capture:
+            niter, residual_sq, tolerance_sq = state()
+
+        x.zero_()
+        wp.capture_launch(capture.graph)
+
+        test.assertEqual(niter.numpy()[0], 3)
+        test.assertLessEqual(residual_sq.numpy()[0], tolerance_sq.numpy()[0])
+        np.testing.assert_allclose(x.numpy(), (1.0, 2.0, 3.0), rtol=1.0e-5, atol=1.0e-5)
+
+        wp.capture_launch(capture.graph)
+        test.assertEqual(niter.numpy()[0], 0)
+        test.assertLessEqual(residual_sq.numpy()[0], tolerance_sq.numpy()[0])
+
+
+def test_gmres_conditional_graph_cycle_iterations(test, device):
+    if not wp.is_conditional_graph_supported():
+        test.skipTest("conditional CUDA graphs are not supported")
+
+    with wp.ScopedDevice(device):
+        A = wp.array((2.0, 3.0, 4.0), dtype=wp.float32, device=device)
+        b = wp.array((2.0, 6.0, 12.0), dtype=wp.float32, device=device)
+        x = wp.zeros_like(b)
+        state = gmres(
+            A,
+            b,
+            x,
+            tol=1.0e-6,
+            restart=3,
+            maxiter=6,
+            check_every=0,
+            use_cuda_graph=True,
+            run=False,
+        )
+
+        state()
+        x.zero_()
+
+        with wp.ScopedCapture() as capture:
+            niter, residual_sq, tolerance_sq = state()
+
+        x.zero_()
+        wp.capture_launch(capture.graph)
+
+        test.assertEqual(niter.numpy()[0], 3)
+        test.assertLessEqual(residual_sq.numpy()[0], tolerance_sq.numpy()[0])
+        np.testing.assert_allclose(x.numpy(), (1.0, 2.0, 3.0), rtol=1.0e-5, atol=1.0e-5)
+
+        wp.capture_launch(capture.graph)
+        test.assertEqual(niter.numpy()[0], 0)
+        test.assertLessEqual(residual_sq.numpy()[0], tolerance_sq.numpy()[0])
+
+
 def test_cr(test, device):
     A, b = _make_spd_system(n=64, seed=123, device=device, dtype=wp.float64)
     M = preconditioner(A, "diag")
@@ -563,7 +785,7 @@ def test_functor_reuse(test, device):
     # For each solver, construct a pre-allocated functor, then re-run on a different
     # (but compatible) system without re-allocating temporary buffers.
     cases = [
-        (cg, CG, _make_spd_system, 32, {"maxiter": 500}),
+        (cg, CG, _make_spd_system, 32, {"maxiter": 500, "residual_refresh": 32}),
         (cr, CR, _make_spd_system, 32, {"maxiter": 500}),
         (bicgstab, BiCGSTAB, _make_nonsymmetric_system, 32, {"maxiter": 500}),
         (gmres, GMRES, _make_nonsymmetric_system, 16, {"tol": 1.0e-3, "restart": 16, "maxiter": 256}),
@@ -598,7 +820,8 @@ def test_functor_preconditioner(test, device):
 
         for func in (cg, cr):
             x = wp.zeros_like(b)
-            state = func(A, b, x, maxiter=500, run=False)
+            kwargs = {"residual_refresh": 32} if func is cg else {}
+            state = func(A, b, x, maxiter=500, run=False, **kwargs)
 
             # No preconditioner on first call
             _, err, atol = state()
@@ -660,6 +883,31 @@ devices = get_test_devices()
 devices_with_graph_capture_allocation = get_test_devices_with_graph_capture_allocation()
 
 add_function_test(TestLinearSolvers, "test_cg", test_cg, devices=devices_with_graph_capture_allocation)
+add_function_test(TestLinearSolvers, "test_cg_residual_refresh", test_cg_residual_refresh, devices=devices)
+add_function_test(
+    TestLinearSolvers,
+    "test_cg_residual_refresh_float32_drift",
+    test_cg_residual_refresh_float32_drift,
+    devices=devices,
+)
+add_function_test(
+    TestLinearSolvers,
+    "test_cg_residual_refresh_validation",
+    test_cg_residual_refresh_validation,
+    devices=[wp.get_device("cpu")],
+)
+add_function_test(
+    TestLinearSolvers,
+    "test_cg_residual_refresh_conditional_graph",
+    test_cg_residual_refresh_conditional_graph,
+    devices=get_cuda_test_devices_with_mempool(),
+)
+add_function_test(
+    TestLinearSolvers,
+    "test_gmres_conditional_graph_cycle_iterations",
+    test_gmres_conditional_graph_cycle_iterations,
+    devices=get_cuda_test_devices_with_mempool(),
+)
 add_function_test(TestLinearSolvers, "test_cr", test_cr, devices=devices_with_graph_capture_allocation)
 add_function_test(TestLinearSolvers, "test_bicgstab", test_bicgstab, devices=devices_with_graph_capture_allocation)
 add_function_test(TestLinearSolvers, "test_gmres", test_gmres, devices=devices_with_graph_capture_allocation)

--- a/warp/tests/test_linear_solvers.py
+++ b/warp/tests/test_linear_solvers.py
@@ -126,7 +126,7 @@ def test_cg(test, device):
     _check_linear_solve(test, A, b, cg, maxiter=30)
 
 
-def test_cg_residual_refresh(test, device):
+def test_conjugate_solver_restart(test, device):
     rng = np.random.default_rng(2027)
     C = rng.standard_normal((12, 12))
     A_np = C.T @ C + 4.0 * np.eye(12)
@@ -143,34 +143,36 @@ def test_cg_residual_refresh(test, device):
         b = wp.array(b_np, dtype=wp.float64, device=device)
         M = preconditioner(A, "diag")
 
-        for preconditioner_op in (None, M):
-            callback_iterations = []
+        for solver in (cg, cr):
+            for preconditioner_op in (None, M):
+                with test.subTest(solver=solver.__name__, preconditioned=preconditioner_op is not None):
+                    callback_iterations = []
 
-            x = wp.zeros_like(b)
-            niter, err, atol = cg(
-                A,
-                b,
-                x,
-                tol=1.0e-10,
-                maxiter=120,
-                M=preconditioner_op,
-                callback=make_callback(callback_iterations),
-                check_every=1,
-                use_cuda_graph=True,
-                residual_refresh=3,
-            )
+                    x = wp.zeros_like(b)
+                    niter, err, atol = solver(
+                        A,
+                        b,
+                        x,
+                        tol=1.0e-10,
+                        maxiter=120,
+                        M=preconditioner_op,
+                        callback=make_callback(callback_iterations),
+                        check_every=1,
+                        use_cuda_graph=True,
+                        restart=3,
+                    )
 
-            test.assertLessEqual(err, atol)
-            test.assertEqual(niter % 3, 0)
-            test.assertEqual(callback_iterations[0], 0)
-            test.assertEqual(callback_iterations[-1], niter)
-            test.assertTrue(all(iteration % 3 == 0 for iteration in callback_iterations))
+                    test.assertLessEqual(err, atol)
+                    test.assertEqual(niter % 3, 0)
+                    test.assertEqual(callback_iterations[0], 0)
+                    test.assertEqual(callback_iterations[-1], niter)
+                    test.assertTrue(all(iteration % 3 == 0 for iteration in callback_iterations))
 
-            true_residual = A_np @ x.numpy() - b_np
-            test.assertLessEqual(np.linalg.norm(true_residual), atol)
+                    true_residual = A_np @ x.numpy() - b_np
+                    test.assertLessEqual(np.linalg.norm(true_residual), atol)
 
 
-def _make_cg_residual_drift_system(batch_count):
+def _make_cg_restart_drift_system(batch_count):
     dof_count = 130
     chain_count = dof_count - 1
     edge_count = chain_count - 1
@@ -199,12 +201,12 @@ def _make_cg_residual_drift_system(batch_count):
     return A, b.reshape(-1), initial.reshape(-1)
 
 
-def test_cg_residual_refresh_float32_drift(test, device):
+def test_cg_restart_float32_drift(test, device):
     interval = 32
     tolerance = 1.0e-6
 
     for batch_count in (1, 3):
-        A_np, b_np, initial_np = _make_cg_residual_drift_system(batch_count)
+        A_np, b_np, initial_np = _make_cg_restart_drift_system(batch_count)
         dof_count = b_np.shape[0] // batch_count
 
         with wp.ScopedDevice(device):
@@ -226,7 +228,7 @@ def test_cg_residual_refresh_float32_drift(test, device):
                     M=preconditioner_op,
                     check_every=interval,
                     use_cuda_graph=True,
-                    residual_refresh=interval,
+                    restart=interval,
                 )
 
                 test.assertLessEqual(err, atol)
@@ -251,63 +253,66 @@ def test_cg_residual_refresh_float32_drift(test, device):
                     )
 
 
-def test_cg_residual_refresh_validation(test, device):
+def test_conjugate_solver_restart_validation(test, device):
     A, b = _make_identity_system(n=3, seed=123, dtype=wp.float64, device=device)
     x = wp.zeros_like(b)
 
-    for value in (True, 1.5):
-        with test.assertRaises(TypeError):
-            cg(A, b, x, run=False, residual_refresh=value)
+    for solver, state_type in ((cg, CG), (cr, CR)):
+        for value in (True, 1.5):
+            with test.assertRaises(TypeError):
+                solver(A, b, x, run=False, restart=value)
 
-    for value in (0, -1):
-        with test.assertRaises(ValueError):
-            cg(A, b, x, run=False, residual_refresh=value)
+        for value in (0, -1):
+            with test.assertRaises(ValueError):
+                solver(A, b, x, run=False, restart=value)
 
-    state = cg(A, b, x, run=False, residual_refresh=np.int64(2))
-    test.assertIsInstance(state, CG)
+        state = solver(A, b, x, run=False, restart=np.int64(2))
+        test.assertIsInstance(state, state_type)
 
-    x.zero_()
-    niter, err, atol = cg(A, b, x, maxiter=0.5, check_every=1, residual_refresh=1)
-    test.assertEqual(niter, 1)
-    test.assertLessEqual(err, atol)
+        x.zero_()
+        niter, err, atol = solver(A, b, x, maxiter=0.5, check_every=1, restart=1)
+        test.assertEqual(niter, 1)
+        test.assertLessEqual(err, atol)
 
 
-def test_cg_residual_refresh_conditional_graph(test, device):
+def test_conjugate_solver_restart_conditional_graph(test, device):
     if not wp.is_conditional_graph_supported():
         test.skipTest("conditional CUDA graphs are not supported")
 
     with wp.ScopedDevice(device):
         A = wp.array((2.0, 3.0, 4.0), dtype=wp.float32, device=device)
         b = wp.array((2.0, 6.0, 12.0), dtype=wp.float32, device=device)
-        x = wp.zeros_like(b)
-        state = cg(
-            A,
-            b,
-            x,
-            tol=1.0e-6,
-            maxiter=6,
-            check_every=0,
-            use_cuda_graph=True,
-            run=False,
-            residual_refresh=3,
-        )
+        for solver in (cg, cr):
+            with test.subTest(solver=solver.__name__):
+                x = wp.zeros_like(b)
+                state = solver(
+                    A,
+                    b,
+                    x,
+                    tol=1.0e-6,
+                    maxiter=6,
+                    check_every=0,
+                    use_cuda_graph=True,
+                    run=False,
+                    restart=3,
+                )
 
-        state()
-        x.zero_()
+                state()
+                x.zero_()
 
-        with wp.ScopedCapture() as capture:
-            niter, residual_sq, tolerance_sq = state()
+                with wp.ScopedCapture() as capture:
+                    niter, residual_sq, tolerance_sq = state()
 
-        x.zero_()
-        wp.capture_launch(capture.graph)
+                x.zero_()
+                wp.capture_launch(capture.graph)
 
-        test.assertEqual(niter.numpy()[0], 3)
-        test.assertLessEqual(residual_sq.numpy()[0], tolerance_sq.numpy()[0])
-        np.testing.assert_allclose(x.numpy(), (1.0, 2.0, 3.0), rtol=1.0e-5, atol=1.0e-5)
+                test.assertEqual(niter.numpy()[0], 3)
+                test.assertLessEqual(residual_sq.numpy()[0], tolerance_sq.numpy()[0])
+                np.testing.assert_allclose(x.numpy(), (1.0, 2.0, 3.0), rtol=1.0e-5, atol=1.0e-5)
 
-        wp.capture_launch(capture.graph)
-        test.assertEqual(niter.numpy()[0], 0)
-        test.assertLessEqual(residual_sq.numpy()[0], tolerance_sq.numpy()[0])
+                wp.capture_launch(capture.graph)
+                test.assertEqual(niter.numpy()[0], 0)
+                test.assertLessEqual(residual_sq.numpy()[0], tolerance_sq.numpy()[0])
 
 
 def test_gmres_conditional_graph_cycle_iterations(test, device):
@@ -785,8 +790,8 @@ def test_functor_reuse(test, device):
     # For each solver, construct a pre-allocated functor, then re-run on a different
     # (but compatible) system without re-allocating temporary buffers.
     cases = [
-        (cg, CG, _make_spd_system, 32, {"maxiter": 500, "residual_refresh": 32}),
-        (cr, CR, _make_spd_system, 32, {"maxiter": 500}),
+        (cg, CG, _make_spd_system, 32, {"maxiter": 500, "restart": 32}),
+        (cr, CR, _make_spd_system, 32, {"maxiter": 500, "restart": 32}),
         (bicgstab, BiCGSTAB, _make_nonsymmetric_system, 32, {"maxiter": 500}),
         (gmres, GMRES, _make_nonsymmetric_system, 16, {"tol": 1.0e-3, "restart": 16, "maxiter": 256}),
     ]
@@ -819,18 +824,18 @@ def test_functor_preconditioner(test, device):
         M = preconditioner(A, "diag")
 
         for func in (cg, cr):
-            x = wp.zeros_like(b)
-            kwargs = {"residual_refresh": 32} if func is cg else {}
-            state = func(A, b, x, maxiter=500, run=False, **kwargs)
+            with test.subTest(solver=func.__name__):
+                x = wp.zeros_like(b)
+                state = func(A, b, x, maxiter=640, restart=32, run=False)
 
-            # No preconditioner on first call
-            _, err, atol = state()
-            test.assertLessEqual(err, atol)
+                # No preconditioner on first call
+                _, err, atol = state()
+                test.assertLessEqual(err, atol)
 
-            # With preconditioner on second call
-            x.zero_()
-            _, err2, atol2 = state(M=M)
-            test.assertLessEqual(err2, atol2)
+                # With preconditioner on second call
+                x.zero_()
+                _, err2, atol2 = state(M=M)
+                test.assertLessEqual(err2, atol2)
 
 
 def test_functor_compat_errors(test, device):
@@ -883,23 +888,23 @@ devices = get_test_devices()
 devices_with_graph_capture_allocation = get_test_devices_with_graph_capture_allocation()
 
 add_function_test(TestLinearSolvers, "test_cg", test_cg, devices=devices_with_graph_capture_allocation)
-add_function_test(TestLinearSolvers, "test_cg_residual_refresh", test_cg_residual_refresh, devices=devices)
+add_function_test(TestLinearSolvers, "test_conjugate_solver_restart", test_conjugate_solver_restart, devices=devices)
 add_function_test(
     TestLinearSolvers,
-    "test_cg_residual_refresh_float32_drift",
-    test_cg_residual_refresh_float32_drift,
+    "test_cg_restart_float32_drift",
+    test_cg_restart_float32_drift,
     devices=devices,
 )
 add_function_test(
     TestLinearSolvers,
-    "test_cg_residual_refresh_validation",
-    test_cg_residual_refresh_validation,
+    "test_conjugate_solver_restart_validation",
+    test_conjugate_solver_restart_validation,
     devices=[wp.get_device("cpu")],
 )
 add_function_test(
     TestLinearSolvers,
-    "test_cg_residual_refresh_conditional_graph",
-    test_cg_residual_refresh_conditional_graph,
+    "test_conjugate_solver_restart_conditional_graph",
+    test_conjugate_solver_restart_conditional_graph,
     devices=get_cuda_test_devices_with_mempool(),
 )
 add_function_test(


### PR DESCRIPTION
## Description

This adds optional restarted variants of Conjugate Gradient and Conjugate Residual through
the keyword-only `restart` argument on `warp.optim.linear.cg()` / `CG` and
`warp.optim.linear.cr()` / `CR`.

In finite precision, a recursively updated residual can drift away from the true `b - A x`
residual. The existing stopping check can therefore report convergence while the computed
solution is still above the requested tolerance. With `restart=N`, each solver recomputes
`b - A x` every `N` iterations, reapplies the preconditioner, updates the residual norm,
and resets its search direction. CR also rebuilds the corresponding `A z`, `p`, and `A p`
state.

The default remains `None`, so existing solve behavior and launch cost are unchanged.
Restart cycles reuse the existing buffers and remain CUDA graph capturable. Enabling the
option adds one matrix-vector product per restart cycle.

## Changes

- Add `restart=N` to `cg()` / `CG` and `cr()` / `CR`.
- Recompute the true residual and reset each solver's search direction at restart boundaries.
- Keep host callbacks, device callbacks, convergence checks, preconditioning, batched
  systems, and reusable solver functors aligned with restart boundaries.
- Correct device-side iteration accounting for captured solver cycles containing multiple
  iterations. This also corrects the returned cycle count for captured GMRES.
- Document validation, cost, return-value semantics, and the complete-cycle behavior that
  may exceed `maxiter` by up to `restart - 1` iterations.
- Add deterministic drift, CPU, CUDA, batched, preconditioned, callback, functor reuse,
  conditional graph capture, validation, and GMRES cycle-count coverage.

## Drift reproduction and actual results

The CG regression uses a deterministic float32 SPD system with 130 degrees of freedom. It is
a 129-node one-dimensional Helmholtz chain plus one isolated degree of freedom, with fixed
nodes every 17 entries, `length_scale=0.18`, seed `7301`, a warm start, and relative
tolerance `1e-6`.

The table reports ratios to the requested tolerance. A true-residual ratio above `1.0`
means the requested tolerance was not met even though CG returned convergence. For batched
cases, the true-residual column is the worst of the three batches.

| Device | Layout | Preconditioner | Baseline returned | Baseline true residual | With restart true residual | Iterations |
|---|---:|---|---:|---:|---:|---:|
| CPU | B1 | None | 0.968 | 11.226 | 0.806 | 32 to 96 |
| CPU | B1 | Jacobi | 0.256 | 10.578 | 0.966 | 32 to 96 |
| CPU | B3 | None | 0.957 | 11.345 | 0.806 | 32 to 96 |
| CPU | B3 | Jacobi | 0.790 | 11.600 | 0.966 | 32 to 96 |
| CUDA | B1 | None | 0.743 | 8.507 | 0.836 | 32 to 96 |
| CUDA | B1 | Jacobi | 0.196 | 8.889 | 0.846 | 32 to 96 |
| CUDA | B3 | None | 0.740 | 9.542 | 0.836 | 32 to 96 |
| CUDA | B3 | Jacobi | 0.197 | 9.205 | 0.981 | 32 to 96 |

Without restart, every configuration reports a residual below tolerance after 32 iterations,
but the explicit true residual is 8.5 to 11.6 times above the target. With `restart=32`,
every configuration reaches the actual requested tolerance after 96 iterations.

These measurements were taken with Warp `1.17.0.dev0`, CUDA Toolkit 13.0, and an NVIDIA
RTX PRO 6000 Blackwell Server Edition MIG device. Explicit residuals were recomputed in
NumPy float64 from the float32 solution.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/latest/project/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for the user-facing change under the `Unreleased` section.

## Validation summary

- Verified the deterministic CG regression on CPU and CUDA, with and without Jacobi
  preconditioning, for unbatched and three-batch layouts.
- Passed the complete CPU `test_linear_solvers.py` suite: 29 tests, with 6 expected
  CUDA-only skips.
- Passed all 28 CUDA test variants on an NVIDIA L4, including CG and CR restart,
  preconditioner reuse, conditional graph capture, and GMRES iteration accounting.
- Passed all pre-commit hooks for the changed files.
- Built the complete Sphinx HTML documentation without warnings.

## Bug fix

This standalone case reproduces the false convergence without enabling this PR's new option:

```python
import numpy as np
import warp as wp
from warp.optim.linear import cg

wp.init()
device = wp.get_device("cuda:0")

dof_count = 130
chain_count = dof_count - 1
edge_count = chain_count - 1
mass = 3.0 / chain_count
edge_weight = 0.18**2 / (3.0 / edge_count)

A_np = mass * np.eye(dof_count)
for edge in range(edge_count):
    A_np[edge, edge] += edge_weight
    A_np[edge + 1, edge + 1] += edge_weight
    A_np[edge, edge + 1] -= edge_weight
    A_np[edge + 1, edge] -= edge_weight

fixed = np.arange(0, chain_count, 17)
A_np[fixed, :] = 0.0
A_np[:, fixed] = 0.0
A_np[fixed, fixed] = 1.0
A_np = A_np.astype(np.float32)

rng = np.random.default_rng(7301)
x0_np = (0.1 * rng.standard_normal(dof_count)).astype(np.float32)
b_np = (mass * x0_np).astype(np.float32)
x0_np[fixed] = 0.0
b_np[fixed] = 0.0

with wp.ScopedDevice(device):
    A = wp.array(A_np, device=device)
    b = wp.array(b_np, device=device)
    x = wp.array(x0_np, device=device)
    niter, reported, effective_tolerance = cg(
        A,
        b,
        x,
        tol=1.0e-6,
        atol=0.0,
        maxiter=512,
        check_every=32,
        use_cuda_graph=False,
    )

true_residual = (
    A_np.astype(np.float64) @ x.numpy().astype(np.float64)
    - b_np.astype(np.float64)
)
true_target = 1.0e-6 * np.linalg.norm(b_np.astype(np.float64))

print(niter)                                      # 32
print(reported / effective_tolerance)             # 0.743, reported converged
print(np.linalg.norm(true_residual) / true_target)  # 8.507, actually above tolerance
```

## New feature / enhancement

Enable periodic restarts on the same solve:

```python
niter, reported, effective_tolerance = cg(
    A,
    b,
    x,
    tol=1.0e-6,
    atol=0.0,
    maxiter=512,
    check_every=32,
    use_cuda_graph=False,
    restart=32,
)
```

For the CUDA reproduction above, this reaches a true-residual ratio of `0.836` after
96 iterations instead of returning at `8.507` times the target.

Related issues: [GH-1708](https://github.com/NVIDIA/warp/issues/1708),
[GH-1707](https://github.com/NVIDIA/warp/issues/1707)

Related PhysicsNeMo PR: https://github.com/NVIDIA/physicsnemo/pull/1875
