### PR TITLE
Support executing Warp definitions from source strings (GH-1640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 ### Added
 
-- Add `wp.exec_source()` for executing trusted Python source containing Warp
-  kernels, functions, and structs with deterministic module identity and useful
-  generated-source diagnostics. The supported contract currently covers CPU
-  execution ([GH-1640](https://github.com/NVIDIA/warp/issues/1640)).
 - Add rebuildable NanoVDB volumes through `wp.Volume.allocate_by_tiles(..., rebuildable=True)`,
   `wp.Volume.allocate_by_voxels(..., rebuildable=True)`, and `wp.Volume.rebuild()`. Support fixed capacities, optional
   point masks, CPU execution, CUDA graph-capturable allocation and rebuilding, and in-place refreshes of rebuildable
@@ -48,6 +44,10 @@
 - Add optional `restart` support to `warp.optim.linear.cg()` and `warp.optim.linear.cr()` for
   recomputing the true residual and resetting the search direction during finite-precision solves
   ([GH-1708](https://github.com/NVIDIA/warp/issues/1708)).
+- Add `wp.exec_source()` for executing trusted Python source containing Warp
+  kernels, functions, and structs with deterministic module identity and useful
+  generated-source diagnostics. The supported contract currently covers CPU
+  execution ([GH-1640](https://github.com/NVIDIA/warp/issues/1640)).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Add `wp.exec_source()` for executing trusted Python source containing Warp
+  kernels, functions, and structs with deterministic module identity and useful
+  generated-source diagnostics. The supported contract currently covers CPU
+  execution ([GH-1640](https://github.com/NVIDIA/warp/issues/1640)).
 - Add rebuildable NanoVDB volumes through `wp.Volume.allocate_by_tiles(..., rebuildable=True)`,
   `wp.Volume.allocate_by_voxels(..., rebuildable=True)`, and `wp.Volume.rebuild()`. Support fixed capacities, optional
   point masks, CPU execution, CUDA graph-capturable allocation and rebuilding, and in-place refreshes of rebuildable

--- a/design/kernel-source-string.md
+++ b/design/kernel-source-string.md
@@ -143,6 +143,26 @@ wp.launch(generated["scale_array"], dim=3, inputs=[values], device="cpu")
 produce several kernels, functions, structs, constants, or imported names. A
 single-kernel API would be too narrow for a module-sized source block.
 
+The name also makes the security boundary visible: unlike an API named
+``compile_source``, it does not imply that the operation only translates code.
+It executes top-level Python statements before any generated kernel is
+launched.
+
+Maintainers may prefer one of these alternatives before the API is released:
+
+- ``load_source`` follows the vocabulary of ``load_module``, but understates
+  that arbitrary top-level Python executes and suggests that a module object is
+  returned.
+- ``module_from_source`` emphasizes module identity, but the return value is a
+  mapping rather than ``wp.Module``.
+- ``kernel_from_source`` is clear for the smallest example, but cannot describe
+  source containing multiple kernels, functions, and structs.
+- ``compile_source`` sounds non-executing and would obscure the trusted-source
+  warning.
+
+No aliases are proposed. One final name keeps the public surface small and
+avoids supporting redundant spellings after release.
+
 The function is defined in `warp/_src/context.py` near the existing kernel and
 module APIs and re-exported from `warp/__init__.py` under Kernel Programming.
 

--- a/design/kernel-source-string.md
+++ b/design/kernel-source-string.md
@@ -1,0 +1,347 @@
+# Execute Warp Definitions from Source Strings
+
+**Status**: Proposed
+
+**Issue**: [GH-1640](https://github.com/NVIDIA/warp/issues/1640)
+
+## Motivation
+
+Warp normally retrieves the source of `@wp.kernel` and `@wp.func` definitions
+from a `.py` file. Functions created by `exec()` have no file-backed source for
+`inspect.getsourcelines()`, so Warp decorators reject them and ask the user to
+save the code to a file.
+
+This prevents short `python -c` experiments and trusted code generators from
+using normal Warp syntax. The existing workaround executes an undecorated
+function in a manually prepared namespace, retrieves a Warp module, and then
+constructs `wp.Kernel` with explicit `source` and `module` arguments. It is hard
+to discover, does not generalize naturally to several definitions, and loses
+useful filename information in code-generation errors.
+
+The proposed API executes trusted in-memory Python source while preserving
+Warp's existing decorators, modules, hashing, code generation, compiled-code
+cache, and CPU execution path.
+
+## Requirements
+
+| ID | Requirement | Priority | Notes |
+| --- | --- | --- | --- |
+| R1 | Execute source containing normal Warp decorators | Must | Supports `@wp.kernel`, `@wp.func`, and `@wp.struct` |
+| R2 | Work when invoked through `python -c` | Must | Primary command-line use case |
+| R3 | Preserve a meaningful virtual filename and source-block line numbers | Must | Applies to Python and Warp errors |
+| R4 | Use the existing Warp module and CPU compilation paths | Must | No separate compiler or compiled-code cache |
+| R5 | Support multiple top-level definitions in one source block | Must | Kernels, functions, structs, constants, and imports |
+| R6 | Define deterministic module naming and collision behavior | Must | Prevents accidental replacement and stale state |
+| R7 | Roll back partial Warp registration when execution fails | Must | Failed calls leave no generated module behind |
+| R8 | Reuse identical named source without executing it again | Should | Avoids duplicate objects and registry growth |
+| R9 | Leave file-defined kernel behavior unchanged | Must | Existing decorators retain their current behavior |
+| R10 | Clearly identify the trusted-source security boundary | Must | The API does not sandbox Python |
+| R11 | Specify and test CPU behavior only | Must | GPU/CUDA behavior is outside the design |
+
+**Non-goals:**
+
+- Sandboxing or safely executing untrusted source.
+- GPU/CUDA behavior or compatibility guarantees.
+- Hot reloading changed source under an existing module name.
+- A new kernel language or parser.
+- Package installation or dependency resolution.
+- Persistent generated-module serialization.
+- Cross-process namespace reuse beyond Warp's existing compiled-code cache.
+
+## Design
+
+### Approach
+
+Add `wp.exec_source()`, which compiles trusted Python source with a synthetic
+filename and executes it in a named namespace. The source uses normal Warp
+decorators, so existing registration and compilation paths remain unchanged.
+
+A synthetic filename is a descriptive filename that identifies source held in
+memory rather than on disk. A namespace is the dictionary of names visible to
+the executed source.
+
+The source is temporarily registered in Python's `linecache`, the standard
+cache used by inspection and traceback tools, while decorators inspect it.
+Warp's `Adjoint` objects retain the parsed source needed for later code
+generation, allowing the temporary entry to be removed when `exec()` finishes.
+
+Each successful call owns a generated Warp module and a read-only mapping of
+the names created by the source. Here, a mapping is a dictionary-like object
+whose entries cannot be changed by the caller. An internal registry provides
+deterministic same-source reuse and rejects unsafe name collisions.
+
+### Alternatives Considered
+
+**Automatically wrap undecorated functions:** This matches the existing
+workaround, but the helper would have to guess which functions are kernels and
+manually handle helpers, structs, overloads, and source slices. Explicit
+`Kernel(source=...)` also reports an unknown filename and function-relative
+line numbers.
+
+**Return one kernel:** This is convenient for the smallest example but cannot
+represent a source block containing several related definitions.
+
+**Return the mutable execution namespace:** This exposes infrastructure names
+and implies that mutating the dictionary is a supported way to alter a
+generated module.
+
+**Create a `types.ModuleType` and add it to `sys.modules`:** Attribute access is
+convenient, but Python loaders, package semantics, imports, and removal become
+part of the module lifecycle. A named namespace plus `linecache` is sufficient
+for source inspection.
+
+**Extend decorators with an explicit source provider:** This avoids
+`linecache`, but broadens the `@wp.kernel`, `@wp.func`, and `Adjoint` interfaces
+for a use case that can be handled at one public entry point.
+
+**Replace changed source in place:** Warp can retain older same-key kernel
+objects and lazily rebuild their shared module executable. Exposing that
+behavior as hot reload would make old references and module dependencies hard
+to reason about. Changed source requires a new module name instead.
+
+**Use random default module names:** Random names avoid immediate collisions
+but prevent deterministic reuse and grow process-global registry state across
+identical calls.
+
+### Key Implementation Details
+
+#### Public API
+
+```python
+def exec_source(
+    source: str,
+    *,
+    module_name: str | None = None,
+) -> Mapping[str, Any]:
+    ...
+```
+
+Example:
+
+```python
+import warp as wp
+
+generated = wp.exec_source(
+    """
+@wp.func
+def scale(x: float):
+    return x * 2.0
+
+@wp.kernel
+def scale_array(values: wp.array[wp.float32]):
+    i = wp.tid()
+    values[i] = scale(values[i])
+""",
+    module_name="generated_scale",
+)
+
+values = wp.array([1.0, 2.0, 3.0], dtype=wp.float32, device="cpu")
+wp.launch(generated["scale_array"], dim=3, inputs=[values], device="cpu")
+```
+
+`exec_source` reflects that the operation executes ordinary Python and can
+produce several kernels, functions, structs, constants, or imported names. A
+single-kernel API would be too narrow for a module-sized source block.
+
+The function is defined in `warp/_src/context.py` near the existing kernel and
+module APIs and re-exported from `warp/__init__.py` under Kernel Programming.
+
+#### Accepted Source
+
+The source is ordinary trusted Python. Warp constructs use their normal
+decorators:
+
+- `@wp.kernel` defines a kernel.
+- `@wp.func` defines a function callable from Warp code.
+- `@wp.struct` defines a Warp structure.
+
+Plain functions are executed as ordinary Python functions and are not
+automatically converted into kernels. Definitions must be top-level within one
+source block. A generated module cannot be extended across several calls.
+
+Absolute imports behave normally. Relative imports are unsupported because a
+generated namespace has no package and is not added to `sys.modules`.
+
+#### Execution Namespace
+
+The private namespace starts with:
+
+```python
+{
+    "__name__": resolved_module_name,
+    "__file__": synthetic_filename,
+    "__package__": None,
+    "wp": warp,
+}
+```
+
+Python adds `__builtins__` during execution. The alias `warp` is not injected;
+source that needs that spelling imports it normally.
+
+The returned read-only mapping contains public names created by the submitted
+source. The reserved names `wp`, `__name__`, `__file__`, `__package__`, and
+`__builtins__` are excluded. Imports and ordinary Python values are retained
+because they can be useful results or dependencies.
+
+The private namespace remains alive with the generated-source record because
+Python functions refer to their globals dictionary. Reusing identical source
+returns the same mapping object.
+
+#### Module Naming
+
+`module_name` is optional. An explicit name must be a non-empty dotted Python
+identifier: every component separated by `.` must satisfy
+`str.isidentifier()` and must not be a Python keyword.
+
+When omitted, the name is derived from the exact UTF-8 source bytes:
+
+```text
+__warp_source_<first 16 hexadecimal characters of SHA-256(source)>
+```
+
+The source digest, a SHA-256 fingerprint of the submitted text, is distinct
+from Warp's module hash. Warp's module hash continues to identify compiled
+content, including referenced constructs, types, options, and build settings.
+
+#### Synthetic Filename and Source Inspection
+
+The synthetic filename includes the resolved module name and source identity:
+
+```text
+<warp-source:generated_scale:4a1b2c3d4e5f>
+```
+
+The complete source is compiled with this filename. Its exact lines are placed
+in `linecache` while `exec()` runs, allowing `inspect.getsourcelines()` to
+extract decorated functions with correct complete-source line offsets.
+
+Compilation does not inherit `__future__` flags from Warp's implementation
+module. The submitted source controls its own future statements, so internal
+compiler settings cannot silently change annotation behavior.
+
+The helper removes its `linecache` entry in a `finally` block. `Adjoint`
+instances retain their parsed source, and generic kernel/function overloads
+construct new `Adjoint` instances from that stored source.
+
+#### Generated-Source Registry
+
+An internal registry in `warp/_src/context.py`, alongside `user_modules`, stores
+one record per generated module. A record owns:
+
+- the resolved module name;
+- the exact source digest;
+- the synthetic filename;
+- the private execution namespace; and
+- the read-only result mapping.
+
+The registry is separate from `user_modules`: the former tracks source identity
+and namespace lifetime, while the latter remains Warp's authority for kernels,
+functions, structs, dependencies, hashes, and executables.
+
+#### Reuse and Collisions
+
+| Existing state | Request | Behavior |
+| --- | --- | --- |
+| No matching name | Any source | Execute and register the generated module |
+| Generated name with identical source | Same source | Return the existing mapping without re-executing source |
+| Generated name with different source | Changed source | Raise `ValueError` |
+| Existing file-backed Python or Warp module | Any source | Raise `ValueError` without modifying existing state |
+| Same source with a different explicit name | Same source | Create a distinct generated module |
+| Same symbol name in different generated modules | Any source | Allow; Warp modules isolate the symbols |
+
+Generated source is immutable after successful registration. Callers use a new
+module name for changed source.
+
+The helper does not create a `ModuleType` or add an entry to `sys.modules`.
+
+#### Execution and Rollback
+
+The operation proceeds in this order:
+
+1. Validate `source` and `module_name`.
+2. Calculate the source digest and synthetic filename.
+3. Return an identical generated record or reject a collision.
+4. Compile the complete source before modifying Warp registries.
+5. Create the private namespace and temporary `linecache` entry.
+6. Execute the source and let existing decorators register Warp constructs.
+7. Build the read-only result mapping.
+8. Publish the generated-source record.
+9. Remove the temporary `linecache` entry.
+
+Compilation before registry mutation makes syntax errors atomic: a failed
+operation does not leave a partially registered generated module.
+Other exceptions can occur after an earlier decorator has registered a
+construct. A failed call removes all state owned by the generated name:
+
+1. Remove the temporary `linecache` entry.
+2. Detach dependency edges from the partial Warp module.
+3. Unload CPU executables created by top-level source actions.
+4. Remove the partial module from `user_modules`.
+5. Discard the namespace and generated-source record.
+6. Re-raise the original exception with its traceback.
+
+Generated names cannot refer to pre-existing modules, so rollback does not
+modify state owned by file-defined or previously generated modules.
+
+#### CPU Scope
+
+All specified behavior and tests target CPU kernels. The helper contains no
+device-specific compilation logic; it prepares Warp definitions and delegates
+later compilation to the existing module path.
+
+GPU/CUDA behavior is unspecified and outside this design.
+
+#### Security
+
+`exec_source` executes ordinary Python. Source can import modules, access files,
+start processes, mutate global state, or perform any action allowed to the
+current process.
+
+The API documentation includes this warning:
+
+> Only execute source you trust. This function does not sandbox Python code.
+
+## Testing Strategy
+
+All launch tests explicitly use `device="cpu"`.
+
+### Core Behavior
+
+- Define and launch one kernel with verified CPU output.
+- Run the complete workflow in a `python -c` subprocess.
+- Define multiple kernels in one source block.
+- Use a generated `@wp.func` from a kernel.
+- Use a generated `@wp.struct` from a kernel.
+- Use imports and constants from generated definitions.
+- Verify that the result contains source-defined names and excludes reserved
+  namespace entries.
+
+### Diagnostics
+
+- Report a Python syntax error with the synthetic filename and exact line.
+- Report a Warp code-generation error with the synthetic filename and exact
+  line.
+- Preserve a useful traceback for a top-level execution exception.
+
+### Identity and Collisions
+
+- Derive a deterministic default name.
+- Return the same result for an identical name and source.
+- Reject changed source under an existing generated name without mutation.
+- Allow identical symbols under distinct explicit names.
+- Reject collision with a file-backed Warp module.
+- Keep identical source under different explicit names distinct.
+
+### Failure Atomicity and Lifecycle
+
+- Clean up a failure before the first decorator.
+- Clean up a failure after one decorated definition succeeds.
+- Remove generated registry, Warp module, dependency, executable, and
+  `linecache` state after failure.
+- Compile on CPU after successful `linecache` cleanup.
+- Create generic overloads after successful `linecache` cleanup.
+- Leave ordinary file-defined CPU kernels unaffected.
+
+Tests use `unittest`. A focused test module is added to `default_suite()` in
+`warp/tests/unittest_suites.py`; subprocess coverage follows the pattern in
+`test_modules_lite.py`.

--- a/design/kernel-source-string.md
+++ b/design/kernel-source-string.md
@@ -199,9 +199,9 @@ Python adds `__builtins__` during execution. The alias `warp` is not injected;
 source that needs that spelling imports it normally.
 
 The returned read-only mapping contains public names created by the submitted
-source. The reserved names `wp`, `__name__`, `__file__`, `__package__`, and
-`__builtins__` are excluded. Imports and ordinary Python values are retained
-because they can be useful results or dependencies.
+source. The reserved names `wp`, `__name__`, `__file__`, `__package__`,
+`__builtins__`, and `__doc__` are excluded. Imports and ordinary Python values
+are retained because they can be useful results or dependencies.
 
 The private namespace remains alive with the generated-source record because
 Python functions refer to their globals dictionary. Reusing identical source
@@ -258,6 +258,13 @@ The registry is separate from `user_modules`: the former tracks source identity
 and namespace lifetime, while the latter remains Warp's authority for kernels,
 functions, structs, dependencies, hashes, and executables.
 
+Generated-source transactions and normal Warp module lookup share a
+re-entrant registry lock. The lock covers collision checking, source
+execution, publication, and rollback, so another thread calling
+`get_module()` cannot observe or retain a partially populated generated
+module. Re-entrancy allows decorators executed by the source to resolve the
+generated module on the transaction's thread.
+
 #### Reuse and Collisions
 
 | Existing state | Request | Behavior |
@@ -302,6 +309,9 @@ construct. A failed call removes all state owned by the generated name:
 
 Generated names cannot refer to pre-existing modules, so rollback does not
 modify state owned by file-defined or previously generated modules.
+Concurrent lookup or creation of the same name cannot interleave with the
+transaction, so rollback removes only the partial module created by that
+transaction.
 
 #### CPU Scope
 
@@ -358,6 +368,8 @@ All launch tests explicitly use `device="cpu"`.
 - Clean up a failure after one decorated definition succeeds.
 - Remove generated registry, Warp module, dependency, executable, and
   `linecache` state after failure.
+- Prevent a concurrent module lookup from retaining a partial module when
+  source execution fails.
 - Compile on CPU after successful `linecache` cleanup.
 - Create generic overloads after successful `linecache` cleanup.
 - Leave ordinary file-defined CPU kernels unaffected.

--- a/docs/api_reference/warp.rst
+++ b/docs/api_reference/warp.rst
@@ -276,6 +276,7 @@ Kernel Programming
    WarpCodegenTypeError
    WarpCodegenValueError
    address_of
+   exec_source
    func
    func_grad
    func_native

--- a/docs/user_guide/programming_model/code_generation.rst
+++ b/docs/user_guide/programming_model/code_generation.rst
@@ -180,17 +180,27 @@ code generators that do not have a backing ``.py`` file:
     values = wp.array([1.0, 2.0, 3.0], dtype=wp.float32, device="cpu")
     wp.launch(generated["scale"], dim=3, inputs=[values, 2.0], device="cpu")
 
+Source passed to ``wp.exec_source()`` is ordinary Python with top-level Warp
+definitions. It may contain ``@wp.kernel``, ``@wp.func``, and ``@wp.struct``
+decorators, imports, constants, and other top-level Python statements. Plain
+functions are not automatically converted to Warp kernels. Absolute imports
+work normally; relative imports are unsupported because generated source does
+not belong to a Python package.
+
 The return value is a read-only mapping containing the names created by the
 source. A mapping is a dictionary-like object; definitions are retrieved with
-expressions such as ``generated["scale"]``. Infrastructure names supplied by
-Warp, including ``wp`` and ``__name__``, are not returned.
+expressions such as ``generated["scale"]`` and
+``generated["scale_value"]``. Infrastructure names supplied by Warp,
+including ``wp`` and ``__name__``, are not returned.
 
 The optional ``module_name`` is a dotted Python identifier. If it is omitted,
 Warp derives a deterministic name from the exact source text. Repeating the
 same source and resolved name returns the existing mapping without executing
 the source again. To execute changed source, choose a new module name; Warp
 rejects changed source under an existing name to prevent stale definitions and
-compiled executables.
+compiled executables. Generated modules are immutable after registration;
+``wp.exec_source()`` does not provide hot reload. Use a new module name when
+the source changes.
 
 Syntax errors and Warp code-generation errors use a synthetic filename that
 identifies the generated module and source. A synthetic filename is a virtual

--- a/docs/user_guide/programming_model/code_generation.rst
+++ b/docs/user_guide/programming_model/code_generation.rst
@@ -152,6 +152,60 @@ if a :ref:`custom replay function <custom-gradient-functions>` is provided, the 
 
 Warp passes the generated source code to native compilers (e.g., LLVM for CPU and NVRTC for CUDA) to produce executable code that is invoked when launching kernels.
 
+Executing Warp definitions from a source string
+-----------------------------------------------
+
+:func:`wp.exec_source() <warp.exec_source>` executes trusted Python source that
+contains normal Warp decorators. This is useful for command-line programs and
+code generators that do not have a backing ``.py`` file:
+
+.. code:: python
+
+    import warp as wp
+
+    generated = wp.exec_source(
+        """
+    @wp.func
+    def scale_value(value: float, factor: float):
+        return value * factor
+
+    @wp.kernel
+    def scale(values: wp.array(dtype=wp.float32), factor: float):
+        i = wp.tid()
+        values[i] = scale_value(values[i], factor)
+    """,
+        module_name="generated_scale",
+    )
+
+    values = wp.array([1.0, 2.0, 3.0], dtype=wp.float32, device="cpu")
+    wp.launch(generated["scale"], dim=3, inputs=[values, 2.0], device="cpu")
+
+The return value is a read-only mapping containing the names created by the
+source. A mapping is a dictionary-like object; definitions are retrieved with
+expressions such as ``generated["scale"]``. Infrastructure names supplied by
+Warp, including ``wp`` and ``__name__``, are not returned.
+
+The optional ``module_name`` is a dotted Python identifier. If it is omitted,
+Warp derives a deterministic name from the exact source text. Repeating the
+same source and resolved name returns the existing mapping without executing
+the source again. To execute changed source, choose a new module name; Warp
+rejects changed source under an existing name to prevent stale definitions and
+compiled executables.
+
+Syntax errors and Warp code-generation errors use a synthetic filename that
+identifies the generated module and source. A synthetic filename is a virtual
+name used for diagnostics when source does not exist as a file.
+
+.. warning::
+
+    Only execute source you trust. ``wp.exec_source()`` executes ordinary
+    Python with the permissions of the current process and does not provide a
+    sandbox.
+
+The supported contract currently covers CPU kernel creation, compilation,
+execution, diagnostics, and module lifecycle. CUDA behavior is not yet part of
+this API's compatibility guarantee.
+
 .. _external_references:
 
 External References and Constants

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -304,6 +304,7 @@ from warp._src.codegen import WarpCodegenKeyError as WarpCodegenKeyError
 from warp._src.codegen import WarpCodegenTypeError as WarpCodegenTypeError
 from warp._src.codegen import WarpCodegenValueError as WarpCodegenValueError
 
+from warp._src.context import exec_source as exec_source
 from warp._src.context import func as func
 from warp._src.context import func_grad as func_grad
 from warp._src.context import func_replay as func_replay

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -98,6 +98,7 @@ from warp._src.codegen import WarpCodegenIndexError as WarpCodegenIndexError
 from warp._src.codegen import WarpCodegenKeyError as WarpCodegenKeyError
 from warp._src.codegen import WarpCodegenTypeError as WarpCodegenTypeError
 from warp._src.codegen import WarpCodegenValueError as WarpCodegenValueError
+from warp._src.context import exec_source as exec_source
 from warp._src.context import func as func
 from warp._src.context import func_grad as func_grad
 from warp._src.context import func_replay as func_replay

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2298,8 +2298,11 @@ class _GeneratedSourceRecord(NamedTuple):
 
 
 _generated_source_modules: dict[str, _GeneratedSourceRecord] = {}
-_generated_source_lock = threading.RLock()
-_generated_source_reserved_names = frozenset({"__builtins__", "__file__", "__name__", "__package__", "wp"})
+# Serializes Warp module lookup/creation with generated-source transactions.
+# Re-entrancy lets decorators executed by exec_source() resolve their module
+# while the outer source transaction holds the lock.
+_module_registry_lock = threading.RLock()
+_generated_source_reserved_names = frozenset({"__builtins__", "__doc__", "__file__", "__name__", "__package__", "wp"})
 
 
 def _validate_generated_module_name(module_name: str) -> None:
@@ -2338,8 +2341,8 @@ def exec_source(source: str, *, module_name: str | None = None) -> Mapping[str, 
 
     Returns:
         A read-only mapping containing names created by ``source``. The
-        execution-environment names ``wp``, ``__builtins__``, ``__file__``,
-        ``__name__``, and ``__package__`` are excluded.
+        execution-environment names ``wp``, ``__builtins__``, ``__doc__``,
+        ``__file__``, ``__name__``, and ``__package__`` are excluded.
 
     Raises:
         TypeError: If ``source`` is not a string or ``module_name`` is neither
@@ -2367,7 +2370,7 @@ def exec_source(source: str, *, module_name: str | None = None) -> Mapping[str, 
     # compiler flags from this implementation module.
     code = compile(source, synthetic_filename, "exec", dont_inherit=True)
 
-    with _generated_source_lock:
+    with _module_registry_lock:
         existing_record = _generated_source_modules.get(module_name)
         if existing_record is not None:
             if existing_record.source_digest == source_digest:
@@ -2436,6 +2439,7 @@ def get_module(name: str) -> Module:
     return _get_module(name)
 
 
+@synchronized(_module_registry_lock)
 def _get_module(name: str, qualname: str | None = None) -> Module:
     """Return or create the Warp module a construct should be registered into.
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -15,6 +15,8 @@ import inspect
 import io
 import itertools
 import json
+import keyword
+import linecache
 import operator
 import os
 import platform
@@ -2284,6 +2286,129 @@ def register_api_function(
 
 # global dictionary of modules
 user_modules: dict[str, Module] = {}
+
+
+class _GeneratedSourceRecord(NamedTuple):
+    """State retained for source executed by :func:`_exec_source`."""
+
+    source_digest: str
+    synthetic_filename: str
+    namespace: dict[str, Any]
+    result: Mapping[str, Any]
+
+
+_generated_source_modules: dict[str, _GeneratedSourceRecord] = {}
+_generated_source_lock = threading.RLock()
+_generated_source_reserved_names = frozenset({"__builtins__", "__file__", "__name__", "__package__", "wp"})
+
+
+def _validate_generated_module_name(module_name: str) -> None:
+    """Validate a module name used for generated Warp source.
+
+    Args:
+        module_name: Dotted Python module name to validate.
+
+    Raises:
+        ValueError: If the name is empty or contains an invalid or reserved
+            Python identifier.
+    """
+    components = module_name.split(".")
+    if not module_name or any(not component.isidentifier() or keyword.iskeyword(component) for component in components):
+        raise ValueError(f"Generated Warp module name must be a valid dotted Python identifier, got {module_name!r}")
+
+
+def _exec_source(source: str, *, module_name: str | None = None) -> Mapping[str, Any]:
+    """Execute trusted Python source containing decorated Warp definitions.
+
+    This is a private prototype for evaluating normal ``@wp.kernel``,
+    ``@wp.func``, and ``@wp.struct`` definitions without a backing Python file.
+    The source executes with the privileges of the current process and is not
+    sandboxed.
+
+    Args:
+        source: Trusted Python source to execute.
+        module_name: Logical Warp module name. When omitted, a deterministic
+            name is derived from the exact UTF-8 source bytes.
+
+    Returns:
+        A read-only mapping containing names created by ``source``. Names
+        reserved for the execution environment are excluded.
+
+    Raises:
+        TypeError: If ``source`` is not a string or ``module_name`` is neither
+            a string nor ``None``.
+        ValueError: If ``module_name`` is invalid, collides with an existing
+            module, or refers to different generated source.
+
+    Warning:
+        Only execute source you trust. This function does not sandbox Python
+        code.
+    """
+    if not isinstance(source, str):
+        raise TypeError(f"Generated Warp source must be a string, got {type(source).__name__}")
+    if module_name is not None and not isinstance(module_name, str):
+        raise TypeError(f"Generated Warp module name must be a string or None, got {type(module_name).__name__}")
+
+    source_digest = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    if module_name is None:
+        module_name = f"__warp_source_{source_digest[:16]}"
+    else:
+        _validate_generated_module_name(module_name)
+
+    synthetic_filename = f"<warp-source:{module_name}:{source_digest[:12]}>"
+    # Generated source controls its own future statements and must not inherit
+    # compiler flags from this implementation module.
+    code = compile(source, synthetic_filename, "exec", dont_inherit=True)
+
+    with _generated_source_lock:
+        existing_record = _generated_source_modules.get(module_name)
+        if existing_record is not None:
+            if existing_record.source_digest == source_digest:
+                return existing_record.result
+            raise ValueError(f"Generated Warp module {module_name!r} already exists with different source")
+
+        if module_name in user_modules or module_name in sys.modules:
+            raise ValueError(f"Generated Warp module name {module_name!r} collides with an existing module")
+
+        namespace = {
+            "__file__": synthetic_filename,
+            "__name__": module_name,
+            "__package__": None,
+            "wp": warp,
+        }
+        source_lines = source.splitlines(keepends=True)
+        cache_entry = (len(source), None, source_lines, synthetic_filename)
+        missing_cache_entry = object()
+        previous_cache_entry = linecache.cache.get(synthetic_filename, missing_cache_entry)
+        linecache.cache[synthetic_filename] = cache_entry
+
+        try:
+            exec(code, namespace)
+
+            result_values = {
+                name: value for name, value in namespace.items() if name not in _generated_source_reserved_names
+            }
+            result = types.MappingProxyType(result_values)
+            _generated_source_modules[module_name] = _GeneratedSourceRecord(
+                source_digest=source_digest,
+                synthetic_filename=synthetic_filename,
+                namespace=namespace,
+                result=result,
+            )
+            return result
+        except BaseException:
+            partial_module = user_modules.pop(module_name, None)
+            if partial_module is not None:
+                partial_module._detach_references()
+                partial_module.unload()
+            _generated_source_modules.pop(module_name, None)
+            raise
+        finally:
+            if linecache.cache.get(synthetic_filename) is cache_entry:
+                if previous_cache_entry is missing_cache_entry:
+                    linecache.cache.pop(synthetic_filename, None)
+                else:
+                    linecache.cache[synthetic_filename] = previous_cache_entry
 
 
 def get_module(name: str) -> Module:

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2289,7 +2289,7 @@ user_modules: dict[str, Module] = {}
 
 
 class _GeneratedSourceRecord(NamedTuple):
-    """State retained for source executed by :func:`_exec_source`."""
+    """State retained for source executed by :func:`exec_source`."""
 
     source_digest: str
     synthetic_filename: str
@@ -2317,13 +2317,19 @@ def _validate_generated_module_name(module_name: str) -> None:
         raise ValueError(f"Generated Warp module name must be a valid dotted Python identifier, got {module_name!r}")
 
 
-def _exec_source(source: str, *, module_name: str | None = None) -> Mapping[str, Any]:
+def exec_source(source: str, *, module_name: str | None = None) -> Mapping[str, Any]:
     """Execute trusted Python source containing decorated Warp definitions.
 
-    This is a private prototype for evaluating normal ``@wp.kernel``,
-    ``@wp.func``, and ``@wp.struct`` definitions without a backing Python file.
-    The source executes with the privileges of the current process and is not
-    sandboxed.
+    The source can contain normal ``@wp.kernel``, ``@wp.func``, and
+    ``@wp.struct`` definitions without a backing Python file. Definitions are
+    registered in one generated Warp module and can be retrieved from the
+    returned mapping.
+
+    When ``module_name`` is omitted, the name is derived from the exact source
+    text. Repeating a call with the same resolved name and source returns the
+    existing mapping without executing the source again. A resolved name cannot
+    be reused for changed source or collide with an existing Python or Warp
+    module.
 
     Args:
         source: Trusted Python source to execute.
@@ -2331,8 +2337,9 @@ def _exec_source(source: str, *, module_name: str | None = None) -> Mapping[str,
             name is derived from the exact UTF-8 source bytes.
 
     Returns:
-        A read-only mapping containing names created by ``source``. Names
-        reserved for the execution environment are excluded.
+        A read-only mapping containing names created by ``source``. The
+        execution-environment names ``wp``, ``__builtins__``, ``__file__``,
+        ``__name__``, and ``__package__`` are excluded.
 
     Raises:
         TypeError: If ``source`` is not a string or ``module_name`` is neither

--- a/warp/tests/test_exec_source.py
+++ b/warp/tests/test_exec_source.py
@@ -5,6 +5,7 @@ import gc
 import linecache
 import subprocess
 import sys
+import threading
 import types
 import unittest
 
@@ -204,6 +205,72 @@ raise RuntimeError("failure after registration")
         self.assertNotIn(module_name, context._generated_source_modules)
         self.assertFalse(any(name.startswith(f"<warp-source:{module_name}:") for name in linecache.cache))
 
+    def test_failed_source_does_not_remove_concurrent_module_lookup(self):
+        module_name = "warp.tests.exec_source.concurrent_failure"
+        source_entered = threading.Event()
+        source_release = threading.Event()
+        lookup_started = threading.Event()
+        lookup_finished = threading.Event()
+        source_errors = []
+        looked_up_modules = []
+
+        test_module = sys.modules[__name__]
+        test_module.source_entered = source_entered
+        test_module.source_release = source_release
+        source = f"""
+import importlib
+
+test_module = importlib.import_module({__name__!r})
+
+@wp.kernel
+def partial(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i]
+
+test_module.source_entered.set()
+if not test_module.source_release.wait(10.0):
+    raise RuntimeError("timed out waiting to fail")
+raise RuntimeError("concurrent failure")
+"""
+
+        def execute_source():
+            try:
+                wp.exec_source(source, module_name=module_name)
+            except BaseException as error:
+                source_errors.append(error)
+
+        def lookup_module():
+            lookup_started.set()
+            looked_up_modules.append(wp.get_module(module_name))
+            lookup_finished.set()
+
+        source_thread = threading.Thread(target=execute_source)
+        lookup_thread = threading.Thread(target=lookup_module)
+        try:
+            source_thread.start()
+            self.assertTrue(source_entered.wait(5.0))
+
+            lookup_thread.start()
+            self.assertTrue(lookup_started.wait(5.0))
+            self.assertFalse(lookup_finished.wait(0.1))
+        finally:
+            source_release.set()
+            source_thread.join(5.0)
+            lookup_thread.join(5.0)
+            del test_module.source_entered
+            del test_module.source_release
+
+        self.assertFalse(source_thread.is_alive())
+        self.assertFalse(lookup_thread.is_alive())
+        self.assertEqual(len(source_errors), 1)
+        self.assertIsInstance(source_errors[0], RuntimeError)
+        self.assertEqual(str(source_errors[0]), "concurrent failure")
+        self.assertEqual(len(looked_up_modules), 1)
+        self.assertIs(looked_up_modules[0], context.user_modules[module_name])
+        self.assertNotIn("partial", looked_up_modules[0].kernels)
+
+        context.user_modules.pop(module_name)
+
     def test_failed_source_does_not_retain_its_namespace(self):
         global failed_payload_ref
 
@@ -270,10 +337,13 @@ def identity(values: wp.array(dtype=wp.float32)):
         self.assertNotIn(synthetic_filename, linecache.cache)
 
     def test_result_is_read_only_and_excludes_reserved_names(self):
-        generated = wp.exec_source("value = 42", module_name="warp.tests.exec_source.result_mapping")
+        generated = wp.exec_source(
+            '"""Generated module documentation."""\nvalue = 42',
+            module_name="warp.tests.exec_source.result_mapping",
+        )
         self.assertIsInstance(generated, types.MappingProxyType)
         self.assertEqual(generated["value"], 42)
-        for reserved_name in ("__builtins__", "__file__", "__name__", "__package__", "wp"):
+        for reserved_name in ("__builtins__", "__doc__", "__file__", "__name__", "__package__", "wp"):
             self.assertNotIn(reserved_name, generated)
         with self.assertRaises(TypeError):
             generated["value"] = 0  # type: ignore[index]

--- a/warp/tests/test_exec_source.py
+++ b/warp/tests/test_exec_source.py
@@ -26,8 +26,11 @@ def file_defined_increment(values: wp.array(dtype=wp.float32)):
 class TestExecSource(unittest.TestCase):
     """Test execution of trusted source containing Warp definitions."""
 
+    def test_public_export(self):
+        self.assertIs(wp.exec_source, context.exec_source)
+
     def test_kernel_with_array_and_scalar_arguments(self):
-        generated = context._exec_source(
+        generated = wp.exec_source(
             """
 @wp.kernel
 def scale(values: wp.array(dtype=wp.float32), factor: float):
@@ -46,7 +49,7 @@ import numpy as np
 import warp as wp
 from warp._src import context
 
-generated = context._exec_source('''
+generated = wp.exec_source('''
 @wp.kernel
 def double(values: wp.array(dtype=wp.float32)):
     i = wp.tid()
@@ -62,7 +65,7 @@ print('OK')
         self.assertIn("OK", result.stdout)
 
     def test_multiple_kernels(self):
-        generated = context._exec_source(
+        generated = wp.exec_source(
             """
 @wp.kernel
 def add_one(values: wp.array(dtype=wp.float32)):
@@ -82,7 +85,7 @@ def multiply_two(values: wp.array(dtype=wp.float32)):
         np.testing.assert_allclose(values.numpy(), np.array([4.0, 6.0], dtype=np.float32))
 
     def test_function_struct_import_and_annotations(self):
-        generated = context._exec_source(
+        generated = wp.exec_source(
             """
 import math
 
@@ -113,13 +116,13 @@ rounded = math.ceil(1.25)
 
     def test_input_validation(self):
         with self.assertRaisesRegex(TypeError, "source must be a string"):
-            context._exec_source(None)  # type: ignore[arg-type]
+            wp.exec_source(None)  # type: ignore[arg-type]
         with self.assertRaisesRegex(TypeError, "module name must be a string or None"):
-            context._exec_source("", module_name=1)  # type: ignore[arg-type]
+            wp.exec_source("", module_name=1)  # type: ignore[arg-type]
         for module_name in ("", "invalid-name", "valid.invalid-name", "valid.class"):
             with self.subTest(module_name=module_name):
                 with self.assertRaisesRegex(ValueError, "valid dotted Python identifier"):
-                    context._exec_source("", module_name=module_name)
+                    wp.exec_source("", module_name=module_name)
 
     def test_syntax_error_location(self):
         module_name = "warp.tests.exec_source.syntax_error"
@@ -129,7 +132,7 @@ def broken(values: wp.array(dtype=wp.float32)):
     values[0] =
 """
         with self.assertRaises(SyntaxError) as raised:
-            context._exec_source(source, module_name=module_name)
+            wp.exec_source(source, module_name=module_name)
         self.assertTrue(raised.exception.filename.startswith(f"<warp-source:{module_name}:"))
         self.assertEqual(raised.exception.lineno, 4)
         self.assertNotIn(module_name, context.user_modules)
@@ -137,7 +140,7 @@ def broken(values: wp.array(dtype=wp.float32)):
 
     def test_codegen_error_location(self):
         module_name = "warp.tests.exec_source.codegen_error"
-        generated = context._exec_source(
+        generated = wp.exec_source(
             """
 @wp.kernel
 def broken(values: wp.array(dtype=wp.float32)):
@@ -157,7 +160,7 @@ def broken(values: wp.array(dtype=wp.float32)):
     def test_runtime_error_before_registration(self):
         module_name = "warp.tests.exec_source.early_failure"
         with self.assertRaisesRegex(RuntimeError, "early failure"):
-            context._exec_source('raise RuntimeError("early failure")', module_name=module_name)
+            wp.exec_source('raise RuntimeError("early failure")', module_name=module_name)
         self.assertNotIn(module_name, context.user_modules)
         self.assertNotIn(module_name, context._generated_source_modules)
 
@@ -172,7 +175,7 @@ def partial(values: wp.array(dtype=wp.float32)):
 raise SystemExit(7)
 """
         with self.assertRaises(SystemExit):
-            context._exec_source(source, module_name=module_name)
+            wp.exec_source(source, module_name=module_name)
         self.assertNotIn(module_name, context.user_modules)
         self.assertNotIn(module_name, context._generated_source_modules)
 
@@ -187,7 +190,7 @@ def partial(values: wp.array(dtype=wp.float32)):
 raise RuntimeError("failure after registration")
 """
         try:
-            context._exec_source(source, module_name=module_name)
+            wp.exec_source(source, module_name=module_name)
         except RuntimeError as error:
             self.assertIn("failure after registration", str(error))
             traceback = error.__traceback__
@@ -225,7 +228,7 @@ def partial(values: wp.array(dtype=wp.float32)):
 raise RuntimeError("discard namespace")
 """
         with self.assertRaisesRegex(RuntimeError, "discard namespace"):
-            context._exec_source(source, module_name=module_name)
+            wp.exec_source(source, module_name=module_name)
 
         gc.collect()
         self.assertIsNotNone(failed_payload_ref)
@@ -234,7 +237,7 @@ raise RuntimeError("discard namespace")
 
     def test_collision_with_file_backed_module(self):
         with self.assertRaisesRegex(ValueError, "collides with an existing module"):
-            context._exec_source("value = 1", module_name=__name__)
+            wp.exec_source("value = 1", module_name=__name__)
         self.assertIs(wp.get_module(__name__), file_defined_increment.module)
 
     def test_default_name_reuse(self):
@@ -245,15 +248,15 @@ def default_identity(values: wp.array(dtype=wp.float32)):
     values[i] = values[i]
 """
         count_before = len(context._generated_source_modules)
-        first = context._exec_source(source)
-        second = context._exec_source(source)
+        first = wp.exec_source(source)
+        second = wp.exec_source(source)
         self.assertIs(first, second)
         self.assertTrue(first["default_identity"].module.name.startswith("__warp_source_"))
         self.assertEqual(len(context._generated_source_modules), count_before + 1)
 
     def test_success_removes_linecache_entry(self):
         module_name = "warp.tests.exec_source.linecache_success"
-        generated = context._exec_source(
+        generated = wp.exec_source(
             """
 @wp.kernel
 def identity(values: wp.array(dtype=wp.float32)):
@@ -267,7 +270,7 @@ def identity(values: wp.array(dtype=wp.float32)):
         self.assertNotIn(synthetic_filename, linecache.cache)
 
     def test_result_is_read_only_and_excludes_reserved_names(self):
-        generated = context._exec_source("value = 42", module_name="warp.tests.exec_source.result_mapping")
+        generated = wp.exec_source("value = 42", module_name="warp.tests.exec_source.result_mapping")
         self.assertIsInstance(generated, types.MappingProxyType)
         self.assertEqual(generated["value"], 42)
         for reserved_name in ("__builtins__", "__file__", "__name__", "__package__", "wp"):
@@ -278,21 +281,21 @@ def identity(values: wp.array(dtype=wp.float32)):
     def test_explicit_name_reuse(self):
         source = "value = object()"
         module_name = "warp.tests.exec_source.explicit_reuse"
-        first = context._exec_source(source, module_name=module_name)
-        second = context._exec_source(source, module_name=module_name)
+        first = wp.exec_source(source, module_name=module_name)
+        second = wp.exec_source(source, module_name=module_name)
         self.assertIs(first, second)
         self.assertIs(first["value"], second["value"])
 
     def test_changed_source_is_rejected_without_mutation(self):
         module_name = "warp.tests.exec_source.changed_rejected"
-        first = context._exec_source("value = 1", module_name=module_name)
+        first = wp.exec_source("value = 1", module_name=module_name)
         with self.assertRaisesRegex(ValueError, "different source"):
-            context._exec_source("value = 2", module_name=module_name)
+            wp.exec_source("value = 2", module_name=module_name)
         self.assertIs(context._generated_source_modules[module_name].result, first)
         self.assertEqual(first["value"], 1)
 
     def test_same_symbol_in_different_modules(self):
-        first = context._exec_source(
+        first = wp.exec_source(
             """
 @wp.kernel
 def shared(values: wp.array(dtype=wp.float32)):
@@ -301,7 +304,7 @@ def shared(values: wp.array(dtype=wp.float32)):
 """,
             module_name="warp.tests.exec_source.shared_a",
         )
-        second = context._exec_source(
+        second = wp.exec_source(
             """
 @wp.kernel
 def shared(values: wp.array(dtype=wp.float32)):
@@ -325,8 +328,8 @@ def operation(values: wp.array(dtype=wp.float32)):
     i = wp.tid()
     values[i] = values[i] * {factor}.0
 """
-        first = context._exec_source(template.format(factor=2), module_name="warp.tests.exec_source.body_a")
-        second = context._exec_source(template.format(factor=5), module_name="warp.tests.exec_source.body_b")
+        first = wp.exec_source(template.format(factor=2), module_name="warp.tests.exec_source.body_a")
+        second = wp.exec_source(template.format(factor=5), module_name="warp.tests.exec_source.body_b")
         first_values = wp.array([3.0], dtype=wp.float32, device="cpu")
         second_values = wp.array([3.0], dtype=wp.float32, device="cpu")
         wp.launch(first["operation"], dim=1, inputs=[first_values], device="cpu")
@@ -350,17 +353,17 @@ def operation(values: wp.array(dtype=wp.float32), parameters: Parameters):
     i = wp.tid()
     values[i] = helper(values[i], parameters)
 """
-        unchanged_a = context._exec_source(
+        unchanged_a = wp.exec_source(
             template.format(extra_field="", helper_suffix=""), module_name="warp.tests.exec_source.hash_base_a"
         )
-        unchanged_b = context._exec_source(
+        unchanged_b = wp.exec_source(
             template.format(extra_field="", helper_suffix=""), module_name="warp.tests.exec_source.hash_base_b"
         )
-        helper_changed = context._exec_source(
+        helper_changed = wp.exec_source(
             template.format(extra_field="", helper_suffix="+ 1.0"),
             module_name="warp.tests.exec_source.hash_helper",
         )
-        struct_changed = context._exec_source(
+        struct_changed = wp.exec_source(
             template.format(extra_field="offset: wp.float32", helper_suffix=""),
             module_name="warp.tests.exec_source.hash_struct",
         )
@@ -371,7 +374,7 @@ def operation(values: wp.array(dtype=wp.float32), parameters: Parameters):
 
     def test_file_defined_kernel_and_lookup_are_unaffected(self):
         original_module = wp.get_module(__name__)
-        context._exec_source(
+        wp.exec_source(
             """
 @wp.kernel
 def generated_identity(values: wp.array(dtype=wp.float32)):

--- a/warp/tests/test_exec_source.py
+++ b/warp/tests/test_exec_source.py
@@ -1,0 +1,391 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+import linecache
+import subprocess
+import sys
+import types
+import unittest
+
+import numpy as np
+
+import warp as wp
+from warp._src import context
+from warp._src.codegen import WarpCodegenKeyError
+
+failed_payload_ref = None
+
+
+@wp.kernel
+def file_defined_increment(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i] + 1.0
+
+
+class TestExecSource(unittest.TestCase):
+    """Test execution of trusted source containing Warp definitions."""
+
+    def test_kernel_with_array_and_scalar_arguments(self):
+        generated = context._exec_source(
+            """
+@wp.kernel
+def scale(values: wp.array(dtype=wp.float32), factor: float):
+    i = wp.tid()
+    values[i] = values[i] * factor
+""",
+            module_name="warp.tests.exec_source.array_scalar",
+        )
+        values = wp.array([1.0, 2.0, 3.0], dtype=wp.float32, device="cpu")
+        wp.launch(generated["scale"], dim=values.shape, inputs=[values, 3.0], device="cpu")
+        np.testing.assert_allclose(values.numpy(), np.array([3.0, 6.0, 9.0], dtype=np.float32))
+
+    def test_subprocess_workflow(self):
+        code = """
+import numpy as np
+import warp as wp
+from warp._src import context
+
+generated = context._exec_source('''
+@wp.kernel
+def double(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i] * 2.0
+''', module_name='warp.tests.exec_source.subprocess')
+values = wp.array([1.0, 2.0], dtype=wp.float32, device='cpu')
+wp.launch(generated['double'], dim=2, inputs=[values], device='cpu')
+np.testing.assert_allclose(values.numpy(), np.array([2.0, 4.0], dtype=np.float32))
+print('OK')
+"""
+        result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("OK", result.stdout)
+
+    def test_multiple_kernels(self):
+        generated = context._exec_source(
+            """
+@wp.kernel
+def add_one(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i] + 1.0
+
+@wp.kernel
+def multiply_two(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i] * 2.0
+""",
+            module_name="warp.tests.exec_source.multiple_kernels",
+        )
+        values = wp.array([1.0, 2.0], dtype=wp.float32, device="cpu")
+        wp.launch(generated["add_one"], dim=values.shape, inputs=[values], device="cpu")
+        wp.launch(generated["multiply_two"], dim=values.shape, inputs=[values], device="cpu")
+        np.testing.assert_allclose(values.numpy(), np.array([4.0, 6.0], dtype=np.float32))
+
+    def test_function_struct_import_and_annotations(self):
+        generated = context._exec_source(
+            """
+import math
+
+@wp.struct
+class Parameters:
+    factor: wp.float32
+
+@wp.func
+def apply_factor(value: wp.float32, parameters: Parameters):
+    return value * parameters.factor
+
+@wp.kernel
+def transform(values: wp.array(dtype=wp.float32), parameters: Parameters):
+    i = wp.tid()
+    values[i] = apply_factor(values[i], parameters)
+
+rounded = math.ceil(1.25)
+""",
+            module_name="warp.tests.exec_source.constructs",
+        )
+        parameters = generated["Parameters"]()
+        parameters.factor = 4.0
+        values = wp.array([1.0, 2.0], dtype=wp.float32, device="cpu")
+        wp.launch(generated["transform"], dim=values.shape, inputs=[values, parameters], device="cpu")
+        np.testing.assert_allclose(values.numpy(), np.array([4.0, 8.0], dtype=np.float32))
+        self.assertEqual(generated["rounded"], 2)
+        self.assertIn("math", generated)
+
+    def test_input_validation(self):
+        with self.assertRaisesRegex(TypeError, "source must be a string"):
+            context._exec_source(None)  # type: ignore[arg-type]
+        with self.assertRaisesRegex(TypeError, "module name must be a string or None"):
+            context._exec_source("", module_name=1)  # type: ignore[arg-type]
+        for module_name in ("", "invalid-name", "valid.invalid-name", "valid.class"):
+            with self.subTest(module_name=module_name):
+                with self.assertRaisesRegex(ValueError, "valid dotted Python identifier"):
+                    context._exec_source("", module_name=module_name)
+
+    def test_syntax_error_location(self):
+        module_name = "warp.tests.exec_source.syntax_error"
+        source = """value = 1
+@wp.kernel
+def broken(values: wp.array(dtype=wp.float32)):
+    values[0] =
+"""
+        with self.assertRaises(SyntaxError) as raised:
+            context._exec_source(source, module_name=module_name)
+        self.assertTrue(raised.exception.filename.startswith(f"<warp-source:{module_name}:"))
+        self.assertEqual(raised.exception.lineno, 4)
+        self.assertNotIn(module_name, context.user_modules)
+        self.assertNotIn(module_name, context._generated_source_modules)
+
+    def test_codegen_error_location(self):
+        module_name = "warp.tests.exec_source.codegen_error"
+        generated = context._exec_source(
+            """
+@wp.kernel
+def broken(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = missing_function(i)
+""",
+            module_name=module_name,
+        )
+        values = wp.zeros(1, dtype=wp.float32, device="cpu")
+        with self.assertRaises(WarpCodegenKeyError) as raised:
+            wp.launch(generated["broken"], dim=1, inputs=[values], device="cpu")
+        message = str(raised.exception)
+        self.assertIn(f"<warp-source:{module_name}:", message)
+        self.assertIn(":5", message)
+        self.assertIn("missing_function", message)
+
+    def test_runtime_error_before_registration(self):
+        module_name = "warp.tests.exec_source.early_failure"
+        with self.assertRaisesRegex(RuntimeError, "early failure"):
+            context._exec_source('raise RuntimeError("early failure")', module_name=module_name)
+        self.assertNotIn(module_name, context.user_modules)
+        self.assertNotIn(module_name, context._generated_source_modules)
+
+    def test_system_exit_after_registration_is_atomic(self):
+        module_name = "warp.tests.exec_source.system_exit"
+        source = """
+@wp.kernel
+def partial(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i]
+
+raise SystemExit(7)
+"""
+        with self.assertRaises(SystemExit):
+            context._exec_source(source, module_name=module_name)
+        self.assertNotIn(module_name, context.user_modules)
+        self.assertNotIn(module_name, context._generated_source_modules)
+
+    def test_failure_after_registration_is_atomic(self):
+        module_name = "warp.tests.exec_source.partial_failure"
+        source = """
+@wp.kernel
+def partial(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i]
+
+raise RuntimeError("failure after registration")
+"""
+        try:
+            context._exec_source(source, module_name=module_name)
+        except RuntimeError as error:
+            self.assertIn("failure after registration", str(error))
+            traceback = error.__traceback__
+        else:
+            self.fail("Expected source execution to fail")
+        self.assertIsNotNone(traceback)
+        while traceback.tb_next is not None:
+            traceback = traceback.tb_next
+        self.assertTrue(traceback.tb_frame.f_code.co_filename.startswith(f"<warp-source:{module_name}:"))
+        self.assertNotIn(module_name, context.user_modules)
+        self.assertNotIn(module_name, context._generated_source_modules)
+        self.assertFalse(any(name.startswith(f"<warp-source:{module_name}:") for name in linecache.cache))
+
+    def test_failed_source_does_not_retain_its_namespace(self):
+        global failed_payload_ref
+
+        module_name = "warp.tests.exec_source.failed_namespace"
+        source = f"""
+import weakref
+import importlib
+
+test_module = importlib.import_module({__name__!r})
+
+class Payload:
+    pass
+
+payload = Payload()
+test_module.failed_payload_ref = weakref.ref(payload)
+
+@wp.kernel
+def partial(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i]
+
+raise RuntimeError("discard namespace")
+"""
+        with self.assertRaisesRegex(RuntimeError, "discard namespace"):
+            context._exec_source(source, module_name=module_name)
+
+        gc.collect()
+        self.assertIsNotNone(failed_payload_ref)
+        self.assertIsNone(failed_payload_ref())
+        failed_payload_ref = None
+
+    def test_collision_with_file_backed_module(self):
+        with self.assertRaisesRegex(ValueError, "collides with an existing module"):
+            context._exec_source("value = 1", module_name=__name__)
+        self.assertIs(wp.get_module(__name__), file_defined_increment.module)
+
+    def test_default_name_reuse(self):
+        source = """
+@wp.kernel
+def default_identity(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i]
+"""
+        count_before = len(context._generated_source_modules)
+        first = context._exec_source(source)
+        second = context._exec_source(source)
+        self.assertIs(first, second)
+        self.assertTrue(first["default_identity"].module.name.startswith("__warp_source_"))
+        self.assertEqual(len(context._generated_source_modules), count_before + 1)
+
+    def test_success_removes_linecache_entry(self):
+        module_name = "warp.tests.exec_source.linecache_success"
+        generated = context._exec_source(
+            """
+@wp.kernel
+def identity(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i]
+""",
+            module_name=module_name,
+        )
+        synthetic_filename = generated["identity"].adj.filename
+        self.assertTrue(synthetic_filename.startswith(f"<warp-source:{module_name}:"))
+        self.assertNotIn(synthetic_filename, linecache.cache)
+
+    def test_result_is_read_only_and_excludes_reserved_names(self):
+        generated = context._exec_source("value = 42", module_name="warp.tests.exec_source.result_mapping")
+        self.assertIsInstance(generated, types.MappingProxyType)
+        self.assertEqual(generated["value"], 42)
+        for reserved_name in ("__builtins__", "__file__", "__name__", "__package__", "wp"):
+            self.assertNotIn(reserved_name, generated)
+        with self.assertRaises(TypeError):
+            generated["value"] = 0  # type: ignore[index]
+
+    def test_explicit_name_reuse(self):
+        source = "value = object()"
+        module_name = "warp.tests.exec_source.explicit_reuse"
+        first = context._exec_source(source, module_name=module_name)
+        second = context._exec_source(source, module_name=module_name)
+        self.assertIs(first, second)
+        self.assertIs(first["value"], second["value"])
+
+    def test_changed_source_is_rejected_without_mutation(self):
+        module_name = "warp.tests.exec_source.changed_rejected"
+        first = context._exec_source("value = 1", module_name=module_name)
+        with self.assertRaisesRegex(ValueError, "different source"):
+            context._exec_source("value = 2", module_name=module_name)
+        self.assertIs(context._generated_source_modules[module_name].result, first)
+        self.assertEqual(first["value"], 1)
+
+    def test_same_symbol_in_different_modules(self):
+        first = context._exec_source(
+            """
+@wp.kernel
+def shared(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i] * 2.0
+""",
+            module_name="warp.tests.exec_source.shared_a",
+        )
+        second = context._exec_source(
+            """
+@wp.kernel
+def shared(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i] * 3.0
+""",
+            module_name="warp.tests.exec_source.shared_b",
+        )
+        first_values = wp.array([2.0], dtype=wp.float32, device="cpu")
+        second_values = wp.array([2.0], dtype=wp.float32, device="cpu")
+        wp.launch(first["shared"], dim=1, inputs=[first_values], device="cpu")
+        wp.launch(second["shared"], dim=1, inputs=[second_values], device="cpu")
+        np.testing.assert_allclose(first_values.numpy(), np.array([4.0], dtype=np.float32))
+        np.testing.assert_allclose(second_values.numpy(), np.array([6.0], dtype=np.float32))
+        self.assertIsNot(first["shared"].module, second["shared"].module)
+
+    def test_changed_body_does_not_launch_stale_executable(self):
+        template = """
+@wp.kernel
+def operation(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i] * {factor}.0
+"""
+        first = context._exec_source(template.format(factor=2), module_name="warp.tests.exec_source.body_a")
+        second = context._exec_source(template.format(factor=5), module_name="warp.tests.exec_source.body_b")
+        first_values = wp.array([3.0], dtype=wp.float32, device="cpu")
+        second_values = wp.array([3.0], dtype=wp.float32, device="cpu")
+        wp.launch(first["operation"], dim=1, inputs=[first_values], device="cpu")
+        wp.launch(second["operation"], dim=1, inputs=[second_values], device="cpu")
+        np.testing.assert_allclose(first_values.numpy(), np.array([6.0], dtype=np.float32))
+        np.testing.assert_allclose(second_values.numpy(), np.array([15.0], dtype=np.float32))
+
+    def test_dependency_changes_affect_module_hash(self):
+        template = """
+@wp.struct
+class Parameters:
+    factor: wp.float32
+    {extra_field}
+
+@wp.func
+def helper(value: wp.float32, parameters: Parameters):
+    return value * parameters.factor {helper_suffix}
+
+@wp.kernel
+def operation(values: wp.array(dtype=wp.float32), parameters: Parameters):
+    i = wp.tid()
+    values[i] = helper(values[i], parameters)
+"""
+        unchanged_a = context._exec_source(
+            template.format(extra_field="", helper_suffix=""), module_name="warp.tests.exec_source.hash_base_a"
+        )
+        unchanged_b = context._exec_source(
+            template.format(extra_field="", helper_suffix=""), module_name="warp.tests.exec_source.hash_base_b"
+        )
+        helper_changed = context._exec_source(
+            template.format(extra_field="", helper_suffix="+ 1.0"),
+            module_name="warp.tests.exec_source.hash_helper",
+        )
+        struct_changed = context._exec_source(
+            template.format(extra_field="offset: wp.float32", helper_suffix=""),
+            module_name="warp.tests.exec_source.hash_struct",
+        )
+        base_hash = unchanged_a["operation"].module.hash_module()
+        self.assertEqual(base_hash, unchanged_b["operation"].module.hash_module())
+        self.assertNotEqual(base_hash, helper_changed["operation"].module.hash_module())
+        self.assertNotEqual(base_hash, struct_changed["operation"].module.hash_module())
+
+    def test_file_defined_kernel_and_lookup_are_unaffected(self):
+        original_module = wp.get_module(__name__)
+        context._exec_source(
+            """
+@wp.kernel
+def generated_identity(values: wp.array(dtype=wp.float32)):
+    i = wp.tid()
+    values[i] = values[i]
+""",
+            module_name="warp.tests.exec_source.file_kernel_control",
+        )
+        values = wp.array([1.0, 2.0], dtype=wp.float32, device="cpu")
+        wp.launch(file_defined_increment, dim=values.shape, inputs=[values], device="cpu")
+        self.assertIs(wp.get_module(__name__), original_module)
+        np.testing.assert_allclose(values.numpy(), np.array([2.0, 3.0], dtype=np.float32))
+
+
+if __name__ == "__main__":
+    wp.init()
+    unittest.main(verbosity=2)

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -184,6 +184,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestCoreExamples,
         TestOptimExamples,
     )
+    from warp.tests.test_exec_source import TestExecSource
     from warp.tests.test_fabricarray import TestFabricArray
     from warp.tests.test_factory_style_array_annotations import TestFactoryStyleArrayAnnotations
     from warp.tests.test_fast_math import TestFastMath
@@ -330,6 +331,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestDiagnostics,
         TestDLPack,
         TestEnum,
+        TestExecSource,
         TestCoreExamples,
         TestOptimExamples,
         TestFactoryStyleArrayAnnotations,


### PR DESCRIPTION
## Description

Add `wp.exec_source()` as a public API for executing trusted Python source containing decorated Warp definitions without requiring a backing `.py` file.

Warp normally obtains kernel source through Python's inspection machinery. Functions created directly through `exec()` do not have inspectable file-backed source, so attempting to decorate them with `@wp.kernel` currently fails unless callers manually create a module, provide source text to `wp.Kernel`, and manage source-location information themselves.

This enhancement packages that existing source and module machinery into a supported interface. It enables concise command-line experiments such as `python -c "..."` and generated Warp programs while preserving useful filenames and line numbers in Python syntax and Warp code-generation errors.

The initial supported and locally validated contract is intentionally limited to CPU kernel execution. This PR does not claim GPU or CUDA compatibility.

Addresses #1640.

## Changes

### Public API

Add:

```python
wp.exec_source(source: str, *, module_name: str | None = None) -> Mapping[str, Any]
```

The source is ordinary trusted Python and may contain:

- `@wp.kernel` definitions;
- `@wp.func` definitions;
- `@wp.struct` definitions;
- imports;
- constants; and
- other top-level Python statements.

Warp provides `wp` in the execution namespace. Plain Python functions are not automatically converted into Warp kernels; definitions intended for Warp must use the normal Warp decorators.

The function returns a read-only mapping containing the names created by the source. Internal execution names such as `wp`, `__name__`, `__file__`, `__package__`, and `__builtins__` are excluded from that mapping.

### Module identity and reuse

When `module_name` is omitted, Warp derives a deterministic generated module name from the SHA-256 digest of the exact UTF-8 source text.

When an explicit name is provided, it must be a valid dotted Python identifier.

Repeated execution follows these rules:

- the same resolved module name and identical source return the existing read-only mapping without executing the source again;
- the same explicit module name with changed source is rejected;
- generated names that collide with existing Python or Warp modules are rejected;
- the same symbol name may be used safely in separate generated modules; and
- changed source can be executed by assigning it a different module name.

Rejecting changed source under an existing name prevents an already compiled executable or previously registered definition from being reused silently.

The observable identity behavior is summarized below:

| Existing state | New call | Result |
| --- | --- | --- |
| No generated module | Name omitted | Derive a deterministic name from the exact source and execute it |
| No generated module | Valid explicit name | Execute the source under that name |
| Same resolved name and same source | Repeated call | Return the existing mapping without executing again |
| Same explicit name and changed source | Repeated call | Raise `ValueError` without changing the existing module |
| Same source and different explicit name | New call | Create a separate generated module |
| Same symbol name in different generated modules | New call | Keep the definitions and compiled modules separate |
| Name belonging to an existing Python or Warp module | New call | Raise `ValueError` before executing source |
| Invalid dotted module name | New call | Raise `ValueError` before changing registry state |

### Diagnostics

Generated source receives a synthetic filename containing its logical module name and a source-digest prefix, for example:

```text
<warp-source:generated_scale:0123456789ab>
```

The source is temporarily registered with Python's `linecache` while it is evaluated. This allows Python syntax errors and Warp code-generation errors to report the generated filename, source line, and line number without requiring a physical file.

The temporary `linecache` entry is restored or removed after execution. Successfully created Warp objects retain their synthetic source filename for later code-generation diagnostics.

### Failure handling and lifecycle

Source execution is performed under the generated-source registry lock so that creation and reuse decisions are atomic.

If execution fails after one or more Warp definitions have been registered, the implementation:

- removes the partially registered Warp module;
- detaches registered module references;
- unloads partial executable state;
- removes the generated-source record;
- restores the previous `linecache` state; and
- re-raises the original exception.

Failed execution therefore does not leave a discoverable half-populated module or retain the failed execution namespace unexpectedly.

### Security boundary

`wp.exec_source()` executes Python code with the privileges of the current process. It is intended only for trusted source and does not provide a sandbox, restricted interpreter, dependency resolver, or package-installation mechanism.

### Design boundaries and non-goals

This PR intentionally does not add:

- execution of untrusted or sandboxed Python;
- automatic conversion of undecorated Python functions into Warp kernels;
- replacement or hot reloading of an existing generated module;
- persistent serialization of generated modules;
- custom import resolution or support for relative imports;
- package or dependency installation;
- a new parser or alternate code-generation pipeline;
- native C++ or CUDA changes; or
- a GPU/CUDA compatibility guarantee.

These boundaries keep the implementation focused on making the existing Warp source/module workflow accessible through one public function.

### Documentation

This PR adds:

- a design document describing the API contract and alternatives;
- a user-guide example covering source definition, returned objects, and CPU launch;
- documentation for accepted source, module naming, reuse, collisions, diagnostics, imports, and security;
- an API-reference entry for `wp.exec_source()`; and
- an `Unreleased` changelog entry linked to GH-1640.

## Questions for maintainers

This is opened as a draft because the issue did not prescribe an exact public API. Feedback is particularly welcome on these choices:

1. Is `wp.exec_source()` an appropriate public name, or would a name emphasizing module loading be clearer?
2. Should the function continue returning a read-only mapping of all source-defined names, or should it expose a different module-like result?
3. Is rejecting changed source under an existing name preferable to supporting explicit replacement and invalidation?
4. Is deterministic naming from exact source bytes appropriate when `module_name` is omitted?
5. Should the initial documented compatibility contract remain CPU-only, or must CUDA validation be completed before the API can be accepted?

The design document records the alternatives considered so that changes to these decisions can be evaluated without reconstructing the investigation.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/warp/latest/project/contribution_guide.html).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] [CHANGELOG.md](CHANGELOG.md) is updated for this user-facing change under the `Unreleased` section.

## Validation summary

The existing behavior was first reproduced on a CPU-only Warp build. Directly executing source containing `@wp.kernel` failed because Python inspection could not recover source from the string. The existing manual workaround succeeded when the caller explicitly managed the source, namespace, Warp module, and kernel construction.

The new `TestExecSource` suite covers 22 cases, including:

- public API export;
- array and scalar kernel arguments;
- direct subprocess execution corresponding to `python -c`;
- multiple kernels from one source string;
- `@wp.func` and `@wp.struct` dependencies;
- imports and annotations;
- input and module-name validation;
- Python syntax-error filenames and line numbers;
- Warp code-generation diagnostics;
- runtime failures before and after Warp registration;
- rollback for `RuntimeError` and `SystemExit`;
- cleanup of failed execution namespaces and temporary `linecache` entries;
- collision with file-backed modules;
- deterministic default naming;
- identical-source reuse;
- changed-source rejection without registry mutation;
- identical symbols in separate modules;
- prevention of stale executable reuse;
- module-hash changes caused by helper and struct changes; and
- preservation of existing file-defined modules and kernels.

After the final rebase and direct-execution test correction:

- all 22 tests passed when `warp/tests/test_exec_source.py` was executed directly;
- all 22 tests passed through Warp's suite runner;
- generated-file, version-consistency, Ruff, formatting, and typo hooks passed for the corrected test; and
- `git diff --check` passed.

Additional validation performed on the feature branch:

- 138 related context, module, code-generation, and code-generation-instancing tests passed;
- the broader available-device suite passed 3,637 tests with 526 skipped;
- a manual `python -c` workflow compiled and launched a generated CPU kernel and produced the expected output;
- pre-commit hooks passed both for all contribution files and for the complete repository;
- the strict HTML documentation build completed successfully for 982 source files with warnings treated as errors; and
- every contribution commit contains a DCO sign-off matching its author email.

The repository-wide doctest run completed 94 examples with eight failures outside this contribution:

- four random tile examples produced values different from their recorded random samples;
- one differentiability example produced a different pre-existing gradient value;
- one tile example compared timing-dependent output; and
- two runtime examples require CUDA, which is unavailable in the local build.

None of these doctest failures involved `wp.exec_source()`, the changed code-generation guide, or another file changed by this PR.

Validation was performed with Warp 1.17.0.dev0 on:

```text
Device: cpu
Processor: AMD64 Family 23 Model 96
CUDA: disabled in this build
```

The implementation, tests, documentation claims, and validation boundary in this PR are CPU-only. GPU and CUDA behavior is outside the scope of this contribution.

## New feature / enhancement

The following example defines a Warp function and kernel from a source string and launches the generated kernel on CPU:

```python
import warp as wp

generated = wp.exec_source(
    """
@wp.func
def scale_value(value: float, factor: float):
    return value * factor

@wp.kernel
def scale(values: wp.array(dtype=wp.float32), factor: float):
    i = wp.tid()
    values[i] = scale_value(values[i], factor)
""",
    module_name="generated_scale",
)

values = wp.array([1.0, 2.0, 3.0], dtype=wp.float32, device="cpu")

wp.launch(
    generated["scale"],
    dim=values.shape,
    inputs=[values, 2.0],
    device="cpu",
)

print(values.numpy())
# [2. 4. 6.]
```

Multiple definitions can be retrieved from the returned mapping:

```python
scale_kernel = generated["scale"]
scale_function = generated["scale_value"]
```

Only trusted source should be passed to `wp.exec_source()`. The function executes ordinary Python and does not provide sandboxing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wp.exec_source()` for executing trusted Python source containing Warp kernels, functions, and structs.
  * Supports deterministic naming, caching, diagnostics, and read-only access to generated results.
  * Currently supports CPU execution.

* **Documentation**
  * Added API reference, programming guidance, usage examples, security notes, and current compatibility details.
  * Added an Unreleased changelog entry.

* **Bug Fixes**
  * Added validation and cleanup safeguards for failed execution and naming conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->