### PR TITLE
Fix wp.grad() custom gradient dependencies

### DIFF
--- a/changelog/1794.fixed.md
+++ b/changelog/1794.fixed.md
@@ -1,0 +1,1 @@
+Fix `wp.grad()` calls failing to compile when custom `@wp.func_grad` implementations were not otherwise referenced or when forward and reverse dependencies passed through ordinary helpers, and fix under-reserving shared memory when custom gradients used tile operations.

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -1473,8 +1473,6 @@ def specialize_callable_func(func, callable_arg_values):
         source=func.adj.source,
     )
     specialized_func.adj.callable_arg_values = dict(callable_arg_values)
-    specialized_func.adj.used_by_backward_kernel = func.adj.used_by_backward_kernel
-    specialized_func.adj.force_adjoint_codegen = func.adj.force_adjoint_codegen
 
     specializations[specialization_key] = specialized_func
     return specialized_func
@@ -1660,13 +1658,8 @@ class Adjoint:
         adj.skip_forward_codegen = skip_forward_codegen
         # whether the generation of the adjoint code is skipped for this function
         adj.skip_reverse_codegen = skip_reverse_codegen
-        # Whether this function is used by a kernel that has has the backward pass enabled.
-        adj.used_by_backward_kernel = False
-        # Whether to force adjoint code generation regardless of enable_backward setting.
-        # This is used by warp.grad() to ensure the adjoint exists even in forward-only modules.
-        adj.force_adjoint_codegen = False
-        # Whether this function uses warp.grad() calls. Such functions are generated in a
-        # separate pass after adjoints, and don't have their own adjoints generated.
+        # Whether this function uses warp.grad() calls. Such functions don't have their own
+        # adjoints generated because higher-order gradients are unsupported.
         adj.uses_grad_call = False
 
         # extract name of source file
@@ -1817,7 +1810,7 @@ class Adjoint:
         return adj.get_own_required_shared() + adj.max_required_extra_shared_memory
 
     # backward counterpart of get_total_required_shared();
-    # callee frames come from ModuleBuilder._propagate_backward_shared_memory
+    # callee frames come from ModuleBuilder._propagate_shared_memory
     def get_total_required_shared_backward(adj):
         # x2: the reverse pass declares own tiles requires_grad, pairing each with an equal-sized gradient buffer
         return adj.get_own_required_shared() * 2 + adj.max_required_extra_shared_memory_backward
@@ -2003,10 +1996,13 @@ class Adjoint:
         # backward-pass counterpart, resolved by ModuleBuilder._propagate_backward_shared_memory
         adj.max_required_extra_shared_memory_backward = 0
 
-        # recorded at call sites for ModuleBuilder's post-build propagation passes
+        # Ordinary calls target forward functions, while wp.grad() calls target adjoints;
+        # ModuleBuilder's completed-graph analyses traverse these edges differently.
         adj.called_user_functions = {}
+        adj.called_grad_functions = {}
 
-        # wp.ref[T] callees lacking a manual adjoint; rejected post-build, once used_by_backward_kernel is final
+        # wp.ref[T] callees lacking a manual adjoint; rejected by ModuleBuilder once
+        # backward reachability is final.
         adj.unvalidated_ref_calls = []
 
         # Function-specialized functions replace selected argument Vars with
@@ -2599,14 +2595,8 @@ class Adjoint:
 
         # if it is a user-function then build it recursively
         if not func.is_builtin():
-            # record the call-graph edge for the post-build propagation passes
+            # record the call-graph edge for the completed-graph analyses
             adj.called_user_functions.setdefault(func, None)
-            # If the function called is a user function,
-            # we need to ensure its adjoint is also being generated.
-            if adj.used_by_backward_kernel:
-                func.adj.used_by_backward_kernel = True
-            if adj.force_adjoint_codegen:
-                func.adj.force_adjoint_codegen = True
 
             if adj.builder is None:
                 func.build(None, adj.builder_options)
@@ -2734,10 +2724,6 @@ class Adjoint:
             if isinstance(func_arg_var, warp._src.context.Function) and not func_arg_var.is_builtin():
                 # a function-valued argument is a call-graph edge too
                 adj.called_user_functions.setdefault(func_arg_var, None)
-                if adj.used_by_backward_kernel:
-                    func_arg_var.adj.used_by_backward_kernel = True
-                if adj.force_adjoint_codegen:
-                    func_arg_var.adj.force_adjoint_codegen = True
 
                 if adj.builder is None:
                     func_arg_var.build(None, adj.builder_options)
@@ -2781,9 +2767,9 @@ class Adjoint:
         else:
             adj.add_forward(forward_call, replay=replay_call)
 
-        # Skip reverse call generation for functions that use warp.grad() - they don't have
-        # meaningful adjoints (the gradient of a gradient call is not supported).
-        skip_reverse = not func.is_builtin() and func.adj.uses_grad_call
+        # Functions that use warp.grad() need a custom gradient to supply a meaningful adjoint;
+        # otherwise generating their reverse call would require unsupported higher-order gradients.
+        skip_reverse = not func.is_builtin() and func.custom_grad_func is None and func.adj.uses_grad_call
         # Higher-order built-ins pass callable args to native adjoint helpers.
         # Only generate the reverse call when those callables have adjoints.
         has_nondifferentiable_callable_arg = any(
@@ -2792,8 +2778,8 @@ class Adjoint:
 
         if func.is_differentiable and func_args and not skip_reverse and not has_nondifferentiable_callable_arg:
             # Ref-param functions are not automatically differentiable and a silent skip would
-            # produce wrong gradients, but used_by_backward_kernel is not known yet (callers may
-            # still be built); ModuleBuilder rejects the recorded calls once it is final
+            # produce wrong gradients, but backward reachability is not known yet (callers may
+            # still be built); ModuleBuilder rejects the recorded calls once it is final.
             if func_has_ref_params and not adj.has_manual_ref_adjoint(func):
                 adj.unvalidated_ref_calls.append(func)
             adj_args = tuple(reverse_adj_args)
@@ -2828,7 +2814,7 @@ class Adjoint:
             adj.alloc_shared_extra(func.adj.get_total_required_shared() + extra_shared_memory)
         else:
             adj.alloc_shared_extra(extra_shared_memory)
-        # user-function callee frames are folded in post-build by ModuleBuilder._propagate_backward_shared_memory
+        # user-function callee frames are folded in post-build by ModuleBuilder._propagate_shared_memory
         # x2: the builtin's adjoint needs LTO workspace too; matches the previous blanket backward sizing
         adj.alloc_shared_extra_backward(extra_shared_memory * 2)
 
@@ -2844,7 +2830,7 @@ class Adjoint:
         This generates inline code in the forward pass that:
         1. Creates local variables for adjoint inputs (initialized to 0)
         2. Creates local variable(s) for adjoint output (initialized to 1.0)
-        3. Calls the function's auto-generated adjoint
+        3. Calls the function's adjoint
         4. Returns the adjoint inputs as a tuple (or single value if 1 input)
 
         Note:
@@ -2856,26 +2842,8 @@ class Adjoint:
         if not func.is_differentiable:
             raise WarpCodegenError(f"Cannot compute gradient of non-differentiable function '{func.key}'")
 
-        # Mark this function as using grad() - it will be generated in a later pass
-        # and won't have its own adjoint generated.
-        # Exception: Custom gradient functions (custom_reverse_mode=True) ARE adjoints,
-        # so they don't need their own adjoints and should be generated in the adjoint pass.
-        if not adj.custom_reverse_mode:
-            adj.uses_grad_call = True
-
-        # Warn if this kernel has backward enabled, since the gradient call
-        # is forward-only and won't participate in automatic differentiation.
-        if adj.used_by_backward_kernel:
-            log_warning(
-                f'grad() call for function "{func.key}" is used in a kernel with enable_backward=True. The gradient call does NOT participate in automatic differentiation - gradients will not flow through this call in the backward pass.'
-            )
-
-        # Ensure the function is built so its adjoint code exists.
+        # Build user functions before checking that their adjoint code can be generated.
         if not func.is_builtin():
-            # Force adjoint code generation for the function.
-            func.adj.force_adjoint_codegen = True
-
-            # Build the function if not already built
             if adj.builder is None:
                 func.build(None, adj.builder_options)
             elif func not in adj.builder.functions:
@@ -2891,6 +2859,14 @@ class Adjoint:
 
         if return_type is None:
             raise WarpCodegenError(f"Cannot compute gradient of void function '{func.key}'")
+
+        # Mark this function as using grad() so its own adjoint is not generated.
+        # Exception: Custom gradient functions (custom_reverse_mode=True) ARE adjoints,
+        # so they don't need their own adjoints.
+        if not adj.custom_reverse_mode:
+            adj.uses_grad_call = True
+
+        adj.called_grad_functions.setdefault(func, None)
 
         # Function parameters are specialization inputs, not native function
         # arguments, and their adjoints are not representable.
@@ -4613,8 +4589,6 @@ class Adjoint:
                     transformers=func.adj.transformers,
                     source=func.adj.source,
                 )
-                probe_adj.used_by_backward_kernel = func.adj.used_by_backward_kernel
-                probe_adj.force_adjoint_codegen = func.adj.force_adjoint_codegen
                 probe_adj.build(None, adj.builder_options)
             except Exception:
                 return None
@@ -6553,6 +6527,18 @@ static void adj_{name}(
 
 """
 
+cpu_forward_function_declaration_template = """
+static {return_type} {name}(
+    {forward_args});
+
+"""
+
+cpu_reverse_function_declaration_template = """
+static void adj_{name}(
+    {reverse_args});
+
+"""
+
 cuda_forward_function_template = """
 // {filename}:{lineno}
 {line_directive}static CUDA_CALLABLE {return_type} {name}(
@@ -6568,6 +6554,18 @@ cuda_reverse_function_template = """
     {reverse_args})
 {{
 {reverse_body}{line_directive}}}
+
+"""
+
+cuda_forward_function_declaration_template = """
+static CUDA_CALLABLE {return_type} {name}(
+    {forward_args});
+
+"""
+
+cuda_reverse_function_declaration_template = """
+static CUDA_CALLABLE void adj_{name}(
+    {reverse_args});
 
 """
 
@@ -7102,10 +7100,13 @@ def codegen_func_reverse(adj, func_type="kernel", device="cpu", grid_stride=Fals
     return "".join(l.lstrip() if l.lstrip().startswith("#line") else indent_block + l for l in lines)
 
 
-def codegen_func(adj, c_func_name: str, device="cpu", options=None, forward_only=False, reverse_only=False):
-    if options is None:
-        options = {}
-
+def codegen_func(
+    adj,
+    c_func_name: str,
+    device="cpu",
+    declaration_only: bool = False,
+    generate_adjoint: bool = False,
+) -> str:
     # Build line directive for function definition (subtract 1 to account for 1-indexing of AST line numbers)
     # This is used as a catch-all C-to-Python source line mapping for any code that does not have
     # a direct mapping to a Python source line.
@@ -7210,20 +7211,30 @@ def codegen_func(adj, c_func_name: str, device="cpu", options=None, forward_only
     if template_params:
         template_prefix = "template<" + ", ".join(f"typename {t}" for t in template_params) + ">\n"
 
+    # Declaration mode selects prototypes with the same target-specific signatures
+    # as the definitions emitted in the following pass.
     if device == "cpu":
-        forward_template = cpu_forward_function_template
-        reverse_template = cpu_reverse_function_template
+        if declaration_only:
+            forward_template = cpu_forward_function_declaration_template
+            reverse_template = cpu_reverse_function_declaration_template
+        else:
+            forward_template = cpu_forward_function_template
+            reverse_template = cpu_reverse_function_template
     elif device == "cuda":
-        forward_template = cuda_forward_function_template
-        reverse_template = cuda_reverse_function_template
+        if declaration_only:
+            forward_template = cuda_forward_function_declaration_template
+            reverse_template = cuda_reverse_function_declaration_template
+        else:
+            forward_template = cuda_forward_function_template
+            reverse_template = cuda_reverse_function_template
     else:
         raise ValueError(f"Device {device} is not supported")
 
     # codegen body
-    forward_body = codegen_func_forward(adj, func_type="function", device=device)
+    forward_body = "" if declaration_only else codegen_func_forward(adj, func_type="function", device=device)
 
     s = ""
-    if not adj.skip_forward_codegen and not reverse_only:
+    if not adj.skip_forward_codegen:
         s += template_prefix + forward_template.format(
             name=c_func_name,
             return_type=return_type,
@@ -7234,23 +7245,15 @@ def codegen_func(adj, c_func_name: str, device="cpu", options=None, forward_only
             line_directive=func_line_directive,
         )
 
-    if not adj.skip_reverse_codegen and not forward_only:
-        if adj.custom_reverse_mode:
+    if not adj.skip_reverse_codegen and not adj.uses_grad_call:
+        if declaration_only:
+            reverse_body = ""
+        elif adj.custom_reverse_mode:
             reverse_body = "\t// user-defined adjoint code\n" + forward_body
+        elif generate_adjoint:
+            reverse_body = codegen_func_reverse(adj, func_type="function", device=device)
         else:
-            # Generate adjoint code if:
-            # - enable_backward is True and the function is used by a backward kernel, OR
-            # - force_adjoint_codegen is True (set by warp.grad() to ensure adjoint exists)
-            # Note: Functions using warp.grad() won't have their adjoints called anyway
-            # (the reverse call is skipped in add_call), so we can skip generating them.
-            should_generate_adjoint = (
-                options.get("enable_backward", True) and adj.used_by_backward_kernel
-            ) or adj.force_adjoint_codegen
-            should_generate_adjoint = should_generate_adjoint and not adj.uses_grad_call
-            if should_generate_adjoint:
-                reverse_body = codegen_func_reverse(adj, func_type="function", device=device)
-            else:
-                reverse_body = '\t// reverse mode disabled (module option "enable_backward" is False or no dependent kernel found with "enable_backward")\n'
+            reverse_body = '\t// reverse mode disabled (module option "enable_backward" is False or no dependent kernel found with "enable_backward")\n'
         s += template_prefix + reverse_template.format(
             name=c_func_name,
             return_type=return_type,
@@ -7265,7 +7268,14 @@ def codegen_func(adj, c_func_name: str, device="cpu", options=None, forward_only
     return s
 
 
-def codegen_snippet(adj, name, snippet, adj_snippet, replay_snippet, forward_only=False, reverse_only=False):
+def codegen_snippet(
+    adj,
+    name,
+    snippet,
+    adj_snippet,
+    replay_snippet,
+    declaration_only: bool = False,
+) -> str:
     if adj.return_var is not None and len(adj.return_var) == 1:
         return_type = adj.return_var[0].ctype()
     else:
@@ -7326,52 +7336,56 @@ def codegen_snippet(adj, name, snippet, adj_snippet, replay_snippet, forward_onl
     forward_ref_aliases_str = "".join(forward_ref_aliases)
     reverse_ref_aliases_str = "".join(reverse_ref_aliases)
 
-    forward_template = cuda_forward_function_template
-    replay_template = cuda_forward_function_template
-    reverse_template = cuda_reverse_function_template
+    # Native snippets use CUDA-callable signatures on both targets; declaration
+    # mode changes only the wrapper so prototypes and definitions stay identical.
+    if declaration_only:
+        forward_template = cuda_forward_function_declaration_template
+        replay_template = cuda_forward_function_declaration_template
+        reverse_template = cuda_reverse_function_declaration_template
+    else:
+        forward_template = cuda_forward_function_template
+        replay_template = cuda_forward_function_template
+        reverse_template = cuda_reverse_function_template
 
     s = ""
 
-    # Pass 1: Forward and replay (both are "forward-like" functions)
-    if not reverse_only:
-        s += template_prefix + forward_template.format(
-            name=name,
+    # Forward and replay functions share a signature but may use different bodies.
+    s += template_prefix + forward_template.format(
+        name=name,
+        return_type=return_type,
+        forward_args=indent(forward_args),
+        forward_body=forward_ref_aliases_str + snippet,
+        filename=adj.filename,
+        lineno=adj.fun_lineno,
+        line_directive="",
+    )
+
+    if replay_snippet is not None:
+        s += template_prefix + replay_template.format(
+            name="replay_" + name,
             return_type=return_type,
             forward_args=indent(forward_args),
-            forward_body=forward_ref_aliases_str + snippet,
+            forward_body=forward_ref_aliases_str + replay_snippet,
             filename=adj.filename,
             lineno=adj.fun_lineno,
             line_directive="",
         )
 
-        if replay_snippet is not None:
-            s += template_prefix + replay_template.format(
-                name="replay_" + name,
-                return_type=return_type,
-                forward_args=indent(forward_args),
-                forward_body=forward_ref_aliases_str + replay_snippet,
-                filename=adj.filename,
-                lineno=adj.fun_lineno,
-                line_directive="",
-            )
+    if adj_snippet:
+        reverse_body = reverse_ref_aliases_str + adj_snippet
+    else:
+        reverse_body = reverse_ref_aliases_str
 
-    # Pass 2: Reverse/adjoint only
-    if not forward_only:
-        if adj_snippet:
-            reverse_body = reverse_ref_aliases_str + adj_snippet
-        else:
-            reverse_body = reverse_ref_aliases_str
-
-        s += template_prefix + reverse_template.format(
-            name=name,
-            return_type=return_type,
-            reverse_args=indent(reverse_args),
-            forward_body=snippet,
-            reverse_body=reverse_body,
-            filename=adj.filename,
-            lineno=adj.fun_lineno,
-            line_directive="",
-        )
+    s += template_prefix + reverse_template.format(
+        name=name,
+        return_type=return_type,
+        reverse_args=indent(reverse_args),
+        forward_body=snippet,
+        reverse_body=reverse_body,
+        filename=adj.filename,
+        lineno=adj.fun_lineno,
+        line_directive="",
+    )
 
     return s
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2834,6 +2834,23 @@ class ModuleHasher:
         return self.unique_kernels.values()
 
 
+def _iter_user_grad_functions(adj: warp._src.codegen.Adjoint) -> Iterable[Function]:
+    """Iterate user-function targets of explicit gradient calls in ``adj``.
+
+    Keeping this helper at module scope prevents recursive shared-memory folds
+    from capturing and retaining a ``ModuleBuilder`` instance.
+    """
+    return (func for func in adj.called_grad_functions if not func.is_builtin())
+
+
+# ``ModuleBuilder`` is an internal compiler helper. Its code-generation pipeline is:
+# 1. Lower each unique kernel and every ordinary function it reaches, recording
+#    ordinary calls separately from explicit ``wp.grad()`` calls.
+# 2. Complete deferred custom-gradient, replay, and explicit-gradient dependencies
+#    so later passes see the full call graph.
+# 3. Validate the graph and determine which user functions need adjoint bodies.
+# 4. Fold forward and backward shared-memory requirements through both kinds of calls.
+# 5. Emit LTO declarations and structs, then function declarations, definitions, and kernels.
 class ModuleBuilder:
     def __init__(self, module, options, hasher=None):
         self.functions = {}
@@ -2854,15 +2871,13 @@ class ModuleBuilder:
         for kernel in self.kernels:
             self.build_kernel(kernel)
 
-        # build deferred functions
-        for func in self.deferred_functions:
-            self.build_function(func)
+        # complete all dependencies before running graph-wide propagation
+        self._complete_function_dependencies()
 
-        # propagate used_by_backward_kernel now that the full call graph is known
-        self._propagate_used_by_backward_kernel()
+        self._required_adjoint_functions = self._analyze_function_dependencies()
 
-        # propagate callee replay/reverse shared-memory needs into backward-kernel sizing
-        self._propagate_backward_shared_memory()
+        # finalize forward and backward shared-memory requirements over the complete graph
+        self._propagate_shared_memory()
 
     def build_struct_recursive(self, struct: warp._src.codegen.Struct):
         structs = []
@@ -2948,9 +2963,6 @@ class ModuleBuilder:
         return struct_hashes
 
     def build_kernel(self, kernel):
-        if kernel.options.get("enable_backward", True):
-            kernel.adj.used_by_backward_kernel = True
-
         if self._kernel_has_invalid_return_annotation(kernel) or self._kernel_has_value_return(kernel):
             raise WarpCodegenTypeError(f"'{kernel.key}': {_KERNEL_RETURN_ERROR}")
 
@@ -2968,22 +2980,115 @@ class ModuleBuilder:
             # use dict to preserve import order
             self.functions[func] = None
 
-    def _propagate_used_by_backward_kernel(self):
-        # build_function() memoizes, so a helper built from a forward-only path before a backward
-        # kernel reaches it keeps its callees stubbed; re-propagate across the graph to a fixpoint.
-        worklist = [obj.adj for obj in (*self.kernels, *self.functions) if obj.adj.used_by_backward_kernel]
-        # worklist algorithm: an adj is enqueued only on a False->True flip, so the loop exits even on cycles
-        while worklist:
-            adj = worklist.pop()
-            for callee in adj.called_user_functions:
-                if not callee.adj.used_by_backward_kernel:
-                    callee.adj.used_by_backward_kernel = True
-                    worklist.append(callee.adj)
-        # backward use is final only now, so this is where wp.ref[T] calls recorded by
-        # add_call are rejected (a manual adjoint may also have been registered since)
-        for obj in (*self.kernels, *self.functions):
-            adj = obj.adj
-            if not adj.used_by_backward_kernel:
+    def _get_effective_kernel_options(self, kernel) -> dict[str, Any]:
+        """Return module options with explicit kernel overrides applied."""
+        return self.options | kernel.options
+
+    def _build_deferred_functions(self):
+        """Build custom gradient and replay bodies found through ordinary calls."""
+        for func in self.deferred_functions:
+            self.build_function(func)
+
+    def _complete_function_dependencies(self):
+        """Complete ordinary and explicit-gradient dependencies to a fixed point."""
+        processed = set()
+        while True:
+            self._build_deferred_functions()
+            pending = [obj.adj for obj in (*self.functions, *self.kernels) if obj.adj not in processed]
+            if not pending:
+                break
+
+            for adj in pending:
+                processed.add(adj)
+                for callee in adj.called_user_functions:
+                    for extra_func in (callee.custom_grad_func, callee.custom_replay_func):
+                        if extra_func is not None:
+                            self.build_function(extra_func)
+                for grad_func in _iter_user_grad_functions(adj):
+                    if grad_func.custom_grad_func is not None:
+                        self.build_function(grad_func.custom_grad_func)
+
+    @staticmethod
+    def _find_unsupported_grad_function(func: Function) -> Function | None:
+        """Find a function that makes generating ``func``'s adjoint unsupported.
+
+        The traversal includes ``func`` and functions reached transitively through
+        ordinary call edges. Functions with custom gradients end traversal because
+        their adjoints do not differentiate through their primal call graphs.
+
+        Returns:
+            A reachable function that calls ``wp.grad()`` without a custom gradient,
+            or ``None`` if no such function exists.
+        """
+        pending = [func]
+        visited = set()
+        while pending:
+            current = pending.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+
+            if current.custom_grad_func is not None:
+                continue
+            if current.adj.uses_grad_call:
+                return current
+
+            pending.extend(current.adj.called_user_functions)
+
+        return None
+
+    def _analyze_function_dependencies(self) -> set[Function]:
+        """Analyze the completed call graph and return functions requiring adjoints."""
+        adjs = [obj.adj for obj in (*self.kernels, *self.functions)]
+        backward_kernels = [
+            kernel for kernel in self.kernels if self._get_effective_kernel_options(kernel)["enable_backward"]
+        ]
+        backward_reachable = set()
+        pending_adjs = [kernel.adj for kernel in backward_kernels]
+        while pending_adjs:
+            adj = pending_adjs.pop()
+            if adj in backward_reachable:
+                continue
+            backward_reachable.add(adj)
+            pending_adjs.extend(func.adj for func in adj.called_user_functions)
+
+        required_adjoint_functions = set()
+        pending_functions = []
+
+        def require(func: Function) -> None:
+            if func.custom_grad_func is not None or func.adj.uses_grad_call:
+                return
+            if func not in required_adjoint_functions:
+                required_adjoint_functions.add(func)
+                pending_functions.append(func)
+
+        for kernel in backward_kernels:
+            for func in kernel.adj.called_user_functions:
+                require(func)
+
+        for adj in adjs:
+            for grad_func in _iter_user_grad_functions(adj):
+                require(grad_func)
+
+        while pending_functions:
+            func = pending_functions.pop()
+            for callee in func.adj.called_user_functions:
+                require(callee)
+
+        for adj in adjs:
+            for grad_func in _iter_user_grad_functions(adj):
+                unsupported = self._find_unsupported_grad_function(grad_func)
+                if unsupported is not None:
+                    raise WarpCodegenError(
+                        f"Cannot compute gradient of function '{grad_func.key}' because generating its adjoint would "
+                        f"differentiate through wp.grad() in function '{unsupported.key}'; "
+                        "higher-order gradients are not supported"
+                    )
+
+        # Backward use is final only now, so this is where wp.ref[T] calls recorded by
+        # add_call are rejected (a manual adjoint may also have been registered since).
+        for adj in adjs:
+            if adj not in backward_reachable:
                 continue
             for callee in adj.unvalidated_ref_calls:
                 if adj.has_manual_ref_adjoint(callee):
@@ -2996,52 +3101,111 @@ class ModuleBuilder:
                     "with adj_snippet for a manually written adjoint."
                 )
 
-    def _propagate_backward_shared_memory(self):
-        # a backward call site replays the callee's forward, then calls its reverse; the two frames
-        # pop between the calls, so the larger one bounds the contribution. Custom grad/replay
-        # bodies are forward-emitted with no gradient buffers, hence counted once
+            for grad_func in adj.called_grad_functions:
+                log_warning(
+                    f'grad() call for function "{grad_func.key}" is used in a kernel with '
+                    "enable_backward=True. The gradient call does NOT participate in "
+                    "automatic differentiation - gradients will not flow through this "
+                    "call in the backward pass."
+                )
+
+        return required_adjoint_functions
+
+    def _propagate_shared_memory(self) -> None:
+        """Finalize forward and backward shared memory over the complete call graph."""
         adjs = [obj.adj for obj in (*self.functions, *self.kernels)]
+        forward_folded = set()
+        forward_folding = set()
+        backward_folded = set()
+        backward_folding = set()
 
-        # make sure custom grads/replays are built before reading their rooflines
-        # (callees reached through function-valued arguments are not in deferred_functions)
-        for adj in adjs:
+        def fold_grad_requirement(grad_func: Function) -> int:
+            """Return the shared memory required by an explicit gradient call."""
+            if grad_func.custom_grad_func is not None:
+                grad_adj = grad_func.custom_grad_func.adj
+                fold_forward(grad_adj)
+                return grad_adj.get_total_required_shared()
+
+            grad_adj = grad_func.adj
+            fold_backward(grad_adj)
+            return grad_adj.get_total_required_shared_backward()
+
+        def fold_forward(adj: warp._src.codegen.Adjoint) -> None:
+            """Fold transitive forward shared-memory requirements into an adjoint."""
+            if adj in forward_folded:
+                return
+            if adj in forward_folding:
+                raise RuntimeError(
+                    f"Cannot size forward shared memory for '{adj.fun_name}': the call graph contains a cycle"
+                )
+            forward_folding.add(adj)
             for callee in adj.called_user_functions:
-                for extra_fn in (callee.custom_grad_func, callee.custom_replay_func):
-                    if extra_fn is not None:
-                        self.build_function(extra_fn)
+                fold_forward(callee.adj)
 
-        # one pass in callees-before-callers order reaches the fixpoint: build_function()
-        # registers a function only after its callees finished building, so self.functions
-        # insertion order is topological, and kernels are roots
-        folded = set()
-        for adj in adjs:
+            required = adj.max_required_extra_shared_memory
+            for callee in adj.called_user_functions:
+                required = max(required, callee.adj.get_total_required_shared())
+            for grad_func in _iter_user_grad_functions(adj):
+                required = max(required, fold_grad_requirement(grad_func))
+
+            adj.max_required_extra_shared_memory = required
+            forward_folding.remove(adj)
+            forward_folded.add(adj)
+
+        def fold_backward(adj: warp._src.codegen.Adjoint) -> None:
+            """Fold transitive replay and reverse shared-memory requirements into an adjoint."""
+            if adj in backward_folded:
+                return
+            if adj in backward_folding:
+                raise RuntimeError(
+                    f"Cannot size backward shared memory for '{adj.fun_name}': the call graph contains a cycle"
+                )
+
+            fold_forward(adj)
+            backward_folding.add(adj)
+            for callee in adj.called_user_functions:
+                replay_adj = callee.custom_replay_func.adj if callee.custom_replay_func is not None else callee.adj
+                fold_forward(replay_adj)
+                if callee.custom_grad_func is not None:
+                    fold_forward(callee.custom_grad_func.adj)
+                else:
+                    fold_backward(callee.adj)
+
             required = adj.max_required_extra_shared_memory_backward
             for callee in adj.called_user_functions:
                 if callee.custom_replay_func is not None:
                     replay = callee.custom_replay_func.adj.get_total_required_shared()
                 else:
                     replay = callee.adj.get_total_required_shared()
+
                 if callee.custom_grad_func is not None:
                     reverse = callee.custom_grad_func.adj.get_total_required_shared()
-                elif callee.adj not in folded:
-                    # fail loudly instead of silently under-reserving
-                    raise RuntimeError(
-                        f"Cannot size backward shared memory for '{adj.fun_name}': callee '{callee.key}' was not "
-                        "sized first; the call graph should be acyclic and functions registered callees-first"
-                    )
                 else:
                     reverse = callee.adj.get_total_required_shared_backward()
-                # max: the replay frame pops before the reverse frame pushes, so the two never coexist
+
                 required = max(required, replay, reverse)
+
+            for grad_func in _iter_user_grad_functions(adj):
+                required = max(required, fold_grad_requirement(grad_func))
+
             adj.max_required_extra_shared_memory_backward = required
-            folded.add(adj)
+            backward_folding.remove(adj)
+            backward_folded.add(adj)
+
+        for adj in adjs:
+            fold_forward(adj)
+
+        for adj in adjs:
+            suppresses_user_adjoint = adj.is_user_function and adj.uses_grad_call
+            if not adj.custom_reverse_mode and not adj.skip_reverse_codegen and not suppresses_user_adjoint:
+                fold_backward(adj)
 
     def build_meta(self):
         meta = {}
 
         for kernel in self.kernels:
             name = kernel.get_mangled_name()
-            options = self.options | kernel.options
+            options = self._get_effective_kernel_options(kernel)
 
             meta[name + "_cuda_kernel_forward_smem_bytes"] = kernel.adj.get_total_required_shared()
             if options["enable_backward"]:
@@ -3060,17 +3224,21 @@ class ModuleBuilder:
             [self.fatbins[key] for key in sorted(self.fatbins)],
         )
 
-    def _codegen_functions(self, functions, device, forward_only=False, reverse_only=False):
+    def _codegen_functions(
+        self,
+        functions,
+        device,
+        declaration_only: bool = False,
+    ) -> str:
         """Helper to generate code for a list of functions.
 
         Args:
-            functions: Iterable of functions to generate code for
-            device: Target device ('cpu' or 'cuda')
-            forward_only: If True, generate only forward code
-            reverse_only: If True, generate only reverse/adjoint code
+            functions: Iterable of functions to generate code for.
+            device: Target device (``cpu`` or ``cuda``).
+            declaration_only: Whether to generate declarations without definitions.
 
         Returns:
-            Generated C++ source code as a string
+            Generated C++ source code.
         """
         source = ""
         for func in functions:
@@ -3079,9 +3247,8 @@ class ModuleBuilder:
                     func.adj,
                     c_func_name=func.native_func,
                     device=device,
-                    options=self.options,
-                    forward_only=forward_only,
-                    reverse_only=reverse_only,
+                    declaration_only=declaration_only,
+                    generate_adjoint=func in self._required_adjoint_functions,
                 )
             else:
                 source += warp._src.codegen.codegen_snippet(
@@ -3090,8 +3257,7 @@ class ModuleBuilder:
                     snippet=func.native_snippet,
                     adj_snippet=func.adj_native_snippet,
                     replay_snippet=func.replay_snippet,
-                    forward_only=forward_only,
-                    reverse_only=reverse_only,
+                    declaration_only=declaration_only,
                 )
         return source
 
@@ -3118,38 +3284,11 @@ class ModuleBuilder:
                 )
                 visited_structs.add(struct.hash)
 
-        # Three-pass code generation:
-        # Pass 1: Forward functions that don't use wp.grad()
-        # Pass 2: All adjoint functions (custom grads before auto-adjoints)
-        # Pass 3: Forward functions that use wp.grad() (these call adjoints, so must come after pass 2)
-        #         Note: Functions using wp.grad() don't have adjoints generated.
-
-        # Separate functions into those that use grad() and those that don't
-        grad_functions = [f for f in self.functions.keys() if f.adj.uses_grad_call]
-        non_grad_functions = [f for f in self.functions.keys() if not f.adj.uses_grad_call]
-
-        # Pass 1: Forward functions that don't use grad()
-        source += self._codegen_functions(non_grad_functions, device, forward_only=True)
-
-        # Pass 2: Reverse/adjoint functions with custom grads sorted before auto-adjoints
-        # Build set of functions that ARE custom gradients (decorated with @wp.func_grad)
-        # Note: f.custom_grad_func tells us if f HAS a custom gradient, but we need to know
-        # which functions ARE custom gradients themselves (i.e., appear as someone's custom_grad_func)
-        # Note: Functions that use wp.grad() don't have adjoints generated (their reverse calls
-        # are skipped in add_call since the gradient of a gradient call is not supported)
-        custom_grad_set = {f.custom_grad_func for f in non_grad_functions if f.custom_grad_func is not None}
-
-        # Separate functions that ARE custom grads from all others, preserving original order
-        custom_grad_functions = [f for f in non_grad_functions if f in custom_grad_set]
-        other_functions = [f for f in non_grad_functions if f not in custom_grad_set]
-
-        # Generate adjoints: custom grads first, then other functions
-        # This ensures custom grads are defined before any auto-adjoints that call them
-        source += self._codegen_functions(custom_grad_functions + other_functions, device, reverse_only=True)
-
-        # Pass 3: Forward functions that use wp.grad()
-        # These must come after pass 2 because they call adjoint functions
-        source += self._codegen_functions(grad_functions, device, forward_only=True)
+        # Declare every generated function before emitting definitions. Forward and reverse calls
+        # can alternate through ordinary helpers, custom gradients, and explicit wp.grad() calls,
+        # so no definition order alone can satisfy every legal dependency chain.
+        source += self._codegen_functions(self.functions, device, declaration_only=True)
+        source += self._codegen_functions(self.functions, device)
 
         for kernel in self.kernels:
             source += warp._src.codegen.codegen_kernel(kernel, device=device, options=self.options)

--- a/warp/tests/test_func.py
+++ b/warp/tests/test_func.py
@@ -343,6 +343,125 @@ def test_grad(test, device):
     assert_np_equal(z.numpy(), 3.0 * x_np)
 
 
+def test_grad_rejects_higher_order(test, device):
+    """Reject taking ``wp.grad()`` of a function that calls ``wp.grad()``."""
+
+    @wp.func(module="unique")
+    def inner(x: float):
+        return x * x
+
+    @wp.func(module="unique")
+    def target(x: float):
+        return wp.grad(inner)(x)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def evaluate(out: wp.array[float]):
+        out[0] = wp.grad(target)(3.0)
+
+    with test.assertRaisesRegex(wp.WarpCodegenError, "higher-order gradients are not supported"):
+        wp.launch(evaluate, dim=1, outputs=[wp.zeros(1, dtype=float, device=device)], device=device)
+
+
+def test_grad_rejects_transitive_higher_order(test, device):
+    """Reject gradients that transitively differentiate through ``wp.grad()``."""
+
+    @wp.func(module="unique")
+    def inner(x: float):
+        return x * x
+
+    @wp.func(module="unique")
+    def helper(x: float):
+        return wp.grad(inner)(x)
+
+    @wp.func(module="unique")
+    def target(x: float):
+        return helper(x)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def evaluate(out: wp.array[float]):
+        out[0] = wp.grad(target)(3.0)
+
+    with test.assertRaisesRegex(wp.WarpCodegenError, "higher-order gradients are not supported"):
+        wp.launch(evaluate, dim=1, outputs=[wp.zeros(1, dtype=float, device=device)], device=device)
+
+
+def test_grad_allows_nested_target_with_custom_grad(test, device):
+    """Allow ``wp.grad()`` of a nested-gradient target with a custom gradient."""
+
+    @wp.func(module="unique")
+    def inner(x: float):
+        return x * x
+
+    @wp.func(module="unique")
+    def target(x: float):
+        return wp.grad(inner)(x)
+
+    @wp.func_grad(target)
+    def adj_target(x: float, adj_ret: float):
+        wp.adjoint[x] += 2.0 * adj_ret
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def evaluate(out: wp.array[float]):
+        out[0] = wp.grad(target)(3.0)
+
+    out = wp.zeros(1, dtype=float, device=device)
+    wp.launch(evaluate, dim=1, outputs=[out], device=device)
+    np.testing.assert_allclose(out.numpy(), [2.0])
+
+
+def test_grad_allows_transitive_custom_gradient(test, device):
+    """Allow gradients through a nested helper that supplies a custom gradient."""
+
+    @wp.func(module="unique")
+    def inner(x: float):
+        return x * x
+
+    @wp.func(module="unique")
+    def helper(x: float):
+        return wp.grad(inner)(x)
+
+    @wp.func_grad(helper)
+    def adj_helper(x: float, adj_ret: float):
+        wp.adjoint[x] += 2.0 * adj_ret
+
+    @wp.func(module="unique")
+    def target(x: float):
+        return helper(x)
+
+    @wp.kernel(module="unique", enable_backward=False)
+    def evaluate(out: wp.array[float]):
+        out[0] = wp.grad(target)(3.0)
+
+    out = wp.zeros(1, dtype=float, device=device)
+    wp.launch(evaluate, dim=1, outputs=[out], device=device)
+    np.testing.assert_allclose(out.numpy(), [2.0])
+
+
+def test_grad_propagates_adjoint_requirement(test, device):
+    """Propagate explicit-gradient adjoints after an earlier forward call."""
+
+    module = wp.Module(f"test_grad_propagates_adjoint_requirement_{device.alias.replace(':', '_')}")
+
+    @wp.func(module=module)
+    def inner(x: float):
+        return x * x
+
+    @wp.func(module=module)
+    def target(x: float):
+        return inner(x)
+
+    @wp.kernel(module=module, enable_backward=False)
+    def evaluate(primal: wp.array[float], gradient: wp.array[float]):
+        primal[0] = target(3.0)
+        gradient[0] = wp.grad(target)(3.0)
+
+    primal = wp.zeros(1, dtype=float, device=device)
+    gradient = wp.zeros(1, dtype=float, device=device)
+    wp.launch(evaluate, dim=1, outputs=[primal, gradient], device=device)
+    np.testing.assert_allclose(primal.numpy(), [9.0])
+    np.testing.assert_allclose(gradient.numpy(), [6.0])
+
+
 @wp.func
 def safe_sqrt(x: float):
     return wp.sqrt(x)
@@ -664,6 +783,36 @@ add_kernel_test(
     TestFunc, kernel=test_return_annotation_none, name="test_return_annotation_none", dim=1, devices=devices
 )
 add_function_test(TestFunc, func=test_grad, name="test_grad", devices=devices)
+add_function_test(
+    TestFunc,
+    func=test_grad_rejects_higher_order,
+    name="test_grad_rejects_higher_order",
+    devices=devices,
+)
+add_function_test(
+    TestFunc,
+    func=test_grad_rejects_transitive_higher_order,
+    name="test_grad_rejects_transitive_higher_order",
+    devices=devices,
+)
+add_function_test(
+    TestFunc,
+    func=test_grad_allows_nested_target_with_custom_grad,
+    name="test_grad_allows_nested_target_with_custom_grad",
+    devices=devices,
+)
+add_function_test(
+    TestFunc,
+    func=test_grad_allows_transitive_custom_gradient,
+    name="test_grad_allows_transitive_custom_gradient",
+    devices=devices,
+)
+add_function_test(
+    TestFunc,
+    func=test_grad_propagates_adjoint_requirement,
+    name="test_grad_propagates_adjoint_requirement",
+    devices=devices,
+)
 add_function_test(TestFunc, func=test_grad_in_func_grad, name="test_grad_in_func_grad", devices=devices)
 
 

--- a/warp/tests/test_grad_customs.py
+++ b/warp/tests/test_grad_customs.py
@@ -682,6 +682,152 @@ def test_native_snippet_in_custom_grad(test, device):
     assert_np_equal(inputs.grad.numpy(), expected_grad, tol=1e-4)
 
 
+WP_GRAD_CUSTOM_PROVIDER_MODULE = wp.Module("grad_custom_wp_grad_provider")
+WP_GRAD_CUSTOM_CALLER_MODULE = wp.Module("grad_custom_wp_grad_caller")
+
+
+@wp.func(module=WP_GRAD_CUSTOM_PROVIDER_MODULE)
+def wp_grad_custom_square(x: float):
+    return x * x
+
+
+@wp.func_grad(wp_grad_custom_square)
+def adj_wp_grad_custom_square(x: float, adj_ret: float):
+    wp.adjoint[x] += 2.0 * x * adj_ret
+
+
+@wp.kernel(module=WP_GRAD_CUSTOM_CALLER_MODULE, enable_backward=False)
+def wp_grad_custom_square_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(wp_grad_custom_square)(x[0])
+
+
+def test_wp_grad_builds_unreferenced_custom_grad(test, device):
+    """Build a custom gradient reached only through ``wp.grad()``."""
+    x = wp.array([3.0], dtype=float, device=device)
+    out = wp.zeros_like(x)
+
+    wp.launch(wp_grad_custom_square_kernel, dim=1, inputs=[x], outputs=[out], device=device)
+
+    assert_np_equal(out.numpy(), np.array([6.0], dtype=np.float32))
+
+
+WP_GRAD_NESTED_PROVIDER_MODULE = wp.Module("grad_custom_wp_grad_nested_provider")
+WP_GRAD_NESTED_CALLER_MODULE = wp.Module("grad_custom_wp_grad_nested_caller")
+
+
+@wp.func(module=WP_GRAD_NESTED_PROVIDER_MODULE)
+def wp_grad_nested_auto(x: float):
+    return x * x
+
+
+@wp.func(module=WP_GRAD_NESTED_PROVIDER_MODULE)
+def wp_grad_nested_custom(x: float):
+    return x * x * x
+
+
+@wp.func_grad(wp_grad_nested_custom)
+def adj_wp_grad_nested_custom(x: float, adj_ret: float):
+    wp.adjoint[x] += 3.0 * x * x * adj_ret
+
+
+@wp.func(module=WP_GRAD_NESTED_PROVIDER_MODULE)
+def wp_grad_nested_outer(x: float):
+    return x
+
+
+@wp.func_grad(wp_grad_nested_outer)
+def adj_wp_grad_nested_outer(x: float, adj_ret: float):
+    auto_grad = wp.grad(wp_grad_nested_auto)(x)
+    custom_grad = wp.grad(wp_grad_nested_custom)(x)
+    wp.adjoint[x] += (auto_grad + custom_grad) * adj_ret
+
+
+@wp.kernel(module=WP_GRAD_NESTED_CALLER_MODULE, enable_backward=False)
+def wp_grad_nested_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(wp_grad_nested_outer)(x[0])
+
+
+def test_wp_grad_orders_nested_user_gradients(test, device):
+    """Emit adjoints used by nested ``wp.grad()`` calls before their custom caller."""
+    x = wp.array([3.0], dtype=float, device=device)
+    out = wp.zeros_like(x)
+
+    wp.launch(wp_grad_nested_kernel, dim=1, inputs=[x], outputs=[out], device=device)
+
+    assert_np_equal(out.numpy(), np.array([33.0], dtype=np.float32))
+
+
+_WP_GRAD_CUSTOM_HELPER_PROVIDER = wp.Module("grad_custom_wp_grad_custom_helper_provider")
+
+
+@wp.func(module=_WP_GRAD_CUSTOM_HELPER_PROVIDER)
+def wp_grad_custom_helper_inner(x: float):
+    return x * x
+
+
+@wp.func(module=_WP_GRAD_CUSTOM_HELPER_PROVIDER)
+def wp_grad_custom_helper(x: float):
+    return wp.grad(wp_grad_custom_helper_inner)(x)
+
+
+@wp.func(module=_WP_GRAD_CUSTOM_HELPER_PROVIDER)
+def wp_grad_custom_helper_outer(x: float):
+    return x
+
+
+@wp.func_grad(wp_grad_custom_helper_outer)
+def adj_wp_grad_custom_helper_outer(x: float, adj_ret: float):
+    wp.adjoint[x] += wp_grad_custom_helper(x) * adj_ret
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def wp_grad_custom_helper_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(wp_grad_custom_helper_outer)(x[0])
+
+
+def test_wp_grad_declares_helper_called_by_custom_grad(test, device):
+    """Declare an ordinary helper before a custom gradient calls it."""
+    x = wp.array([3.0], dtype=float, device=device)
+    out = wp.zeros_like(x)
+
+    wp.launch(wp_grad_custom_helper_kernel, dim=1, inputs=[x], outputs=[out], device=device)
+
+    assert_np_equal(out.numpy(), np.array([6.0], dtype=np.float32))
+
+
+_WP_GRAD_ORDINARY_HELPER_PROVIDER = wp.Module("grad_custom_wp_grad_ordinary_helper_provider")
+
+
+@wp.func(module=_WP_GRAD_ORDINARY_HELPER_PROVIDER)
+def wp_grad_ordinary_helper_inner(x: float):
+    return x * x
+
+
+@wp.func(module=_WP_GRAD_ORDINARY_HELPER_PROVIDER)
+def wp_grad_ordinary_helper(x: float):
+    return wp.grad(wp_grad_ordinary_helper_inner)(x)
+
+
+@wp.func(module=_WP_GRAD_ORDINARY_HELPER_PROVIDER)
+def wp_grad_ordinary_helper_outer(x: float):
+    return wp_grad_ordinary_helper(x)
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def wp_grad_ordinary_helper_kernel(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp_grad_ordinary_helper_outer(x[0])
+
+
+def test_wp_grad_declares_helper_called_by_forward(test, device):
+    """Declare a gradient-using helper before an ordinary caller calls it."""
+    x = wp.array([3.0], dtype=float, device=device)
+    out = wp.zeros_like(x)
+
+    wp.launch(wp_grad_ordinary_helper_kernel, dim=1, inputs=[x], outputs=[out], device=device)
+
+    assert_np_equal(out.numpy(), np.array([6.0], dtype=np.float32))
+
+
 def test_custom_grad_tile_matmul(test, device):
     """A custom func_grad on a function that uses tile_matmul."""
     M = 4
@@ -770,6 +916,30 @@ add_function_test(
 )
 add_function_test(
     TestGradCustoms, "test_native_snippet_in_custom_grad", test_native_snippet_in_custom_grad, devices=devices
+)
+add_function_test(
+    TestGradCustoms,
+    "test_wp_grad_builds_unreferenced_custom_grad",
+    test_wp_grad_builds_unreferenced_custom_grad,
+    devices=devices,
+)
+add_function_test(
+    TestGradCustoms,
+    "test_wp_grad_orders_nested_user_gradients",
+    test_wp_grad_orders_nested_user_gradients,
+    devices=devices,
+)
+add_function_test(
+    TestGradCustoms,
+    "test_wp_grad_declares_helper_called_by_custom_grad",
+    test_wp_grad_declares_helper_called_by_custom_grad,
+    devices=devices,
+)
+add_function_test(
+    TestGradCustoms,
+    "test_wp_grad_declares_helper_called_by_forward",
+    test_wp_grad_declares_helper_called_by_forward,
+    devices=devices,
 )
 add_function_test(TestGradCustoms, "test_custom_grad_tile_matmul", test_custom_grad_tile_matmul, devices=devices)
 

--- a/warp/tests/test_options.py
+++ b/warp/tests/test_options.py
@@ -24,12 +24,17 @@ def scale(
     y[0] = x[0] ** 2.0
 
 
+@wp.func
+def square_func(x: float):
+    return x * x
+
+
 @wp.kernel(enable_backward=True)
 def scale_1(
     x: wp.array[float],
     y: wp.array[float],
 ):
-    y[0] = x[0] ** 2.0
+    y[0] = square_func(x[0])
 
 
 @wp.kernel(enable_backward=False)
@@ -74,6 +79,7 @@ def test_options_backward_2(test, device):
 
 
 def test_options_backward_3(test, device):
+    """An explicit kernel override must enable adjoints for user-function helpers."""
     x = wp.array([3.0], dtype=float, requires_grad=True, device=device)
     y = wp.zeros_like(x)
 

--- a/warp/tests/tile/test_tile_shared_memory.py
+++ b/warp/tests/tile/test_tile_shared_memory.py
@@ -1292,6 +1292,186 @@ def test_tile_custom_grad_shared_forward(test, device):
     test.assertLess(hooks.backward_smem_bytes, 2 * hooks.forward_smem_bytes + scratch_bytes)
 
 
+_WP_GRAD_SHARED_M = 16
+_WP_GRAD_SHARED_BLOCK_DIM = 32
+_WP_GRAD_SHARED_PROVIDER = wp.Module("tile_wp_grad_custom_grad_shared_provider")
+_WP_GRAD_NESTED_SHARED_PROVIDER = wp.Module("tile_wp_grad_nested_shared_provider")
+
+
+@wp.func(module=_WP_GRAD_SHARED_PROVIDER)
+def wp_grad_custom_shared_objective(x: float):
+    return x * x
+
+
+@wp.func_grad(wp_grad_custom_shared_objective)
+def adj_wp_grad_custom_shared_objective(x: float, adj_ret: float):
+    scratch = wp.tile_ones(shape=(_WP_GRAD_SHARED_M, _WP_GRAD_SHARED_M), dtype=float, storage="shared")
+    wp.adjoint[x] += (2.0 * x + wp.tile_sum(scratch)[0] * 0.0) * adj_ret
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def evaluate_wp_grad_custom_shared(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(wp_grad_custom_shared_objective)(x[0])
+
+
+@wp.func(module=_WP_GRAD_SHARED_PROVIDER)
+def call_wp_grad_custom_shared(x: float):
+    return wp.grad(wp_grad_custom_shared_objective)(x)
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def evaluate_wp_grad_custom_shared_helper(x: wp.array[float], out: wp.array[float]):
+    out[0] = call_wp_grad_custom_shared(x[0])
+
+
+@wp.func(module=_WP_GRAD_SHARED_PROVIDER)
+def call_wp_grad_custom_shared_backward(x: float):
+    return wp.grad(wp_grad_custom_shared_objective)(x)
+
+
+@wp.kernel(module="unique")
+def evaluate_wp_grad_custom_shared_helper_backward(x: wp.array[float], out: wp.array[float]):
+    out[0] = call_wp_grad_custom_shared_backward(x[0])
+
+
+@wp.kernel(module="unique")
+def evaluate_wp_grad_custom_shared_backward(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(wp_grad_custom_shared_objective)(x[0])
+
+
+@wp.func(module=_WP_GRAD_NESTED_SHARED_PROVIDER)
+def wp_grad_nested_shared_inner(x: float):
+    return x * x
+
+
+@wp.func_grad(wp_grad_nested_shared_inner)
+def adj_wp_grad_nested_shared_inner(x: float, adj_ret: float):
+    scratch = wp.tile_ones(shape=(_WP_GRAD_SHARED_M, _WP_GRAD_SHARED_M), dtype=float, storage="shared")
+    wp.adjoint[x] += (2.0 * x + wp.tile_sum(scratch)[0] * 0.0) * adj_ret
+
+
+@wp.func(module=_WP_GRAD_NESTED_SHARED_PROVIDER)
+def wp_grad_nested_shared_middle(x: float):
+    return x
+
+
+@wp.func_grad(wp_grad_nested_shared_middle)
+def adj_wp_grad_nested_shared_middle(x: float, adj_ret: float):
+    wp.adjoint[x] += wp.grad(wp_grad_nested_shared_inner)(x) * adj_ret
+
+
+@wp.func(module=_WP_GRAD_NESTED_SHARED_PROVIDER)
+def wp_grad_nested_shared_outer(x: float):
+    return x
+
+
+@wp.func_grad(wp_grad_nested_shared_outer)
+def adj_wp_grad_nested_shared_outer(x: float, adj_ret: float):
+    wp.adjoint[x] += wp.grad(wp_grad_nested_shared_middle)(x) * adj_ret
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def evaluate_wp_grad_nested_shared(x: wp.array[float], out: wp.array[float]):
+    out[0] = wp.grad(wp_grad_nested_shared_outer)(x[0])
+
+
+def test_tile_wp_grad_custom_grad_shared(test, device):
+    """Include a custom gradient's tile storage in explicit-gradient forward shared memory."""
+    module_exec = evaluate_wp_grad_custom_shared.module.load(device, _WP_GRAD_SHARED_BLOCK_DIM)
+    hooks = module_exec.get_kernel_hooks(evaluate_wp_grad_custom_shared)
+    required = _WP_GRAD_SHARED_M * _WP_GRAD_SHARED_M * 4
+
+    test.assertGreaterEqual(hooks.forward_smem_bytes, required)
+
+
+def test_tile_wp_grad_custom_grad_shared_helper(test, device):
+    """Propagate an explicit gradient's tile storage through an ordinary helper call."""
+    module_exec = evaluate_wp_grad_custom_shared_helper.module.load(device, _WP_GRAD_SHARED_BLOCK_DIM)
+    hooks = module_exec.get_kernel_hooks(evaluate_wp_grad_custom_shared_helper)
+    required = _WP_GRAD_SHARED_M * _WP_GRAD_SHARED_M * 4
+    test.assertGreaterEqual(hooks.forward_smem_bytes, required)
+
+    x = wp.array([3.0], dtype=float, device=device)
+    out = wp.zeros_like(x)
+    wp.launch_tiled(
+        evaluate_wp_grad_custom_shared_helper,
+        dim=1,
+        inputs=[x],
+        outputs=[out],
+        block_dim=_WP_GRAD_SHARED_BLOCK_DIM,
+        device=device,
+    )
+    np.testing.assert_allclose(out.numpy(), [6.0])
+
+
+def test_tile_wp_grad_custom_grad_shared_helper_backward(test, device):
+    """Propagate an explicit gradient's tile storage through a helper during backward replay."""
+    module_exec = evaluate_wp_grad_custom_shared_helper_backward.module.load(device, _WP_GRAD_SHARED_BLOCK_DIM)
+    hooks = module_exec.get_kernel_hooks(evaluate_wp_grad_custom_shared_helper_backward)
+    required = _WP_GRAD_SHARED_M * _WP_GRAD_SHARED_M * 4
+    test.assertGreaterEqual(hooks.forward_smem_bytes, required)
+    test.assertGreaterEqual(hooks.backward_smem_bytes, required)
+
+    x = wp.array([3.0], dtype=float, device=device, requires_grad=True)
+    out = wp.zeros(1, dtype=float, device=device, requires_grad=True)
+    with wp.Tape() as tape:
+        wp.launch_tiled(
+            evaluate_wp_grad_custom_shared_helper_backward,
+            dim=1,
+            inputs=[x],
+            outputs=[out],
+            block_dim=_WP_GRAD_SHARED_BLOCK_DIM,
+            device=device,
+        )
+
+    tape.backward(grads={out: wp.ones_like(out)})
+    np.testing.assert_allclose(out.numpy(), [6.0])
+
+
+def test_tile_wp_grad_custom_grad_shared_backward(test, device):
+    """Reserve an explicit gradient's tile storage while replaying a backward kernel."""
+    module_exec = evaluate_wp_grad_custom_shared_backward.module.load(device, _WP_GRAD_SHARED_BLOCK_DIM)
+    hooks = module_exec.get_kernel_hooks(evaluate_wp_grad_custom_shared_backward)
+    required = _WP_GRAD_SHARED_M * _WP_GRAD_SHARED_M * 4
+    test.assertGreaterEqual(hooks.forward_smem_bytes, required)
+    test.assertGreaterEqual(hooks.backward_smem_bytes, required)
+
+    x = wp.array([3.0], dtype=float, device=device, requires_grad=True)
+    out = wp.zeros(1, dtype=float, device=device, requires_grad=True)
+    with wp.Tape() as tape:
+        wp.launch_tiled(
+            evaluate_wp_grad_custom_shared_backward,
+            dim=1,
+            inputs=[x],
+            outputs=[out],
+            block_dim=_WP_GRAD_SHARED_BLOCK_DIM,
+            device=device,
+        )
+
+    tape.backward(grads={out: wp.ones_like(out)})
+    np.testing.assert_allclose(out.numpy(), [6.0])
+
+
+def test_tile_wp_grad_nested_custom_grad_shared(test, device):
+    """Discover and size a multi-hop chain of explicit custom gradients."""
+    module_exec = evaluate_wp_grad_nested_shared.module.load(device, _WP_GRAD_SHARED_BLOCK_DIM)
+    hooks = module_exec.get_kernel_hooks(evaluate_wp_grad_nested_shared)
+    required = _WP_GRAD_SHARED_M * _WP_GRAD_SHARED_M * 4
+    test.assertGreaterEqual(hooks.forward_smem_bytes, required)
+
+    x = wp.array([3.0], dtype=float, device=device)
+    out = wp.zeros_like(x)
+    wp.launch_tiled(
+        evaluate_wp_grad_nested_shared,
+        dim=1,
+        inputs=[x],
+        outputs=[out],
+        block_dim=_WP_GRAD_SHARED_BLOCK_DIM,
+        device=device,
+    )
+    np.testing.assert_allclose(out.numpy(), [6.0])
+
+
 class TestTileSharedMemoryMessages(unittest.TestCase):
     """Message formatting for over-budget shared memory requests, independent of any device."""
 
@@ -1435,6 +1615,36 @@ add_function_test(
     TestTileSharedMemory,
     "test_tile_custom_grad_shared_forward",
     test_tile_custom_grad_shared_forward,
+    devices=devices,
+)
+add_function_test(
+    TestTileSharedMemory,
+    "test_tile_wp_grad_custom_grad_shared",
+    test_tile_wp_grad_custom_grad_shared,
+    devices=devices,
+)
+add_function_test(
+    TestTileSharedMemory,
+    "test_tile_wp_grad_custom_grad_shared_helper",
+    test_tile_wp_grad_custom_grad_shared_helper,
+    devices=devices,
+)
+add_function_test(
+    TestTileSharedMemory,
+    "test_tile_wp_grad_custom_grad_shared_helper_backward",
+    test_tile_wp_grad_custom_grad_shared_helper_backward,
+    devices=devices,
+)
+add_function_test(
+    TestTileSharedMemory,
+    "test_tile_wp_grad_custom_grad_shared_backward",
+    test_tile_wp_grad_custom_grad_shared_backward,
+    devices=devices,
+)
+add_function_test(
+    TestTileSharedMemory,
+    "test_tile_wp_grad_nested_custom_grad_shared",
+    test_tile_wp_grad_nested_custom_grad_shared,
     devices=devices,
 )
 add_function_test(


### PR DESCRIPTION
## Description

Fix `wp.grad()` calls to user functions whose adjoints are reachable only through an explicit gradient call. This includes custom `@wp.func_grad` implementations, ordinary helpers, function-valued arguments, and nested custom-gradient paths. Closes #1794.

The module builder previously ran some graph-wide analysis before all deferred dependencies were known. Generated code also relied on function definition order, while shared-memory accounting covered only immediate forward requirements. Depending on build order, the generated source could reference missing adjoints or launch CUDA kernels with too little shared memory.

The builder now completes the call graph before analyzing backward reachability and adjoint requirements. Custom gradients form differentiation boundaries. Automatic higher-order gradients through `wp.grad()` are rejected with a `WarpCodegenError`, while nested `wp.grad()` targets remain valid when a custom gradient provides the adjoint. Shared-memory requirements are folded over the completed graph, and declarations are emitted before definitions so legal dependency chains do not depend on definition order.

```mermaid
flowchart TD
    A["Lower kernels and reachable functions"] --> B["Complete ordinary, custom-gradient,<br/>replay, and explicit-gradient dependencies"]
    B --> C["Analyze the completed call graph"]
    C --> D["Determine backward reachability<br/>and required adjoint bodies"]
    C --> E{"Explicit-gradient target"}
    E -->|"Custom @wp.func_grad"| F["Use the custom gradient<br/>as a differentiation boundary"]
    E -->|"Automatic adjoint"| G{"Target or an ordinary callee<br/>contains wp.grad()"}
    G -->|"Yes"| H["Raise WarpCodegenError<br/>for unsupported higher-order gradients"]
    G -->|"No"| I["Require the target and its<br/>ordinary callees' adjoints"]
    D --> J["Fold forward and backward<br/>shared-memory requirements"]
    F --> J
    I --> J
    J --> K["Emit function declarations"]
    K --> L["Emit definitions and kernels"]
```

## Changes

- Track ordinary user-function calls separately from explicit `wp.grad()` targets, including function-valued arguments.
- Complete deferred custom-gradient, replay, and explicit-gradient dependencies to a fixed point.
- Derive backward reachability and required adjoint bodies from the completed graph without leaving build-specific reachability flags on reusable functions.
- Respect module and kernel `enable_backward` options during adjoint analysis.
- Reject direct and transitive automatic higher-order gradients while allowing a custom gradient to form a differentiation boundary.
- Emit function declarations before definitions so forward, replay, and reverse calls do not depend on definition order.
- Fold forward and backward shared-memory requirements through ordinary calls, explicit gradients, custom gradients, and replay functions.
- Avoid retaining `ModuleBuilder` instances through recursive graph helpers.
- Add direct, nested, helper-mediated, build-order, mixed-dependency, shared-memory, and backward-execution regression coverage.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

- Verified the reproduction below fails on `main` because the generated source references an undeclared custom adjoint, and passes on CPU and CUDA with this change.
- Verified direct and transitive automatic higher-order targets raise the expected `WarpCodegenError`, while custom-gradient boundaries remain supported.
- Verified direct, nested, helper-mediated, and backward-replay cases reserve the required shared memory, including a CUDA `Tape.backward()` execution.
- Ran focused CPU and CUDA tests covering gradients, custom gradients, function-valued targets, option behavior, and kernel garbage collection.
- Ran the repository pre-commit hooks on all changed files.

## Bug fix

On `main`, this example fails to compile because `adj_square_0` is referenced but not emitted:

```python
import warp as wp


provider = wp.Module("wp_grad_custom_grad_provider")
caller = wp.Module("wp_grad_custom_grad_caller")


@wp.func(module=provider)
def square(x: float):
    return x * x


@wp.func_grad(square)
def adj_square(x: float, adj_ret: float):
    wp.adjoint[x] += 2.0 * x * adj_ret


@wp.kernel(module=caller, enable_backward=False)
def evaluate_gradient(x: wp.array[float], out: wp.array[float]):
    out[0] = wp.grad(square)(x[0])


device = "cpu"
x = wp.array([3.0], dtype=float, device=device)
out = wp.zeros_like(x)
wp.launch(evaluate_gradient, dim=1, inputs=[x], outputs=[out], device=device)

result = out.numpy()
if result[0] != 6.0:
    raise RuntimeError(f"expected gradient 6.0, got {result[0]}")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `wp.grad()` compilation for unreferenced custom gradients and helper dependencies.
  * Corrected dependency ordering for nested automatic and custom gradients.
  * Improved shared-memory reservation for tile operations involving custom and nested gradients.
* **Tests**
  * Added coverage for gradient results, nested gradients, helper dependencies, and shared-memory usage in forward and backward operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->