### PR TITLE
Check exported symbols across native platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1138,44 +1138,238 @@ jobs:
 
   check-unnamespaced-symbols:
     if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
-    runs-on: ubuntu-latest
+    name: check-unnamespaced-symbols (${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
     needs: build-warp
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux-x86_64-cuda13
+            artifact-name: build-artifact-ubuntu-x86_64-cuda13
+            symbol-format: elf
+            allow-nv-optimus: false
+          - os: ubuntu-24.04-arm
+            platform: linux-aarch64-cuda13
+            artifact-name: build-artifact-ubuntu-aarch64-cuda13
+            symbol-format: elf
+            allow-nv-optimus: false
+          - os: windows-2022
+            platform: windows-x86_64-cuda13
+            artifact-name: build-artifact-windows-cuda13
+            symbol-format: pe
+            allow-nv-optimus: true
+          - os: macos-latest
+            platform: macos-aarch64-cpu
+            artifact-name: build-artifact-macos
+            symbol-format: macho
+            allow-nv-optimus: false
+          - os: windows-11-arm
+            platform: windows-aarch64-cpu
+            artifact-name: build-artifact-windows-aarch64-cpu
+            symbol-format: pe
+            allow-nv-optimus: false
     steps:
       - name: Download Warp build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          name: build-artifact-ubuntu-x86_64-cuda13
+          name: ${{ matrix.artifact-name }}
           path: warp/bin/
-      - name: Check for un-namespaced symbols
+      - name: Check ELF exports
+        if: matrix.symbol-format == 'elf'
+        shell: bash
         run: |
-          echo "Checking for un-namespaced symbols..."
-          LIBRARIES_TO_CHECK="warp/bin/warp.so warp/bin/warp-clang.so"
-          found_symbols=""
+          set -uo pipefail
+          libraries=(warp/bin/warp.so warp/bin/warp-clang.so)
+          failed=0
 
-          for lib in $LIBRARIES_TO_CHECK; do
-            echo "--> Checking $lib"
-            if [ ! -f "$lib" ]; then
-              echo "ERROR: $lib not found"
-              found_symbols="true"
+          for library in "${libraries[@]}"; do
+            echo "--> Checking $library"
+            if [ ! -f "$library" ]; then
+              echo "::error::$library not found"
+              failed=1
               continue
             fi
-            output=$(readelf -Ws "$lib" | awk '$7 ~ /^[0-9]+$/ && $8 !~ /^(_?wp_|PyInit__warp_)/ {print $8}' | grep -Ev '^(_Z|__|\.)' || true)
-            
-            if [ -n "$output" ]; then
-              echo "ERROR: Found un-namespaced symbols in $lib:"
-              echo "$output"
-              found_symbols="true"
+            if ! readelf_output=$(readelf --dyn-syms --wide "$library"); then
+              echo "::error::readelf failed for $library"
+              failed=1
+              continue
+            fi
+
+            symbols=()
+            while IFS= read -r symbol; do
+              [ -n "$symbol" ] && symbols+=("$symbol")
+            done < <(
+              printf '%s\n' "$readelf_output" \
+                | awk '$5 ~ /^(GLOBAL|WEAK)$/ && $7 != "UND" && NF >= 8 {sub(/@.*/, "", $8); if ($8 != "") print $8}' \
+                | sort -u
+            )
+            if [ "${#symbols[@]}" -eq 0 ]; then
+              echo "::error::No exports were parsed from $library"
+              failed=1
+              continue
+            fi
+
+            unexpected=()
+            library_name=$(basename "$library")
+            for symbol in "${symbols[@]}"; do
+              case "$symbol" in
+                wp_*|_wp_*|PyInit__warp_*) continue ;;
+              esac
+              if [ "$library_name" = "warp-clang.so" ] \
+                && { [ "$symbol" = "__jit_debug_descriptor" ] \
+                  || [ "$symbol" = "__jit_debug_register_code" ]; }; then
+                continue
+              fi
+              unexpected+=("$symbol")
+            done
+
+            if [ "${#unexpected[@]}" -ne 0 ]; then
+              echo "::error::Unexpected exports in $library"
+              printf '  %s\n' "${unexpected[@]}"
+              failed=1
             fi
           done
 
-          if [ -n "$found_symbols" ]; then
-            echo "FAIL: Un-namespaced symbols detected. Please prefix them with 'wp_' or '_wp_'."
-            exit 1
-          fi
+          [ "$failed" -eq 0 ] || exit 1
+      - name: Check Mach-O exports
+        if: matrix.symbol-format == 'macho'
+        shell: bash
+        run: |
+          set -uo pipefail
+          libraries=(warp/bin/libwarp.dylib warp/bin/libwarp-clang.dylib)
+          failed=0
 
-          echo "SUCCESS: All symbols are correctly namespaced."
+          for library in "${libraries[@]}"; do
+            echo "--> Checking $library"
+            if [ ! -f "$library" ]; then
+              echo "::error::$library not found"
+              failed=1
+              continue
+            fi
+            if ! nm_output=$(nm -gjU "$library"); then
+              echo "::error::nm failed for $library"
+              failed=1
+              continue
+            fi
+
+            symbols=()
+            while IFS= read -r symbol; do
+              [ -n "$symbol" ] && symbols+=("$symbol")
+            done < <(printf '%s\n' "$nm_output" | sed 's/^_//' | sort -u)
+            if [ "${#symbols[@]}" -eq 0 ]; then
+              echo "::error::No exports were parsed from $library"
+              failed=1
+              continue
+            fi
+
+            unexpected=()
+            library_name=$(basename "$library")
+            for symbol in "${symbols[@]}"; do
+              case "$symbol" in
+                wp_*|_wp_*|PyInit__warp_*) continue ;;
+              esac
+              if [ "$library_name" = "libwarp-clang.dylib" ] \
+                && { [ "$symbol" = "__jit_debug_descriptor" ] \
+                  || [ "$symbol" = "__jit_debug_register_code" ]; }; then
+                continue
+              fi
+              unexpected+=("$symbol")
+            done
+
+            if [ "${#unexpected[@]}" -ne 0 ]; then
+              echo "::error::Unexpected exports in $library"
+              printf '  %s\n' "${unexpected[@]}"
+              failed=1
+            fi
+          done
+
+          [ "$failed" -eq 0 ] || exit 1
+      - name: Check PE exports
+        if: matrix.symbol-format == 'pe'
+        env:
+          ALLOW_NV_OPTIMUS: ${{ matrix.allow-nv-optimus }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          if (!(Test-Path -LiteralPath $vswhere)) {
+            throw "vswhere.exe was not found"
+          }
+          $dumpbin = & $vswhere -latest -products '*' -find 'VC\Tools\MSVC\**\dumpbin.exe' | Select-Object -First 1
+          if (!$dumpbin) {
+            throw "vswhere found no dumpbin.exe"
+          }
+
+          $libraries = @("warp/bin/warp.dll", "warp/bin/warp-clang.dll")
+          $failed = $false
+          foreach ($library in $libraries) {
+            Write-Host "--> Checking $library"
+            if (!(Test-Path -LiteralPath $library)) {
+              Write-Host "::error::$library not found"
+              $failed = $true
+              continue
+            }
+
+            $dumpbinOutput = & $dumpbin /nologo /exports $library 2>&1
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "::error::dumpbin failed for $library"
+              $dumpbinOutput | Write-Host
+              $failed = $true
+              continue
+            }
+            $symbols = @(
+              $dumpbinOutput |
+                ForEach-Object {
+                  if ($_ -match '^\s+\d+\s+[0-9A-Fa-f]+\s+[0-9A-Fa-f]+\s+(\S+)') {
+                    $Matches[1]
+                  }
+                } |
+                Sort-Object -Unique
+            )
+            if ($symbols.Count -eq 0) {
+              Write-Host "::error::No exports were parsed from $library"
+              $failed = $true
+              continue
+            }
+
+            $libraryName = Split-Path -Leaf $library
+            $unexpected = [System.Collections.Generic.List[string]]::new()
+            foreach ($symbol in $symbols) {
+              $allowed = $symbol.StartsWith("wp_") `
+                -or $symbol.StartsWith("_wp_") `
+                -or $symbol.StartsWith("PyInit__warp_")
+              if ($libraryName -eq "warp-clang.dll" -and $symbol -in @(
+                "__jit_debug_descriptor",
+                "__jit_debug_register_code"
+              )) {
+                $allowed = $true
+              }
+              if (
+                $env:ALLOW_NV_OPTIMUS -eq "true" `
+                  -and $libraryName -eq "warp.dll" `
+                  -and $symbol -eq "NvOptimusEnablementCuda"
+              ) {
+                $allowed = $true
+              }
+              if (!$allowed) {
+                $unexpected.Add($symbol)
+              }
+            }
+
+            if ($unexpected.Count -ne 0) {
+              Write-Host "::error::Unexpected exports in $library"
+              $unexpected | Sort-Object | ForEach-Object { Write-Host "  $_" }
+              $failed = $true
+            }
+          }
+
+          if ($failed) {
+            throw "Unexpected exported symbols were found"
+          }
 
   # Validate that the type stub file (warp/__init__.pyi) passes static type checking.
   type-check-stubs:

--- a/build_llvm.py
+++ b/build_llvm.py
@@ -470,6 +470,7 @@ def build_warp_clang_for_arch(args, lib_name: str, arch: str) -> None:
                 )
 
         libs = []
+        exported_symbols_file = None
 
         for _, _, libraries in os.walk(libpath):
             libs.extend(libraries)
@@ -486,6 +487,7 @@ def build_warp_clang_for_arch(args, lib_name: str, arch: str) -> None:
             libs = [f"-l{lib[3:-2]}" for lib in libs if os.path.splitext(lib)[1] == ".a"]
             if sys.platform == "darwin":
                 libs += libs  # prevents unresolved symbols due to link order
+                exported_symbols_file = os.path.join(build_path, "native", "warp-clang.macos.exports")
             else:
                 libs.insert(0, "-Wl,--start-group")
                 libs.append("-Wl,--end-group")
@@ -503,6 +505,7 @@ def build_warp_clang_for_arch(args, lib_name: str, arch: str) -> None:
             arch=arch,
             libs=libs,
             mode=args.mode if args.build_llvm else "release",
+            exported_symbols_file=exported_symbols_file,
         )
 
     except Exception as e:

--- a/changelog/1758.fixed.md
+++ b/changelog/1758.fixed.md
@@ -1,0 +1,2 @@
+Fix the macOS Warp Clang library exposing embedded LLVM and Clang symbols that could conflict with other loaded
+libraries.

--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -579,7 +579,16 @@ def _get_architectures_cu13(
     return gencode_opts, clang_arch_flags
 
 
-def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str] | None = None, mode=None):
+def build_dll_for_arch(
+    args,
+    dll_path,
+    cpp_paths,
+    cu_paths,
+    arch,
+    libs: list[str] | None = None,
+    mode=None,
+    exported_symbols_file: str | None = None,
+):
     mode = args.mode if (mode is None) else mode
     cuda_home = args.cuda_path
     cuda_cmd = None
@@ -911,6 +920,8 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str
                 elapsed = (time.perf_counter_ns() - wall_clock) / 1000000.0
                 print(f"build took {elapsed:.2f} ms ({args.jobs:d} workers)")
 
+        opt_exported_symbols = ""
+
         if sys.platform == "darwin":
             # macOS linker rejects undefined symbols by default. Permit dynamic
             # lookup here, then validate below so unexpected unresolved symbols
@@ -918,6 +929,8 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str
             opt_undefined = "-Wl,-undefined,dynamic_lookup"
             opt_exclude_libs = ""
             opt_static_runtime = ""
+            if exported_symbols_file is not None:
+                opt_exported_symbols = f'-Wl,-exported_symbols_list,"{exported_symbols_file}"'
         else:
             # -z lazy: pin lazy PLT binding so dlopen(..., RTLD_LAZY) works for non-Python
             # C++ hosts even on distros that flip the default to -z now via RELRO.
@@ -929,7 +942,7 @@ def build_dll_for_arch(args, dll_path, cpp_paths, cu_paths, arch, libs: list[str
 
         with ScopedTimer("link", active=args.verbose):
             origin = "@loader_path" if (sys.platform == "darwin") else "$ORIGIN"
-            link_cmd = f"{cpp_compiler} {version} -shared -Wl,-rpath,'{origin}' {opt_static_runtime} {opt_undefined} {opt_exclude_libs}{sanitize_ld} -o '{dll_path}' {' '.join(ld_inputs + libs)}"
+            link_cmd = f"{cpp_compiler} {version} -shared -Wl,-rpath,'{origin}' {opt_static_runtime} {opt_undefined} {opt_exported_symbols} {opt_exclude_libs}{sanitize_ld} -o '{dll_path}' {' '.join(ld_inputs + libs)}"
             run_cmd(link_cmd)
 
             # Platform-specific paths collect all undefined symbol names.

--- a/warp/native/warp-clang.macos.exports
+++ b/warp/native/warp-clang.macos.exports
@@ -1,0 +1,4 @@
+_wp_*
+__wp_*
+___jit_debug_descriptor
+___jit_debug_register_code


### PR DESCRIPTION
## Description

Enforce Warp's exported-symbol namespace across the standard CUDA 13 Linux and Windows builds, macOS Apple Silicon, and Windows ARM64. This also prevents the macOS Warp Clang library produced by `build_lib.py` from exporting embedded LLVM and Clang symbols that could conflict with other libraries loaded into the same process.

## Changes

- Replace the Linux-only symbol check with a five-platform GitHub Actions matrix covering Ubuntu x86-64 CUDA 13, Ubuntu AArch64 CUDA 13, Windows x86-64 CUDA 13, macOS Apple Silicon CPU, and Windows ARM64 CPU.
- Inspect both the Warp and Warp Clang libraries using each platform's native tooling: `readelf`, `nm`, and `dumpbin`.
- Permit only Warp namespace prefixes and the required library-scoped JIT debugger and NVIDIA Optimus exceptions.
- Restrict the macOS Warp Clang link produced by `build_lib.py` with an exported-symbols list.
- Add a changelog fragment for the macOS symbol-visibility fix.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

- Confirmed that the pre-change macOS artifact exports embedded LLVM and Clang symbols, including `LLVMAddSymbol`.
- Ran pre-commit checks over all five changed files.
- Parsed the updated GitHub Actions workflow and verified the exact five-entry matrix.
- Ran the strict ELF export check against both local `build_lib.py` libraries with no unexpected symbols.
- Ran the complete CPU test suite: 3,636 tests passed with 532 expected skips on the CPU-only build.
- GitHub-hosted macOS and Windows validation will run on this pull request and must pass before merge.

## Bug fix

Before this change, inspecting the macOS Warp Clang library reports embedded LLVM exports:

```bash
nm -gjU warp/bin/libwarp-clang.dylib | sed 's/^_//' | grep '^LLVM'
```

The output includes symbols such as `LLVMAddSymbol`. After this change, the library exports only Warp namespaces and the two required JIT debugger symbols.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS Warp Clang symbol conflicts with other loaded libraries.
  * Improved compatibility across Linux, macOS, Windows, and Windows ARM builds by validating exported symbols.
  * Preserved required Warp, Python, JIT, and Windows CUDA symbols while detecting unexpected exports and missing libraries.
  * Improved build reliability by reporting invalid or incomplete native library exports during validation.

* **Documentation**
  * Added a changelog entry describing the macOS symbol-export fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->