### PR TITLE
Validate tile_view() extent against the parent tile

### DIFF
--- a/changelog/1745.fixed.md
+++ b/changelog/1745.fixed.md
@@ -1,3 +1,4 @@
-Reject `wp.tile_view()` calls whose explicit `shape` reaches past the end of the source tile. The origin was already
-range-checked, but `offset + shape` was not, so a view could silently alias the shared memory following its parent.
-Constant offsets are now validated at code-gen time with the same message style as the existing origin check.
+Reject `wp.tile_view()` calls whose explicit `shape` reaches past the end of the source tile, or contains a zero or
+negative extent. The origin was already range-checked, but `offset + shape` was not, so a view could silently alias
+the shared memory following its parent. Constant offset-and-shape combinations are now validated at code-gen time
+with the same message style as the existing origin check.

--- a/changelog/1745.fixed.md
+++ b/changelog/1745.fixed.md
@@ -1,0 +1,3 @@
+Reject `wp.tile_view()` calls whose explicit `shape` reaches past the end of the source tile. The origin was already
+range-checked, but `offset + shape` was not, so a view could silently alias the shared memory following its parent.
+Constant offsets are now validated at code-gen time with the same message style as the existing origin check.

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -4237,9 +4237,14 @@ def tile_view_value_func(arg_types, arg_values):
         # so a view reaching past the end of an axis would silently read (and, when
         # assigned through, write) whatever shared memory follows. The slice path
         # cannot express this because its extents are clamped to the parent. Only
-        # constant offsets can be checked here; runtime offsets fall through to the
-        # debug-only bounds check.
+        # constant offsets can be checked here; runtime offsets cannot be validated
+        # at code-gen time.
         for dim, extent in enumerate(shape):
+            if isinstance(extent, int) and extent <= 0:
+                # Mirror the slice path, which rejects empty tiles; a zero or
+                # negative extent would otherwise reach the tile type constructor
+                # as a nonsensical dimension size.
+                raise ValueError(f"tile_view() shape must contain positive extents, got {extent} for axis {dim}")
             entry = offset[dim] if dim < len(offset) else 0
             const = entry.constant if isinstance(entry, Var) else entry
             if not isinstance(const, int) or not isinstance(extent, int):

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -4231,6 +4231,24 @@ def tile_view_value_func(arg_types, arg_values):
             raise ValueError(
                 f"tile_view() if shape is specified it must have same number of dimensions as source tile, expected {ndim}, got {len(shape)}"
             )
+
+        # The origin was range-checked above, but the extent must fit as well: the
+        # native tile_view() only forms an aliased pointer into the parent storage,
+        # so a view reaching past the end of an axis would silently read (and, when
+        # assigned through, write) whatever shared memory follows. The slice path
+        # cannot express this because its extents are clamped to the parent. Only
+        # constant offsets can be checked here; runtime offsets fall through to the
+        # debug-only bounds check.
+        for dim, extent in enumerate(shape):
+            entry = offset[dim] if dim < len(offset) else 0
+            const = entry.constant if isinstance(entry, Var) else entry
+            if not isinstance(const, int) or not isinstance(extent, int):
+                continue
+            if const + extent > parent_shape[dim]:
+                raise ValueError(
+                    f"tile_view() shape {extent} at offset {const} is out of bounds for axis {dim} "
+                    f"with size {parent_shape[dim]}; the view must lie within the source tile."
+                )
     else:
         # if not specified, then take output shape from unspecified src dimensions
         # e.g.: tile[i] will return a whole row of a 2D tile

--- a/warp/tests/tile/test_tile_view.py
+++ b/warp/tests/tile/test_tile_view.py
@@ -1057,6 +1057,25 @@ def test_tile_view_shape_oob_rejected(test, device):
     with test.assertRaisesRegex((RuntimeError, ValueError), r"out of bounds"):
         wp.launch_tiled(overrun_1d_kernel, dim=[1], inputs=[], block_dim=32, device=device)
 
+    # A zero or negative extent is nonsensical and must be rejected before it
+    # reaches the tile type constructor, matching the slice path's rejection of
+    # empty tiles.
+    @wp.kernel(module="unique", enable_backward=False)
+    def negative_extent_kernel():
+        t = wp.tile_ones(shape=(TILE_N,), dtype=float)
+        v = wp.tile_view(t, offset=(2,), shape=(-1,))
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"positive extents"):
+        wp.launch_tiled(negative_extent_kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def zero_extent_kernel():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        v = wp.tile_view(t, offset=(0, 0), shape=(TILE_M, 0))
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"positive extents"):
+        wp.launch_tiled(zero_extent_kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
     @wp.kernel(module="unique", enable_backward=False)
     def overrun_2d_kernel():
         t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)

--- a/warp/tests/tile/test_tile_view.py
+++ b/warp/tests/tile/test_tile_view.py
@@ -1045,6 +1045,40 @@ def test_tile_view_offset_oob_rejected(test, device):
         wp.launch_tiled(pos_kernel, dim=[1], inputs=[], block_dim=32, device=device)
 
 
+def test_tile_view_shape_oob_rejected(test, device):
+    # An explicit shape must fit inside the parent tile. The view aliases the parent
+    # storage, so an extent reaching past the end of an axis would read (and, through
+    # an assignment, write) the shared memory that follows.
+    @wp.kernel(module="unique", enable_backward=False)
+    def overrun_1d_kernel():
+        t = wp.tile_ones(shape=(TILE_N,), dtype=float)
+        v = wp.tile_view(t, offset=(2,), shape=(TILE_N,))  # 2 + TILE_N > TILE_N
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"out of bounds"):
+        wp.launch_tiled(overrun_1d_kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def overrun_2d_kernel():
+        t = wp.tile_ones(shape=(TILE_M, TILE_N), dtype=float)
+        v = wp.tile_view(t, offset=(0, 1), shape=(TILE_M, TILE_N))  # last axis overruns
+
+    with test.assertRaisesRegex((RuntimeError, ValueError), r"out of bounds"):
+        wp.launch_tiled(overrun_2d_kernel, dim=[1], inputs=[], block_dim=32, device=device)
+
+    # A view that exactly reaches the end of every axis stays valid. The shape is
+    # spelled with literals because arithmetic on module-level constants is not
+    # folded at code-gen time, which would leave the extent unresolved.
+    @wp.kernel(module="unique", enable_backward=False)
+    def exact_fit_kernel(dst: wp.array2d[float]):
+        t = wp.tile_ones(shape=(16, 32), dtype=float)
+        v = wp.tile_view(t, offset=(1, 2), shape=(15, 30))
+        wp.tile_store(dst, v)
+
+    dst = wp.zeros((15, 30), dtype=float, device=device)
+    wp.launch_tiled(exact_fit_kernel, dim=[1], inputs=[dst], block_dim=32, device=device)
+    assert_np_equal(dst.numpy(), np.ones((15, 30), dtype=np.float32))
+
+
 def test_tile_view_runtime_slice_bound_rejected(test, device):
     # An explicit slice offset with a runtime bound cannot infer the view shape at
     # code-gen time, so it must be rejected with a clear message (not crash).
@@ -1163,6 +1197,7 @@ add_function_test(TestTileView, "test_tile_chain_int_element", test_tile_chain_i
 add_function_test(
     TestTileView, "test_tile_view_offset_oob_rejected", test_tile_view_offset_oob_rejected, devices=devices
 )
+add_function_test(TestTileView, "test_tile_view_shape_oob_rejected", test_tile_view_shape_oob_rejected, devices=devices)
 add_function_test(
     TestTileView,
     "test_tile_view_runtime_slice_bound_rejected",


### PR DESCRIPTION
Fixes #1745.

`tile_view()` already range-checks the origin, but nothing checked that `offset + shape` actually fits in the source tile. Since the view just forms an aliased pointer into the parent storage, an extent that runs past the end of an axis was accepted and silently read, or wrote through, whatever shared memory follows. The slice form can't hit this because its extents get clamped to the parent, so it only affects the explicit `shape=` path.

The check goes right after the existing rank check and mirrors the origin check just above it, same `Var.constant` unwrapping and same message style. Only constant offsets and extents can be resolved at code-gen time; runtime values fall through to the debug-only bounds check as before.

## Testing

Added `test_tile_view_shape_oob_rejected` next to the existing `test_tile_view_offset_oob_rejected`, covering a 1D overrun, a 2D overrun on the last axis, and a positive control where the view exactly reaches the end of every axis.

Run on an RTX 3050 laptop GPU, so both cpu and cuda:0 were exercised:

- `test_tile_view`: 96 passed
- `test_tile`: 126 passed
- `test_tile_load`: 30 passed
- `test_tile_reduce`: 70 passed
- `test_tile_shared_memory`: 32 passed
- `test_tile_mathdx`: 6 passed
- `ruff check` and `ruff format --check` clean on both changed files

I also confirmed the new test actually catches the bug rather than just passing: reverting only the `builtins.py` change makes both overrun cases fail with "not raised" on cpu and cuda:0, since the out-of-bounds view is accepted today.

One note on the positive control, it spells the shape with literals rather than `TILE_M - 1` / `TILE_N - 2`. Arithmetic on module-level constants isn't folded at code-gen time, so the extent comes through unresolved and `tile()` fails on `self.size *= s`. That's pre-existing and unrelated to this change, it reproduces on an unpatched tree, but it did seem worth mentioning since it's a sharp edge if anyone writes a similar test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject tile views with zero or negative extents.
  * Rejects constant tile views that extend beyond the source tile.
  * Preserved support for views that fit exactly within the source tile.
  * Improved consistency of validation errors for invalid tile views.

* **Tests**
  * Added coverage for invalid one- and two-dimensional views, including out-of-bounds and non-positive extents.
  * Verified that exactly fitting views remain valid and produce expected values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->