### PR TITLE
Fix kernel enable_backward for tile LTOs

### DIFF
--- a/changelog/+wp-grad-custom-grad.fixed.md
+++ b/changelog/+wp-grad-custom-grad.fixed.md
@@ -1,0 +1,3 @@
+Fix `wp.grad()` calls to functions with custom `@wp.func_grad` implementations failing to compile when the custom
+gradient was not otherwise referenced, and under-reserving forward shared memory when the custom gradient used tile
+operations.

--- a/changelog/1717.fixed.md
+++ b/changelog/1717.fixed.md
@@ -1,0 +1,3 @@
+Fix per-kernel `enable_backward` overrides being ignored while compiling kernels and shared functions. This caused
+module-level `enable_backward=False` to suppress required helper adjoints when re-enabled on a kernel, and caused
+unused MathDx backward LTOs when disabled on a kernel.

--- a/changelog/1717.fixed.md
+++ b/changelog/1717.fixed.md
@@ -1,0 +1,2 @@
+Fix `enable_backward=False` being ignored by MathDx-based tile operations when set on a kernel rather than on its
+module, which caused unused backward LTOs to be compiled and increased cold compilation time.

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -15710,9 +15710,9 @@ def tile_matmul_lto_dispatch_func(
         raise TypeError(
             "tile_matmul() does not support bfloat16 'a' or 'b' tiles when the backward pass is enabled. "
             "Allowed accumulator dtypes are float16, float32, and float64 (the backward pass uses 'a' "
-            "and 'b' as accumulators for adjA and adjB). If gradients are not needed, set "
-            "`enable_backward=False` on the kernel's module, e.g. "
-            "`wp.set_module_options({'enable_backward': False})`."
+            "and 'b' as accumulators for adjA and adjB). If gradients are not needed, disable the backward "
+            "pass with `@wp.kernel(enable_backward=False)` on the kernel, or "
+            "`wp.set_module_options({'enable_backward': False})` for the whole module."
         )
 
     if (

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -14908,9 +14908,9 @@ def tile_matmul_lto_dispatch_func(
         raise TypeError(
             "tile_matmul() does not support bfloat16 'a' or 'b' tiles when the backward pass is enabled. "
             "Allowed accumulator dtypes are float16, float32, and float64 (the backward pass uses 'a' "
-            "and 'b' as accumulators for adjA and adjB). If gradients are not needed, set "
-            "`enable_backward=False` on the kernel's module, e.g. "
-            "`wp.set_module_options({'enable_backward': False})`."
+            "and 'b' as accumulators for adjA and adjB). If gradients are not needed, disable the backward "
+            "pass with `@wp.kernel(enable_backward=False)` on the kernel, or "
+            "`wp.set_module_options({'enable_backward': False})` for the whole module."
         )
 
     if (

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -1961,7 +1961,7 @@ class Adjoint:
 
     # generate function ssa form and adjoint
     @synchronized(_codegen_lock)
-    def build(adj, builder, default_builder_options=None, callable_arg_values=None):
+    def build(adj, builder, default_builder_options=None, callable_arg_values=None, builder_options=None):
         # arg Var read/write flags are held during module rebuilds, so we reset here even when skipping a build
         for arg in adj.args:
             arg.is_read = False
@@ -1978,7 +1978,12 @@ class Adjoint:
         if default_builder_options is None:
             default_builder_options = {}
 
-        if adj.builder:
+        # ``builder_options`` lets a caller supply options the builder itself does not hold, notably a kernel's
+        # options merged over the module's. ``default_builder_options`` is different: it applies only when there
+        # is no builder at all.
+        if builder_options is not None:
+            adj.builder_options = builder_options
+        elif adj.builder:
             adj.builder_options = adj.builder.options
         else:
             adj.builder_options = default_builder_options
@@ -2016,6 +2021,9 @@ class Adjoint:
 
         # recorded at call sites for ModuleBuilder's post-build propagation passes
         adj.called_user_functions = set()
+        # wp.grad() invokes a user function's adjoint from forward code, so its backward shared-memory roofline
+        # contributes to this function's forward shared-memory requirement.
+        adj.called_grad_functions = set()
 
         # wp.ref[T] callees lacking a manual adjoint; rejected post-build, once used_by_backward_kernel is final
         adj.unvalidated_ref_calls = []
@@ -2398,6 +2406,41 @@ class Adjoint:
 
         return func.native_snippet is not None and func.adj_native_snippet is not None
 
+    def add_user_function_dependency(adj, func):
+        """Record and build a user function reached through a forward call edge."""
+        adj.called_user_functions.add(func)
+        uses_generated_adjoint = func.uses_generated_adjoint
+        used_by_backward_kernel = adj.used_by_backward_kernel and uses_generated_adjoint
+
+        if adj.builder is None:
+            # Builder-less analysis has no graph-finalization pass, so propagate requirements directly.
+            if used_by_backward_kernel:
+                func.adj.used_by_backward_kernel = True
+            if adj.force_adjoint_codegen and uses_generated_adjoint:
+                func.adj.force_adjoint_codegen = True
+
+            builder_options = adj.builder_options
+            if not uses_generated_adjoint:
+                builder_options = builder_options | {"enable_backward": False}
+            func.build(None, builder_options)
+            return
+
+        # Custom gradient and replay bodies must be built before forced-adjoint preparation so any wp.grad()
+        # dependencies they contain can promote and rebuild their own primal call graphs.
+        for deferred_func in (func.custom_grad_func, func.custom_replay_func):
+            if deferred_func is not None and deferred_func not in adj.builder.deferred_functions:
+                adj.builder.deferred_functions.append(deferred_func)
+
+        if func in adj.builder.functions:
+            return
+
+        adj.builder.build_function(
+            func,
+            # Discover the complete body before deciding whether its adjoint can and must be emitted.
+            enable_backward=False,
+            used_by_backward_kernel=used_by_backward_kernel,
+        )
+
     def emit_ref_adjoint_pointer(adj, var, prelude: list[str] | None = None):
         if var.ref_origin is None:
             raise WarpCodegenError(
@@ -2611,28 +2654,7 @@ class Adjoint:
 
         # if it is a user-function then build it recursively
         if not func.is_builtin():
-            # record the call-graph edge for the post-build propagation passes
-            adj.called_user_functions.add(func)
-            # If the function called is a user function,
-            # we need to ensure its adjoint is also being generated.
-            if adj.used_by_backward_kernel:
-                func.adj.used_by_backward_kernel = True
-            if adj.force_adjoint_codegen:
-                func.adj.force_adjoint_codegen = True
-
-            if adj.builder is None:
-                func.build(None, adj.builder_options)
-
-            elif func not in adj.builder.functions:
-                adj.builder.build_function(func)
-                # add custom grad, replay functions to the list of functions
-                # to be built later (invalid code could be generated if we built them now)
-                # so that they are not missed when only the forward function is imported
-                # from another module
-                if func.custom_grad_func:
-                    adj.builder.deferred_functions.append(func.custom_grad_func)
-                if func.custom_replay_func:
-                    adj.builder.deferred_functions.append(func.custom_replay_func)
+            adj.add_user_function_dependency(func)
 
             adj.deterministic.include_function_call(func, bound_args)
 
@@ -2744,17 +2766,7 @@ class Adjoint:
 
             # if the argument is a function (and not a builtin), then build it recursively
             if isinstance(func_arg_var, warp._src.context.Function) and not func_arg_var.is_builtin():
-                # a function-valued argument is a call-graph edge too
-                adj.called_user_functions.add(func_arg_var)
-                if adj.used_by_backward_kernel:
-                    func_arg_var.adj.used_by_backward_kernel = True
-                if adj.force_adjoint_codegen:
-                    func_arg_var.adj.force_adjoint_codegen = True
-
-                if adj.builder is None:
-                    func_arg_var.build(None, adj.builder_options)
-                else:
-                    adj.builder.build_function(func_arg_var)
+                adj.add_user_function_dependency(func_arg_var)
 
             if parameter_is_ref:
                 fwd_args.append(func_arg_var)
@@ -2884,14 +2896,25 @@ class Adjoint:
 
         # Ensure the function is built so its adjoint code exists.
         if not func.is_builtin():
-            # Force adjoint code generation for the function.
-            func.adj.force_adjoint_codegen = True
+            adj.called_grad_functions.add(func)
+
+            # Builder-backed calls are promoted from the completed graph. Builder-less analysis has no
+            # finalization pass, so it must propagate the requirement directly.
+            if func.uses_generated_adjoint and adj.builder is None:
+                func.adj.force_adjoint_codegen = True
 
             # Build the function if not already built
             if adj.builder is None:
-                func.build(None, adj.builder_options)
+                builder_options = adj.builder_options
+                if not func.uses_generated_adjoint:
+                    builder_options = builder_options | {"enable_backward": False}
+                func.build(None, builder_options)
             elif func not in adj.builder.functions:
-                adj.builder.build_function(func)
+                adj.builder.build_function(
+                    func,
+                    enable_backward=False,
+                    used_by_backward_kernel=False,
+                )
 
         # Get return type
         bound_arg_types = {k: get_arg_type(v) for k, v in bound_args.items()}
@@ -7262,7 +7285,7 @@ def codegen_func(adj, c_func_name: str, device="cpu", options=None, forward_only
             if should_generate_adjoint:
                 reverse_body = codegen_func_reverse(adj, func_type="function", device=device)
             else:
-                reverse_body = '\t// reverse mode disabled (module option "enable_backward" is False or no dependent kernel found with "enable_backward")\n'
+                reverse_body = '\t// reverse mode disabled (the "enable_backward" kernel or module option is False, or no dependent kernel found with "enable_backward")\n'
         s += template_prefix + reverse_template.format(
             name=c_func_name,
             return_type=return_type,

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -1951,7 +1951,7 @@ class Adjoint:
 
     # generate function ssa form and adjoint
     @synchronized(_codegen_lock)
-    def build(adj, builder, default_builder_options=None, callable_arg_values=None):
+    def build(adj, builder, default_builder_options=None, callable_arg_values=None, builder_options=None):
         # arg Var read/write flags are held during module rebuilds, so we reset here even when skipping a build
         for arg in adj.args:
             arg.is_read = False
@@ -1968,7 +1968,12 @@ class Adjoint:
         if default_builder_options is None:
             default_builder_options = {}
 
-        if adj.builder:
+        # ``builder_options`` lets a caller supply options the builder itself does not hold, notably a kernel's
+        # options merged over the module's. ``default_builder_options`` is different: it applies only when there
+        # is no builder at all.
+        if builder_options is not None:
+            adj.builder_options = builder_options
+        elif adj.builder:
             adj.builder_options = adj.builder.options
         else:
             adj.builder_options = default_builder_options
@@ -2006,6 +2011,9 @@ class Adjoint:
 
         # recorded at call sites for ModuleBuilder's post-build propagation passes
         adj.called_user_functions = set()
+        # wp.grad() invokes a user function's adjoint from forward code, so its backward shared-memory roofline
+        # contributes to this function's forward shared-memory requirement.
+        adj.called_grad_functions = set()
 
         # wp.ref[T] callees lacking a manual adjoint; rejected post-build, once used_by_backward_kernel is final
         adj.unvalidated_ref_calls = []
@@ -2874,6 +2882,8 @@ class Adjoint:
 
         # Ensure the function is built so its adjoint code exists.
         if not func.is_builtin():
+            adj.called_grad_functions.add(func)
+
             # Force adjoint code generation for the function.
             func.adj.force_adjoint_codegen = True
 
@@ -7264,7 +7274,7 @@ def codegen_func(adj, c_func_name: str, device="cpu", options=None, forward_only
             if should_generate_adjoint:
                 reverse_body = codegen_func_reverse(adj, func_type="function", device=device)
             else:
-                reverse_body = '\t// reverse mode disabled (module option "enable_backward" is False or no dependent kernel found with "enable_backward")\n'
+                reverse_body = '\t// reverse mode disabled (the "enable_backward" kernel or module option is False, or no dependent kernel found with "enable_backward")\n'
         s += template_prefix + reverse_template.format(
             name=c_func_name,
             return_type=return_type,

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -473,6 +473,11 @@ class Function:
     def is_builtin(self) -> bool:
         return self.func is None
 
+    @property
+    def uses_generated_adjoint(self) -> bool:
+        """Whether reverse calls use the adjoint generated from this function's primal body."""
+        return self.custom_grad_func is None
+
     def is_simple(self) -> bool:
         if self.variadic:
             return False
@@ -668,8 +673,8 @@ class Function:
         bound_args = tuple(bound_args.arguments.values())
         return call_builtin_from_desc(desc, bound_args)
 
-    def build(self, builder: ModuleBuilder | None, default_builder_options=None):
-        self.adj.build(builder, default_builder_options)
+    def build(self, builder: ModuleBuilder | None, default_builder_options=None, builder_options=None):
+        self.adj.build(builder, default_builder_options, builder_options=builder_options)
 
         # complete the function return type after we have analyzed it (inferred from return statement in ast)
         if not self.value_func:
@@ -2847,9 +2852,12 @@ class ModuleBuilder:
     def __init__(self, module, options, hasher=None):
         self.functions = {}
         self.structs = {}
+        # Keep the resolved module options as the immutable base for per-kernel option merges.
+        self.default_kernel_options = options
         self.options = options
         self.module = module
         self.deferred_functions = []
+        self.deferred_function_index = 0
         self.fatbins = {}  # map from <some identifier> to fatbins, to add at link time
         self.ltoirs = {}  # map from lto symbol to lto binary
         self.ltoirs_decl = {}  # map from lto symbol to lto forward declaration
@@ -2860,18 +2868,27 @@ class ModuleBuilder:
 
         # build all unique kernels
         self.kernels = hasher.get_unique_kernels()
+
         for kernel in self.kernels:
             self.build_kernel(kernel)
 
         # build deferred functions
-        for func in self.deferred_functions:
-            self.build_function(func)
+        self._build_deferred_functions()
 
-        # propagate used_by_backward_kernel now that the full call graph is known
-        self._propagate_used_by_backward_kernel()
+        # wp.grad() can target a function with a custom gradient that is otherwise unreachable. Build those custom
+        # bodies, including nested wp.grad() dependencies, before forced-adjoint preparation and code generation.
+        self._build_grad_custom_functions()
+
+        # Functions are initially built forward-only so their bodies can reveal whether an adjoint is meaningful.
+        # Promote functions that are reachable from a backward-enabled kernel, or forced by wp.grad(), until
+        # rebuilding no longer changes the call graph or its effective backward requirements.
+        self._prepare_adjoint_functions()
 
         # propagate callee replay/reverse shared-memory needs into backward-kernel sizing
         self._propagate_backward_shared_memory()
+
+    def _get_effective_kernel_options(self, kernel):
+        return self.default_kernel_options | kernel.options
 
     def build_struct_recursive(self, struct: warp._src.codegen.Struct):
         structs = []
@@ -2957,35 +2974,153 @@ class ModuleBuilder:
         return struct_hashes
 
     def build_kernel(self, kernel):
-        if kernel.options.get("enable_backward", True):
-            kernel.adj.used_by_backward_kernel = True
+        options = self._get_effective_kernel_options(kernel)
+        kernel.adj.used_by_backward_kernel = options["enable_backward"]
 
         if self._kernel_has_invalid_return_annotation(kernel) or self._kernel_has_value_return(kernel):
             raise WarpCodegenTypeError(f"'{kernel.key}': {_KERNEL_RETURN_ERROR}")
 
-        kernel.adj.build(self)
+        # Kernel options must reach the tile LTO dispatch, which reads ``adj.builder_options``.
+        kernel.adj.build(self, builder_options=options)
 
         if kernel.adj.return_var is not None:
             raise WarpCodegenTypeError(f"'{kernel.key}': {_KERNEL_RETURN_ERROR}")
 
-    def build_function(self, func):
+    def build_function(self, func, enable_backward=None, used_by_backward_kernel=None):
         if func in self.functions:
             return
         else:
-            func.build(self)
+            builder_options = self.options
+            if enable_backward is not None:
+                builder_options = builder_options | {"enable_backward": enable_backward}
+            if used_by_backward_kernel is not None:
+                # Adjoint state is shared across builders, so overwrite rather than only setting True.
+                func.adj.used_by_backward_kernel = used_by_backward_kernel
+
+            func.build(self, builder_options=builder_options)
 
             # use dict to preserve import order
             self.functions[func] = None
 
+    def _build_deferred_functions(self):
+        """Build custom gradient and replay bodies as forward-only functions."""
+
+        while self.deferred_function_index < len(self.deferred_functions):
+            func = self.deferred_functions[self.deferred_function_index]
+            self.deferred_function_index += 1
+            self.build_function(func, enable_backward=False, used_by_backward_kernel=False)
+
+    def _build_grad_custom_functions(self):
+        """Build custom gradients reached through ``wp.grad()`` until no new ones are found."""
+
+        processed = set()
+        while True:
+            pending = [
+                obj.adj
+                for obj in (*self.functions, *self.kernels)
+                if obj.adj not in processed and not obj.adj.skip_build
+            ]
+            if not pending:
+                break
+            for adj in pending:
+                processed.add(adj)
+                for grad_func in adj.called_grad_functions:
+                    if grad_func.custom_grad_func is not None:
+                        self.build_function(
+                            grad_func.custom_grad_func,
+                            enable_backward=False,
+                            used_by_backward_kernel=False,
+                        )
+
+    def _prepare_adjoint_functions(self) -> None:
+        """Prepare functions that require Warp-generated backward code.
+
+        Each pass recomputes which functions are needed by backward-enabled
+        kernels and ``wp.grad()`` calls, including functions they call indirectly.
+        Functions that need generated backward code are rebuilt with backward code
+        generation enabled. A rebuild can reveal more functions to build, so the
+        method repeats until there is nothing else to rebuild.
+
+        Each function is rebuilt at most once. A function with a custom gradient
+        already provides its backward implementation, and a function that calls
+        ``wp.grad()`` does not get generated backward code. Failed builds are also
+        skipped because their recorded calls may be stale.
+        """
+
+        # Track rebuild attempts separately from options so a build that returns without updating its options
+        # cannot be selected forever.
+        rebuilt = set()
+        while True:
+            self._propagate_used_by_backward_kernel()
+            self._propagate_force_adjoint_codegen()
+
+            rebuild = [
+                func
+                for func in self.functions
+                if (func.adj.used_by_backward_kernel or func.adj.force_adjoint_codegen)
+                and func.uses_generated_adjoint
+                and not func.adj.skip_build
+                and not func.adj.uses_grad_call
+                and func not in rebuilt
+                and not func.adj.builder_options.get("enable_backward", True)
+            ]
+            if not rebuild:
+                break
+            for func in rebuild:
+                adj = func.adj
+                rebuilt.add(func)
+                adj.build(self, builder_options=adj.builder_options | {"enable_backward": True})
+
+            self._build_deferred_functions()
+            self._build_grad_custom_functions()
+
+    def _propagate_force_adjoint_codegen(self):
+        # Recompute from wp.grad() calls in this builder because Adjoint state is shared across module builds.
+        for func in self.functions:
+            func.adj.force_adjoint_codegen = False
+
+        worklist = []
+        for obj in (*self.kernels, *self.functions):
+            adj = obj.adj
+            if adj.skip_build:
+                continue
+            for grad_func in adj.called_grad_functions:
+                if grad_func.uses_generated_adjoint and not grad_func.adj.force_adjoint_codegen:
+                    grad_func.adj.force_adjoint_codegen = True
+                    worklist.append(grad_func.adj)
+
+        while worklist:
+            adj = worklist.pop()
+            if adj.skip_build:
+                continue
+            if adj.is_user_function and adj.uses_grad_call:
+                continue
+            for callee in adj.called_user_functions:
+                if callee.uses_generated_adjoint and not callee.adj.force_adjoint_codegen:
+                    callee.adj.force_adjoint_codegen = True
+                    worklist.append(callee.adj)
+
     def _propagate_used_by_backward_kernel(self):
-        # build_function() memoizes, so a helper built from a forward-only path before a backward
-        # kernel reaches it keeps its callees stubbed; re-propagate across the graph to a fixpoint.
-        worklist = [obj.adj for obj in (*self.kernels, *self.functions) if obj.adj.used_by_backward_kernel]
+        # Recompute from this builder's kernel roots because Adjoint state is shared across module builds.
+        for func in self.functions:
+            func.adj.used_by_backward_kernel = False
+
+        worklist = []
+        for kernel in self.kernels:
+            kernel.adj.used_by_backward_kernel = self._get_effective_kernel_options(kernel)["enable_backward"]
+            if kernel.adj.used_by_backward_kernel:
+                worklist.append(kernel.adj)
+
         # worklist algorithm: an adj is enqueued only on a False->True flip, so the loop exits even on cycles
         while worklist:
             adj = worklist.pop()
+            if adj.skip_build:
+                continue
+            # Calls to this function omit its reverse call, so its ordinary callees are replay-only on this path.
+            if adj.is_user_function and adj.uses_grad_call:
+                continue
             for callee in adj.called_user_functions:
-                if not callee.adj.used_by_backward_kernel:
+                if callee.uses_generated_adjoint and not callee.adj.used_by_backward_kernel:
                     callee.adj.used_by_backward_kernel = True
                     worklist.append(callee.adj)
         # backward use is final only now, so this is where wp.ref[T] calls recorded by
@@ -3021,18 +3156,82 @@ class ModuleBuilder:
             for callee in adj.called_user_functions:
                 for extra_fn in (callee.custom_grad_func, callee.custom_replay_func):
                     if extra_fn is not None:
-                        self.build_function(extra_fn)
+                        self.build_function(
+                            extra_fn,
+                            enable_backward=False,
+                            used_by_backward_kernel=False,
+                        )
 
-        # one pass in callees-before-callers order reaches the fixpoint: build_function()
-        # registers a function only after its callees finished building, so self.functions
-        # insertion order is topological, and kernels are roots
-        folded = set()
-        for adj in adjs:
+        # Custom gradient bodies can discover wp.grad() targets after their callers were registered, so insertion
+        # order is not necessarily topological. Fold forward and backward rooflines separately: a custom gradient
+        # calling its primal is a valid forward dependency, not a recursive request for its own gradient.
+        adjs = [obj.adj for obj in (*self.functions, *self.kernels)]
+        forward_folded = set()
+        forward_folding = set()
+        backward_folded = set()
+        backward_folding = set()
+
+        def fold_grad_requirement(grad_func):
+            """Fold and return the shared-memory frame executed by ``wp.grad()``."""
+
+            if grad_func.custom_grad_func is not None:
+                grad_adj = grad_func.custom_grad_func.adj
+                fold_forward(grad_adj)
+                return grad_adj.get_total_required_shared()
+
+            grad_adj = grad_func.adj
+            fold_backward(grad_adj)
+            return grad_adj.get_total_required_shared_backward()
+
+        def fold_forward(adj):
+            if adj in forward_folded:
+                return
+            if adj in forward_folding:
+                raise RuntimeError(f"Cannot size shared memory for '{adj.fun_name}': the call graph contains a cycle")
+
             # an errored adj (skip_build) has stale edges and can never launch; keep its value
-            # as-is, marked folded so live callers of such a function don't trip the guard below
+            # as-is, marked folded so live callers of such a function can still be inspected
             if adj.skip_build:
-                folded.add(adj)
-                continue
+                forward_folded.add(adj)
+                return
+
+            forward_folding.add(adj)
+            for callee in adj.called_user_functions:
+                fold_forward(callee.adj)
+
+            forward_required = adj.max_required_extra_shared_memory
+            for callee in adj.called_user_functions:
+                forward_required = max(forward_required, callee.adj.get_total_required_shared())
+            for grad_func in adj.called_grad_functions:
+                forward_required = max(forward_required, fold_grad_requirement(grad_func))
+            adj.max_required_extra_shared_memory = forward_required
+            forward_folding.remove(adj)
+            forward_folded.add(adj)
+
+        def fold_backward(adj):
+            """Fold replay and reverse shared-memory dependencies before this adjoint."""
+
+            if adj in backward_folded:
+                return
+            if adj in backward_folding:
+                raise RuntimeError(f"Cannot size shared memory for '{adj.fun_name}': the call graph contains a cycle")
+
+            fold_forward(adj)
+            if adj.skip_build:
+                backward_folded.add(adj)
+                return
+
+            backward_folding.add(adj)
+            for callee in adj.called_user_functions:
+                if callee.custom_replay_func is not None:
+                    fold_forward(callee.custom_replay_func.adj)
+                else:
+                    fold_forward(callee.adj)
+                if callee.custom_grad_func is not None:
+                    fold_forward(callee.custom_grad_func.adj)
+                else:
+                    fold_backward(callee.adj)
+
             required = adj.max_required_extra_shared_memory_backward
             for callee in adj.called_user_functions:
                 if callee.custom_replay_func is not None:
@@ -3041,25 +3240,30 @@ class ModuleBuilder:
                     replay = callee.adj.get_total_required_shared()
                 if callee.custom_grad_func is not None:
                     reverse = callee.custom_grad_func.adj.get_total_required_shared()
-                elif callee.adj not in folded:
-                    # fail loudly instead of silently under-reserving
-                    raise RuntimeError(
-                        f"Cannot size backward shared memory for '{adj.fun_name}': callee '{callee.key}' was not "
-                        "sized first; the call graph should be acyclic and functions registered callees-first"
-                    )
                 else:
                     reverse = callee.adj.get_total_required_shared_backward()
                 # max: the replay frame pops before the reverse frame pushes, so the two never coexist
                 required = max(required, replay, reverse)
+            for grad_func in adj.called_grad_functions:
+                # wp.grad() is forward-only, but the forward body is replayed by this backward function.
+                required = max(required, fold_grad_requirement(grad_func))
             adj.max_required_extra_shared_memory_backward = required
-            folded.add(adj)
+            backward_folding.remove(adj)
+            backward_folded.add(adj)
+
+        for adj in adjs:
+            fold_forward(adj)
+        for adj in adjs:
+            suppresses_user_adjoint = adj.is_user_function and adj.uses_grad_call
+            if not adj.custom_reverse_mode and not adj.skip_reverse_codegen and not suppresses_user_adjoint:
+                fold_backward(adj)
 
     def build_meta(self):
         meta = {}
 
         for kernel in self.kernels:
             name = kernel.get_mangled_name()
-            options = self.options | kernel.options
+            options = self._get_effective_kernel_options(kernel)
 
             meta[name + "_cuda_kernel_forward_smem_bytes"] = kernel.adj.get_total_required_shared()
             if options["enable_backward"]:
@@ -3090,7 +3294,7 @@ class ModuleBuilder:
                     func.adj,
                     c_func_name=func.native_func,
                     device=device,
-                    options=self.options,
+                    options=func.adj.builder_options,
                     forward_only=forward_only,
                     reverse_only=reverse_only,
                 )
@@ -3105,6 +3309,39 @@ class ModuleBuilder:
                     reverse_only=reverse_only,
                 )
         return source
+
+    @staticmethod
+    def _order_reverse_functions(functions):
+        """Return functions with every emitted reverse dependency before its callers."""
+
+        function_set = set(functions)
+        ordered = []
+        visited = set()
+        visiting = set()
+
+        def reverse_implementation(func):
+            return func.custom_grad_func or func
+
+        def visit(func):
+            if func in visited or func in visiting:
+                return
+            visiting.add(func)
+            if func.adj.custom_reverse_mode:
+                callees = func.adj.called_grad_functions
+            else:
+                callees = func.adj.called_user_functions
+            for callee in callees:
+                dependency = reverse_implementation(callee)
+                if dependency in function_set:
+                    visit(dependency)
+            visiting.remove(func)
+            visited.add(func)
+            ordered.append(func)
+
+        for func in functions:
+            visit(func)
+
+        return ordered
 
     def codegen(self, device):
         source = ""
@@ -3130,7 +3367,7 @@ class ModuleBuilder:
 
         # Three-pass code generation:
         # Pass 1: Forward functions that don't use wp.grad()
-        # Pass 2: All adjoint functions (custom grads before auto-adjoints)
+        # Pass 2: All adjoint functions in reverse-dependency order
         # Pass 3: Forward functions that use wp.grad() (these call adjoints, so must come after pass 2)
         #         Note: Functions using wp.grad() don't have adjoints generated.
 
@@ -3141,29 +3378,18 @@ class ModuleBuilder:
         # Pass 1: Forward functions that don't use grad()
         source += self._codegen_functions(non_grad_functions, device, forward_only=True)
 
-        # Pass 2: Reverse/adjoint functions with custom grads sorted before auto-adjoints
-        # Build set of functions that ARE custom gradients (decorated with @wp.func_grad)
-        # Note: f.custom_grad_func tells us if f HAS a custom gradient, but we need to know
-        # which functions ARE custom gradients themselves (i.e., appear as someone's custom_grad_func)
-        # Note: Functions that use wp.grad() don't have adjoints generated (their reverse calls
-        # are skipped in add_call since the gradient of a gradient call is not supported)
-        custom_grad_set = {f.custom_grad_func for f in non_grad_functions if f.custom_grad_func is not None}
-
-        # Separate functions that ARE custom grads from all others, preserving original order
-        custom_grad_functions = [f for f in non_grad_functions if f in custom_grad_set]
-        other_functions = [f for f in non_grad_functions if f not in custom_grad_set]
-
-        # Generate adjoints: custom grads first, then other functions
-        # This ensures custom grads are defined before any auto-adjoints that call them
-        source += self._codegen_functions(custom_grad_functions + other_functions, device, reverse_only=True)
+        # Pass 2: Reverse/adjoint functions. Ordinary adjoints depend on their callees' reverse implementations,
+        # while custom gradients can depend on wp.grad() targets from their forward-emitted bodies.
+        reverse_functions = self._order_reverse_functions(non_grad_functions)
+        source += self._codegen_functions(reverse_functions, device, reverse_only=True)
 
         # Pass 3: Forward functions that use wp.grad()
         # These must come after pass 2 because they call adjoint functions
         source += self._codegen_functions(grad_functions, device, forward_only=True)
 
         for kernel in self.kernels:
-            source += warp._src.codegen.codegen_kernel(kernel, device=device, options=self.options)
-            source += warp._src.codegen.codegen_module(kernel, device=device, options=self.options)
+            source += warp._src.codegen.codegen_kernel(kernel, device=device, options=self.default_kernel_options)
+            source += warp._src.codegen.codegen_module(kernel, device=device, options=self.default_kernel_options)
 
         # Detect whether this module uses bfloat16; if not, define WP_NO_BFLOAT16
         # to skip compiling bfloat16 overloads in builtin.h (significant LLVM speedup).
@@ -3782,7 +4008,9 @@ class Module:
         with _codegen_lock:
             for kernel in hasher.get_unique_kernels():
                 if rebuild:
-                    kernel.adj.build(None, builder_options)
+                    # Match ModuleBuilder.build_kernel: determinism metadata must be captured under the same
+                    # merged options the real build uses.
+                    kernel.adj.build(None, builder_options=builder_options | kernel.options)
                 snapshot[kernel.get_mangled_name()] = kernel.adj.det_meta
         return snapshot
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2781,12 +2781,25 @@ class ModuleBuilder:
 
         # build all unique kernels
         self.kernels = hasher.get_unique_kernels()
+
+        # ``@wp.func`` bodies are memoized once per module and are built with these options, so a shared helper
+        # must assume its most permissive caller. Only drop backward codegen and backward LTOs when no kernel in
+        # the module can reach a backward pass at all. A builder with no kernels keeps the module's own setting,
+        # since an empty kernel set says nothing about what backward codegen is needed.
+        if self.kernels and not any(k.options.get("enable_backward", True) for k in self.kernels):
+            self.options = self.options | {"enable_backward": False}
+
         for kernel in self.kernels:
             self.build_kernel(kernel)
 
         # build deferred functions
         for func in self.deferred_functions:
             self.build_function(func)
+
+        # wp.grad() forces function adjoints even in modules where every kernel disables its automatic backward
+        # pass. Those functions were initially built from the builder-wide forward-only options, so rebuild them
+        # with backward LTO dispatch enabled after the initial call graph has been built.
+        self._prepare_forced_adjoint_functions()
 
         # propagate used_by_backward_kernel now that the full call graph is known
         self._propagate_used_by_backward_kernel()
@@ -2884,7 +2897,9 @@ class ModuleBuilder:
         if self._kernel_has_invalid_return_annotation(kernel) or self._kernel_has_value_return(kernel):
             raise WarpCodegenTypeError(f"'{kernel.key}': {_KERNEL_RETURN_ERROR}")
 
-        kernel.adj.build(self)
+        # Kernel options must reach the tile LTO dispatch, which reads ``adj.builder_options``. Every other
+        # consumer of ``enable_backward`` already merges them, e.g. ``build_meta`` below.
+        kernel.adj.build(self, builder_options=self.options | kernel.options)
 
         if kernel.adj.return_var is not None:
             raise WarpCodegenTypeError(f"'{kernel.key}': {_KERNEL_RETURN_ERROR}")
@@ -2897,6 +2912,38 @@ class ModuleBuilder:
 
             # use dict to preserve import order
             self.functions[func] = None
+
+    def _prepare_forced_adjoint_functions(self):
+        """Prepare ``wp.grad()`` targets and their transitive callees for backward code generation."""
+
+        # wp.grad() marks its direct target after that function may already have been memoized. Propagate the flag
+        # through the finished call graph so every adjoint called by the target's reverse body is emitted.
+        worklist = [func.adj for func in self.functions if func.adj.force_adjoint_codegen]
+        while worklist:
+            adj = worklist.pop()
+            for callee in adj.called_user_functions:
+                if not callee.adj.force_adjoint_codegen:
+                    callee.adj.force_adjoint_codegen = True
+                    worklist.append(callee.adj)
+
+        # Rebuilding can discover new callees, so rescan to a fixpoint. Track attempts separately from options so a
+        # build that returns without updating its options cannot be selected forever; failed builds are skipped.
+        rebuilt = set()
+        while True:
+            rebuild = [
+                func
+                for func in self.functions
+                if func.adj.force_adjoint_codegen
+                and not func.adj.skip_build
+                and func not in rebuilt
+                and not func.adj.builder_options.get("enable_backward", True)
+            ]
+            if not rebuild:
+                break
+            for func in rebuild:
+                adj = func.adj
+                rebuilt.add(func)
+                adj.build(self, builder_options=adj.builder_options | {"enable_backward": True})
 
     def _propagate_used_by_backward_kernel(self):
         # build_function() memoizes, so a helper built from a forward-only path before a backward
@@ -2954,6 +3001,18 @@ class ModuleBuilder:
             if adj.skip_build:
                 folded.add(adj)
                 continue
+
+            forward_required = adj.max_required_extra_shared_memory
+            for grad_func in adj.called_grad_functions:
+                if grad_func.adj not in folded:
+                    raise RuntimeError(
+                        f"Cannot size forward shared memory for '{adj.fun_name}': wp.grad() target "
+                        f"'{grad_func.key}' was not sized first; the call graph should be acyclic and functions "
+                        "registered callees-first"
+                    )
+                forward_required = max(forward_required, grad_func.adj.get_total_required_shared_backward())
+            adj.max_required_extra_shared_memory = forward_required
+
             required = adj.max_required_extra_shared_memory_backward
             for callee in adj.called_user_functions:
                 if callee.custom_replay_func is not None:
@@ -3684,7 +3743,9 @@ class Module:
         with _codegen_lock:
             for kernel in hasher.get_unique_kernels():
                 if rebuild:
-                    kernel.adj.build(None, builder_options)
+                    # Match ModuleBuilder.build_kernel: determinism metadata must be captured under the same
+                    # merged options the real build uses.
+                    kernel.adj.build(None, builder_options=builder_options | kernel.options)
                 snapshot[kernel.get_mangled_name()] = kernel.adj.det_meta
         return snapshot
 

--- a/warp/config.py
+++ b/warp/config.py
@@ -311,7 +311,8 @@ This setting can be overridden at the module level by setting the ``"compile_tim
 enable_backward: bool = True
 """Enable compilation of kernel backward passes.
 
-This setting can be overridden at the module level by setting the ``"enable_backward"`` module option.
+This setting can be overridden per module with the ``"enable_backward"`` module option, or per kernel with
+``@wp.kernel(enable_backward=False)``.
 """
 
 default_grid_stride: bool = True

--- a/warp/tests/cuda/test_cluster_dim.py
+++ b/warp/tests/cuda/test_cluster_dim.py
@@ -46,7 +46,7 @@ def cuda_kernel_source(kernel) -> str:
     Builds the module's adjoints via ModuleBuilder so codegen state (e.g.
     ``fun_def_lineno``) is populated, then invokes codegen directly.
     """
-    options = kernel.module.resolve_options(wp.config) | kernel.options
+    options = kernel.module.resolve_options(wp.config)
     ModuleBuilder(kernel.module, options)
     return codegen.codegen_kernel(kernel, device="cuda", options=options)
 

--- a/warp/tests/test_options.py
+++ b/warp/tests/test_options.py
@@ -24,12 +24,17 @@ def scale(
     y[0] = x[0] ** 2.0
 
 
+@wp.func
+def square(x: float):
+    return x * x
+
+
 @wp.kernel(enable_backward=True)
 def scale_1(
     x: wp.array[float],
     y: wp.array[float],
 ):
-    y[0] = x[0] ** 2.0
+    y[0] = square(x[0])
 
 
 @wp.kernel(enable_backward=False)

--- a/warp/tests/tile/test_tile_cholesky.py
+++ b/warp/tests/tile/test_tile_cholesky.py
@@ -413,12 +413,7 @@ def test_tile_cholesky_upper_backward(dtype):
 def test_tile_cholesky_block_cholesky(test, device):
     BLOCK_SIZE = wp.constant(TILE_M // 2)
 
-    # enable_backward belongs in module_options, not as a kernel kwarg: the LTO
-    # dispatch for tile_matmul/tile_cholesky/tile_lower_solve reads the module
-    # builder's options, which kernel kwargs are not merged into. As a kwarg it
-    # still suppresses the C++ backward, but libmathdx builds the unused
-    # backward GEMM/TRSM LTOs anyway.
-    @wp.kernel(module="unique", module_options={"enable_backward": False})
+    @wp.kernel(enable_backward=False, module="unique")
     def block_cholesky_kernel(
         A: wp.array2d[float],
         L: wp.array2d[float],
@@ -462,7 +457,7 @@ def test_tile_cholesky_block_cholesky(test, device):
 
                 wp.tile_store(L, sol_tile, offset=(i, k))
 
-    @wp.kernel(module="unique", module_options={"enable_backward": False})
+    @wp.kernel(enable_backward=False, module="unique")
     def block_cholesky_solve_kernel(
         L: wp.array2d[float],
         b: wp.array2d[float],

--- a/warp/tests/tile/test_tile_mathdx_lto.py
+++ b/warp/tests/tile/test_tile_mathdx_lto.py
@@ -1,0 +1,678 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for MathDx LTO selection in tile kernels that use automatic differentiation.
+
+Add cases here when they inspect or run the forward and backward LTOs produced
+for ``enable_backward``, ``wp.grad()``, and custom-gradient call graphs.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+import warp as wp
+from warp._src.context import ModuleBuilder
+from warp.tests.unittest_utils import *
+
+wp.init()  # For wp._src.context.runtime.core.wp_is_mathdx_enabled()
+
+TILE_M = wp.constant(8)
+TILE_N = wp.constant(4)
+TILE_K = wp.constant(8)
+TILE_DIM = 32
+
+
+# Most kernels below are built through ModuleBuilder only to inspect how many LTOs the tile dispatch generates,
+# so they add no NVRTC compilation. They share float32 register-tile parameters and TILE_DIM threads so their LTOs
+# reuse the same on-disk cache entries. Because count_module_ltos() counts the entire owning module, unique modules
+# isolate the enabled/disabled comparisons. The wp.grad() regression additionally launches its kernel to verify that
+# retained backward LTOs execute correctly.
+
+
+@wp.kernel(module="unique")
+def tile_matmul_backward_enabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def tile_matmul_kernel_option_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.kernel(module="unique", module_options={"enable_backward": False})
+def tile_matmul_module_option_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.func
+def tile_matmul_helper(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.kernel(module="unique")
+def tile_matmul_via_func_enabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    tile_matmul_helper(A, B, C)
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def tile_matmul_via_func_disabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    tile_matmul_helper(A, B, C)
+
+
+@wp.func
+def tile_matmul_grad_helper(x: float):
+    a = wp.tile_ones(shape=(TILE_M, TILE_M), dtype=wp.float32, storage="register") * x
+    c = wp.tile_zeros(shape=(TILE_M, TILE_M), dtype=wp.float32)
+    wp.tile_matmul(a, a, c)
+    return wp.tile_sum(c)[0]
+
+
+@wp.func
+def tile_matmul_grad_target(x: float):
+    return tile_matmul_grad_helper(x)
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def tile_matmul_grad_disabled_kernel(x: wp.array[float], out: wp.array[float]):
+    a = wp.tile_ones(shape=(TILE_M, TILE_M), dtype=wp.float32, storage="register") * x[0]
+    c = wp.tile_zeros(shape=(TILE_M, TILE_M), dtype=wp.float32)
+    wp.tile_matmul(a, a, c)
+    out[0] = wp.tile_sum(c)[0]
+
+
+@wp.kernel(module="tile_mathdx_grad", enable_backward=False)
+def tile_matmul_grad_forward_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = tile_matmul_grad_target(x[0])
+
+
+@wp.kernel(module="tile_mathdx_grad", enable_backward=False)
+def tile_matmul_via_grad_kernel(
+    x: wp.array[float],
+    grad_x: wp.array[float],
+):
+    grad_x[0] = wp.grad(tile_matmul_grad_target)(x[0])
+
+
+# Both kernels share a single module on purpose, so they also share one memoized tile_matmul_helper body.
+# module="unique" would give each its own module and defeat the test.
+@wp.kernel(module="tile_mathdx_mixed_backward")
+def tile_matmul_mixed_enabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    tile_matmul_helper(A, B, C)
+
+
+@wp.kernel(module="tile_mathdx_mixed_backward", enable_backward=False)
+def tile_matmul_mixed_disabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    tile_matmul_helper(A, B, C)
+
+
+@wp.func
+def tile_matmul_bf16_forward_first_helper(
+    A: wp.array2d[wp.bfloat16], B: wp.array2d[wp.bfloat16], C: wp.array2d[wp.float32]
+):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.kernel(module="tile_mathdx_disjoint_forward_first", enable_backward=False)
+def tile_matmul_bf16_forward_first_kernel(
+    A: wp.array2d[wp.bfloat16], B: wp.array2d[wp.bfloat16], C: wp.array2d[wp.float32]
+):
+    tile_matmul_bf16_forward_first_helper(A, B, C)
+
+
+@wp.kernel(module="tile_mathdx_disjoint_forward_first")
+def tile_matmul_unrelated_backward_second_kernel():
+    pass
+
+
+@wp.kernel(module="tile_mathdx_disjoint_backward_first")
+def tile_matmul_unrelated_backward_first_kernel():
+    pass
+
+
+@wp.func
+def tile_matmul_bf16_backward_first_helper(
+    A: wp.array2d[wp.bfloat16], B: wp.array2d[wp.bfloat16], C: wp.array2d[wp.float32]
+):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.kernel(module="tile_mathdx_disjoint_backward_first", enable_backward=False)
+def tile_matmul_bf16_backward_first_kernel(
+    A: wp.array2d[wp.bfloat16], B: wp.array2d[wp.bfloat16], C: wp.array2d[wp.float32]
+):
+    tile_matmul_bf16_backward_first_helper(A, B, C)
+
+
+CUSTOM_GRAD_PROVIDER_MODULE = wp.Module("tile_mathdx_custom_grad_provider")
+CUSTOM_GRAD_BACKWARD_MODULE = wp.Module("tile_mathdx_custom_grad_backward")
+CUSTOM_GRAD_WP_GRAD_MODULE = wp.Module("tile_mathdx_custom_grad_wp_grad")
+CUSTOM_GRAD_CALLABLE_MODULE = wp.Module("tile_mathdx_custom_grad_callable")
+for module in (
+    CUSTOM_GRAD_PROVIDER_MODULE,
+    CUSTOM_GRAD_BACKWARD_MODULE,
+    CUSTOM_GRAD_WP_GRAD_MODULE,
+    CUSTOM_GRAD_CALLABLE_MODULE,
+):
+    module.options["enable_backward"] = False
+
+
+@wp.func(module=CUSTOM_GRAD_PROVIDER_MODULE)
+def tile_matmul_bf16_custom_grad_leaf(x: float):
+    a = wp.tile_ones(shape=(TILE_M, TILE_M), dtype=wp.bfloat16, storage="register") * wp.bfloat16(x)
+    b = wp.tile_ones(shape=(TILE_M, TILE_M), dtype=wp.bfloat16, storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_M), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    return wp.tile_sum(c)[0]
+
+
+@wp.func(module=CUSTOM_GRAD_PROVIDER_MODULE)
+def tile_matmul_bf16_custom_grad_target(x: float):
+    return tile_matmul_bf16_custom_grad_leaf(x)
+
+
+@wp.func_grad(tile_matmul_bf16_custom_grad_target)
+def adj_tile_matmul_bf16_custom_grad_target(x: float, adj_ret: float):
+    wp.adjoint[x] += 512.0 * adj_ret
+
+
+@wp.kernel(module=CUSTOM_GRAD_BACKWARD_MODULE, enable_backward=True)
+def tile_matmul_bf16_custom_grad_backward_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = tile_matmul_bf16_custom_grad_target(x[0])
+
+
+@wp.kernel(module=CUSTOM_GRAD_WP_GRAD_MODULE, enable_backward=False)
+def tile_matmul_bf16_custom_grad_wp_grad_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(tile_matmul_bf16_custom_grad_target)(x[0])
+
+
+@wp.func(module=CUSTOM_GRAD_WP_GRAD_MODULE)
+def tile_matmul_bf16_custom_grad_wp_grad_func(x: float):
+    return wp.grad(tile_matmul_bf16_custom_grad_target)(x)
+
+
+@wp.func(module=CUSTOM_GRAD_PROVIDER_MODULE)
+def tile_matmul_custom_grad_callable_objective(x: float):
+    return x * x
+
+
+@wp.func(module=CUSTOM_GRAD_PROVIDER_MODULE)
+def tile_matmul_bf16_custom_grad_callable_target(x: float) -> float:
+    return tile_matmul_bf16_custom_grad_target(x) + tile_matmul_custom_grad_callable_objective(x)
+
+
+@wp.func_grad(tile_matmul_bf16_custom_grad_callable_target)
+def adj_tile_matmul_bf16_custom_grad_callable_target(x: float, adj_ret: float):
+    wp.adjoint[x] += (512.0 + wp.grad(tile_matmul_custom_grad_callable_objective)(x)) * adj_ret
+
+
+@wp.kernel(module=CUSTOM_GRAD_CALLABLE_MODULE, enable_backward=True)
+def tile_matmul_bf16_custom_grad_callable_kernel():
+    values = wp.tile_ones(shape=(TILE_M,), dtype=float, storage="register")
+    wp.tile_map(tile_matmul_bf16_custom_grad_callable_target, values)
+
+
+@wp.func
+def stale_grad_force_leaf(x: float):
+    return x * x
+
+
+@wp.func
+def stale_grad_force_target(x: float):
+    return stale_grad_force_leaf(x)
+
+
+@wp.kernel(module="tile_mathdx_grad_force_source", enable_backward=False)
+def stale_grad_force_source_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(stale_grad_force_target)(x[0])
+
+
+@wp.kernel(module="tile_mathdx_grad_force_sink", enable_backward=False)
+def stale_grad_force_sink_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = stale_grad_force_target(x[0])
+
+
+WP_GRAD_HELPER_MODULE = wp.Module("tile_mathdx_wp_grad_helper")
+WP_GRAD_HELPER_MODULE.options["enable_backward"] = False
+
+
+@wp.func(module=WP_GRAD_HELPER_MODULE)
+def wp_grad_helper_objective(x: float):
+    return x * x
+
+
+@wp.func(module=WP_GRAD_HELPER_MODULE)
+def wp_grad_helper_forward_leaf(x: float):
+    return x + 1.0
+
+
+@wp.func(module=WP_GRAD_HELPER_MODULE)
+def tile_matmul_bf16_wp_grad_helper(x: float):
+    a = wp.tile_ones(shape=(TILE_M, TILE_M), dtype=wp.bfloat16, storage="register") * wp.bfloat16(x)
+    b = wp.tile_ones(shape=(TILE_M, TILE_M), dtype=wp.bfloat16, storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_M), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    return wp.tile_sum(c)[0] + wp_grad_helper_forward_leaf(x) + wp.grad(wp_grad_helper_objective)(x)
+
+
+@wp.kernel(module=WP_GRAD_HELPER_MODULE, enable_backward=True)
+def tile_matmul_bf16_wp_grad_helper_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = tile_matmul_bf16_wp_grad_helper(x[0])
+
+
+def count_module_ltos(kernel, device):
+    """Return how many LTOs ``ModuleBuilder`` generates for the module owning ``kernel``.
+
+    ``output_arch`` is not part of ``resolve_options()``; it is injected later during codegen. When it is None the
+    tile dispatch returns early without building any LTO, so it must be supplied here or the count is always zero.
+    ``block_dim`` matches the value the neighboring tests launch with, so the LTO cache entries are shared.
+    """
+    module = kernel.module
+    options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {"output_arch": module._get_compile_arch(device)}
+    return len(ModuleBuilder(module, options).ltoirs)
+
+
+def test_enable_backward_kernel_option_reaches_lto_dispatch(test, device):
+    """Suppress backward LTOs for a kernel-level ``enable_backward=False``, matching ``module_options``."""
+    enabled = count_module_ltos(tile_matmul_backward_enabled_kernel, device)
+    kernel_option = count_module_ltos(tile_matmul_kernel_option_kernel, device)
+    module_option = count_module_ltos(tile_matmul_module_option_kernel, device)
+
+    test.assertEqual(kernel_option, module_option)
+    test.assertLess(kernel_option, enabled)
+
+
+def test_enable_backward_kernel_option_reaches_func_bodies(test, device):
+    """Drop backward LTOs from a ``@wp.func`` body when no kernel in the module needs the backward pass."""
+    enabled = count_module_ltos(tile_matmul_via_func_enabled_kernel, device)
+    disabled = count_module_ltos(tile_matmul_via_func_disabled_kernel, device)
+
+    test.assertLess(disabled, enabled)
+
+
+def test_enable_backward_union_preserves_mixed_module_backward(test, device):
+    """Keep backward LTOs for a shared ``@wp.func`` when only some kernels in the module disable backward."""
+    enabled = count_module_ltos(tile_matmul_via_func_enabled_kernel, device)
+    disabled = count_module_ltos(tile_matmul_via_func_disabled_kernel, device)
+
+    module = tile_matmul_mixed_enabled_kernel.module
+    test.assertIs(tile_matmul_mixed_disabled_kernel.module, module)
+    options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {"output_arch": module._get_compile_arch(device)}
+    orders = (
+        (tile_matmul_mixed_enabled_kernel, tile_matmul_mixed_disabled_kernel),
+        (tile_matmul_mixed_disabled_kernel, tile_matmul_mixed_enabled_kernel),
+    )
+
+    for kernels in orders:
+        with test.subTest(first_kernel=kernels[0].key):
+            ordered_hasher = SimpleNamespace(get_unique_kernels=lambda kernels=kernels: kernels)
+            mixed = len(ModuleBuilder(module, options, hasher=ordered_hasher).ltoirs)
+
+            test.assertEqual(mixed, enabled)
+            test.assertGreater(mixed, disabled)
+
+
+def test_forward_only_bf16_helper_ignores_unrelated_backward_kernel(test, device):
+    """Build a forward-only BF16 helper without backward LTOs when its module also has an unrelated
+    backward-enabled kernel, independently of kernel build order."""
+
+    cases = (
+        (
+            tile_matmul_bf16_forward_first_kernel,
+            tile_matmul_unrelated_backward_second_kernel,
+            tile_matmul_bf16_forward_first_helper,
+        ),
+        (
+            tile_matmul_unrelated_backward_first_kernel,
+            tile_matmul_bf16_backward_first_kernel,
+            tile_matmul_bf16_backward_first_helper,
+        ),
+    )
+
+    for first_kernel, second_kernel, helper in cases:
+        with test.subTest(first_kernel=first_kernel.key):
+            module = first_kernel.module
+            test.assertIs(module, second_kernel.module)
+            options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {
+                "output_arch": module._get_compile_arch(device)
+            }
+            ordered_hasher = SimpleNamespace(get_unique_kernels=lambda kernels=(first_kernel, second_kernel): kernels)
+
+            builder = ModuleBuilder(module, options, hasher=ordered_hasher)
+
+            test.assertIn(helper, builder.functions)
+            test.assertFalse(helper.adj.builder_options["enable_backward"])
+
+
+def test_custom_grad_primal_stays_forward_only_in_backward_kernel(test, device):
+    """Keep a custom-gradient primal and its callees forward-only when its kernel enables backward."""
+    module = tile_matmul_bf16_custom_grad_backward_kernel.module
+    options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {"output_arch": module._get_compile_arch(device)}
+    builder = ModuleBuilder(module, options)
+
+    test.assertIn(tile_matmul_bf16_custom_grad_target, builder.functions)
+    test.assertIn(tile_matmul_bf16_custom_grad_leaf, builder.functions)
+    test.assertFalse(tile_matmul_bf16_custom_grad_target.adj.builder_options["enable_backward"])
+    test.assertFalse(tile_matmul_bf16_custom_grad_leaf.adj.builder_options["enable_backward"])
+    test.assertFalse(tile_matmul_bf16_custom_grad_target.adj.used_by_backward_kernel)
+    test.assertFalse(tile_matmul_bf16_custom_grad_leaf.adj.used_by_backward_kernel)
+
+    x = wp.array([1.0], dtype=float, requires_grad=True, device=device)
+    out = wp.zeros_like(x)
+    with wp.Tape() as tape:
+        wp.launch_tiled(
+            tile_matmul_bf16_custom_grad_backward_kernel,
+            dim=1,
+            inputs=[x],
+            outputs=[out],
+            block_dim=TILE_DIM,
+            device=device,
+        )
+
+    tape.backward(grads={out: wp.ones_like(out)})
+    np.testing.assert_allclose(out.numpy(), [512.0])
+    # Every thread in the tiled block calls the scalar function and accumulates its custom gradient into x[0].
+    np.testing.assert_allclose(x.grad.numpy(), [512.0 * TILE_DIM])
+
+
+def test_wp_grad_custom_grad_target_stays_forward_only(test, device):
+    """Use a custom gradient without generating backward code for its primal call graph."""
+    module = tile_matmul_bf16_custom_grad_wp_grad_kernel.module
+    options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {"output_arch": module._get_compile_arch(device)}
+    builder = ModuleBuilder(module, options)
+
+    test.assertIn(tile_matmul_bf16_custom_grad_target, builder.functions)
+    test.assertIn(tile_matmul_bf16_custom_grad_leaf, builder.functions)
+    test.assertIn(tile_matmul_bf16_custom_grad_target.custom_grad_func, builder.functions)
+    test.assertFalse(tile_matmul_bf16_custom_grad_target.adj.force_adjoint_codegen)
+    test.assertFalse(tile_matmul_bf16_custom_grad_leaf.adj.force_adjoint_codegen)
+    test.assertFalse(tile_matmul_bf16_custom_grad_target.adj.builder_options["enable_backward"])
+    test.assertFalse(tile_matmul_bf16_custom_grad_leaf.adj.builder_options["enable_backward"])
+
+    x = wp.array([1.0], dtype=float, device=device)
+    out = wp.zeros_like(x)
+    wp.launch_tiled(
+        tile_matmul_bf16_custom_grad_wp_grad_kernel,
+        dim=1,
+        inputs=[x],
+        outputs=[out],
+        block_dim=TILE_DIM,
+        device=device,
+    )
+    np.testing.assert_allclose(out.numpy(), [512.0])
+
+
+def test_custom_grad_callable_stays_forward_only_in_backward_kernel(test, device):
+    """Keep a custom-gradient operator forward-only when passed to a differentiable builtin."""
+    module = tile_matmul_bf16_custom_grad_callable_kernel.module
+    options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {"output_arch": module._get_compile_arch(device)}
+    builder = ModuleBuilder(module, options)
+
+    test.assertIn(tile_matmul_bf16_custom_grad_callable_target, builder.functions)
+    test.assertIn(tile_matmul_bf16_custom_grad_target, builder.functions)
+    test.assertIn(tile_matmul_bf16_custom_grad_leaf, builder.functions)
+    test.assertIn(tile_matmul_custom_grad_callable_objective, builder.functions)
+    test.assertFalse(tile_matmul_bf16_custom_grad_callable_target.adj.builder_options["enable_backward"])
+    test.assertFalse(tile_matmul_bf16_custom_grad_target.adj.builder_options["enable_backward"])
+    test.assertFalse(tile_matmul_bf16_custom_grad_leaf.adj.builder_options["enable_backward"])
+    test.assertTrue(tile_matmul_custom_grad_callable_objective.adj.builder_options["enable_backward"])
+    test.assertTrue(tile_matmul_custom_grad_callable_objective.adj.force_adjoint_codegen)
+    test.assertFalse(tile_matmul_bf16_custom_grad_callable_target.adj.used_by_backward_kernel)
+    test.assertFalse(tile_matmul_bf16_custom_grad_target.adj.used_by_backward_kernel)
+    test.assertFalse(tile_matmul_bf16_custom_grad_leaf.adj.used_by_backward_kernel)
+
+
+def test_wp_grad_preserves_backward_ltos(test, device):
+    """Keep and execute backward LTOs forced by ``wp.grad()`` in a forward-only kernel."""
+    disabled = count_module_ltos(tile_matmul_grad_disabled_kernel, device)
+    forced = count_module_ltos(tile_matmul_via_grad_kernel, device)
+    test.assertIs(tile_matmul_grad_forward_kernel.module, tile_matmul_via_grad_kernel.module)
+    test.assertGreater(forced, disabled)
+
+    x = 0.25
+    x_wp = wp.array([x], dtype=wp.float32, device=device)
+    grad_x_wp = wp.zeros_like(x_wp)
+
+    wp.launch_tiled(
+        tile_matmul_via_grad_kernel,
+        dim=1,
+        inputs=[x_wp],
+        outputs=[grad_x_wp],
+        block_dim=TILE_DIM,
+        device=device,
+    )
+
+    expected = 2.0 * TILE_M * TILE_M * TILE_M * x
+    np.testing.assert_allclose(grad_x_wp.numpy(), [expected], rtol=1.0e-5, atol=1.0e-5)
+
+
+class TestTileMathDxLTO(unittest.TestCase):
+    def test_wp_grad_helper_stays_forward_only(self):
+        """Discover a ``wp.grad()`` helper before applying backward-only tile constraints."""
+        module = tile_matmul_bf16_wp_grad_helper_kernel.module
+        options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {"output_arch": None}
+
+        builder = ModuleBuilder(module, options)
+
+        self.assertIn(tile_matmul_bf16_wp_grad_helper, builder.functions)
+        self.assertIn(wp_grad_helper_forward_leaf, builder.functions)
+        self.assertIn(wp_grad_helper_objective, builder.functions)
+        self.assertTrue(tile_matmul_bf16_wp_grad_helper.adj.uses_grad_call)
+        self.assertTrue(tile_matmul_bf16_wp_grad_helper.adj.used_by_backward_kernel)
+        self.assertFalse(tile_matmul_bf16_wp_grad_helper.adj.builder_options["enable_backward"])
+        self.assertFalse(tile_matmul_bf16_wp_grad_helper.adj.force_adjoint_codegen)
+        self.assertFalse(wp_grad_helper_forward_leaf.adj.used_by_backward_kernel)
+        self.assertFalse(wp_grad_helper_forward_leaf.adj.builder_options["enable_backward"])
+        self.assertFalse(wp_grad_helper_forward_leaf.adj.force_adjoint_codegen)
+        self.assertFalse(wp_grad_helper_objective.adj.used_by_backward_kernel)
+        self.assertTrue(wp_grad_helper_objective.adj.builder_options["enable_backward"])
+        self.assertTrue(wp_grad_helper_objective.adj.force_adjoint_codegen)
+
+    def test_wp_grad_custom_grad_builderless_target_stays_forward_only(self):
+        """Keep ``wp.grad()`` analysis without a builder from generating backward code for a custom-gradient primal."""
+        tile_matmul_bf16_custom_grad_target.adj.force_adjoint_codegen = False
+        tile_matmul_bf16_custom_grad_leaf.adj.force_adjoint_codegen = False
+        module = tile_matmul_bf16_custom_grad_wp_grad_func.module
+        options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {
+            "enable_backward": True,
+            "output_arch": None,
+        }
+
+        tile_matmul_bf16_custom_grad_wp_grad_func.adj.build(None, options)
+
+        self.assertFalse(tile_matmul_bf16_custom_grad_target.adj.force_adjoint_codegen)
+        self.assertFalse(tile_matmul_bf16_custom_grad_leaf.adj.force_adjoint_codegen)
+        self.assertFalse(tile_matmul_bf16_custom_grad_target.adj.builder_options["enable_backward"])
+        self.assertFalse(tile_matmul_bf16_custom_grad_leaf.adj.builder_options["enable_backward"])
+
+    def test_prepare_adjoint_functions_resets_stale_grad_force(self):
+        """Derive ``wp.grad()`` force flags from the current builder instead of prior builds."""
+
+        def build_single_kernel(kernel):
+            module = kernel.module
+            options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {"output_arch": None}
+            hasher = SimpleNamespace(get_unique_kernels=lambda: (kernel,))
+            return ModuleBuilder(module, options, hasher=hasher)
+
+        orders = (
+            (stale_grad_force_sink_kernel, stale_grad_force_source_kernel),
+            (stale_grad_force_source_kernel, stale_grad_force_sink_kernel),
+        )
+        for first_kernel, second_kernel in orders:
+            with self.subTest(first_kernel=first_kernel.key):
+                for kernel in (first_kernel, second_kernel):
+                    builder = build_single_kernel(kernel)
+                    expected = kernel is stale_grad_force_source_kernel
+
+                    self.assertIn(stale_grad_force_target, builder.functions)
+                    self.assertIn(stale_grad_force_leaf, builder.functions)
+                    self.assertEqual(stale_grad_force_target.adj.force_adjoint_codegen, expected)
+                    self.assertEqual(stale_grad_force_leaf.adj.force_adjoint_codegen, expected)
+                    self.assertEqual(stale_grad_force_target.adj.builder_options["enable_backward"], expected)
+                    self.assertEqual(stale_grad_force_leaf.adj.builder_options["enable_backward"], expected)
+
+    def test_prepare_adjoint_functions_skips_failed_functions(self):
+        """Do not rebuild forced adjoints whose earlier build failed."""
+
+        class TestFunction:
+            pass
+
+        func = TestFunction()
+        func.adj = SimpleNamespace(
+            builder_options={"enable_backward": False},
+            called_grad_functions=set(),
+            called_user_functions=set(),
+            force_adjoint_codegen=True,
+            is_user_function=True,
+            skip_build=True,
+            uses_grad_call=False,
+        )
+        func.uses_generated_adjoint = True
+
+        def fail_build(*args, **kwargs):
+            self.fail("A skipped function was rebuilt")
+
+        func.adj.build = fail_build
+
+        kernel = TestFunction()
+        kernel.adj = TestFunction()
+        kernel.adj.called_grad_functions = {func}
+        kernel.adj.called_user_functions = set()
+        kernel.adj.skip_build = False
+        kernel.adj.unvalidated_ref_calls = []
+        kernel.adj.used_by_backward_kernel = False
+        kernel.options = {"enable_backward": False}
+
+        builder = ModuleBuilder.__new__(ModuleBuilder)
+        builder.functions = {func: None}
+        builder.kernels = (kernel,)
+        builder.default_kernel_options = {"enable_backward": False}
+        builder._prepare_adjoint_functions()
+
+    def test_prepare_adjoint_functions_rebuilds_each_function_once(self):
+        """Stop selecting a forced adjoint after its first rebuild attempt."""
+
+        class TestFunction:
+            pass
+
+        build_count = 0
+
+        def count_build(*args, **kwargs):
+            nonlocal build_count
+            build_count += 1
+            if build_count > 1:
+                self.fail("A forced adjoint was rebuilt more than once")
+
+        func = TestFunction()
+        func.adj = TestFunction()
+        func.adj.build = count_build
+        func.adj.builder_options = {"enable_backward": False}
+        func.adj.called_grad_functions = set()
+        func.adj.called_user_functions = set()
+        func.adj.force_adjoint_codegen = True
+        func.adj.is_user_function = True
+        func.adj.skip_build = False
+        func.adj.uses_grad_call = False
+        func.custom_grad_func = None
+        func.uses_generated_adjoint = True
+
+        kernel = TestFunction()
+        kernel.adj = TestFunction()
+        kernel.adj.called_grad_functions = {func}
+        kernel.adj.called_user_functions = set()
+        kernel.adj.skip_build = False
+        kernel.adj.unvalidated_ref_calls = []
+        kernel.adj.used_by_backward_kernel = False
+        kernel.options = {"enable_backward": False}
+
+        builder = ModuleBuilder.__new__(ModuleBuilder)
+        builder.deferred_function_index = 0
+        builder.deferred_functions = []
+        builder.functions = {func: None}
+        builder.kernels = (kernel,)
+        builder.default_kernel_options = {"enable_backward": False}
+        builder.options = {"enable_backward": False}
+        builder._prepare_adjoint_functions()
+
+        self.assertEqual(build_count, 1)
+
+
+mathdx_devices = get_cuda_test_devices() if wp._src.context.runtime.core.wp_is_mathdx_enabled() else []
+
+add_function_test(
+    TestTileMathDxLTO,
+    "test_enable_backward_kernel_option_reaches_lto_dispatch",
+    test_enable_backward_kernel_option_reaches_lto_dispatch,
+    devices=mathdx_devices,
+)
+add_function_test(
+    TestTileMathDxLTO,
+    "test_enable_backward_kernel_option_reaches_func_bodies",
+    test_enable_backward_kernel_option_reaches_func_bodies,
+    devices=mathdx_devices,
+)
+add_function_test(
+    TestTileMathDxLTO,
+    "test_enable_backward_union_preserves_mixed_module_backward",
+    test_enable_backward_union_preserves_mixed_module_backward,
+    devices=mathdx_devices,
+)
+add_function_test(
+    TestTileMathDxLTO,
+    "test_forward_only_bf16_helper_ignores_unrelated_backward_kernel",
+    test_forward_only_bf16_helper_ignores_unrelated_backward_kernel,
+    devices=mathdx_devices,
+)
+add_function_test(
+    TestTileMathDxLTO,
+    "test_custom_grad_primal_stays_forward_only_in_backward_kernel",
+    test_custom_grad_primal_stays_forward_only_in_backward_kernel,
+    devices=mathdx_devices,
+)
+add_function_test(
+    TestTileMathDxLTO,
+    "test_wp_grad_custom_grad_target_stays_forward_only",
+    test_wp_grad_custom_grad_target_stays_forward_only,
+    devices=mathdx_devices,
+)
+add_function_test(
+    TestTileMathDxLTO,
+    "test_custom_grad_callable_stays_forward_only_in_backward_kernel",
+    test_custom_grad_callable_stays_forward_only_in_backward_kernel,
+    devices=mathdx_devices,
+)
+add_function_test(
+    TestTileMathDxLTO,
+    "test_wp_grad_preserves_backward_ltos",
+    test_wp_grad_preserves_backward_ltos,
+    devices=mathdx_devices,
+)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/warp/tests/tile/test_tile_mathdx_lto.py
+++ b/warp/tests/tile/test_tile_mathdx_lto.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+
+import warp as wp
+from warp._src.context import ModuleBuilder
+from warp.tests.unittest_utils import *
+
+wp.init()  # For wp._src.context.runtime.core.wp_is_mathdx_enabled()
+
+TILE_M = wp.constant(8)
+TILE_N = wp.constant(4)
+TILE_K = wp.constant(8)
+TILE_DIM = 32
+
+
+# Most kernels below are built through ModuleBuilder only to inspect how many LTOs the tile dispatch generates,
+# so they add no NVRTC compilation. They share float32 register-tile parameters and TILE_DIM threads so their LTOs
+# reuse the same on-disk cache entries. The wp.grad() regression additionally launches its kernel to verify that
+# the retained backward LTOs execute correctly.
+
+
+@wp.kernel(module="unique")
+def tile_matmul_backward_enabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def tile_matmul_kernel_option_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.kernel(module="unique", module_options={"enable_backward": False})
+def tile_matmul_module_option_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.func
+def tile_matmul_helper(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    a = wp.tile_load(A, shape=(TILE_M, TILE_K), offset=(0, 0), storage="register")
+    b = wp.tile_load(B, shape=(TILE_K, TILE_N), offset=(0, 0), storage="register")
+    c = wp.tile_zeros(shape=(TILE_M, TILE_N), dtype=wp.float32)
+    wp.tile_matmul(a, b, c)
+    wp.tile_store(C, c)
+
+
+@wp.kernel(module="unique")
+def tile_matmul_via_func_enabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    tile_matmul_helper(A, B, C)
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def tile_matmul_via_func_disabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    tile_matmul_helper(A, B, C)
+
+
+@wp.func
+def tile_matmul_grad_helper(x: float):
+    a = wp.tile_ones(shape=(TILE_M, TILE_M), dtype=wp.float32, storage="register") * x
+    c = wp.tile_zeros(shape=(TILE_M, TILE_M), dtype=wp.float32)
+    wp.tile_matmul(a, a, c)
+    return wp.tile_sum(c)[0]
+
+
+@wp.func
+def tile_matmul_grad_target(x: float):
+    return tile_matmul_grad_helper(x)
+
+
+@wp.kernel(module="tile_mathdx_grad", enable_backward=False)
+def tile_matmul_grad_forward_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = tile_matmul_grad_target(x[0])
+
+
+@wp.kernel(module="tile_mathdx_grad", enable_backward=False)
+def tile_matmul_via_grad_kernel(
+    x: wp.array[float],
+    grad_x: wp.array[float],
+):
+    grad_x[0] = wp.grad(tile_matmul_grad_target)(x[0])
+
+
+# Both kernels share a single module on purpose, so they also share one memoized tile_matmul_helper body.
+# module="unique" would give each its own module and defeat the test.
+@wp.kernel(module="tile_mathdx_mixed_backward")
+def tile_matmul_mixed_enabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    tile_matmul_helper(A, B, C)
+
+
+@wp.kernel(module="tile_mathdx_mixed_backward", enable_backward=False)
+def tile_matmul_mixed_disabled_kernel(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
+    tile_matmul_helper(A, B, C)
+
+
+def _lto_test_device(test):
+    """Return a CUDA device suitable for inspecting LTO dispatch, or skip the test."""
+    if not wp._src.context.runtime.core.wp_is_mathdx_enabled():
+        test.skipTest("MathDx is not enabled")
+    devices = get_cuda_test_devices()
+    if not devices:
+        test.skipTest("No CUDA device is available")
+    return devices[0]
+
+
+def count_module_ltos(kernel, device):
+    """Return how many LTOs ``ModuleBuilder`` generates for the module owning ``kernel``.
+
+    ``output_arch`` is not part of ``resolve_options()``; it is injected later during codegen. When it is None the
+    tile dispatch returns early without building any LTO, so it must be supplied here or the count is always zero.
+    ``block_dim`` matches the value the neighboring tests launch with, so the LTO cache entries are shared.
+    """
+    module = kernel.module
+    options = module.resolve_options(wp.config, block_dim=TILE_DIM) | {"output_arch": module._get_compile_arch(device)}
+    return len(ModuleBuilder(module, options).ltoirs)
+
+
+class TestTileMathDxLTO(unittest.TestCase):
+    def test_prepare_forced_adjoint_functions_skips_failed_functions(self):
+        """Do not rebuild forced adjoints whose earlier build failed."""
+
+        class TestFunction:
+            pass
+
+        func = TestFunction()
+        func.adj = SimpleNamespace(
+            builder_options={"enable_backward": False},
+            called_user_functions=set(),
+            force_adjoint_codegen=True,
+            skip_build=True,
+        )
+
+        def fail_build(*args, **kwargs):
+            self.fail("A skipped function was rebuilt")
+
+        func.adj.build = fail_build
+
+        builder = ModuleBuilder.__new__(ModuleBuilder)
+        builder.functions = {func: None}
+        builder._prepare_forced_adjoint_functions()
+
+    def test_prepare_forced_adjoint_functions_rebuilds_each_function_once(self):
+        """Stop selecting a forced adjoint after its first rebuild attempt."""
+
+        class TestFunction:
+            pass
+
+        build_count = 0
+
+        def count_build(*args, **kwargs):
+            nonlocal build_count
+            build_count += 1
+            if build_count > 1:
+                self.fail("A forced adjoint was rebuilt more than once")
+
+        func = TestFunction()
+        func.adj = SimpleNamespace(
+            build=count_build,
+            builder_options={"enable_backward": False},
+            called_user_functions=set(),
+            force_adjoint_codegen=True,
+            skip_build=False,
+        )
+
+        builder = ModuleBuilder.__new__(ModuleBuilder)
+        builder.functions = {func: None}
+        builder._prepare_forced_adjoint_functions()
+
+        self.assertEqual(build_count, 1)
+
+    def test_enable_backward_kernel_option_reaches_lto_dispatch(self):
+        """Suppress backward LTOs for a kernel-level ``enable_backward=False``, matching ``module_options``."""
+        device = _lto_test_device(self)
+
+        enabled = count_module_ltos(tile_matmul_backward_enabled_kernel, device)
+        kernel_option = count_module_ltos(tile_matmul_kernel_option_kernel, device)
+        module_option = count_module_ltos(tile_matmul_module_option_kernel, device)
+
+        self.assertEqual(kernel_option, module_option)
+        self.assertLess(kernel_option, enabled)
+
+    def test_enable_backward_kernel_option_reaches_func_bodies(self):
+        """Drop backward LTOs from a ``@wp.func`` body when no kernel in the module needs the backward pass."""
+        device = _lto_test_device(self)
+
+        enabled = count_module_ltos(tile_matmul_via_func_enabled_kernel, device)
+        disabled = count_module_ltos(tile_matmul_via_func_disabled_kernel, device)
+
+        self.assertLess(disabled, enabled)
+
+    def test_enable_backward_union_preserves_mixed_module_backward(self):
+        """Keep backward LTOs for a shared ``@wp.func`` when only some kernels in the module disable backward."""
+        device = _lto_test_device(self)
+
+        enabled = count_module_ltos(tile_matmul_via_func_enabled_kernel, device)
+        disabled = count_module_ltos(tile_matmul_via_func_disabled_kernel, device)
+        mixed = count_module_ltos(tile_matmul_mixed_enabled_kernel, device)
+
+        # tile_matmul_mixed_disabled_kernel shares the module, so referencing it here documents that both
+        # kernels are built together even though the count is taken from the module, not the kernel.
+        self.assertIs(tile_matmul_mixed_disabled_kernel.module, tile_matmul_mixed_enabled_kernel.module)
+
+        self.assertEqual(mixed, enabled)
+        self.assertGreater(mixed, disabled)
+
+    def test_wp_grad_preserves_backward_ltos(self):
+        """Keep and execute backward LTOs forced by ``wp.grad()`` in a forward-only kernel."""
+        device = _lto_test_device(self)
+
+        enabled = count_module_ltos(tile_matmul_via_func_enabled_kernel, device)
+        forced = count_module_ltos(tile_matmul_via_grad_kernel, device)
+        self.assertIs(tile_matmul_grad_forward_kernel.module, tile_matmul_via_grad_kernel.module)
+        self.assertEqual(forced, enabled)
+
+        x = 0.25
+        x_wp = wp.array([x], dtype=wp.float32, device=device)
+        grad_x_wp = wp.zeros_like(x_wp)
+
+        wp.launch_tiled(
+            tile_matmul_via_grad_kernel,
+            dim=1,
+            inputs=[x_wp],
+            outputs=[grad_x_wp],
+            block_dim=TILE_DIM,
+            device=device,
+        )
+
+        expected = 2.0 * TILE_M * TILE_M * TILE_M * x
+        np.testing.assert_allclose(grad_x_wp.numpy(), [expected], rtol=1.0e-5, atol=1.0e-5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2, failfast=True)

--- a/warp/tests/tile/test_tile_shared_memory.py
+++ b/warp/tests/tile/test_tile_shared_memory.py
@@ -1292,6 +1292,94 @@ def test_tile_custom_grad_shared_forward(test, device):
     test.assertLess(hooks.backward_smem_bytes, 2 * hooks.forward_smem_bytes + scratch_bytes)
 
 
+WP_GRAD_TILE_M = 8
+WP_GRAD_SHARED_DIM = 16
+WP_GRAD_BLOCK_DIM = 32
+
+
+@wp.func
+def shared_matmul_objective(x: float):
+    a = wp.tile_ones(shape=(WP_GRAD_TILE_M, WP_GRAD_TILE_M), dtype=float, storage="register") * x
+    c = wp.tile_zeros(shape=(WP_GRAD_TILE_M, WP_GRAD_TILE_M), dtype=float)
+    wp.tile_matmul(a, a, c)
+    scratch = wp.tile_ones(shape=(WP_GRAD_SHARED_DIM, WP_GRAD_SHARED_DIM), dtype=float, storage="shared")
+    return wp.tile_sum(c)[0] + wp.tile_sum(scratch)[0] * 0.0
+
+
+@wp.func
+def shared_scratch_objective(x: float):
+    return x * x
+
+
+@wp.func_grad(shared_scratch_objective)
+def adj_shared_scratch_objective(x: float, adj_ret: float):
+    scratch = wp.tile_ones(shape=(WP_GRAD_TILE_M, WP_GRAD_TILE_M), dtype=float, storage="shared")
+    scratch_sum = wp.tile_sum(scratch)[0]
+    wp.adjoint[x] += (wp.grad(shared_matmul_objective)(x) + scratch_sum * 0.0) * adj_ret
+
+
+@wp.func
+def nested_custom_grad_objective(x: float):
+    return x * x
+
+
+@wp.func_grad(nested_custom_grad_objective)
+def adj_nested_custom_grad_objective(x: float, adj_ret: float):
+    wp.adjoint[x] += wp.grad(shared_scratch_objective)(x) * adj_ret
+
+
+@wp.kernel(enable_backward=False)
+def eval_nested_custom_grad_forward_only(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(nested_custom_grad_objective)(x[0])
+
+
+# Isolate this kernel because its intentional wp.grad() call with backward enabled emits a warning while building
+# its module. Keeping it out of the shared file module prevents unrelated tests from emitting it, while defining it
+# at module scope avoids recreating and hashing the kernel for every device-parameterized test invocation.
+@wp.kernel(module="unique")
+def eval_nested_custom_grad_with_backward(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(nested_custom_grad_objective)(x[0])
+
+
+def test_tile_wp_grad_custom_grad_shared(test, device):
+    """Size nested custom-gradient frames in forward- and backward-enabled kernels."""
+    forward_module = eval_nested_custom_grad_forward_only.module
+    forward_options = forward_module.resolve_options(wp.config, block_dim=WP_GRAD_BLOCK_DIM) | {
+        "output_arch": forward_module._get_compile_arch(device)
+    }
+    forward_builder = warp_context.ModuleBuilder(forward_module, forward_options)
+    forward_meta = forward_builder.build_meta()
+
+    forward_name = eval_nested_custom_grad_forward_only.get_mangled_name() + "_cuda_kernel_forward_smem_bytes"
+    nested_backward_bytes = 2 * WP_GRAD_SHARED_DIM * WP_GRAD_SHARED_DIM * 4
+    custom_grad_bytes = WP_GRAD_TILE_M * WP_GRAD_TILE_M * 4
+    test.assertGreaterEqual(forward_meta[forward_name], nested_backward_bytes + custom_grad_bytes)
+
+    backward_module = eval_nested_custom_grad_with_backward.module
+    backward_options = backward_module.resolve_options(wp.config, block_dim=WP_GRAD_BLOCK_DIM) | {
+        "output_arch": backward_module._get_compile_arch(device)
+    }
+    backward_builder = warp_context.ModuleBuilder(backward_module, backward_options)
+    backward_meta = backward_builder.build_meta()
+    backward_forward_name = eval_nested_custom_grad_with_backward.get_mangled_name() + "_cuda_kernel_forward_smem_bytes"
+    backward_name = eval_nested_custom_grad_with_backward.get_mangled_name() + "_cuda_kernel_backward_smem_bytes"
+    expected_grad_bytes = nested_backward_bytes + custom_grad_bytes
+    test.assertGreaterEqual(backward_meta[backward_name], expected_grad_bytes)
+    test.assertEqual(backward_meta[backward_name], backward_meta[backward_forward_name])
+
+    x = wp.array([3.0], dtype=float, device=device)
+    out = wp.zeros_like(x)
+    wp.launch_tiled(
+        eval_nested_custom_grad_forward_only,
+        dim=1,
+        inputs=[x],
+        outputs=[out],
+        block_dim=WP_GRAD_BLOCK_DIM,
+        device=device,
+    )
+    np.testing.assert_allclose(out.numpy(), [2.0 * WP_GRAD_TILE_M * WP_GRAD_TILE_M * WP_GRAD_TILE_M * 3.0])
+
+
 class TestTileSharedMemoryMessages(unittest.TestCase):
     """Message formatting for over-budget shared memory requests, independent of any device."""
 
@@ -1305,6 +1393,7 @@ class TestTileSharedMemoryMessages(unittest.TestCase):
 
 
 devices = get_cuda_test_devices()
+unique_cuda_devices = get_cuda_test_devices(mode="unique")
 
 
 class TestTileSharedMemory(unittest.TestCase):
@@ -1436,6 +1525,12 @@ add_function_test(
     "test_tile_custom_grad_shared_forward",
     test_tile_custom_grad_shared_forward,
     devices=devices,
+)
+add_function_test(
+    TestTileSharedMemory,
+    "test_tile_wp_grad_custom_grad_shared",
+    test_tile_wp_grad_custom_grad_shared,
+    devices=unique_cuda_devices,
 )
 add_function_test(
     TestTileSharedMemory,

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -267,6 +267,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.tile.test_tile_load_indexed import TestTileLoadIndexed
     from warp.tests.tile.test_tile_load_vectorized import TestTileLoadVectorized
     from warp.tests.tile.test_tile_mathdx import TestTileMathDx
+    from warp.tests.tile.test_tile_mathdx_lto import TestTileMathDxLTO
     from warp.tests.tile.test_tile_matmul import TestTileMatmul
     from warp.tests.tile.test_tile_matmul_no_mathdx import TestTileMatmulNoMathDx
     from warp.tests.tile.test_tile_matmul_strides import TestTileMatmulStrides
@@ -437,6 +438,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestTileLoadIndexed,
         TestTileLoadVectorized,
         TestTileMathDx,
+        TestTileMathDxLTO,
         TestTileMatmul,
         TestTileMatmulNoMathDx,
         TestTileMatmulStrides,

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -267,6 +267,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.tile.test_tile_load_indexed import TestTileLoadIndexed
     from warp.tests.tile.test_tile_load_vectorized import TestTileLoadVectorized
     from warp.tests.tile.test_tile_mathdx import TestTileMathDx
+    from warp.tests.tile.test_tile_mathdx_lto import TestTileMathDxLTO
     from warp.tests.tile.test_tile_matmul import TestTileMatmul
     from warp.tests.tile.test_tile_matmul_no_mathdx import TestTileMatmulNoMathDx
     from warp.tests.tile.test_tile_matmul_strides import TestTileMatmulStrides
@@ -434,6 +435,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestTileLoadIndexed,
         TestTileLoadVectorized,
         TestTileMathDx,
+        TestTileMathDxLTO,
         TestTileMatmul,
         TestTileMatmulNoMathDx,
         TestTileMatmulStrides,


### PR DESCRIPTION
## Description

Fix kernel-level `enable_backward=False` propagation to MathDx tile LTO dispatch. This avoids compiling unused backward LTOs while retaining backward LTOs explicitly required by `wp.grad()`.

Closes #1717.

## Changes

- Merge per-kernel options into adjoint builds so tile dispatch observes `enable_backward=False`.
- Preserve backward code and MathDx LTOs for shared helpers reached by enabled kernels or forced by `wp.grad()`.
- Include explicit gradient targets in shared-memory sizing.
- Bound forced-adjoint rebuilding, skip functions whose earlier build failed, and document the forced-adjoint preparation invariant.
- Add focused LTO-count and runtime-gradient coverage in `test_tile_mathdx_lto.py`, update the block-Cholesky test to use the kernel option, and clarify the public option documentation.
- Add a Towncrier fragment for the user-facing fix.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment because this change affects users.

## Validation summary

- Verified the new `wp.grad()` regression failed before the review fix because the forced module generated one LTO instead of the three required for the forward and backward MathDx paths.
- Verified the skipped-adjoint regressions fail before the guard: one attempts to rebuild a failed function, and one selects the same function repeatedly.
- Passed all six `TestTileMathDxLTO` tests after rebasing onto the latest `main`, including the executable nested-gradient regression and both rebuild-loop regressions.
- Passed two focused deterministic-metadata tests covering cache refresh and launch metadata.
- Passed four focused CPU/CUDA `wp.grad()` tests on a preceding revision.
- Confirmed the Towncrier draft renders the GH-1717 fragment in the Fixed section.
- The full 15,120-test suite passed on an earlier revision. It was not rerun after the review fixes and latest rebase; the focused test module and all pre-commit hooks pass on the current revision.

## Bug fix

Without this change, the kernel option suppresses generated C++ backward code but does not suppress MathDx backward LTO generation:

```python
import warp as wp


@wp.kernel(enable_backward=False)
def gemm(A: wp.array2d[float], B: wp.array2d[float], C: wp.array2d[float]):
    a = wp.tile_load(A, shape=(8, 8), offset=(0, 0), storage="register")
    b = wp.tile_load(B, shape=(8, 4), offset=(0, 0), storage="register")
    c = wp.tile_zeros(shape=(8, 4), dtype=wp.float32)
    wp.tile_matmul(a, b, c)
    wp.tile_store(C, c)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MathDx tile operations now honor kernel-level backward-computation settings.
  * Prevented unnecessary backward compilation for disabled or unused gradients, reducing cold compilation time.
  * Improved diagnostics for disabling backward computation at kernel or module scope.
  * Ensured gradients explicitly requested through `wp.grad()` are generated correctly.
  * Improved consistency when combining module-level and kernel-level backward settings.
* **Documentation**
  * Clarified how to disable backward computation at the kernel level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->