### PR TITLE
Document launch access checks

### DIFF
--- a/changelog/1693.documentation.md
+++ b/changelog/1693.documentation.md
@@ -1,0 +1,4 @@
+Document how a kernel launch checks its Warp array arguments for cross-device access. Explain what the default relaxed
+mode lets through (a segmentation fault in a CPU kernel, or a CUDA illegal memory access), which allocations `CHECKED`
+can and cannot verify, and why `STRICT` also rejects cross-device allocations the launch device could legitimately
+access.

--- a/docs/user_guide/debugging.rst
+++ b/docs/user_guide/debugging.rst
@@ -282,6 +282,45 @@ If a bug with Warp's kernel caching logic is suspected, kernel caching can be di
 
     wp.config.cache_kernels = False
 
+Cross-Device Array Access
+-------------------------
+
+A cross-device launch runs a kernel on one device with an array allocated on
+another. If the launch device cannot access the array, a CPU kernel may fail
+with a segmentation fault (``SIGSEGV``), or CUDA may report error 700
+(``an illegal memory access was encountered``). The default
+``wp.config.LaunchArrayAccessMode.RELAXED`` mode does not check array
+accessibility before a kernel runs.
+
+Whether a cross-device launch is valid depends on which device accesses the
+array and how the array was allocated. System capabilities and access settings
+also matter, so the same launch may work on one system and fail on another. Use
+:func:`wp.can_access(device, array) <warp.can_access>` to check a specific
+allocation. See :ref:`cross_device_memory_access` for the full access model and
+platform-specific examples.
+
+To diagnose a suspected cross-device array access failure without rejecting
+supported access, enable checked validation:
+
+.. code-block:: python
+
+    wp.config.launch_array_access_mode = wp.config.LaunchArrayAccessMode.CHECKED
+
+``CHECKED`` raises a ``RuntimeError`` before execution when Warp can determine
+that an array is inaccessible. If Warp cannot verify a custom or externally
+managed allocation, it emits a warning and allows the launch to proceed.
+
+Use ``STRICT`` to require every Warp array argument to be allocated on the
+launch device. It also rejects cross-device allocations that the hardware
+could access:
+
+.. code-block:: python
+
+    wp.config.launch_array_access_mode = wp.config.LaunchArrayAccessMode.STRICT
+
+See :ref:`launch_array_access_checks` for the complete behavior, limitations,
+and performance considerations.
+
 CUDA Error Verification
 -----------------------
 

--- a/docs/user_guide/execution_and_performance/memory_management.rst
+++ b/docs/user_guide/execution_and_performance/memory_management.rst
@@ -616,6 +616,8 @@ Set up a shared RMM pool for PyTorch and Warp:
     a = wp.zeros(1000, dtype=wp.float32, device="cuda:0")
 
 
+.. _cross_device_memory_access:
+
 Cross-Device Memory Access
 --------------------------
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -9619,16 +9619,34 @@ def _format_array_memory_kind(value: warp.array) -> str:
     return f"memory_kinds=[{', '.join(kind_names)}]"
 
 
-def _raise_launch_array_access_error(kernel, arg_name: str, value: warp.array, device: Device) -> None:
+def _raise_launch_array_access_error(
+    kernel,
+    arg_name: str,
+    value: warp.array,
+    device: Device,
+    mode: warp.config.LaunchArrayAccessMode,
+) -> None:
     memory_kind = _format_array_memory_kind(value)
-    raise RuntimeError(
-        f"Error launching kernel '{kernel.key}', trying to launch on device='{device}', "
-        f"but input array for argument '{arg_name}' is on device={value.device} ({memory_kind}), "
-        f"whose memory is not accessible or cannot be verified as accessible from "
-        f"'{device}'. Move the array to '{device}', enable the required peer/mempool/coherent access, "
-        f"or set warp.config.launch_array_access_mode = warp.config.LaunchArrayAccessMode.RELAXED "
-        f"only if this launch is valid for the hardware and memory kind."
-    )
+    if mode == warp.config.LaunchArrayAccessMode.STRICT:
+        # STRICT rejects any off-device array, even one the launch device could access.
+        raise RuntimeError(
+            f"Error launching kernel '{kernel.key}' on device='{device}': "
+            "warp.config.LaunchArrayAccessMode.STRICT requires every Warp array argument "
+            f"to be allocated on the launch device, but argument '{arg_name}' is on "
+            f"device={value.device} ({memory_kind}). Move the array to '{device}', or use "
+            "warp.config.LaunchArrayAccessMode.CHECKED to allow the launch when the launch "
+            "device can access this allocation."
+        )
+    else:
+        # CHECKED only reaches here once the array is classified as inaccessible.
+        raise RuntimeError(
+            f"Error launching kernel '{kernel.key}', trying to launch on device='{device}', "
+            f"but input array for argument '{arg_name}' is on device={value.device} ({memory_kind}), "
+            f"whose memory is not accessible or cannot be verified as accessible from "
+            f"'{device}'. Move the array to '{device}', enable the required peer/mempool/coherent access, "
+            f"or set warp.config.launch_array_access_mode = warp.config.LaunchArrayAccessMode.RELAXED "
+            f"only if this launch is valid for the hardware and memory kind."
+        )
 
 
 def _warn_unknown_launch_array_access(kernel, arg_name: str, value: warp.array, device: Device) -> None:
@@ -9659,11 +9677,11 @@ def _validate_launch_array_access(kernel, arg_name: str, value: warp.array, devi
         return
 
     if mode == warp.config.LaunchArrayAccessMode.STRICT:
-        _raise_launch_array_access_error(kernel, arg_name, value, device)
+        _raise_launch_array_access_error(kernel, arg_name, value, device, mode)
     elif mode == warp.config.LaunchArrayAccessMode.CHECKED:
         access_status = _classify_array_access_from_device(value, device)
         if access_status == _ArrayAccessStatus.INACCESSIBLE:
-            _raise_launch_array_access_error(kernel, arg_name, value, device)
+            _raise_launch_array_access_error(kernel, arg_name, value, device, mode)
         elif access_status == _ArrayAccessStatus.UNKNOWN:
             _warn_unknown_launch_array_access(kernel, arg_name, value, device)
         return
@@ -10596,6 +10614,18 @@ def launch(
     """Launch a Warp kernel on the target device
 
     Kernel launches are asynchronous with respect to the calling Python thread.
+
+    The default ``wp.config.LaunchArrayAccessMode.RELAXED`` mode does not check
+    whether array arguments are accessible from the launch device. Cross-device
+    access depends on the access direction, memory kind, and system
+    capabilities. An inaccessible array may cause a segmentation fault in a
+    CPU kernel or a CUDA illegal memory access. Set
+    :attr:`warp.config.launch_array_access_mode` to
+    ``wp.config.LaunchArrayAccessMode.CHECKED`` to detect known-invalid
+    accesses before launch. Use ``wp.config.LaunchArrayAccessMode.STRICT`` to
+    require every Warp array argument to be allocated on the launch device,
+    including cross-device allocations the hardware could access. See
+    :ref:`launch_array_access_checks` for details and limitations.
 
     Args:
         kernel: The name of a Warp kernel function, decorated with the :func:`@wp.kernel <warp.kernel>` decorator

--- a/warp/tests/cuda/test_unified_memory.py
+++ b/warp/tests/cuda/test_unified_memory.py
@@ -261,7 +261,7 @@ def test_unified_memory_relaxed_allows_cpu_launch_with_gpu_array(test, device):
 
 
 def test_unified_memory_strict_rejects_cuda_launch_with_pinned_cpu_array(test, device):
-    """Strict mode restores the original same-device rule."""
+    """Strict mode explains that it enforces the same-device rule."""
 
     if not device.is_uva:
         test.skipTest(f"{device} does not support unified virtual addressing")
@@ -269,9 +269,23 @@ def test_unified_memory_strict_rejects_cuda_launch_with_pinned_cpu_array(test, d
     src = wp.array(np.arange(4, dtype=np.float32), dtype=wp.float32, device="cpu", pinned=True)
     dst = wp.empty(4, dtype=wp.float32, device=device)
 
+    test.assertTrue(wp.can_access(device, src))
+
     with launch_array_access_mode(wp.config.LaunchArrayAccessMode.STRICT):
-        with test.assertRaisesRegex(RuntimeError, "is on device=cpu"):
+        with test.assertRaises(RuntimeError) as exception_context:
             wp.launch(read_cpu_write_gpu, dim=src.size, inputs=[src], outputs=[dst], device=device, record_cmd=True)
+
+    message = str(exception_context.exception)
+    test.assertIn(
+        "warp.config.LaunchArrayAccessMode.STRICT requires every Warp array argument "
+        "to be allocated on the launch device",
+        message,
+    )
+    test.assertIn(f"argument 'src' is on device={src.device}", message)
+    test.assertIn(f"on device='{device}'", message)
+    test.assertIn("memory_kind=PINNED", message)
+    test.assertIn("use warp.config.LaunchArrayAccessMode.CHECKED", message)
+    test.assertNotIn("not accessible or cannot be verified", message)
 
 
 def test_unified_memory_cuda_launch_reads_cpu_array_when_supported(test, device):


### PR DESCRIPTION
> **Draft:** opened primarily to exercise CI/CD on this branch. Review is welcome but not being requested yet.

## Description

`wp.launch` runs in `LaunchArrayAccessMode.RELAXED` by default, which performs no array accessibility checks. When an argument is not reachable from the launch device, the failure surfaces as a segmentation fault in a CPU kernel or as CUDA error 700 (`an illegal memory access was encountered`), neither of which points back at the array that caused it. That behavior was undocumented, which is the reporting gap behind #1693.

This documents what each mode does and does not catch, and makes the `STRICT` rejection explain itself. Previously `STRICT` reused the `CHECKED` error text, so refusing a perfectly accessible cross-device array produced a message claiming the memory "is not accessible or cannot be verified as accessible". That is misleading: on systems where the launch device really can reach the allocation, the array was rejected by policy, not by capability.

## Changes

- **Launch diagnostics** (`warp/_src/context.py`): give `STRICT` its own error naming the policy as the reason and pointing at `CHECKED` as the way to allow hardware-supported cross-device access. `CHECKED` keeps its existing accessibility wording, which is only reached once an array is classified as inaccessible.
- **Debugging guide**: new "Cross-Device Array Access" section covering the segfault / CUDA 700 symptoms, how to opt into `CHECKED` or `STRICT`, and the fact that `CHECKED` warns rather than raises when it cannot verify an externally managed allocation.
- **`launch` docstring**: describe the accessibility checks and link to the detailed reference.
- **Memory management guide**: add the `cross_device_memory_access` anchor so the debugging guide can point at the full access model.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

Verified the two modes stay distinct on a machine with GPU-to-CPU access available (`GPU->CPU mem: True`), which is the configuration where the old shared message was actively wrong. Launching a kernel on `cuda:0` against a `device="cpu"` array raises the new policy-specific error under `STRICT`, and is allowed under `CHECKED` because the memory is in fact reachable. That difference is the point of the change: `CHECKED` no longer describes accessible memory as invalid.

- `warp/tests/cuda/test_unified_memory.py`: 54 tests pass (2 skipped). This file carries the launch access assertions updated here.
- `uv run --extra docs build_docs.py`: builds clean with no Sphinx warnings, which also confirms the new `:ref:` targets (`launch_array_access_checks`, `cross_device_memory_access`) resolve.
- `uvx pre-commit run`: all hooks pass on the changed files.
- Towncrier renders `changelog/1693.documentation.md` as a single Documentation bullet with the issue link.

Not run: the full test suite. The change is limited to documentation plus one error message on an already-failing path, so the blast radius is small, but CI on this PR is the real check.

## New feature / enhancement

`STRICT` now explains that the rejection is a policy decision and names the escape hatch. Actual output from this branch:

```python
import warp as wp

wp.config.launch_array_access_mode = wp.config.LaunchArrayAccessMode.STRICT

a = wp.zeros(4, dtype=float, device="cpu")
wp.launch(scale, dim=4, inputs=[a], device="cuda:0")
```

```
RuntimeError: Error launching kernel 'scale' on device='cuda:0':
warp.config.LaunchArrayAccessMode.STRICT requires every Warp array argument to be
allocated on the launch device, but argument 'a' is on device=cpu
(memory_kind=HOST). Move the array to 'cuda:0', or use
warp.config.LaunchArrayAccessMode.CHECKED to allow the launch when the launch
device can access this allocation.
```

The same launch under `CHECKED` proceeds on this system, since `cuda:0` can read host memory here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for diagnosing cross-device array access failures.
  * Documented `RELAXED`, `CHECKED`, and `STRICT` launch access modes, including configuration examples and allocation checks.
  * Added a reference link for cross-device memory access documentation.

* **Bug Fixes**
  * Improved launch validation messages to accurately distinguish inaccessible memory from memory rejected by strict same-device validation.
  * Clarified diagnostics for CPU and CUDA cross-device access failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->