### PR TITLE
Enable Windows ARM64 CPU builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    env:
+      UV_PYTHON: ${{ matrix.python_request || '3.12' }}
     strategy:
       fail-fast: false
       matrix:
@@ -42,36 +44,50 @@ jobs:
             platform: windows
             cuda-version: "12.9.2"
             cuda-platform: windows-x86_64
+            build-args: ""
             artifact-name: build-artifact-windows-cuda12
           - os: windows-2022
             platform: windows
             cuda-version: "13.0.3"
             cuda-platform: windows-x86_64
+            build-args: ""
             artifact-name: build-artifact-windows-cuda13
+          - os: windows-11-arm
+            platform: windows-aarch64
+            python_request: cpython-3.12-windows-aarch64-none
+            cuda-version: ""
+            cuda-platform: ""
+            build-args: --no-cuda
+            artifact-name: build-artifact-windows-aarch64-cpu
           - os: ubuntu-24.04
             platform: ubuntu-x86_64
             cuda-version: "12.9.2"
             cuda-platform: linux-x86_64
+            build-args: ""
             artifact-name: build-artifact-ubuntu-x86_64-cuda12
           - os: ubuntu-24.04
             platform: ubuntu-x86_64
             cuda-version: "13.0.3"
             cuda-platform: linux-x86_64
+            build-args: ""
             artifact-name: build-artifact-ubuntu-x86_64-cuda13
           - os: ubuntu-24.04-arm
             platform: ubuntu-aarch64
             cuda-version: "12.9.2"
             cuda-platform: linux-aarch64
+            build-args: ""
             artifact-name: build-artifact-ubuntu-aarch64-cuda12
           - os: ubuntu-24.04-arm
             platform: ubuntu-aarch64
             cuda-version: "13.0.3"
             cuda-platform: linux-sbsa
+            build-args: ""
             artifact-name: build-artifact-ubuntu-aarch64-cuda13
           - os: macos-latest
             platform: macos
             cuda-version: ''
             cuda-platform: ''
+            build-args: ""
             artifact-name: build-artifact-macos
     steps:
       - name: Checkout repository
@@ -96,7 +112,7 @@ jobs:
           path: warp/bin/
           # Hash only native-binary inputs. VERSION.md changes flow through
           # generated warp/native/version.h, which is covered by native headers.
-          key: build-${{ matrix.artifact-name }}-${{ matrix.cuda-version }}-${{ hashFiles('build_lib.py', 'build_llvm.py', 'warp/_src/build_dll.py', 'warp/native/**/*.cpp', 'warp/native/**/*.cu', 'warp/native/**/*.cuh', 'warp/native/**/*.h', 'warp/native/libdevice/*.bc', 'warp/native/warp.map', 'deps/libmathdx-deps.packman.xml', '.github/actions/setup-warp-cuda/action.yml', 'tools/ci/cuda_toolkit.py', 'tools/ci/cuda_toolkit_requirements.json', 'tools/ci/cuda_toolkit_lock.json') }}
+          key: build-${{ matrix.artifact-name }}-${{ matrix.cuda-version }}-${{ hashFiles('build_lib.py', 'build_llvm.py', 'warp/_src/build_architecture.py', 'warp/_src/build_dll.py', 'warp/native/clang/clang.cpp', 'warp/native/**/*.cpp', 'warp/native/**/*.cu', 'warp/native/**/*.cuh', 'warp/native/**/*.h', 'warp/native/libdevice/*.bc', 'warp/native/warp.map', 'deps/llvm-deps.packman.xml', 'deps/libmathdx-deps.packman.xml', '.github/actions/setup-warp-cuda/action.yml', 'tools/ci/cuda_toolkit.py', 'tools/ci/cuda_toolkit_requirements.json', 'tools/ci/cuda_toolkit_lock.json') }}
       
       - name: Set up CUDA Toolkit for Warp
         if: steps.cache-build.outputs.cache-hit != 'true' && matrix.cuda-version != ''
@@ -106,10 +122,12 @@ jobs:
           platform: ${{ matrix.cuda-platform }}
           cache-read: ${{ github.repository == 'NVIDIA/warp' }}
           cache-write: ${{ github.repository == 'NVIDIA/warp' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-') || inputs.allow-ctk-cache-save) }}
-      
+
       - name: Build Warp
         if: steps.cache-build.outputs.cache-hit != 'true'
-        run: uv run build_lib.py
+        env:
+          WARP_CACHE_PATH: ${{ runner.temp }}/warp-cache-${{ matrix.artifact-name }}
+        run: uv run build_lib.py ${{ matrix.build-args }}
       
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -118,7 +136,6 @@ jobs:
           path: warp/bin/
           retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
       
-
   build-warp-python-free-threaded:
     if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
     runs-on: ubuntu-24.04
@@ -175,6 +192,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
+    env:
+      UV_PYTHON: ${{ matrix.python_request || '3.12' }}
     strategy:
       fail-fast: false
       matrix:
@@ -184,16 +203,32 @@ jobs:
             platform: windows
             cuda-version: "13.0.3"
             cuda-platform: windows-x86_64
+            warp-enable-cuda: "ON"
+            msvc-component: Microsoft.VisualStudio.Component.VC.Tools.x86.x64
+            msvc-host-arch: x64
+            msvc-target-arch: x64
             warp-cache-path-suffix: '\warp-cache-cmake'
+          - os: windows-11-arm
+            platform: windows-aarch64
+            python_request: cpython-3.12-windows-aarch64-none
+            cuda-version: ""
+            cuda-platform: ""
+            warp-enable-cuda: "OFF"
+            msvc-component: Microsoft.VisualStudio.Component.VC.Tools.ARM64
+            msvc-host-arch: arm64
+            msvc-target-arch: arm64
+            warp-cache-path-suffix: /warp-cache-cmake-windows-aarch64
           - os: ubuntu-24.04
             platform: ubuntu-x86_64
             cuda-version: "13.0.3"
             cuda-platform: linux-x86_64
+            warp-enable-cuda: "ON"
             warp-cache-path-suffix: /warp-cache-cmake
           - os: ubuntu-24.04-arm
             platform: ubuntu-aarch64
             cuda-version: "13.0.3"
             cuda-platform: linux-sbsa
+            warp-enable-cuda: "ON"
             warp-cache-path-suffix: /warp-cache-cmake
     steps:
       - name: Checkout repository
@@ -211,6 +246,7 @@ jobs:
         run: uv python install
 
       - name: Set up CUDA Toolkit for Warp
+        if: matrix.warp-enable-cuda == 'ON'
         uses: ./.github/actions/setup-warp-cuda
         with:
           version: ${{ matrix.cuda-version }}
@@ -227,51 +263,82 @@ jobs:
         run: uv sync --no-install-project
 
       - name: Set up MSVC developer environment
-        if: matrix.platform == 'windows'
+        if: startsWith(matrix.platform, 'windows')
         run: |
           $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          $vsPath = & $vswhere -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          $vsPath = & $vswhere -latest -requires "${{ matrix.msvc-component }}" -property installationPath
           $vsDevCmd = Join-Path $vsPath "Common7\Tools\VsDevCmd.bat"
           if (!(Test-Path $vsDevCmd)) {
             throw "VsDevCmd.bat was not found"
           }
 
           $before = @{}
+          $developerEnvironment = @{}
           Get-ChildItem Env: | ForEach-Object { $before[$_.Name] = $_.Value }
-          cmd /c "`"$vsDevCmd`" -arch=x64 -host_arch=x64 > nul && set" |
+          cmd /c "`"$vsDevCmd`" -arch=${{ matrix.msvc-target-arch }} -host_arch=${{ matrix.msvc-host-arch }} > nul && set" |
             ForEach-Object {
               $name, $value = $_ -split '=', 2
-              if ($name -and $before[$name] -ne $value) {
-                "$name=$value" >> $env:GITHUB_ENV
+              if ($name) {
+                $developerEnvironment[$name] = $value
+                if ($before[$name] -ne $value) {
+                  "$name=$value" >> $env:GITHUB_ENV
+                }
               }
             }
 
+          if ("${{ matrix.platform }}" -eq "windows-aarch64") {
+            if ($developerEnvironment["VSCMD_ARG_HOST_ARCH"] -ne "arm64") {
+              throw "MSVC host architecture is not arm64"
+            }
+            if ($developerEnvironment["VSCMD_ARG_TGT_ARCH"] -ne "arm64") {
+              throw "MSVC target architecture is not arm64"
+            }
+          }
+
       - name: Build Warp with CMake
-        if: matrix.platform != 'windows'
+        if: ${{ !startsWith(matrix.platform, 'windows') }}
         env:
           WARP_CACHE_PATH: ${{ runner.temp }}${{ matrix.warp-cache-path-suffix }}
         run: |
-          cuda_path="${CUDA_HOME:-${CUDA_PATH:-}}"
-          if [ -z "$cuda_path" ]; then
-            echo "CUDA_HOME or CUDA_PATH must be set" >&2
-            exit 1
+          cmake_args=(
+            -S .
+            -B _build/cmake
+            -G Ninja
+            -DCMAKE_BUILD_TYPE=Release
+            "-DWARP_ENABLE_CUDA=${{ matrix.warp-enable-cuda }}"
+          )
+          if [ "${{ matrix.warp-enable-cuda }}" = "ON" ]; then
+            cuda_path="${CUDA_HOME:-${CUDA_PATH:-}}"
+            if [ -z "$cuda_path" ]; then
+              echo "CUDA_HOME or CUDA_PATH must be set" >&2
+              exit 1
+            fi
+            cmake_args+=("-DWARP_CUDA_PATH:PATH=$cuda_path")
           fi
-          cmake -S . -B _build/cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DWARP_CUDA_PATH:PATH="$cuda_path"
+          cmake "${cmake_args[@]}"
           cmake --build _build/cmake --parallel
 
       - name: Build Warp with CMake
-        if: matrix.platform == 'windows'
+        if: startsWith(matrix.platform, 'windows')
         env:
           WARP_CACHE_PATH: ${{ runner.temp }}${{ matrix.warp-cache-path-suffix }}
         run: |
-          if (!$env:CUDA_PATH) {
-            throw "CUDA_PATH must be set"
+          $cmakeArgs = @(
+            "-S", ".",
+            "-B", "_build/cmake",
+            "-G", "Ninja",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_C_COMPILER=cl",
+            "-DCMAKE_CXX_COMPILER=cl",
+            "-DWARP_ENABLE_CUDA=${{ matrix.warp-enable-cuda }}"
+          )
+          if ("${{ matrix.warp-enable-cuda }}" -eq "ON") {
+            if (!$env:CUDA_PATH) {
+              throw "CUDA_PATH must be set"
+            }
+            $cmakeArgs += "-DWARP_CUDA_PATH:PATH=$env:CUDA_PATH"
           }
-          cmake -S . -B _build/cmake -G Ninja `
-            -DCMAKE_BUILD_TYPE=Release `
-            -DCMAKE_C_COMPILER=cl `
-            -DCMAKE_CXX_COMPILER=cl `
-            "-DWARP_CUDA_PATH:PATH=$env:CUDA_PATH"
+          cmake @cmakeArgs
           cmake --build _build/cmake --parallel
 
       - name: Verify Warp diagnostics
@@ -312,6 +379,8 @@ jobs:
     needs: build-warp
     permissions:
       contents: read
+    env:
+      UV_PYTHON: ${{ matrix.python_request || '3.12' }}
     strategy:
       fail-fast: false
       matrix:
@@ -320,6 +389,11 @@ jobs:
             platform: windows
             artifact-name: build-artifact-windows-cuda12
             jax-extra: jax>=0.5
+          - os: windows-11-arm
+            platform: windows-aarch64
+            python_request: cpython-3.12-windows-aarch64-none
+            artifact-name: build-artifact-windows-aarch64-cpu
+            jax-extra: ""
           - os: ubuntu-24.04
             platform: ubuntu-x86_64
             artifact-name: build-artifact-ubuntu-x86_64-cuda13
@@ -354,7 +428,16 @@ jobs:
           path: warp/bin/
       
       - name: Run Tests
+        if: matrix.jax-extra != ''
+        env:
+          WARP_CACHE_PATH: ${{ runner.temp }}/warp-cache-${{ matrix.artifact-name }}-tests
         run: uv run --extra dev --with "${{ matrix.jax-extra }}" -m warp.tests --junit-report-xml rspec.xml -s autodetect
+
+      - name: Run Tests
+        if: matrix.jax-extra == ''
+        env:
+          WARP_CACHE_PATH: ${{ runner.temp }}/warp-cache-${{ matrix.artifact-name }}-tests
+        run: uv run --extra dev -m warp.tests --junit-report-xml rspec.xml -s autodetect
       
       - name: Test Summary
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4

--- a/build_lib.py
+++ b/build_lib.py
@@ -28,6 +28,7 @@ import time
 import build_llvm
 import warp._src.build_dll as build_dll
 import warp.config as config
+from warp._src.build_architecture import machine_architecture
 from warp._src.generated_files import generate_exports_header_file, generate_version_header
 
 
@@ -194,7 +195,7 @@ def find_libmathdx(cuda_toolkit_major_version: int, base_path: str) -> str | Non
         "pull",
         "--verbose",
         "--platform",
-        f"{platform.system()}-{build_dll.machine_architecture()}".lower(),
+        f"{platform.system()}-{machine_architecture()}".lower(),
         "--include-tag",
         f"cu{cuda_toolkit_major_version}",
         os.path.join(base_path, "deps", "libmathdx-deps.packman.xml"),
@@ -431,7 +432,7 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
     # Warn if building on Intel Mac (cross-compiling for ARM64)
-    if platform.system() == "Darwin" and platform.machine() == "x86_64":
+    if platform.system() == "Darwin" and machine_architecture() == "x86_64":
         print("=" * 80)
         print("WARNING: Building Warp on Intel-based macOS")
         print("=" * 80)
@@ -628,7 +629,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         is_gitlab_ci_windows = os.getenv("GITLAB_CI") is not None and platform.system() == "Windows"
-        is_intel_mac = platform.system() == "Darwin" and platform.machine() == "x86_64"
+        is_intel_mac = platform.system() == "Darwin" and machine_architecture() == "x86_64"
 
         if is_gitlab_ci_windows or is_intel_mac:
             if is_gitlab_ci_windows:
@@ -645,7 +646,7 @@ def main(argv: list[str] | None = None) -> int:
                 compiler = "clang++" if args.clang_build_toolchain else args.host_compiler
                 # GCC ships libasan.so; Clang ships libclang_rt.asan-<arch>.so.
                 runtime_name = (
-                    f"libclang_rt.asan-{platform.machine()}.so"
+                    f"libclang_rt.asan-{machine_architecture()}.so"
                     if "clang" in os.path.basename(compiler)
                     else "libasan.so"
                 )

--- a/build_llvm.py
+++ b/build_llvm.py
@@ -6,7 +6,6 @@
 import hashlib
 import io
 import os
-import platform
 import shutil
 import stat
 import subprocess
@@ -14,6 +13,7 @@ import sys
 import tarfile
 import urllib.request
 
+from warp._src.build_architecture import machine_architecture
 from warp._src.build_dll import *
 
 # set build output path off this file
@@ -70,7 +70,7 @@ def fetch_prebuilt_libraries(arch: str) -> None:
         _run_packman_pull()
     except subprocess.CalledProcessError as e:
         output = e.output or ""
-        is_intel_mac = sys.platform == "darwin" and platform.machine() == "x86_64"
+        is_intel_mac = sys.platform == "darwin" and machine_architecture() == "x86_64"
         # Intel Mac runners cross-compile to aarch64 but can't exec the aarch64-only
         # 7zz packman 8.2.2 installs. Compressed tar archives are decompressed through
         # that helper, so .tar.xz packages hit this too. Remove this branch and

--- a/changelog/1755.added.md
+++ b/changelog/1755.added.md
@@ -1,0 +1,2 @@
+Add native Windows ARM64 support for CPU builds and `win_arm64` wheels. CUDA
+support remains unavailable on Windows ARM64.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,17 +45,17 @@ docs = [
     "myst_parser",
 ]
 benchmark = [
-    "usd-core>=25.5 ; platform_machine != 'aarch64'",
-    "usd-exchange>=2.2 ; python_version >= '3.10' and python_version < '3.13' and platform_machine == 'aarch64'",
+    "usd-core>=25.5 ; (sys_platform != 'linux' or platform_machine != 'aarch64') and (sys_platform != 'win32' or (platform_machine != 'ARM64' and platform_machine != 'arm64' and platform_machine != 'aarch64'))",
+    "usd-exchange>=2.2 ; python_version >= '3.10' and python_version < '3.13' and sys_platform == 'linux' and platform_machine == 'aarch64'",
 ]
 examples = [
-    "blosc>=1.11.1",
+    "blosc>=1.11.1 ; sys_platform != 'win32' or (platform_machine != 'ARM64' and platform_machine != 'arm64' and platform_machine != 'aarch64')",
     "matplotlib>=3.7.5",
     "pillow>=10.4.0",
     "psutil>=7.1.0",
     "pyglet>=2.1.9",
-    "usd-core>=25.5 ; platform_machine != 'aarch64'",
-    "usd-exchange>=2.2 ; python_version >= '3.10' and python_version < '3.13' and platform_machine == 'aarch64'",
+    "usd-core>=25.5 ; (sys_platform != 'linux' or platform_machine != 'aarch64') and (sys_platform != 'win32' or (platform_machine != 'ARM64' and platform_machine != 'arm64' and platform_machine != 'aarch64'))",
+    "usd-exchange>=2.2 ; python_version >= '3.10' and python_version < '3.13' and sys_platform == 'linux' and platform_machine == 'aarch64'",
 ]
 torch-cu12 = [
     "warp-lang[examples]",
@@ -68,7 +68,7 @@ torch-cu13 = [
 dev = [
     "warp-lang[examples]",
     "warp-lang[docs]",
-    "nvtx",
+    "nvtx ; sys_platform != 'win32' or (platform_machine != 'ARM64' and platform_machine != 'arm64' and platform_machine != 'aarch64')",
     "coverage[toml]",
     "ml-dtypes>=0.5.4",
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import importlib.util
 import os
 import pathlib
-import platform
 import shutil
 import sys
 from typing import ClassVar, NamedTuple
 
 import setuptools
 from wheel.bdist_wheel import bdist_wheel
+
+build_architecture_path = pathlib.Path(__file__).parent / "warp" / "_src" / "build_architecture.py"
+build_architecture_spec = importlib.util.spec_from_file_location("warp_build_architecture", build_architecture_path)
+if build_architecture_spec is None or build_architecture_spec.loader is None:
+    raise RuntimeError(f"Could not load build architecture helpers from {build_architecture_path}")
+build_architecture_module = importlib.util.module_from_spec(build_architecture_spec)
+build_architecture_spec.loader.exec_module(build_architecture_module)
+machine_architecture = build_architecture_module.machine_architecture
 
 # Parse --build-option arguments meant for the bdist_wheel command. We have to parse these
 # ourselves because when bdist_wheel runs it's too late to select a subset of libraries for package_data.
@@ -21,7 +29,7 @@ parser.add_argument(
     "-P",
     type=str,
     default="",
-    help="Wheel platform: windows-x86_64|linux-x86_64|linux-aarch64|macos-aarch64",
+    help="Wheel platform: windows-x86_64|windows-aarch64|linux-x86_64|linux-aarch64|macos-aarch64",
 )
 parser.add_argument(
     "--manylinux",
@@ -31,18 +39,6 @@ parser.add_argument(
     help="Manylinux flavor for Linux wheels: manylinux_2_28|manylinux_2_34",
 )
 args = parser.parse_known_args()[0]
-
-
-# returns a canonical machine architecture string
-# - "x86_64" for x86-64, aka. AMD64, aka. x64
-# - "aarch64" for AArch64, aka. ARM64
-def machine_architecture() -> str:
-    machine = platform.machine()
-    if machine == "x86_64" or machine == "AMD64":
-        return "x86_64"
-    if machine == "aarch64" or machine == "arm64":
-        return "aarch64"
-    raise RuntimeError(f"Unrecognized machine architecture {machine}")
 
 
 def machine_os() -> str:
@@ -74,6 +70,7 @@ class Platform(NamedTuple):
 
 platforms = [
     Platform("windows", "x86_64", "Windows x86-64", ".dll", "win_amd64"),
+    Platform("windows", "aarch64", "Windows ARM64", ".dll", "win_arm64"),
     Platform("linux", "x86_64", "Linux x86-64", ".so", "manylinux_2_28_x86_64"),
     Platform("linux", "aarch64", "Linux AArch64", ".so", "manylinux_2_34_aarch64"),
     Platform("macos", "aarch64", "macOS ARM64", ".dylib", "macosx_11_0_arm64"),
@@ -94,7 +91,7 @@ def detect_warp_libraries():
         for p in platforms:
             if os.path.splitext(file.name)[1] == p.extension:
                 # If this is a local build, assume we want a wheel for this machine's architecture
-                if file.parent.name == "bin" and p.arch == machine_architecture():
+                if file.parent.name == "bin" and p.os == machine_os() and p.arch == machine_architecture():
                     detected_libraries.add(Library(file.name, "bin/", p))
                 else:
                     # Expect libraries to be in a subdirectory named after the wheel platform
@@ -132,7 +129,7 @@ if args.command == "bdist_wheel":
         if len(detected_platforms) > 1:
             print("Libraries for multiple platforms were detected.")
             print("Run `python -m build --wheel -C--build-option=-P<platform>` to select a specific one.")
-            print("Available platforms: windows-x86_64, linux-x86_64, linux-aarch64, macos-aarch64")
+            print("Available platforms: windows-x86_64, windows-aarch64, linux-x86_64, linux-aarch64, macos-aarch64")
             # Select the libraries corresponding with the this machine's platform
             for p in platforms:
                 if p.os == machine_os() and p.arch == machine_architecture():
@@ -154,7 +151,7 @@ class WarpBDistWheel(bdist_wheel):
     # setuptools.Command can validate the command line options.
     user_options: ClassVar[list[tuple[str, str, str]]] = [
         *bdist_wheel.user_options,
-        ("platform=", "P", "Wheel platform: windows-x86_64|linux-x86_64|linux-aarch64|macos-aarch64"),
+        ("platform=", "P", "Wheel platform: windows-x86_64|windows-aarch64|linux-x86_64|linux-aarch64|macos-aarch64"),
         ("manylinux=", "M", "Manylinux flavor for Linux wheels: manylinux_2_28|manylinux_2_34"),
     ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2741,25 +2741,25 @@ dependencies = [
 
 [package.optional-dependencies]
 benchmark = [
-    { name = "usd-core", marker = "platform_machine != 'aarch64' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "usd-exchange", marker = "(python_full_version < '3.13' and platform_machine == 'aarch64') or (python_full_version >= '3.13' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine != 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "usd-core", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'ARM64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'aarch64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'arm64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "usd-exchange", marker = "(python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine != 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (sys_platform != 'linux' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
 dev = [
-    { name = "blosc" },
+    { name = "blosc", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (platform_machine == 'ARM64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'arm64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or sys_platform != 'win32'" },
     { name = "coverage", extra = ["toml"] },
     { name = "matplotlib" },
     { name = "ml-dtypes" },
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
     { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
     { name = "nvidia-sphinx-theme" },
-    { name = "nvtx" },
+    { name = "nvtx", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (platform_machine == 'ARM64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'arm64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or sys_platform != 'win32'" },
     { name = "pillow" },
     { name = "pre-commit" },
     { name = "psutil" },
     { name = "pyglet" },
     { name = "sphinx-copybutton" },
-    { name = "usd-core", marker = "platform_machine != 'aarch64' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "usd-exchange", marker = "(python_full_version < '3.13' and platform_machine == 'aarch64') or (python_full_version >= '3.13' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine != 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "usd-core", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'ARM64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'aarch64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'arm64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "usd-exchange", marker = "(python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine != 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (sys_platform != 'linux' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
 docs = [
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
@@ -2769,45 +2769,45 @@ docs = [
     { name = "sphinx-copybutton" },
 ]
 examples = [
-    { name = "blosc" },
+    { name = "blosc", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64') or (platform_machine == 'ARM64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'arm64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or sys_platform != 'win32'" },
     { name = "matplotlib" },
     { name = "pillow" },
     { name = "psutil" },
     { name = "pyglet" },
-    { name = "usd-core", marker = "platform_machine != 'aarch64' or (extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
-    { name = "usd-exchange", marker = "(python_full_version < '3.13' and platform_machine == 'aarch64') or (python_full_version >= '3.13' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine != 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "usd-core", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_machine == 'ARM64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'aarch64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine == 'arm64' and sys_platform == 'win32' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
+    { name = "usd-exchange", marker = "(python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.13' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (platform_machine != 'aarch64' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13') or (sys_platform != 'linux' and extra == 'extra-9-warp-lang-torch-cu12' and extra == 'extra-9-warp-lang-torch-cu13')" },
 ]
 torch-cu12 = [
-    { name = "blosc" },
+    { name = "blosc", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64') or sys_platform != 'win32'" },
     { name = "matplotlib" },
     { name = "pillow" },
     { name = "psutil" },
     { name = "pyglet" },
     { name = "torch", version = "2.13.0+cu126", source = { registry = "https://download.pytorch.org/whl/cu126" } },
-    { name = "usd-core", marker = "platform_machine != 'aarch64'" },
-    { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64'" },
+    { name = "usd-core", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 torch-cu13 = [
-    { name = "blosc" },
+    { name = "blosc", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64') or sys_platform != 'win32'" },
     { name = "matplotlib" },
     { name = "pillow" },
     { name = "psutil" },
     { name = "pyglet" },
     { name = "torch", version = "2.13.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" } },
-    { name = "usd-core", marker = "platform_machine != 'aarch64'" },
-    { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64'" },
+    { name = "usd-core", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'win32') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "usd-exchange", marker = "python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "blosc", marker = "extra == 'examples'", specifier = ">=1.11.1" },
+    { name = "blosc", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and extra == 'examples') or (sys_platform != 'win32' and extra == 'examples')", specifier = ">=1.11.1" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.7.5" },
     { name = "ml-dtypes", marker = "extra == 'dev'", specifier = ">=0.5.4" },
     { name = "myst-parser", marker = "extra == 'docs'" },
     { name = "numpy" },
     { name = "nvidia-sphinx-theme", marker = "extra == 'docs'" },
-    { name = "nvtx", marker = "extra == 'dev'" },
+    { name = "nvtx", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and extra == 'dev') or (sys_platform != 'win32' and extra == 'dev')" },
     { name = "pillow", marker = "extra == 'examples'", specifier = ">=10.4.0" },
     { name = "pre-commit", marker = "extra == 'docs'" },
     { name = "psutil", marker = "extra == 'examples'", specifier = ">=7.1.0" },
@@ -2815,10 +2815,10 @@ requires-dist = [
     { name = "sphinx-copybutton", marker = "extra == 'docs'" },
     { name = "torch", marker = "extra == 'torch-cu12'", specifier = ">=2.7.0", index = "https://download.pytorch.org/whl/cu126", conflict = { package = "warp-lang", extra = "torch-cu12" } },
     { name = "torch", marker = "extra == 'torch-cu13'", specifier = ">=2.9.0", index = "https://download.pytorch.org/whl/cu130", conflict = { package = "warp-lang", extra = "torch-cu13" } },
-    { name = "usd-core", marker = "platform_machine != 'aarch64' and extra == 'benchmark'", specifier = ">=25.5" },
-    { name = "usd-core", marker = "platform_machine != 'aarch64' and extra == 'examples'", specifier = ">=25.5" },
-    { name = "usd-exchange", marker = "python_full_version >= '3.10' and python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'benchmark'", specifier = ">=2.2" },
-    { name = "usd-exchange", marker = "python_full_version >= '3.10' and python_full_version < '3.13' and platform_machine == 'aarch64' and extra == 'examples'", specifier = ">=2.2" },
+    { name = "usd-core", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'win32' and extra == 'benchmark') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'benchmark') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'benchmark')", specifier = ">=25.5" },
+    { name = "usd-core", marker = "(platform_machine != 'ARM64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and sys_platform == 'win32' and extra == 'examples') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'examples') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'examples')", specifier = ">=25.5" },
+    { name = "usd-exchange", marker = "python_full_version >= '3.10' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'benchmark'", specifier = ">=2.2" },
+    { name = "usd-exchange", marker = "python_full_version >= '3.10' and python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'examples'", specifier = ">=2.2" },
     { name = "warp-lang", extras = ["docs"], marker = "extra == 'dev'" },
     { name = "warp-lang", extras = ["examples"], marker = "extra == 'dev'" },
     { name = "warp-lang", extras = ["examples"], marker = "extra == 'torch-cu12'" },

--- a/warp/_src/build_architecture.py
+++ b/warp/_src/build_architecture.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Detect and normalize architectures used by Warp builds.
+
+This module maps platform-specific x86-64 and ARM64 names to the
+canonical identifiers shared by Warp's build, packaging, and runtime code.
+"""
+
+from __future__ import annotations
+
+import platform
+from typing import Literal
+
+Architecture = Literal["x86_64", "aarch64"]
+
+_ARCHITECTURE_ALIASES: dict[str, Architecture] = {
+    "amd64": "x86_64",
+    "x86_64": "x86_64",
+    "arm64": "aarch64",
+    "aarch64": "aarch64",
+}
+
+
+def normalize_architecture(machine: str) -> Architecture:
+    try:
+        return _ARCHITECTURE_ALIASES[machine.strip().lower()]
+    except KeyError:
+        raise RuntimeError(f"Unrecognized machine architecture {machine!r}") from None
+
+
+def machine_architecture() -> Architecture:
+    return normalize_architecture(platform.machine())

--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -7,33 +7,34 @@ import concurrent.futures
 import functools
 import os
 import pathlib
-import platform
 import re
 import shutil
 import subprocess
 import sys
 import time
 
+from warp._src.build_architecture import Architecture, machine_architecture
 from warp._src.utils import ScopedTimer
 
 verbose_cmd = True  # print command lines before executing them
 
 MIN_CTK_VERSION = (12, 0)
 
-# Echoed by our wrapper command before dumping the environment; vcvars64.bat does not emit it.
+# Echoed by our wrapper command before dumping the environment; the MSVC
+# environment script does not emit it.
 _VCVARS_ENV_DUMP_MARKER = "__WARP_VCVARS_ENV_BEGIN__"
 
 
 def _parse_vcvars_environment(output: str) -> dict[str, str]:
-    """Parse environment variables from ``vcvars64.bat && set`` output.
+    """Parse environment variables from selected MSVC script ``&& set`` output.
 
     Scans the command output for ``_VCVARS_ENV_DUMP_MARKER`` and only begins parsing
-    after it, so any banner text emitted by ``vcvars64.bat`` is ignored. Each
+    after it, so any banner text emitted by the selected MSVC script is ignored. Each
     subsequent line is split on the first ``=`` into a ``KEY=VALUE`` pair; lines
     without a separator or with an empty key are skipped.
 
     Args:
-        output: Decoded output of ``vcvars64.bat && echo MARKER && set``.
+        output: Decoded output of selected MSVC script ``&& echo MARKER && set``.
 
     Returns:
         Mapping of environment variable names to values found after the marker.
@@ -56,17 +57,19 @@ def _parse_vcvars_environment(output: str) -> dict[str, str]:
     return env
 
 
-def machine_architecture() -> str:
-    """Return a canonical machine architecture string.
-    - "x86_64" for x86-64, aka. AMD64, aka. x64
-    - "aarch64" for AArch64, aka. ARM64
-    """
-    machine = platform.machine()
-    if machine == "x86_64" or machine == "AMD64":
-        return "x86_64"
-    if machine == "aarch64" or machine == "arm64":
-        return "aarch64"
-    raise RuntimeError(f"Unrecognized machine architecture {machine}")
+def _msvc_toolchain_layout(arch: Architecture) -> tuple[str, str]:
+    if arch == "aarch64":
+        return "HostARM64", "arm64"
+    return "HostX64", "x64"
+
+
+def _msvc_environment_script(vs_path: str, arch: Architecture) -> tuple[str, list[str]]:
+    if arch == "aarch64":
+        return (
+            os.path.join(vs_path, "Common7", "Tools", "VsDevCmd.bat"),
+            ["-arch=arm64", "-host_arch=arm64"],
+        )
+    return os.path.join(vs_path, "VC", "Auxiliary", "Build", "vcvars64.bat"), []
 
 
 def packman_llvm_platform(arch: str) -> str:
@@ -107,9 +110,12 @@ def run_cmd(cmd, print_success_output=True):
         raise e
 
 
-# cut-down version of vcvars64.bat that allows using
+# Cut-down version of the MSVC environment script that allows using
 # custom toolchain locations, returns the compiler program path
-def set_msvc_env(msvc_path, sdk_path):
+def set_msvc_env(msvc_path, sdk_path, host_arch: Architecture | None = None) -> str:
+    host_arch = host_arch or machine_architecture()
+    host_directory, target_directory = _msvc_toolchain_layout(host_arch)
+
     if "INCLUDE" not in os.environ:
         os.environ["INCLUDE"] = ""
 
@@ -125,17 +131,17 @@ def set_msvc_env(msvc_path, sdk_path):
     os.environ["INCLUDE"] += os.pathsep + os.path.join(sdk_path, "include/ucrt")
     os.environ["INCLUDE"] += os.pathsep + os.path.join(sdk_path, "include/shared")
 
-    os.environ["LIB"] += os.pathsep + os.path.join(msvc_path, "lib/x64")
-    os.environ["LIB"] += os.pathsep + os.path.join(sdk_path, "lib/ucrt/x64")
-    os.environ["LIB"] += os.pathsep + os.path.join(sdk_path, "lib/um/x64")
+    os.environ["LIB"] += os.pathsep + os.path.join(msvc_path, "lib", target_directory)
+    os.environ["LIB"] += os.pathsep + os.path.join(sdk_path, "lib", "ucrt", target_directory)
+    os.environ["LIB"] += os.pathsep + os.path.join(sdk_path, "lib", "um", target_directory)
 
-    os.environ["PATH"] += os.pathsep + os.path.join(msvc_path, "bin/HostX64/x64")
-    os.environ["PATH"] += os.pathsep + os.path.join(sdk_path, "bin/x64")
+    os.environ["PATH"] += os.pathsep + os.path.join(msvc_path, "bin", host_directory, target_directory)
+    os.environ["PATH"] += os.pathsep + os.path.join(sdk_path, "bin", target_directory)
 
-    return os.path.join(msvc_path, "bin", "HostX64", "x64", "cl.exe")
+    return os.path.join(msvc_path, "bin", host_directory, target_directory, "cl.exe")
 
 
-def find_host_compiler() -> str:
+def find_host_compiler(host_arch: Architecture | None = None) -> str:
     """Find the host C++ compiler.
 
     On Windows, checks for pre-configured Visual Studio environment before
@@ -146,36 +152,52 @@ def find_host_compiler() -> str:
         Path to compiler executable, or empty string if not found (Windows only).
         Note: Empty string return allows build_lib.py to handle error gracefully.
     """
-    if os.name == "nt":
-        # Check if Visual Studio environment already configured (conda, Docker, vcvars64, etc.)
-        # VCINSTALLDIR and VCToolsVersion are set by vcvars64.bat
-        if os.environ.get("VCINSTALLDIR") or os.environ.get("VCToolsVersion"):
-            if verbose_cmd:
-                print("Visual Studio environment already configured, skipping vcvars64.bat")
+    host_arch = host_arch or machine_architecture()
 
-            cl_path = shutil.which("cl.exe")
-            if cl_path:
+    if os.name == "nt":
+        # Check if Visual Studio environment already configured (conda, Docker, etc.)
+        # VCINSTALLDIR and VCToolsVersion are set by the MSVC environment script.
+        if os.environ.get("VCINSTALLDIR") or os.environ.get("VCToolsVersion"):
+            arm_environment_matches = (
+                os.environ.get("VSCMD_ARG_HOST_ARCH") == "arm64" and os.environ.get("VSCMD_ARG_TGT_ARCH") == "arm64"
+            )
+            if host_arch != "aarch64" or arm_environment_matches:
                 if verbose_cmd:
-                    print(f"Using cl.exe from pre-configured environment: {cl_path}")
-                return cl_path
-            else:
-                # Fall through to auto-configuration if cl.exe not actually available
+                    print("Visual Studio environment already configured, skipping MSVC environment script")
+
+                cl_path = shutil.which("cl.exe")
+                if cl_path:
+                    if verbose_cmd:
+                        print(f"Using cl.exe from pre-configured environment: {cl_path}")
+                    return cl_path
+                # Fall through to auto-configuration if cl.exe is not actually available.
                 if verbose_cmd:
                     print("Warning: VS environment variables set but cl.exe not found, attempting auto-configuration")
+            else:
+                if verbose_cmd:
+                    print("Warning: VS environment is not configured for native ARM64, attempting auto-configuration")
 
         vswhere_path = r"%ProgramFiles(x86)%/Microsoft Visual Studio/Installer/vswhere.exe"
         vswhere_path = os.path.expandvars(vswhere_path)
         if not os.path.isfile(vswhere_path):
             return ""  # Signal to caller that VS not found
 
-        vs_path = run_cmd(f'"{vswhere_path}" -latest -property installationPath').decode().rstrip()
-        vsvars_path = os.path.join(vs_path, "VC\\Auxiliary\\Build\\vcvars64.bat")
+        component = (
+            "Microsoft.VisualStudio.Component.VC.Tools.ARM64"
+            if host_arch == "aarch64"
+            else "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
+        )
+        vs_path = (
+            run_cmd(f'"{vswhere_path}" -latest -requires {component} -property installationPath').decode().rstrip()
+        )
+        vsvars_path, vsvars_arguments = _msvc_environment_script(vs_path, host_arch)
 
         if not os.path.isfile(vsvars_path):
             return ""  # Signal to caller that VS environment script not found
 
+        vsvars_command = " ".join([f'"{vsvars_path}"', *vsvars_arguments])
         output = run_cmd(
-            f'"{vsvars_path}" && echo {_VCVARS_ENV_DUMP_MARKER} && set', print_success_output=False
+            f"{vsvars_command} && echo {_VCVARS_ENV_DUMP_MARKER} && set", print_success_output=False
         ).decode()
 
         os.environ.update(_parse_vcvars_environment(output))
@@ -187,6 +209,11 @@ def find_host_compiler() -> str:
         vc_tools_version = os.environ.get("VCToolsVersion")
         if not vc_tools_version:
             return ""  # Signal to caller that VS environment script did not configure MSVC
+
+        if host_arch == "aarch64" and (
+            os.environ.get("VSCMD_ARG_HOST_ARCH") != "arm64" or os.environ.get("VSCMD_ARG_TGT_ARCH") != "arm64"
+        ):
+            return ""  # Signal to caller that the MSVC environment script selected the wrong architecture
 
         cl_version = vc_tools_version.split(".")
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -45,6 +45,8 @@ from typing import (
     overload as typing_overload,
 )
 
+from warp._src.build_architecture import machine_architecture
+
 if TYPE_CHECKING:
     from typing import ParamSpec
 
@@ -3499,7 +3501,7 @@ class Module:
         # Resolve None-means-autodetect for enable_tiles_in_stack_memory
         enable_tiles = config.enable_tiles_in_stack_memory
         if enable_tiles is None:
-            enable_tiles = platform.machine() == "aarch64"
+            enable_tiles = machine_architecture() == "aarch64"
         options["enable_tiles_in_stack_memory"] = enable_tiles
 
         return options
@@ -5679,7 +5681,7 @@ class Graph:
 
 class Runtime:
     def __init__(self):
-        if platform.system() == "Darwin" and platform.machine() == "x86_64":
+        if platform.system() == "Darwin" and machine_architecture() == "x86_64":
             raise RuntimeError(
                 "Warp no longer supports Intel-based macOS (x86_64). "
                 "Please use Warp 1.9.x or earlier for Intel Mac support, "

--- a/warp/native/clang/clang.cpp
+++ b/warp/native/clang/clang.cpp
@@ -82,12 +82,25 @@ extern void __jit_debug_register_code();
 namespace wp {
 
 #if defined(_WIN32)
-// Windows defaults to using the COFF binary format (aka. "msvc" in the target triple).
-// Override it to use the ELF format to support DWARF debug info, but keep using the
-// Microsoft calling convention (see also https://llvm.org/docs/DebuggingJITedCode.html).
+// Windows x86-64 uses ELF for DWARF debugging while retaining the Microsoft
+// calling convention. ARM64 stays native COFF because LLVM's ELF writer cannot
+// represent Windows relocations, and a non-Windows triple would select the
+// wrong stack-probing and TLS ABI. COFF ARM64 objects are linked by RTDyld
+// because JITLink supports COFF only for x86-64.
+#if defined(__aarch64__) || defined(_M_ARM64)
+static const char* target_triple = "aarch64-pc-windows-msvc";
+#else
 static const char* target_triple = "x86_64-pc-windows-elf";
+#endif
 #else
 static const char* target_triple = LLVM_DEFAULT_TARGET_TRIPLE;
+#endif
+
+// JITLink does not support COFF ARM64; RuntimeDyldCOFFAArch64 does.
+#if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
+static constexpr bool force_legacy_cpu_linker = true;
+#else
+static constexpr bool force_legacy_cpu_linker = false;
 #endif
 
 // Minimum CUDA compute capability that supports all of Warp's features.
@@ -232,7 +245,7 @@ static std::unique_ptr<clang::CompilerInstance> create_compiler(
         args.push_back("+f16c");
 #endif
 
-#if defined(__aarch64__)
+#if defined(__aarch64__) || defined(_M_ARM64)
         if (tiles_in_stack_memory) {
             // Static memory support is broken on AArch64 CPUs. As a workaround we reserve some stack memory on kernel
             // entry, and point the callee-saved x28 register to it so we can access it anywhere. See
@@ -584,7 +597,14 @@ WP_API int wp_compile_cpp(
     else
         target_options.AllowFPOpFusion = llvm::FPOpFusion::Strict;
     llvm::Reloc::Model relocation_model = llvm::Reloc::PIC_;  // Position Independent Code
+#if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
+    // Windows ARM64 is always PIC. With the large code model, __chkstk uses
+    // ADRP+ADD relocations that RTDyld cannot range-extend to warp-clang.dll.
+    // The small model emits a BRANCH26 call, for which RTDyld creates a stub.
+    llvm::CodeModel::Model code_model = llvm::CodeModel::Small;
+#else
     llvm::CodeModel::Model code_model = llvm::CodeModel::Large;  // Don't make assumptions about displacement sizes
+#endif
 
 #if LLVM_VERSION_MAJOR >= 18
     llvm::CodeGenOptLevel codegen_opt;
@@ -745,7 +765,16 @@ static llvm::orc::LLJIT* get_or_create_jit(bool use_legacy_linker)
 #else
                 auto get_memory_manager = []() {
 #endif
+#if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
+                    // Keep code and data in one allocation so ADRP+ADD references
+                    // remain within ±4 GiB. RTDyld's COFF ARM64 relocator neither
+                    // range-checks nor creates stubs for page-relative relocations.
+                    return std::make_unique<llvm::SectionMemoryManager>(
+                        /*MM=*/nullptr, /*ReserveAllocationSpace=*/true
+                    );
+#else
                     return std::make_unique<llvm::SectionMemoryManager>();
+#endif
                 };
                 auto layer
                     = std::make_unique<llvm::orc::RTDyldObjectLinkingLayer>(session, std::move(get_memory_manager));
@@ -871,6 +900,9 @@ static bool warp_clang_is_asan_build()
 // builds (WP_ENABLE_DEBUG=1).
 WP_API int wp_load_obj(const char* object_file, const char* module_name, bool use_legacy_linker)
 {
+    // Windows ARM64 COFF objects require RTDyld.
+    use_legacy_linker = use_legacy_linker || force_legacy_cpu_linker;
+
     std::lock_guard<std::mutex> lock(jit_mutex);
 
     auto* jit = get_or_create_jit(use_legacy_linker);
@@ -904,6 +936,9 @@ WP_API int wp_load_obj(const char* object_file, const char* module_name, bool us
 
         auto error = dll->define(llvm::orc::absoluteSymbols({
 #endif
+            // Keep this table function-only on Windows ARM64. RTDyld can create
+            // long-branch stubs for calls into warp-clang.dll, but not for
+            // page-relative data references. Do not add data symbols here.
             SYMBOL(printf), SYMBOL(puts), SYMBOL(putchar), SYMBOL_T(abs, int (*)(int)), SYMBOL(llabs), SYMBOL(fmodf),
                 SYMBOL_T(fmod, double (*)(double, double)), SYMBOL(logf), SYMBOL_T(log, double (*)(double)),
                 SYMBOL(log2f), SYMBOL_T(log2, double (*)(double)), SYMBOL(log10f), SYMBOL_T(log10, double (*)(double)),


### PR DESCRIPTION
## Description

Add CPU-only Windows ARM64 support while CUDA support is unavailable on
that platform. The change enables native builds, LLVM-backed CPU kernel
compilation, packaging, and GitHub-hosted CI coverage on Windows ARM64.

## Changes

- Normalize x86-64 and ARM64 architecture spellings across build,
  packaging, and runtime code.
- Select native ARM64 MSVC tools and prebuilt LLVM dependencies for
  Windows ARM64 builds.
- Support CPU kernel compilation and loading through warp-clang on
  Windows ARM64.
- Add the `win_arm64` wheel platform and skip unsupported optional
  dependencies using environment markers.
- Build Warp with both build_lib.py and CMake, then run the CPU unit
  suite on GitHub-hosted Windows ARM64 runners.
- Keep CUDA and the CUDA-specific Torch extras unsupported on Windows
  ARM64 for now.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

- A fork workflow dispatch successfully built Warp natively and through
  CMake on Windows ARM64, then passed the full CPU unit suite. The same
  run completed with 28 successful jobs and 7 intentional skips:
  https://github.com/shi-eric/warp/actions/runs/31271844307
- The only code change after that run removed the independent wheel
  validation job; all remaining jobs are unchanged.
- After rebasing onto current `main`, the patch-equivalence check,
  pre-commit hooks, lockfile validation, actionlint, and workflow matrix
  assertions passed.
- `CHANGELOG.md` is unchanged relative to `main`; the user-facing change
  is recorded in `changelog/+windows-arm64-cpu.added.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Windows ARM64 support for CPU builds and `win_arm64` wheels.
  * Added architecture-aware build support across supported x86-64 and ARM64 platforms.
* **Compatibility**
  * Improved platform and Python-version handling for optional dependencies.
  * Added Windows ARM64 compiler and environment validation.
* **Documentation**
  * Clarified supported platform guidance and noted that CUDA is not supported on Windows ARM64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->