### PR TITLE
Fix CUDA BSR compression trailing capacity

### DIFF
--- a/changelog/1769.fixed.md
+++ b/changelog/1769.fixed.md
@@ -1,0 +1,1 @@
+Prevent CUDA BSR compression from treating trailing storage capacity as active blocks.

--- a/warp/native/sparse.cu
+++ b/warp/native/sparse.cu
@@ -1131,7 +1131,7 @@ __global__ void bsr_compress_inplace_rows_indexed_kernel(
 }
 
 __global__ void bsr_compress_inplace_compact_counts_kernel(
-    const int row_count, const int* bsr_offsets, int* row_counts, int* bsr_columns
+    const int row_count, const int nnz_upper_bound, const int* bsr_offsets, int* row_counts, int* bsr_columns
 )
 {
     const int row = blockIdx.x;
@@ -1149,6 +1149,13 @@ __global__ void bsr_compress_inplace_compact_counts_kernel(
     const int row_capacity_end = bsr_offsets[row + 1];
 
     for (int block = row_end + tid; block < row_capacity_end; block += blockDim.x) {
+        bsr_columns[block] = -1;
+    }
+
+    const int64_t tail_beg = bsr_offsets[row_count];
+    const int64_t global_tid = int64_t(row) * blockDim.x + tid;
+    const int64_t global_stride = int64_t(gridDim.x) * blockDim.x;
+    for (int64_t block = tail_beg + global_tid; block < nnz_upper_bound; block += global_stride) {
         bsr_columns[block] = -1;
     }
 }
@@ -1573,7 +1580,7 @@ void wp_bsr_compress_inplace_device_impl(
     constexpr int threads = 128;
     begin_cuda_range(WP_TIMING_KERNEL_BUILTIN, stream, context, "bsr_compress_inplace_compact_counts_kernel");
     bsr_compress_inplace_compact_counts_kernel<<<row_count, threads, 0, stream>>>(
-        row_count, bsr_offsets, row_counts, bsr_columns
+        row_count, nnz_upper_bound, bsr_offsets, row_counts, bsr_columns
     );
 #if _DEBUG
     check_cuda(wp_cuda_context_check(WP_CURRENT_CONTEXT));

--- a/warp/tests/test_sparse.py
+++ b/warp/tests/test_sparse.py
@@ -1011,6 +1011,68 @@ def test_capturability(test, device):
     assert_array_equal(bsr_get_diag(C), wp.full(N, value=wp.mat33(9.0), dtype=wp.mat33, device=device))
 
 
+def _make_bsr_with_trailing_capacity(device):
+    matrix = bsr_zeros(3, 3, float, device=device)
+    matrix.nnz = 6
+    matrix.offsets = wp.array([0, 1, 2, 3], dtype=int, device=device)
+    matrix.columns = wp.array([0, 1, 2, 0, 0, 0], dtype=int, device=device)
+    matrix.values = wp.array([3.0, 7.0, 11.0, 42.0, 42.0, 42.0], dtype=float, device=device)
+    return matrix
+
+
+def _assert_bsr_ignores_trailing_capacity(test, matrix):
+    test.assertIsNone(matrix.row_counts)
+    test.assertEqual(matrix.nnz_sync(), 3)
+    np.testing.assert_array_equal(matrix.offsets.numpy(), np.array([0, 1, 2, 3]))
+    np.testing.assert_array_equal(matrix.columns.numpy()[:3], np.array([0, 1, 2]))
+    np.testing.assert_allclose(matrix.values.numpy()[:3], np.array([3.0, 7.0, 11.0]))
+    np.testing.assert_allclose(_bsr_to_dense(matrix), np.diag([3.0, 7.0, 11.0]))
+
+
+def test_bsr_compress_trailing_capacity(test, device):
+    """Test that compact BSR compression ignores trailing storage capacity."""
+
+    for inplace in (False, True):
+        with test.subTest(inplace=inplace):
+            matrix = _make_bsr_with_trailing_capacity(device)
+            bsr_compress(
+                matrix,
+                prune_numerical_zeros=False,
+                inplace=inplace,
+                topology="compact",
+            )
+            _assert_bsr_ignores_trailing_capacity(test, matrix)
+
+
+def test_bsr_compress_trailing_capacity_capturability(test, device):
+    """Test that captured compact BSR compression ignores trailing storage capacity."""
+
+    for inplace in (False, True):
+        with test.subTest(inplace=inplace):
+            # Warm the generated value-accumulation kernel needed by the
+            # out-of-place path before module loading is disabled for capture.
+            warmup = _make_bsr_with_trailing_capacity(device)
+            bsr_compress(
+                warmup,
+                prune_numerical_zeros=False,
+                inplace=inplace,
+                topology="compact",
+            )
+
+            matrix = _make_bsr_with_trailing_capacity(device)
+            with wp.ScopedDevice(device):
+                with wp.ScopedCapture(force_module_load=False) as capture:
+                    bsr_compress(
+                        matrix,
+                        prune_numerical_zeros=False,
+                        inplace=inplace,
+                        topology="compact",
+                    )
+
+            wp.capture_launch(capture.graph)
+            _assert_bsr_ignores_trailing_capacity(test, matrix)
+
+
 def test_bsr_compress_compact_capturability(test, device):
     """Test that native compact BSR compression is graph-capturable."""
 
@@ -1365,6 +1427,18 @@ add_function_test(TestSparse, "test_bsr_mv_1_3", make_test_bsr_mv((1, 3), wp.flo
 add_function_test(TestSparse, "test_bsr_mv_3_3", make_test_bsr_mv((3, 3), wp.float64), devices=devices)
 
 add_function_test(TestSparse, "test_capturability", test_capturability, devices=cuda_test_devices_with_mempool)
+add_function_test(
+    TestSparse,
+    "test_bsr_compress_trailing_capacity",
+    test_bsr_compress_trailing_capacity,
+    devices=devices,
+)
+add_function_test(
+    TestSparse,
+    "test_bsr_compress_trailing_capacity_capturability",
+    test_bsr_compress_trailing_capacity_capturability,
+    devices=cuda_test_devices_with_mempool,
+)
 add_function_test(
     TestSparse,
     "test_bsr_compress_compact_capturability",


### PR DESCRIPTION
## Description

Closes #1769.

CUDA compact BSR compression used `BsrMatrix.nnz` as the selection bound even when the active data ended at `offsets[nrow]`. Valid-looking entries in trailing storage capacity could therefore be treated as active blocks and appended to the final row.

This change invalidates trailing column entries on the device before selection. The operation remains asynchronous and compatible with CUDA graph capture.

## Changes

- Ignore storage after `offsets[nrow]` when compacting BSR matrices on CUDA.
- Cover trailing capacity for in-place and out-of-place compression in direct and captured execution.
- Add a changelog fragment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

The sparse test module passed all 60 tests, including direct and CUDA graph capture coverage for in-place and out-of-place compact compression. Changed-file pre-commit checks also passed.

## Bug fix

Without this change, compression can include valid-looking entries stored after the terminal row offset:

```python
import warp as wp
import warp.sparse as wps

matrix = wps.bsr_zeros(3, 3, float, device="cuda")
matrix.nnz = 6
matrix.offsets = wp.array([0, 1, 2, 3], dtype=int, device="cuda")
matrix.columns = wp.array([0, 1, 2, 0, 0, 0], dtype=int, device="cuda")
matrix.values = wp.array([3.0, 7.0, 11.0, 42.0, 42.0, 42.0], dtype=float, device="cuda")

wps.bsr_compress(matrix, prune_numerical_zeros=False, inplace=True, topology="compact")

print(matrix.offsets.numpy())
# Before this fix: [0 1 2 6]
# With this fix:   [0 1 2 3]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CUDA BSR matrix compression so trailing unused storage is not treated as active data.
  * Ensured in-place, out-of-place, and CUDA graph-captured compression produces correct compact matrices.

* **Tests**
  * Added coverage for compression with trailing unused capacity, including expected topology and diagonal matrix results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->