### PR TITLE
Reject zero-step array slices

### DIFF
--- a/changelog/1684.fixed.md
+++ b/changelog/1684.fixed.md
@@ -1,0 +1,1 @@
+Reject zero-step array slices instead of leaking an internal assertion or treating them as integer indices.

--- a/docs/user_guide/basics.rst
+++ b/docs/user_guide/basics.rst
@@ -251,6 +251,9 @@ stride:
      [-1.  5. -1.  7.]
      [-1.  9. -1. 11.]]
 
+As with Python slices, a slice step of zero raises
+``ValueError("slice step cannot be zero")``.
+
 Scalar item indexing is intentionally not supported on ``wp.array`` objects at
 Python scope, so ``a[0, 0]`` raises an error. Use slicing to create array views,
 or convert to NumPy with :meth:`array.numpy <warp.array.numpy>` when reading

--- a/docs/user_guide/runtime.rst
+++ b/docs/user_guide/runtime.rst
@@ -198,11 +198,21 @@ To index a multi-dimensional array, use the following kernel syntax::
 
 To create an array slice, use the following syntax, where the number of indices is less than the array dimensions::
 
-    # returns an 1d array slice representing a row of the 2d array
+    # returns a 1D array slice representing a row of the 2D array
     row = input[i]
 
+    # start, stop, step, and column may be runtime expressions
+    view = input[start:stop:step, column]
+
 Slice operators can be concatenated, e.g.: ``s = array[i][j][k]``. Slices can be passed to :func:`wp.func <warp.func>` user functions provided
-the function also declares the expected array dimension. Currently, only single-index slicing is supported.
+the function also declares the expected array dimension.
+
+Unlike slices of fixed-size values, the ``start``, ``stop``, and ``step``
+components of a Warp array slice may be runtime expressions. A slice step of
+zero is invalid. A zero known at compile time raises a code-generation error. If
+a runtime step evaluates to zero, Warp reports the error and fails the kernel:
+the process aborts on CPU, while the CUDA kernel traps and reports a launch
+error.
 
 The following construction methods are provided for allocating zero-initialized and empty (non-initialized) arrays:
 
@@ -1059,8 +1069,9 @@ Indexing and slicing for vectors, matrices, quaternions, and transforms, follow 
 
 Negative indices are wrapped around, such that ``-1`` refers to the last element. Slices always create new copies.
 
-Inside kernels, the ``start / stop / step`` values of a slice must be **compile-time constants**.  Simple element indexing (``v[i]``, ``m[i, j]``) may use run-time
-expressions.
+For these fixed-size types, the ``start / stop / step`` values of a slice must
+be **compile-time constants**. Simple element indexing (``v[i]``, ``m[i, j]``)
+may use runtime expressions.
 
 
 Unpacking

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -12235,7 +12235,7 @@ def view_value_func(arg_types: Mapping[str, type], arg_values: Mapping[str, Any]
                 )
 
         # Each integer index collapses one dimension.
-        int_count = sum(x.step == 0 for x in idx_types)
+        int_count = sum(type_is_int(x) for x in idx_types)
         ndim = arr_type.ndim - int_count
         assert ndim > 0
     else:

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -4353,26 +4353,7 @@ class Adjoint:
                     target.mark_read()
 
             else:
-                # Keep the original source-level indices for deterministic view
-                # tracking before the plain array path rewrites integer indices
-                # into slice arguments for the native view builtin.
                 view_indices = tuple(indices)
-
-                if warp._src.types.matches_array_class(target_type, warp._src.types.array):
-                    # In order to reduce the number of overloads needed in the C
-                    # implementation to support combinations of int/slice indices,
-                    # we convert all integer indices into slices, and set their
-                    # step to 0 if they are representing an integer index.
-                    new_indices = []
-                    for idx in indices:
-                        if not warp._src.types.is_slice(strip_reference(idx.type)):
-                            new_idx = adj.add_builtin_call("slice", (idx, idx, 0))
-                            new_indices.append(new_idx)
-                        else:
-                            new_indices.append(idx)
-
-                    indices = new_indices
-
                 # handles array views (fewer indices than dimensions)
                 out = adj.add_builtin_call("view", [target, *indices])
                 adj.deterministic.track_view(out, target, view_indices)
@@ -4839,6 +4820,8 @@ class Adjoint:
         start = SLICE_BEGIN if node.lower is None else adj.eval(node.lower)
         stop = SLICE_END if node.upper is None else adj.eval(node.upper)
         step = 1 if node.step is None else adj.eval(node.step)
+        if isinstance(step, Var) and step.constant == 0:
+            raise WarpCodegenValueError("Slice step cannot be zero.")
         return adj.add_builtin_call("slice", (start, stop, step))
 
     def store_ref_param_value(adj, name, value, *, augmented=False):

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -3963,6 +3963,8 @@ class array(Array[DType, NDim]):
                     stop = self.shape[idx]
                 if step is None:
                     step = 1
+                if step == 0:
+                    raise ValueError("slice step cannot be zero")
                 if start < 0:
                     start = self.shape[idx] + start
                 if stop < 0:

--- a/warp/native/array.h
+++ b/warp/native/array.h
@@ -816,6 +816,15 @@ template <typename T> CUDA_CALLABLE inline array_t<T> view(array_t<T>& src, int 
 }
 
 
+CUDA_CALLABLE inline slice_t view_arg_as_slice(int index) { return { index, index, 1 }; }
+
+CUDA_CALLABLE inline slice_t view_arg_as_slice(const slice_t& slice) { return slice; }
+
+CUDA_CALLABLE inline bool view_arg_is_slice(int) { return false; }
+
+CUDA_CALLABLE inline bool view_arg_is_slice(const slice_t&) { return true; }
+
+
 template <typename T, size_t... Idxs>
 size_t byte_offset_helper(array_t<T>& src, const slice_t (&slices)[sizeof...(Idxs)], index_sequence<Idxs...>)
 {
@@ -830,13 +839,14 @@ CUDA_CALLABLE inline array_t<T> view(array_t<T>& src, const Slices&... slice_arg
     static_assert(N >= 1 && N <= 4, "view supports 1 to 4 slices");
     assert(src.ndim >= N);
 
-    slice_t slices[N] = { slice_args... };
+    slice_t slices[N] = { view_arg_as_slice(slice_args)... };
+    bool is_slice_arg[N] = { view_arg_is_slice(slice_args)... };
     int slice_idxs[N];
     int slice_count = 0;
 
     for (int i = 0; i < N; ++i) {
-        if (slices[i].step == 0) {
-            // We have a slice representing an integer index.
+        if (!is_slice_arg[i]) {
+            // We have an integer index.
             if (slices[i].start < 0) {
                 slices[i].start += src.shape[i];
             }
@@ -862,7 +872,7 @@ CUDA_CALLABLE inline array_t<T> view(array_t<T>& src, const Slices&... slice_arg
     int dim = 0;
     for (; dim < slice_count; ++dim) {
         int idx = slice_idxs[dim];
-        out.shape[dim] = slice_get_length(slices[idx]);
+        out.shape[dim] = slice_get_length_unchecked(slices[idx]);
         out.strides[dim] = src.strides[idx] * slices[idx].step;
     }
     for (; dim < slice_count + 4 - N; ++dim) {

--- a/warp/native/builtin.h
+++ b/warp/native/builtin.h
@@ -2008,14 +2008,23 @@ struct slice_t {
     }
 };
 
+CUDA_CALLABLE inline void slice_assert_step_nonzero(const slice_t& slice)
+{
+    if (slice.step != 0) {
+        return;
+    }
+
+#if defined(__CUDA_ARCH__)
+    printf("slice step cannot be zero\n");
+    __trap();
+#else
+    _wp_assert("slice step cannot be zero", __FILE__, unsigned(__LINE__));
+#endif
+}
+
 CUDA_CALLABLE inline slice_t slice_adjust_indices(const slice_t& slice, int length)
 {
-#ifndef NDEBUG
-    if (slice.step == 0) {
-        printf("%s:%d slice step cannot be 0\n", __FILE__, __LINE__);
-        assert(0);
-    }
-#endif
+    slice_assert_step_nonzero(slice);
 
     int start, stop;
 
@@ -2036,15 +2045,8 @@ CUDA_CALLABLE inline slice_t slice_adjust_indices(const slice_t& slice, int leng
     return { start, stop, slice.step };
 }
 
-CUDA_CALLABLE inline int slice_get_length(const slice_t& slice)
+CUDA_CALLABLE inline int slice_get_length_unchecked(const slice_t& slice)
 {
-#ifndef NDEBUG
-    if (slice.step == 0) {
-        printf("%s:%d slice step cannot be 0\n", __FILE__, __LINE__);
-        assert(0);
-    }
-#endif
-
     if (slice.step > 0 && slice.start < slice.stop) {
         return 1 + (slice.stop - slice.start - 1) / slice.step;
     }
@@ -2054,6 +2056,12 @@ CUDA_CALLABLE inline int slice_get_length(const slice_t& slice)
     }
 
     return 0;
+}
+
+CUDA_CALLABLE inline int slice_get_length(const slice_t& slice)
+{
+    slice_assert_step_nonzero(slice);
+    return slice_get_length_unchecked(slice);
 }
 
 template <typename T> inline CUDA_CALLABLE T atomic_add(T* buf, T value)

--- a/warp/tests/test_array.py
+++ b/warp/tests/test_array.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import subprocess
+import sys
 import unittest
 from functools import cache
 from typing import Any
@@ -3593,6 +3595,92 @@ def test_array2d_slicing(test, device):
     wp.launch(test_array2d_slicing_kernel, dim=1, inputs=(arr,), device=device)
 
 
+# Keep the fatal-path subprocess from compiling the entire test_array module.
+@wp.kernel(module="unique")
+def dynamic_array_slice_kernel(
+    array: wp.array2d[int],
+    start: int,
+    stop: int,
+    step: int,
+    output: wp.array[int],
+):
+    view = array[start:stop:step, 1]
+    output[0] = view.shape[0]
+    output[1] = view[0]
+    output[2] = view[view.shape[0] - 1]
+
+
+def test_dynamic_array_slice(test, device):
+    """Verify that dynamic array slices handle positive and negative runtime steps."""
+    array = wp.array(tuple(range(18)), dtype=int, shape=(6, 3), device=device)
+    cases = (
+        ("positive", 1, 6, 2, np.array([3, 4, 16], dtype=np.int32)),
+        ("negative", 5, 0, -2, np.array([3, 16, 4], dtype=np.int32)),
+    )
+
+    for name, start, stop, step, expected in cases:
+        with test.subTest(name=name):
+            output = wp.empty(3, dtype=int, device=device)
+            wp.launch(
+                dynamic_array_slice_kernel,
+                dim=1,
+                inputs=[array, start, stop, step, output],
+                device=device,
+            )
+            np.testing.assert_array_equal(output.numpy(), expected)
+
+
+def _trigger_runtime_zero_step(device_alias: str):
+    """Trigger a runtime zero-step array slice on the requested device."""
+    with wp.ScopedDevice(device_alias):
+        array = wp.array(tuple(range(18)), dtype=int, shape=(6, 3))
+        output = wp.empty(3, dtype=int)
+        wp.launch(dynamic_array_slice_kernel, dim=1, inputs=[array, 0, 6, 0, output])
+        wp.synchronize_device()
+
+
+def _run_runtime_zero_step_subprocess(device_alias: str, timeout: int = 120):
+    """Run a runtime zero-step slice in an isolated child process.
+
+    CPU execution aborts, while CUDA execution leaves the context unusable
+    after trapping.
+    """
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from warp.tests.test_array import _trigger_runtime_zero_step; "
+            "_trigger_runtime_zero_step(sys.argv[1])",
+            device_alias,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_array_runtime_zero_step(test, device):
+    """Verify that runtime zero-step array slices fail on each backend.
+
+    Run each case in a subprocess because the CPU path aborts and the CUDA
+    path leaves the context unusable after trapping.
+    """
+    if sys.platform == "win32":
+        test.skipTest(
+            "Skip on Windows because the intentional host abort or CUDA trap may destabilize QA hosts, which cannot "
+            "be identified reliably."
+        )
+
+    result = _run_runtime_zero_step_subprocess(device.alias)
+    output = result.stdout + result.stderr
+    test.assertRegex(output, "slice step cannot be zero")
+    if device.is_cuda:
+        test.assertRegex(output, "Warp CUDA error")
+    else:
+        test.assertNotEqual(result.returncode, 0)
+
+
 @wp.kernel
 def test_array3d_slicing_kernel(arr: wp.array3d[int]):
     sub = arr[-1:]
@@ -3982,6 +4070,48 @@ cuda_devices = get_cuda_test_devices()
 
 
 class TestArray(unittest.TestCase):
+    def test_literal_zero_step_slice_in_kernel(self):
+        """Verify that literal zero-step array slices fail during code generation.
+
+        This validation occurs in device-independent Warp code generation, so
+        use CPU rather than repeating the same frontend failure on each backend.
+        """
+
+        @wp.kernel(module="unique")
+        def invalid_zero_step_slice_1d(a: wp.array[int]):
+            view = a[0:2:0]
+
+        @wp.kernel(module="unique")
+        def invalid_zero_step_slice_2d(a: wp.array2d[int]):
+            view = a[0:2:0]
+
+        @wp.kernel(module="unique")
+        def invalid_zero_step_slice_3d(a: wp.array3d[int]):
+            view = a[0:2:0]
+
+        @wp.kernel(module="unique")
+        def invalid_zero_step_slice_4d(a: wp.array4d[int]):
+            view = a[0:2:0]
+
+        cases = (
+            ("1d", invalid_zero_step_slice_1d, wp.zeros(2, dtype=int, device="cpu")),
+            ("2d", invalid_zero_step_slice_2d, wp.zeros((2, 2), dtype=int, device="cpu")),
+            ("3d", invalid_zero_step_slice_3d, wp.zeros((2, 2, 2), dtype=int, device="cpu")),
+            ("4d", invalid_zero_step_slice_4d, wp.zeros((2, 2, 2, 2), dtype=int, device="cpu")),
+        )
+
+        for name, kernel, array in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(wp.WarpCodegenValueError, "Slice step cannot be zero"):
+                    wp.launch(kernel, dim=1, inputs=[array], device="cpu")
+
+    def test_zero_step_slice_at_python_scope(self):
+        """Verify that Python-scope zero-step array slices raise ``ValueError``."""
+        array = wp.zeros(4, dtype=int, device="cpu")
+
+        with self.assertRaisesRegex(ValueError, "slice step cannot be zero"):
+            _ = array[::0]
+
     def test_array_new_del(self):
         # test the scenario in which an array instance is created but not initialized before gc
         instance = wp.array.__new__(wp.array)
@@ -4125,6 +4255,8 @@ add_function_test(TestArray, "test_array1d_slicing", test_array1d_slicing, devic
 add_function_test(TestArray, "test_array2d_slicing", test_array2d_slicing, devices=devices)
 add_function_test(TestArray, "test_array3d_slicing", test_array3d_slicing, devices=devices)
 add_function_test(TestArray, "test_array4d_slicing", test_array4d_slicing, devices=devices)
+add_function_test(TestArray, "test_dynamic_array_slice", test_dynamic_array_slice, devices=devices)
+add_function_test(TestArray, "test_array_runtime_zero_step", test_array_runtime_zero_step, devices=devices)
 
 add_function_test(TestArray, "test_graph_fill_vecmat", test_graph_fill_vecmat, devices=cuda_devices)
 


### PR DESCRIPTION
## Description

Warp did not consistently reject array slices with a step of zero. A literal zero could leak an internal assertion or be mistaken for an integer index, and a runtime zero could produce an incorrect view. This change rejects zero-step slices consistently at Python scope, during code generation, and at runtime on CPU and CUDA.

Closes #1684

## Changes

- Keep integer indices distinct from slice descriptors in the array view builtin so a zero slice step cannot be confused with a dimension-collapsing index.
- Reject literal zero steps during code generation and Python-scope slicing, and fail runtime zero steps before native slice arithmetic.
- Add coverage for literal slices in 1D through 4D, valid dynamic slices, Python-scope validation, and runtime failures on CPU and CUDA.
- Document runtime slice expressions and zero-step behavior, and add a changelog fragment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

- Rebuilt the native Warp libraries with CUDA 13.0 using `uv run build_lib.py --quick`.
- Ran the 8 focused zero-step and dynamic-slice tests on CPU and two CUDA devices; all passed.
- Ran the pre-commit hooks on all 9 changed files; all passed.
- Built the HTML documentation with Sphinx successfully.
- Did not run the full suite locally, per request; CI will run it.

## Bug fix

Before this change, the following kernel could treat the invalid slice as an integer index and return `20.0`:

```python
import warp as wp

@wp.kernel
def slice_zero(a: wp.array2d[float], start: int, out: wp.array[float]):
    view = a[start:5:0]
    out[0] = view[0]

a = wp.array([[10.0, 11.0, 12.0], [20.0, 21.0, 22.0]], dtype=float, device="cpu")
out = wp.empty(1, dtype=float, device="cpu")
wp.launch(slice_zero, dim=1, inputs=[a, 1, out], device="cpu")
print(out.numpy())
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-dimensional array slicing with runtime start, stop, and step expressions.
  * Added support for positive and negative runtime slice steps.

* **Bug Fixes**
  * Zero-step slices now consistently raise clear errors instead of causing internal failures or incorrect indexing.
  * Corrected array view dimension handling for integer indexing and valid slices.

* **Documentation**
  * Updated user guidance for dynamic slicing and zero-step validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->