### PR TITLE
Fix parallel CPU module loading (GH-1705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,8 @@
   instead of node coordinates in Warp FEM kernels ([GH-1685](https://github.com/NVIDIA/warp/issues/1685)).
 - Reject malformed APIC `.wrp` memory sections containing duplicate region IDs
   or out-of-bounds initial data during graph loading.
+- Fix intermittent missing CPU modules after parallel loading with `wp.force_load(max_workers > 1)`
+  ([GH-1705](https://github.com/NVIDIA/warp/issues/1705)).
 - Fix kernel compilation failing on Windows systems without long-path support enabled when a custom kernel cache
   location is set through `wp.config.kernel_cache_dir` or the `WARP_CACHE_PATH` environment variable. Custom cache
   locations now receive the same `\\?\` long-path treatment as the default location.

--- a/warp/native/clang/clang.cpp
+++ b/warp/native/clang/clang.cpp
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -711,10 +712,15 @@ WP_API int wp_compile_cuda(
 static llvm::orc::LLJIT* jit_default = nullptr;
 static llvm::orc::LLJIT* jit_legacy = nullptr;
 
+// Protect lazy JIT creation and all access to their JITDylib registries.
+// ctypes releases the GIL around native calls, so parallel Module.load()
+// operations can enter wp_load_obj() concurrently. Serializing only these
+// native registry operations keeps module compilation parallel while ensuring
+// every successfully loaded module remains reachable for lookup and unloading.
+static std::mutex jit_mutex;
+
 // Return the JIT instance for the given linker mode, creating it if needed.
-// Note: not thread-safe.  The caller (wp_load_obj) is serialized by Python's
-// Module._compile / Module.load, but if parallel loading is ever introduced at
-// the C++ level a mutex would be needed here.
+// The caller must hold jit_mutex.
 static llvm::orc::LLJIT* get_or_create_jit(bool use_legacy_linker)
 {
     if (use_legacy_linker && jit_legacy)
@@ -865,6 +871,8 @@ static bool warp_clang_is_asan_build()
 // builds (WP_ENABLE_DEBUG=1).
 WP_API int wp_load_obj(const char* object_file, const char* module_name, bool use_legacy_linker)
 {
+    std::lock_guard<std::mutex> lock(jit_mutex);
+
     auto* jit = get_or_create_jit(use_legacy_linker);
     if (!jit)
         return -1;
@@ -997,6 +1005,8 @@ WP_API int wp_load_obj(const char* object_file, const char* module_name, bool us
 
 WP_API int wp_unload_obj(const char* module_name)
 {
+    std::lock_guard<std::mutex> lock(jit_mutex);
+
     auto* jit = find_jit_for_module(module_name);
     if (!jit)
         return 0;
@@ -1014,6 +1024,8 @@ WP_API int wp_unload_obj(const char* module_name)
 
 WP_API uint64_t wp_lookup(const char* dll_name, const char* function_name)
 {
+    std::lock_guard<std::mutex> lock(jit_mutex);
+
     auto* jit = find_jit_for_module(dll_name);
     if (!jit) {
         std::cerr << "Failed to find module: " << dll_name << std::endl;

--- a/warp/tests/test_module_parallel_load.py
+++ b/warp/tests/test_module_parallel_load.py
@@ -6,12 +6,19 @@ wp.force_load() and wp.load_module().
 """
 
 import os
+import subprocess
+import sys
 import tempfile
+import threading
 import unittest
 import uuid
 from importlib import util
+from unittest import mock
+
+import numpy as np
 
 import warp as wp
+import warp._src.context as context
 
 # Chain of shared ``@wp.func`` helpers used by
 # ``TestParallelLoadSharedHelper`` below. Multiple helpers calling each
@@ -113,6 +120,62 @@ def _assert_modules_loaded_on_cpu(test, modules):
         test.assertTrue(has_cpu_exec, f"Module {m.name} was not loaded on CPU")
 
 
+def _make_parallel_cpu_kernel():
+    """Create a kernel in its own module for the parallel CPU load regression."""
+
+    module_name = f"parallel_cpu_load_{uuid.uuid4().hex}"
+
+    @wp.kernel(module=module_name)
+    def transform(values: wp.array[wp.int32]):
+        tid = wp.tid()
+        values[tid] = values[tid] * 2 + 1
+
+    return transform
+
+
+def _run_parallel_cpu_cold_start():
+    """Load and launch four CPU modules concurrently in a fresh subprocess."""
+    wp.init()
+
+    kernels = [_make_parallel_cpu_kernel() for _ in range(4)]
+    modules = [kernel.module for kernel in kernels]
+
+    # This is a fresh process, so none of the calls below should find an
+    # existing CPU JIT instance. Hold each worker at the native loading
+    # boundary until all four are ready, maximizing concurrent first entry
+    # into wp_load_obj() without changing production code.
+    load_barrier = threading.Barrier(len(modules))
+    original_load_obj = context.runtime.llvm.wp_load_obj
+
+    def synchronized_load_obj(*args):
+        load_barrier.wait(timeout=120)
+        return original_load_obj(*args)
+
+    with mock.patch.object(
+        context.runtime.llvm,
+        "wp_load_obj",
+        side_effect=synchronized_load_obj,
+    ):
+        wp.force_load(device="cpu", modules=modules, block_dim=1, max_workers=len(modules))
+
+    # Checking Module.execs is insufficient for this regression: the Python
+    # bookkeeping can contain a module whose native JIT instance is no longer
+    # reachable. Launch every kernel to force native lookup.
+    values = wp.array([0, 1, 2, 3], dtype=wp.int32, device="cpu")
+    for kernel in kernels:
+        wp.launch(
+            kernel,
+            dim=values.shape,
+            inputs=[values],
+            device="cpu",
+            block_dim=1,
+        )
+
+    actual = values.numpy()
+    expected = [15, 31, 47, 63]
+    np.testing.assert_array_equal(actual, expected)
+
+
 class TestModuleParallelLoad(unittest.TestCase):
     def test_force_load_serial(self):
         """Verify that serial compilation (max_workers=0) loads modules correctly."""
@@ -157,6 +220,39 @@ class TestModuleParallelLoad(unittest.TestCase):
         modules = _generate_modules(1)
         wp.force_load(device="cpu", modules=modules, max_workers=2)
         _assert_modules_loaded_on_cpu(self, modules)
+
+    def test_force_load_parallel_cpu_cold_start_kernel_lookup(self):
+        """Verify that modules loaded in parallel remain launchable on the CPU.
+
+        Run in a subprocess because the CPU JIT is process-global and the
+        initialization race can only occur on the first native module loads.
+        Give the subprocess a fresh filesystem cache without clearing Warp's
+        shared test cache, which is unsafe under the parallel test runner.
+        """
+        with tempfile.TemporaryDirectory() as cache_path:
+            env = os.environ.copy()
+            env["WARP_CACHE_PATH"] = cache_path
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    (
+                        "from warp.tests.test_module_parallel_load import _run_parallel_cpu_cold_start; "
+                        "_run_parallel_cpu_cold_start()"
+                    ),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=180,
+            )
+
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Parallel CPU cold-start subprocess failed.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
 
 
 def _assert_modules_loaded_on_cuda(test, modules, device):


### PR DESCRIPTION
## Description

Fix an intermittent race during parallel CPU module loading. Concurrent first-time calls to `wp_load_obj()` could create separate LLVM JIT instances and overwrite the process-global JIT pointer. A module load could therefore report success while its kernels remained unavailable during lookup.

Closes #1705.

## Changes

- Serialize CPU JIT initialization and module-registry operations. Specifically, added a mutex around CPU JIT module loading, unloading, and symbol lookup. The mutex allows only one thread at a time to access the shared LLVM JIT instance and its module registry, preventing concurrent cold-start loads from creating competing JIT instances or making previously loaded modules unreachable.
- Preserve parallel source generation and native compilation.
- Add a cold-process regression test that launches kernels from every parallel-loaded CPU module.
- Document the fix in the unreleased changelog.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/latest/project/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for any user-facing changes under the `Unreleased` section.

## Validation summary

- Reproduced the original issue in 6 of 20 fresh-process runs. Each failure produced the reported missing-module and missing-forward-kernel errors.
- Verified that the new cold-start regression test fails without the native mutex.
- Verified that the regression test passes after rebuilding with the fix.
- Ran the complete parallel module-loading test module. All CPU tests passed; two CUDA-only tests were skipped because the local build was CPU-only.
- Ran the full test suite. All executed tests passed, with only the expected CUDA-dependent tests skipped in the CPU-only environment.
- Verified that CPU debug and release builds succeed.
- Verified the legacy RTDyld CPU-linker test with the synchronization in place.

## Bug fix

The issue can be reproduced intermittently by running this example repeatedly in fresh processes:

```python
import warp as wp


def make_kernel():
    @wp.kernel(module="unique")
    def transform(values: wp.array[wp.int32]):
        tid = wp.tid()
        values[tid] = values[tid] * 2 + 1

    return transform


kernels = [make_kernel() for _ in range(4)]

wp.force_load(
    device="cpu",
    modules=[kernel.module for kernel in kernels],
    block_dim=1,
    max_workers=4,
)

values = wp.array([0, 1, 2, 3], dtype=wp.int32, device="cpu")

for kernel in kernels:
    wp.launch(
        kernel,
        dim=values.shape,
        inputs=[values],
        device="cpu",
        block_dim=1,
    )

assert values.numpy().tolist() == [15, 31, 47, 63]
```

Without the fix, a launch may fail even though every module load reported success:

```text
Failed to find module: wp_<module>_1
RuntimeError: Failed to find forward kernel 'transform'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent missing CPU modules when loading in parallel with `wp.force_load(max_workers > 1)`.
  * Improved reliability and consistency during concurrent module loading, unloading, and lookup operations.
* **Tests**
  * Added regression coverage for parallel CPU module loading during a cold start, including validation in an isolated process and synchronized loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->