### PR TITLE
Clarify APIC example run paths on Windows

### DIFF
--- a/docs/user_guide/runtime.rst
+++ b/docs/user_guide/runtime.rst
@@ -2346,7 +2346,11 @@ Both examples ship with a ``Makefile`` (Unix/Linux) and a ``CMakeLists.txt``
     cmake --build build --config Release
 
     # 3. Run
+    # NINJA / UNIX Makefiles
     ./build/02_apic_visualization                  # or 03_apic_visualization_cpu
+
+    # Visual Studio (Windows)
+    .\build\Release\02_apic_visualization.exe      # or 03_apic_visualization_cpu.exe
 
 Each example directory contains a ``README.md`` with full prerequisites, build
 options, controls, and platform-specific notes.

--- a/warp/examples/cpp/02_apic_visualization/README.md
+++ b/warp/examples/cpp/02_apic_visualization/README.md
@@ -82,7 +82,13 @@ make              # Build everything (auto-captures graph if needed)
 python capture_wave.py                        # Step 1: Capture the graph
 cmake -B build -DCMAKE_BUILD_TYPE=Release     # Step 2: Configure
 cmake --build build --config Release          # Step 3: Build
-./build/02_apic_visualization                 # Step 4: Run
+./build/02_apic_visualization                 # Step 4: Run (Ninja / Unix Makefiles)
+```
+
+If using the Visual Studio generator on Windows, run:
+
+```powershell
+.\build\Release\02_apic_visualization.exe
 ```
 
 **Headless smoke mode**:

--- a/warp/examples/cpp/03_apic_visualization_cpu/README.md
+++ b/warp/examples/cpp/03_apic_visualization_cpu/README.md
@@ -72,6 +72,12 @@ cmake --build build --config Release
 ./build/03_apic_visualization_cpu
 ```
 
+If using the Visual Studio generator on Windows instead of Ninja, run:
+
+```powershell
+.\build\Release\03_apic_visualization_cpu.exe
+```
+
 **Headless smoke mode**:
 
 The example also accepts `--smoke` as a single argv to run a headless


### PR DESCRIPTION
## Description

Clarifies the run commands for the APIC C++ visualization examples when using CMake on Windows.

The docs describe the CMake workflow as cross-platform, but the shown run path assumes a single-configuration generator where executables are placed directly under `build/`. With the Visual Studio generator on Windows, Release executables are placed under `build\Release\`. I encountered this while following the documented commands, and I think clarifying the generator-dependent run path would make the examples easier for new Warp users to run.

The README updates follow the existing style used by the `00_cubin_launch` and `01_source_include` C++ example READMEs, which already document both Unix-style and Windows Visual Studio run paths.

No related issue. Related historical context: #1400 / #1404 fixed APIC C++ example build issues on Linux; this PR only clarifies the documented run path for Windows Visual Studio builds.

## Changes

- Adds the Visual Studio Release executable path to the APIC example docs.
- Makes the APIC C++ example docs consistent with the existing Windows run-path notes in other C++ example READMEs.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] I added a changelog fragment if this change affects users.

## Validation summary

Documentation-only change.

I followed the documented CMake workflow for `03_apic_visualization_cpu` on Windows with the Visual Studio generator and verified that the executable is produced under `build\Release\03_apic_visualization_cpu.exe`.

I also ran `git diff --check`, which passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated APIC C++ example instructions with separate Unix/Ninja and Windows Visual Studio run commands.
  * Added Windows executable paths for APIC visualization examples, including the CPU version.
  * Expanded CUDA APIC documentation for saving and loading sparse matrix operations.
  * Documented graph-capturable `bsr_mm` constraints and removed the previous restriction on sparse topology-building operations.
  * Added kernel-cache guidance and clarified APIC example execution instructions across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->