### PR TITLE
Fix tile_scatter_add() docstring example to match its documented output

### DIFF
--- a/changelog/1743.documentation.md
+++ b/changelog/1743.documentation.md
@@ -1,0 +1,4 @@
+Fix the `wp.tile_scatter_add()` docstring example so it produces the documented `[2. 2. 2. 2.]` output. The example
+used the scalar form of `wp.tid()`, which under `wp.launch_tiled()` returns only the leading (tile) index, so every
+lane binned `data[0]` instead of its own element. The example now unpacks the lane index, matching the neighboring
+`wp.tile_scatter_masked()` example.

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -3497,9 +3497,9 @@ def tile_scatter_add(a: Tile[Any, tuple[int, ...]], i: int32, value: Any, has_va
             def histogram(data: wp.array[float], out: wp.array[float]):
 
                 bins = wp.tile_zeros(dtype=float, shape=4, storage="shared")
-                i = wp.tid()
+                tile_idx, thread_idx = wp.tid()
                 # Bin values in [0, 8) into 4 bins of width 2
-                b = int(data[i] / 2.0)
+                b = int(data[thread_idx] / 2.0)
                 wp.tile_scatter_add(bins, b, 1.0, True)
                 wp.tile_store(out, bins, offset=0)
 

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -5225,9 +5225,9 @@ add_builtin(
             def histogram(data: wp.array[float], out: wp.array[float]):
 
                 bins = wp.tile_zeros(dtype=float, shape=4, storage="shared")
-                i = wp.tid()
+                tile_idx, thread_idx = wp.tid()
                 # Bin values in [0, 8) into 4 bins of width 2
-                b = int(data[i] / 2.0)
+                b = int(data[thread_idx] / 2.0)
                 wp.tile_scatter_add(bins, b, 1.0, True)
                 wp.tile_store(out, bins, offset=0)
 


### PR DESCRIPTION
## Description

The `wp.tile_scatter_add()` docstring example documents `[2. 2. 2. 2.]` but actually prints `[8. 0. 0. 0.]` on CUDA. The example calls `wp.tid()` in scalar form, and since `launch_tiled()` appends the lane dimension to `dim`, that only returns the leading tile index, which is always 0 here. Every lane ends up binning `data[0]` instead of its own element.

Closes #1743

## Changes

- Unpack the lane index in the histogram example (`tile_idx, thread_idx = wp.tid()`), same style as the `wp.tile_scatter_masked()` example right next to it
- Same edit mirrored in `warp/__init__.pyi`
- Changelog fragment

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

Ran the shipped example verbatim on cuda:0 (RTX 3050) and got `[8. 0. 0. 0.]`, matching the issue. Ran the corrected example verbatim and it prints the documented `[2. 2. 2. 2.]`.

One note for reviewers: on `cpu` the corrected example still prints `[1. 0. 0. 0.]`, because `launch_tiled()` forces `block_dim=1` there so only one lane runs the per-thread code. That matches the existing test suite, which registers all `tile_scatter_add` tests with `get_cuda_test_devices()` only, so I left the example as a CUDA-oriented one rather than trying to work around it.

`ruff check` and `ruff format --check` pass on `builtins.py`; the stub file has pre-existing format diffs unrelated to this change (CONTRIBUTING.md notes the expected ruff "Failed" message when regenerating it).

## Bug fix

```python
import warp as wp

@wp.kernel
def histogram(data: wp.array[float], out: wp.array[float]):
    bins = wp.tile_zeros(dtype=float, shape=4, storage="shared")
    i = wp.tid()
    b = int(data[i] / 2.0)
    wp.tile_scatter_add(bins, b, 1.0, True)
    wp.tile_store(out, bins, offset=0)

data = wp.array([0.5, 1.0, 2.5, 3.0, 4.5, 5.0, 6.5, 7.0], dtype=float)
output = wp.zeros(4, dtype=float)
wp.launch_tiled(histogram, dim=[1], inputs=[data, output], block_dim=8)
print(output.numpy())  # documented: [2. 2. 2. 2.]  actual: [8. 0. 0. 0.]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected `tile_scatter_add()` examples to properly unpack tiled thread indices.
  - Updated examples to bin each lane’s corresponding data element.
  - Clarified the expected histogram output: `[2. 2. 2. 2.]`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->