### PR TITLE
Correct Jacobian product terminology in user guide

### DIFF
--- a/docs/user_guide/differentiability.rst
+++ b/docs/user_guide/differentiability.rst
@@ -252,7 +252,7 @@ Jacobians
 #########
 
 To compute the Jacobian matrix :math:`J\in\mathbb{R}^{m\times n}` of a multi-valued function :math:`f: \mathbb{R}^n \to \mathbb{R}^m`,
-we can evaluate an entire row of the Jacobian in parallel by finding the Jacobian-vector product :math:`J^\top \mathbf{e}`.
+we can evaluate an entire row of the Jacobian in parallel by finding the vector-Jacobian product :math:`\mathbf{e}^\top J`.
 The vector :math:`\mathbf{e}\in\mathbb{R}^m` selects the indices in the output buffer to differentiate with respect to.
 In Warp, instead of passing a scalar loss buffer to :meth:`warp.Tape.backward`,
 we pass a dictionary ``grads`` mapping from the function output array to the selection vector :math:`\mathbf{e}`


### PR DESCRIPTION
Updated terminology from 'Jacobian-vector product' to 'vector-Jacobian product' for correctness. Transposed equation (which was correct) to avoid transpose on J.

## Description

Typical autodiff terminology convention is to call eᵀ J the vector-Jacobian product, which is what reverse-mode (like warp) computes.

## Changes

Minor change to docs.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] I added a changelog fragment if this change affects users.

## Validation summary

https://docs.jax.dev/en/latest/notebooks/autodiff_cookbook.html#vector-jacobian-products-vjps-aka-reverse-mode-autodiff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Jacobian explanation to accurately describe the row computation as a vector-Jacobian product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->