### PR TITLE
Fix autograd for backward-disabled kernels

### DIFF
--- a/changelog/1718.fixed.md
+++ b/changelog/1718.fixed.md
@@ -1,0 +1,2 @@
+Fix `warp.autograd.jacobian()` and `gradcheck_tape()` mishandling module-level `enable_backward=False`, and
+allow `jacobian_fd()` for kernels with backward code generation disabled.

--- a/warp/_src/autograd.py
+++ b/warp/_src/autograd.py
@@ -22,6 +22,14 @@ __all__ = [
 ]
 
 
+def _is_kernel_backward_enabled(kernel: wp.Kernel) -> bool:
+    """Return whether backward code generation is enabled for ``kernel``."""
+    return kernel.options.get(
+        "enable_backward",
+        kernel.module.options.get("enable_backward", True),
+    )
+
+
 def gradcheck(
     function: wp.Kernel | Callable,
     dim: tuple[int] | None = None,
@@ -301,7 +309,7 @@ def gradcheck_tape(
             continue
         if kernel.key in blacklist_kernels:
             continue
-        if not kernel.options.get("enable_backward", True):
+        if not _is_kernel_backward_enabled(kernel):
             continue
 
         input_output_mask = input_output_masks.get(kernel.key)
@@ -711,7 +719,7 @@ def jacobian(
         metadata = FunctionMetadata()
 
     if isinstance(function, wp.Kernel):
-        if not function.options.get("enable_backward", True):
+        if not _is_kernel_backward_enabled(function):
             raise ValueError("Kernel must have backward pass enabled to compute Jacobians")
         if outputs is None or len(outputs) == 0:
             raise ValueError("A list of output arguments must be provided to compute kernel Jacobians")
@@ -844,8 +852,6 @@ def jacobian_fd(
         metadata = FunctionMetadata()
 
     if isinstance(function, wp.Kernel):
-        if not function.options.get("enable_backward", True):
-            raise ValueError("Kernel must have backward pass enabled to compute Jacobians")
         if outputs is None or len(outputs) == 0:
             raise ValueError("A list of output arguments must be provided to compute kernel Jacobians")
         if device is None:

--- a/warp/tests/test_grad_debug.py
+++ b/warp/tests/test_grad_debug.py
@@ -120,6 +120,50 @@ def jacobian_plot_scale_kernel(a: wp.array[float], out: wp.array[float]):
     out[tid] = 2.0 * a[tid]
 
 
+_MODULE_BACKWARD_DISABLED = "test_grad_debug_module_backward_disabled"
+_KERNEL_BACKWARD_DISABLED = "test_grad_debug_kernel_backward_disabled"
+
+# Group fixtures by configuration while keeping them isolated from the test module.
+wp.get_module(_MODULE_BACKWARD_DISABLED).options["enable_backward"] = False
+
+
+@wp.kernel(module=_MODULE_BACKWARD_DISABLED)
+def module_backward_disabled_scale_kernel(a: wp.array[float], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = 2.0 * a[tid]
+
+
+@wp.kernel(module=_KERNEL_BACKWARD_DISABLED, enable_backward=False)
+def kernel_backward_disabled_scale_kernel(a: wp.array[float], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = 2.0 * a[tid]
+
+
+@wp.kernel(module=_KERNEL_BACKWARD_DISABLED, enable_backward=False)
+def kernel_backward_disabled_wrong_grad_kernel(a: wp.array[float], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = wrong_grad_func(a[tid])
+
+
+@wp.kernel(module=_MODULE_BACKWARD_DISABLED)
+def module_backward_disabled_wrong_grad_kernel(a: wp.array[float], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = wrong_grad_func(a[tid])
+
+
+@wp.kernel(module=_MODULE_BACKWARD_DISABLED, enable_backward=True)
+def kernel_backward_enabled_scale_kernel(a: wp.array[float], out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = 2.0 * a[tid]
+
+
+def _make_scale_args(device):
+    """Create differentiable inputs and outputs for the scale kernels."""
+    a = wp.array([1.0, 2.0], dtype=wp.float32, requires_grad=True, device=device)
+    out = wp.zeros(2, dtype=wp.float32, requires_grad=True, device=device)
+    return a, out
+
+
 def function_pipeline(a):
     out = wp.zeros_like(a, requires_grad=True)
     wp.launch(
@@ -147,6 +191,82 @@ def test_jacobian_function_pipeline(test, device):
             rtol=1.0e-3,
             err_msg=f"{jacobian_function.__name__} returned an incorrect Jacobian for function_pipeline",
         )
+
+
+def test_jacobian_respects_effective_enable_backward(test, device):
+    """Honor module and kernel backward settings when computing Jacobians.
+
+    Reject both forms of effective disablement, then verify that an explicit
+    kernel-level ``True`` overrides a module-level ``False``.
+    """
+    disabled_kernels = (
+        module_backward_disabled_scale_kernel,
+        kernel_backward_disabled_scale_kernel,
+    )
+    for kernel in disabled_kernels:
+        with test.subTest(kernel=kernel.key):
+            a, out = _make_scale_args(device)
+            with test.assertRaisesRegex(
+                ValueError,
+                "Kernel must have backward pass enabled to compute Jacobians",
+            ):
+                jacobian(kernel, dim=len(a), inputs=[a], outputs=[out])
+
+    # The explicit kernel setting is more specific than the disabled module.
+    a, out = _make_scale_args(device)
+    jacobians = jacobian(
+        kernel_backward_enabled_scale_kernel,
+        dim=len(a),
+        inputs=[a],
+        outputs=[out],
+    )
+    np.testing.assert_allclose(
+        jacobians[(0, 0)].numpy(),
+        np.eye(2, dtype=np.float32) * 2.0,
+        atol=1.0e-3,
+        rtol=1.0e-3,
+    )
+
+
+def test_gradcheck_tape_skips_effectively_disabled_kernels(test, device):
+    """Skip tape launches disabled at either module or kernel scope.
+
+    Record disabled kernels with known incorrect adjoints. A successful result
+    proves neither launch was checked and accepted by coincidence.
+    """
+    with wp.Tape() as tape:
+        for kernel in (
+            module_backward_disabled_wrong_grad_kernel,
+            kernel_backward_disabled_wrong_grad_kernel,
+        ):
+            a, out = _make_scale_args(device)
+            wp.launch(kernel, dim=len(a), inputs=[a], outputs=[out], device=device)
+
+    # Either known-wrong gradient would make this False if its launch were checked.
+    test.assertTrue(gradcheck_tape(tape, raise_exception=False, show_summary=False))
+
+
+def test_jacobian_fd_allows_backward_disabled_kernels(test, device):
+    """Compute finite-difference Jacobians for backward-disabled kernels.
+
+    Exercise module-level and kernel-level disablement. Finite differences use
+    only forward launches, so neither setting should prevent the calculation.
+    """
+    for kernel in (
+        module_backward_disabled_scale_kernel,
+        kernel_backward_disabled_scale_kernel,
+    ):
+        with test.subTest(kernel=kernel.key):
+            a, out = _make_scale_args(device)
+
+            # This path perturbs inputs and launches forward kernels; it needs no adjoint.
+            jacobians = jacobian_fd(kernel, dim=len(a), inputs=[a], outputs=[out])
+            np.testing.assert_allclose(
+                jacobians[(0, 0)].numpy(),
+                np.eye(2, dtype=np.float32) * 2.0,
+                atol=1.0e-3,
+                rtol=1.0e-3,
+            )
 
 
 def test_gradcheck_3d(test, device, dtype):
@@ -558,6 +678,24 @@ add_function_test(TestGradDebug, "test_gradcheck_mixed", test_gradcheck_mixed, d
 add_function_test(TestGradDebug, "test_gradcheck_nan", test_gradcheck_nan, devices=devices)
 add_function_test(TestGradDebug, "test_gradcheck_incorrect", test_gradcheck_incorrect, devices=devices)
 add_function_test(TestGradDebug, "test_gradcheck_tape_mixed", test_gradcheck_tape_mixed, devices=devices)
+add_function_test(
+    TestGradDebug,
+    "test_jacobian_respects_effective_enable_backward",
+    test_jacobian_respects_effective_enable_backward,
+    devices=devices,
+)
+add_function_test(
+    TestGradDebug,
+    "test_gradcheck_tape_skips_effectively_disabled_kernels",
+    test_gradcheck_tape_skips_effectively_disabled_kernels,
+    devices=devices,
+)
+add_function_test(
+    TestGradDebug,
+    "test_jacobian_fd_allows_backward_disabled_kernels",
+    test_jacobian_fd_allows_backward_disabled_kernels,
+    devices=devices,
+)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`wp.autograd.jacobian()` and `gradcheck_tape()` only checked the kernel-local `enable_backward` option, so they ignored module-level disablement. This could make `jacobian()` return an all-zero matrix without explaining that backward code generation was disabled, while `gradcheck_tape()` attempted to validate launches with no adjoint. `jacobian_fd()` had the opposite problem: it rejected kernels disabled at kernel scope even though finite differences only require forward launches.

This change resolves `enable_backward` with kernel options taking precedence over module options. Reverse-mode utilities now reject or skip effectively disabled kernels, while `jacobian_fd()` remains available regardless of the backward setting.

Closes #1718.

## Changes

- Resolve the effective `enable_backward` setting from kernel and module options.
- Apply that setting in `jacobian()` and `gradcheck_tape()`.
- Allow `jacobian_fd()` to run without generated backward code.
- Add CPU and CUDA regression coverage for module disablement, kernel disablement, and kernel-level overrides.
- Add a changelog fragment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

The three regression tests were developed with red/green coverage: they failed with the original behavior and passed after the fix. The strengthened `gradcheck_tape()` test uses incorrect adjoints at both module and kernel scope, so it can only pass when the disabled launches are skipped. The complete `warp/tests/test_grad_debug.py` module passed all 29 tests on CPU and CUDA. Pre-commit checks passed for every changed file.

## Bug fix

```python
import warp as wp

@wp.kernel(module="unique", module_options={"enable_backward": False})
def scale(x: wp.array[float], y: wp.array[float]):
    i = wp.tid()
    y[i] = 2.0 * x[i]

device = wp.get_device()
x = wp.array([1.0, 2.0], dtype=wp.float32, requires_grad=True, device=device)
y = wp.zeros(2, dtype=wp.float32, requires_grad=True, device=device)

jacobians = wp.autograd.jacobian(scale, dim=len(x), inputs=[x], outputs=[y])
print(jacobians[(0, 0)].numpy())
```

Before this change, the example returned an all-zero Jacobian instead of raising an error that backward code generation was disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic differentiation behavior when backward computation is disabled at the module or kernel level.
  * Jacobian and gradient-checking workflows now consistently honor effective backward settings, including kernel-level overrides.
  * Gradient checks correctly skip kernels that do not support backward computation.
  * Finite-difference Jacobians can now be calculated for kernels without generated backward code.
* **Tests**
  * Added coverage for backward settings, overrides, skipped checks, and finite-difference Jacobians.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->