### PR TITLE
Propagate parallel module load errors

### DIFF
--- a/changelog/1749.fixed.md
+++ b/changelog/1749.fixed.md
@@ -1,0 +1,2 @@
+Propagate module compilation and loading failures from parallel `wp.force_load()` and `wp.load_module()` calls
+instead of returning successfully.

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -11429,22 +11429,28 @@ def force_load(
         loaded = [dim for (ctx, dim) in loaded_variants[m] if ctx == d.context]
         return loaded or [None]
 
-    if max_workers <= 1 or (len(devices) * len(modules)) == 1:
-        # serial loading; avoid the overhead of using a thread pool
-        for d in devices:
-            for m in modules:
-                for dim in _load_block_dims(m, d):
-                    m.load(d, block_dim=dim)
-    else:
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+    # Always restore the caller's CUDA context, even if module loading fails.
+    try:
+        if max_workers <= 1 or (len(devices) * len(modules)) == 1:
+            # serial loading; avoid the overhead of using a thread pool
             for d in devices:
                 for m in modules:
                     for dim in _load_block_dims(m, d):
-                        executor.submit(m.load, d, block_dim=dim)
+                        m.load(d, block_dim=dim)
+        else:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = []
+                for d in devices:
+                    for m in modules:
+                        for dim in _load_block_dims(m, d):
+                            futures.append(executor.submit(m.load, d, block_dim=dim))
 
-    if is_cuda_available():
-        # restore original context to avoid side effects
-        runtime.core.wp_cuda_context_set_current(saved_context)
+                for future in futures:
+                    future.result()
+    finally:
+        if is_cuda_available():
+            # restore original context to avoid side effects
+            runtime.core.wp_cuda_context_set_current(saved_context)
 
 
 def _get_caller_module_name(stack_level: int = 1) -> str:

--- a/warp/tests/test_module_parallel_load.py
+++ b/warp/tests/test_module_parallel_load.py
@@ -5,6 +5,7 @@
 wp.force_load() and wp.load_module().
 """
 
+import importlib
 import os
 import subprocess
 import sys
@@ -188,6 +189,47 @@ class TestModuleParallelLoad(unittest.TestCase):
         modules = _generate_modules(4)
         wp.force_load(device="cpu", modules=modules, max_workers=2)
         _assert_modules_loaded_on_cpu(self, modules)
+
+    def test_force_load_parallel_propagates_load_failure(self):
+        """Verify that parallel loading propagates a module-load failure."""
+        module_name = "warp.tests.aux_test_unresolved_func"
+        # Importing registers the invalid kernel without compiling it; force_load() triggers the real codegen error.
+        unresolved_func_module = importlib.import_module(module_name)
+        failed_module = wp.get_module(unresolved_func_module.__name__)
+
+        # The valid companion selects the parallel path and must finish loading before the error reaches the caller.
+        valid_module = _generate_modules(1)[0]
+
+        try:
+            with self.assertRaisesRegex(AttributeError, "Could not find function wp.missing_func"):
+                wp.force_load(device="cpu", modules=[failed_module, valid_module], max_workers=2)
+
+            _assert_modules_loaded_on_cpu(self, [valid_module])
+        finally:
+            # Keep the invalid fixture out of later force_load() calls.
+            context.user_modules.pop(module_name, None)
+            sys.modules.pop(module_name, None)
+
+    @unittest.skipUnless(wp.is_cuda_available(), "Requires CUDA")
+    def test_force_load_restores_cuda_context_on_failure(self):
+        """Verify that a module-load failure restores the calling thread's CUDA context."""
+        module_name = "warp.tests.aux_test_unresolved_func"
+        unresolved_func_module = importlib.import_module(module_name)
+        failed_module = wp.get_module(unresolved_func_module.__name__)
+        valid_module = _generate_modules(1)[0]
+        device = wp.get_device("cuda:0")
+
+        original_context = context.runtime.core.wp_cuda_context_get_current()
+        context.runtime.core.wp_cuda_context_set_current(None)
+        try:
+            with self.assertRaisesRegex(AttributeError, "Could not find function wp.missing_func"):
+                wp.force_load(device=device, modules=[valid_module, failed_module], max_workers=0)
+
+            self.assertIsNone(context.runtime.core.wp_cuda_context_get_current())
+        finally:
+            context.runtime.core.wp_cuda_context_set_current(original_context)
+            context.user_modules.pop(module_name, None)
+            sys.modules.pop(module_name, None)
 
     def test_force_load_config_default(self):
         """Verify that wp.config.load_module_max_workers is respected when max_workers is not passed."""


### PR DESCRIPTION
## Description

Parallel `wp.force_load()` discarded the `Future` returned for each `Module.load()` call when `max_workers > 1`. Executor shutdown waited for the work but never retrieved stored exceptions, so module compilation or loading failures could be reported as successful.

This change retrieves every submitted result in submission order. The original exception is propagated after all submitted loads finish, preserving the existing attempt-all behavior.

Closes #1749.

## Changes

- Retain futures created by parallel module loading and retrieve each result.
- Add a CPU regression test using an existing unresolved-function module to exercise a real code-generation failure and verify a valid companion module still finishes loading.
- Add a changelog fragment for the user-visible correction.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

- Verified the new `test_force_load_parallel_propagates_load_failure` test fails on `upstream/main` because `force_load()` returns without raising.
- Verified the same test passes with the fix and confirms the valid companion module finishes loading before the failure reaches the caller.
- Verified all seven CPU `TestModuleParallelLoad` tests pass, including serial, successful parallel, configuration-default, single-module, and cold-start paths.
- Verified pre-commit passes for all changed files and Towncrier renders the GH-1749 fragment under Fixed.

## Bug fix

### Current behavior

Without this PR, Warp logs the module code-generation error but `wp.force_load()` returns normally, so the final `print()` executes and the process can report a successful warm-up despite the failed module load.

### Behavior with this PR

`wp.force_load()` waits for every submitted module load to finish and then raises the original code-generation error, so callers cannot mistake a failed warm-up for success.

```python
import warp as wp


@wp.kernel
def bad_kernel():
    wp.missing_func(42)


@wp.kernel(module="force_load_valid_companion")
def valid_kernel(values: wp.array[wp.int32]):
    tid = wp.tid()
    values[tid] = 1


wp.force_load(
    device="cpu",
    modules=[bad_kernel.module, valid_kernel.module],
    max_workers=2,
)
print("force_load returned without raising")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parallel module loading now correctly reports compilation and loading failures instead of returning as if loading succeeded.
  * Valid modules continue loading while failures from companion modules are surfaced to the caller.
  * CUDA context is now restored reliably when module loading fails.
* **Tests**
  * Added coverage for failure propagation and CUDA context restoration during module loading.
* **Documentation**
  * Updated the changelog to document the corrected error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->