### PR TITLE
Reject Oversized Scalar Tid Launches

### DIFF
--- a/asv/benchmarks/api/launch.py
+++ b/asv/benchmarks/api/launch.py
@@ -104,6 +104,11 @@ def k0():
     tid = wp.tid()  # noqa: F841
 
 
+@wp.kernel
+def k0_no_tid():
+    pass
+
+
 class KernelLaunchParameters:
     number = 1000
 
@@ -152,6 +157,13 @@ class KernelLaunchParameters:
 
     def time_direct_empty(self):
         wp.launch(k0, dim=1, inputs=[], device="cuda:0")
+
+    def time_direct_empty_no_tid(self):
+        """Measure an empty direct launch that does not consume ``wp.tid()``."""
+        wp.launch(k0_no_tid, dim=1, inputs=[], device="cuda:0")
+
+    time_direct_empty_no_tid.number = 2000
+    time_direct_empty_no_tid.repeat = 20
 
     def time_struct_empty(self):
         wp.launch(ks0, dim=1, inputs=[self.s0], device="cuda:0")

--- a/changelog/1799.fixed.md
+++ b/changelog/1799.fixed.md
@@ -1,0 +1,1 @@
+Raise a `ValueError` when a one-dimensional kernel using scalar `wp.tid()` is launched with an extent greater than `2**31`, preventing signed 32-bit thread coordinates from wrapping in release builds.

--- a/docs/user_guide/debugging.rst
+++ b/docs/user_guide/debugging.rst
@@ -167,7 +167,6 @@ Debug Mode Compilation
 In debug mode, Warp kernels will perform the following additional checks:
 
 * Raise an assertion if there is an array access outside the defined shape.
-* Warn if :func:`wp.tid() <warp.tid>` will return an overflowed value on large grids.
 * (GPU-only) Warn if the CUDA grid dimensions have been capped due to an overflowed number of blocks.
 * (GPU-only) Generate line-number information for device code.
 

--- a/docs/user_guide/limitations.rst
+++ b/docs/user_guide/limitations.rst
@@ -45,8 +45,22 @@ Kernels and User Functions
   Rebinding a function-valued local to a different function or to a non-function value is not supported.
   User functions with ``wp.Function`` parameters also cannot define custom gradient or replay functions.
 
-A limitation of Warp is that each dimension of the grid used to launch a kernel must be representable as a 32-bit
-signed integer. Therefore, no single dimension of a grid should exceed :math:`2^{31}-1`.
+:func:`wp.tid() <warp._src.lang.tid>` returns signed 32-bit thread coordinates. The supported launch extents depend
+on how the kernel uses those coordinates:
+
+* The leading coordinate supports a launch extent up to :math:`2^{31}`, whose largest coordinate is
+  :math:`2^{31}-1`. Warp enforces this limit for kernels that use scalar ``wp.tid()`` and raises a ``ValueError``
+  for a larger leading extent.
+* For tuple-valued ``wp.tid()``, keep each non-leading launch dimension at or below :math:`2^{31}-1`.
+  Multidimensional launch bounds store these extents as signed 32-bit values, so an extent of exactly
+  :math:`2^{31}` can produce incorrect coordinates when an earlier dimension is greater than one. Warp does not
+  currently validate tuple-only launches: a leading extent above :math:`2^{31}` can overflow the first returned
+  coordinate, and a non-leading extent above :math:`2^{31}-1` can corrupt coordinate reconstruction. In a kernel
+  that uses both scalar and tuple-valued ``wp.tid()``, the scalar validation applies only to the leading coordinate.
+
+The total number of threads in a multidimensional grid may exceed :math:`2^{31}` when each returned coordinate stays
+within these limits. Use 64-bit arithmetic when flattening such coordinates into a linear index. See
+:ref:`large-array launch indexing <large_launch_indexing>` for an example.
 
 By default, Warp will try to process one element from the Warp grid in one CUDA thread.
 This is not always possible for kernels launched with multi-dimensional grid bounds, as there are

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -36,6 +36,8 @@ from warp._src.types import *
 # of current compile options (block_dim) etc
 options = {}
 
+_SCALAR_TID_MAX_EXTENT = 2**31
+
 # Extraction products shared across Adjoints of one code object, populated
 # lazily by Adjoint.__init__ (see _SharedFunctionSource).
 # id(code object) -> (weakref to the code object, _SharedFunctionSource).
@@ -2006,6 +2008,9 @@ class Adjoint:
         # recorded at call sites for ModuleBuilder's post-build propagation passes
         adj.called_user_functions = {}
 
+        # Exact launch metadata derived from calls reached by this build.
+        adj.uses_scalar_tid = False
+
         # wp.ref[T] callees lacking a manual adjoint; rejected post-build, once used_by_backward_kernel is final
         adj.unvalidated_ref_calls = []
 
@@ -3869,16 +3874,15 @@ class Adjoint:
             return adj.emit_Call(node.value, return_value_used=False)
         return adj.eval(node.value)
 
-    def check_tid_in_func_error(adj, node):
-        if adj.is_user_function:
-            if hasattr(node.func, "attr") and node.func.attr == "tid":
-                lineno = adj.lineno + adj.fun_lineno
-                line = adj.source_lines[adj.lineno]
-                raise WarpCodegenError(
-                    "tid() may only be called from a Warp kernel, not a Warp function. "
-                    "Instead, obtain the indices from a @wp.kernel and pass them as "
-                    f"arguments to the function {adj.fun_name}, {adj.filename}:{lineno}:\n{line}\n"
-                )
+    def check_tid_in_func_error(adj, func):
+        if adj.is_user_function and func is warp._src.context.builtin_functions["tid"]:
+            lineno = adj.lineno + adj.fun_lineno
+            line = adj.source_lines[adj.lineno]
+            raise WarpCodegenError(
+                "tid() may only be called from a Warp kernel, not a Warp function. "
+                "Instead, obtain the indices from a @wp.kernel and pass them as "
+                f"arguments to the function {adj.fun_name}, {adj.filename}:{lineno}:\n{line}\n"
+            )
 
     def resolve_arg(adj, arg):
         # Always try to start with evaluating the argument since it can help
@@ -4065,8 +4069,6 @@ class Adjoint:
         return result
 
     def emit_Call(adj, node, return_value_used=True):
-        adj.check_tid_in_func_error(node)
-
         # try and lookup function in globals by
         # resolving path (e.g.: module.submodule.attr)
         if hasattr(node.func, "warp_func"):
@@ -4173,10 +4175,15 @@ class Adjoint:
                     f"Could not find function {'.'.join(path)} as a built-in or user-defined function. Note that user functions must be annotated with a @wp.func decorator to be called from a kernel."
                 )
 
+        adj.check_tid_in_func_error(func)
+
         # get expected return count, e.g.: for multi-assignment
         min_outputs = None
         if hasattr(node, "expects"):
             min_outputs = node.expects
+
+        if func is warp._src.context.builtin_functions["tid"] and (min_outputs is None or min_outputs <= 1):
+            adj.uses_scalar_tid = True
 
         # Evaluate positional arguments.
         args = []
@@ -6290,9 +6297,10 @@ class Adjoint:
         """Traverse ``adj.tree`` for referenced constants, types, and user-defined functions.
 
         As a side effect, also sets ``adj.kernel_dim`` (the thread-grid dimension inferred from
-        ``wp.tid()``). It is folded into this traversal rather than walked separately because
-        ``get_references`` already visits every ``Assign`` and runs for every adjoint during
-        module hashing -- which precedes any code generation or launch that reads ``kernel_dim``.
+        ``wp.tid()``) and ``adj.scalar_tid_extent_limit_candidate``. They are folded into this
+        traversal rather than walked separately because ``get_references`` already visits every
+        ``Assign`` and runs for every adjoint during module hashing. The candidate is conservative;
+        code generation records exact reachability before an oversized launch is rejected.
         """
 
         local_variables = set()  # Track local variables appearing on the LHS so we know when variables are shadowed
@@ -6302,8 +6310,7 @@ class Adjoint:
         functions: dict[warp._src.context.Function, Any] = {}
         max_dim = 0  # thread-grid dimension, inferred from wp.tid() unpack arity
         callable_arg_values = getattr(adj, "callable_arg_values", None) or {}
-
-        # Shared single traversal (see reference_nodes); resolved here at hash time.
+        # Shared single traversal (see reference_nodes()); resolved here at hash time.
         for node in adj.reference_nodes():
             if isinstance(node, ast.Name) and node.id not in local_variables:
                 # look up in closure/global variables
@@ -6362,6 +6369,11 @@ class Adjoint:
                     local_variables.add(lhs.id)
 
         adj.kernel_dim = max_dim if max_dim > 0 else 1
+        # Treat every kernel as a potential scalar-`wp.tid()` user until exact
+        # code generation proves otherwise. This conservative gate cannot miss
+        # aliases or transformer-generated calls, and only oversized leading
+        # extents pay for metadata-only code generation.
+        adj.scalar_tid_extent_limit_candidate = _SCALAR_TID_MAX_EXTENT
         return constants, types, functions
 
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -2955,6 +2955,7 @@ class ModuleBuilder:
             raise WarpCodegenTypeError(f"'{kernel.key}': {_KERNEL_RETURN_ERROR}")
 
         kernel.adj.build(self)
+        self.module._cache_kernel_scalar_tid_extent_limit(kernel, self.options["block_dim"])
 
         if kernel.adj.return_var is not None:
             raise WarpCodegenTypeError(f"'{kernel.key}': {_KERNEL_RETURN_ERROR}")
@@ -3426,6 +3427,7 @@ class Module:
         # hash data, including the module hash. Module may store multiple hashes (one per block_dim used)
         self.hashers = {}
         self.resolved_options = {}
+        self._scalar_tid_extent_limits = {}
 
         # LLVM executable modules are identified using strings.  Since it's possible for multiple
         # executable versions to be loaded at the same time, we need a way to ensure uniqueness.
@@ -3768,6 +3770,32 @@ class Module:
                     self.resolved_options[block_dim] = options
 
         return self.hashers[block_dim].get_hash()
+
+    def _cache_kernel_scalar_tid_extent_limit(self, kernel: Kernel, block_dim: int) -> None:
+        """Cache exact scalar ``wp.tid()`` metadata from the kernel's latest build."""
+        limit = warp._src.codegen._SCALAR_TID_MAX_EXTENT if kernel.adj.uses_scalar_tid else None
+        self._scalar_tid_extent_limits[(block_dim, kernel.hash)] = limit
+
+    @synchronized(_codegen_lock)
+    def _get_kernel_scalar_tid_extent_limit(self, kernel: Kernel, block_dim: int | None = None) -> int | None:
+        """Return exact scalar ``wp.tid()`` metadata for a module variant.
+
+        Held under ``_codegen_lock`` so another variant cannot rebuild the shared
+        kernel adjoint between ``kernel.adj.build()`` and caching its
+        ``uses_scalar_tid`` result.
+        """
+        if block_dim is None:
+            block_dim = self.options["block_dim"]
+
+        self.get_module_hash(block_dim)
+        cache_key = (block_dim, kernel.hash)
+
+        if cache_key not in self._scalar_tid_extent_limits:
+            builder_options = self.resolved_options[block_dim] | {"output_arch": None}
+            kernel.adj.build(None, builder_options)
+            self._cache_kernel_scalar_tid_extent_limit(kernel, block_dim)
+
+        return self._scalar_tid_extent_limits[cache_key]
 
     def _snapshot_deterministic_metadata(
         self, block_dim: int, options: dict, rebuild: bool
@@ -4352,6 +4380,7 @@ class Module:
         # clear hash data
         self.hashers = {}
         self.resolved_options = {}
+        self._scalar_tid_extent_limits = {}
 
         # clear build failures
         self.failed_builds = {}
@@ -10297,11 +10326,16 @@ class Launch:
             dim: The dimensions of the launch.
 
         Raises:
+            ValueError: If ``dim`` is invalid, its leading extent exceeds ``2**31`` for a kernel
+                that uses scalar ``wp.tid()``, or the resized grid is incompatible with the launch's
+                CUDA thread-block cluster configuration.
             RuntimeError: If the kernel is not grid-stride and the new dimensions exceed the lean 3D
                 grid capacity (~7e16 work items). Decorate the kernel with
                 ``@wp.kernel(grid_stride=True)`` to support launch dimensions this large.
         """
-        new_bounds = _build_launch_bounds(dim, self.kernel.adj.kernel_dim)
+        dim, _ = _normalize_launch_dim(dim)
+        scalar_tid_extent_limit = _resolve_kernel_scalar_tid_extent_limit(self.kernel, dim, self.block_dim)
+        new_bounds = _build_launch_bounds_from_tuple(dim, self.kernel.adj.kernel_dim, scalar_tid_extent_limit)
 
         # Guard the impossible lean-grid overflow so a resize fails clearly instead of silently
         # dropping work items (matching wp.launch()).
@@ -10663,7 +10697,11 @@ def _normalize_launch_dim(dim: int | Sequence[int]) -> tuple[tuple[int, ...], in
     return dim, total
 
 
-def _build_launch_bounds_from_tuple(dim: tuple[int, ...], kernel_dim: int) -> LaunchBounds:
+def _build_launch_bounds_from_tuple(
+    dim: tuple[int, ...],
+    kernel_dim: int,
+    scalar_tid_extent_limit: int | None = None,
+) -> LaunchBounds:
     """Build launch bounds while preserving legacy ``wp.tid()`` aliasing.
 
     Missing trailing dimensions are padded with 1. Extra trailing dimensions
@@ -10673,6 +10711,14 @@ def _build_launch_bounds_from_tuple(dim: tuple[int, ...], kernel_dim: int) -> La
     padded = dim + (1,) * max(0, kernel_dim - len(dim))
     kept = padded[:kernel_dim]
     extras = padded[kernel_dim:]
+
+    if scalar_tid_extent_limit is not None and kept[0] > scalar_tid_extent_limit:
+        raise ValueError(
+            f"Warp cannot launch a kernel using scalar wp.tid() with extent {kept[0]}. "
+            f"Scalar wp.tid() returns a signed 32-bit coordinate and supports extents up to "
+            f"{scalar_tid_extent_limit}. Use a multidimensional launch and unpack wp.tid() "
+            "to index additional work items uniquely."
+        )
 
     bounds = launch_bounds_t(kept)
     if extras:
@@ -10686,9 +10732,25 @@ def _build_launch_bounds_from_tuple(dim: tuple[int, ...], kernel_dim: int) -> La
     return bounds
 
 
-def _build_launch_bounds(dim: int | Sequence[int], kernel_dim: int) -> LaunchBounds:
+def _resolve_kernel_scalar_tid_extent_limit(kernel: Kernel, dim: tuple[int, ...], block_dim: int | None) -> int | None:
+    """Resolve exact scalar ``wp.tid()`` metadata only when its candidate would reject."""
+    candidate = kernel.adj.scalar_tid_extent_limit_candidate
+    leading_extent = dim[0] if dim else 1
+    if leading_extent <= candidate:
+        return candidate
+
+    return kernel.module._get_kernel_scalar_tid_extent_limit(kernel, block_dim)
+
+
+def _build_kernel_launch_bounds(
+    dim: int | Sequence[int],
+    kernel: Kernel,
+    block_dim: int | None = None,
+) -> LaunchBounds:
+    """Build launch bounds using exact scalar ``wp.tid()`` metadata when required."""
     dim, _ = _normalize_launch_dim(dim)
-    return _build_launch_bounds_from_tuple(dim, kernel_dim)
+    scalar_tid_extent_limit = _resolve_kernel_scalar_tid_extent_limit(kernel, dim, block_dim)
+    return _build_launch_bounds_from_tuple(dim, kernel.adj.kernel_dim, scalar_tid_extent_limit)
 
 
 def launch(
@@ -10813,7 +10875,8 @@ def launch(
                     f"@wp.kernel(grid_stride=True) to launch dimensions this large."
                 )
 
-        bounds = _build_launch_bounds_from_tuple(dim, kernel.adj.kernel_dim)
+        scalar_tid_extent_limit = _resolve_kernel_scalar_tid_extent_limit(kernel, dim, block_dim)
+        bounds = _build_launch_bounds_from_tuple(dim, kernel.adj.kernel_dim, scalar_tid_extent_limit)
 
         # first param is the number of threads
         params = [bounds]

--- a/warp/_src/jax/custom_call.py
+++ b/warp/_src/jax/custom_call.py
@@ -5,7 +5,7 @@ import ctypes
 from functools import reduce
 
 import warp as wp
-from warp._src.context import _build_launch_bounds, _raise_cuda_launch_error, _validate_cluster_launch, type_str
+from warp._src.context import _build_kernel_launch_bounds, _raise_cuda_launch_error, _validate_cluster_launch, type_str
 from warp._src.jax import get_jax_device
 from warp._src.logger import log_warning
 from warp._src.types import array_t, matches_array_class, strides_from_shape
@@ -95,7 +95,7 @@ def _warp_custom_callback(stream, buffers, opaque, opaque_len):
 
     # Parse launch dimensions.
     dims = [int(d) for d in dim_str.split(",")]
-    bounds = _build_launch_bounds(dims, kernel.adj.kernel_dim)
+    bounds = _build_kernel_launch_bounds(dims, kernel)
 
     # Parse arguments.
     arg_strings = args_str.split(";")
@@ -336,6 +336,11 @@ def _create_jax_warp_primitive():
         else:
             dims = launch_dims
             warp_dims = launch_dims
+
+        # JAX 0.4.25-0.7.x uses this legacy custom-call path, so reject
+        # oversized scalar coordinates during lowering before XLA allocates outputs.
+        _build_kernel_launch_bounds(warp_dims, wp_kernel)
+
         # Figure out the types and shapes of the input arrays.
         arg_strings = []
         operand_layouts = []

--- a/warp/_src/jax/ffi.py
+++ b/warp/_src/jax/ffi.py
@@ -13,10 +13,10 @@ from collections.abc import Callable
 from enum import IntEnum
 
 import warp as wp
-from warp._src.codegen import get_full_arg_spec, make_full_qualified_name
+from warp._src.codegen import _SCALAR_TID_MAX_EXTENT, get_full_arg_spec, make_full_qualified_name
 from warp._src.context import (
     CudaMemcpyKind,
-    _build_launch_bounds,
+    _build_kernel_launch_bounds,
     _raise_cuda_launch_error,
     _validate_cluster_launch,
     invoke,
@@ -156,6 +156,17 @@ def _load_ffi_module(module, device, block_dim=None):
             f"Failed to load Warp module '{module.name}' on device '{device}' after a previous build failure"
         )
     return module_exec
+
+
+def _validate_ffi_kernel_launch_bounds(dim, kernel, block_dim=None) -> None:
+    """Validate platform-neutral tracing against every possible FFI target."""
+    cuda_block_dim = 256 if block_dim is None else block_dim
+    kernel.module.get_module_hash(cuda_block_dim)
+    _build_kernel_launch_bounds(dim, kernel, cuda_block_dim)
+
+    leading_extent = dim[0] if dim else 1
+    if leading_extent > _SCALAR_TID_MAX_EXTENT and cuda_block_dim != 1:
+        _build_kernel_launch_bounds(dim, kernel, 1)
 
 
 def _preload_ffi_module(module, mode, block_dim=None):
@@ -384,6 +395,11 @@ class FfiKernel:
         else:
             launch_dims = tuple(launch_dims)
 
+        # Tracing is platform-neutral even when lowering later targets a specific
+        # device. Validate oversized launches against both supported target variants
+        # before JAX constructs output buffer types.
+        _validate_ffi_kernel_launch_bounds(launch_dims, self.kernel, self.block_dim)
+
         # output shapes
         if isinstance(output_dims, dict):
             # assume a dictionary of shapes keyed on argument name
@@ -540,7 +556,8 @@ class FfiKernel:
                         # roll batch size into the first launch dimension
                         launch_dims = (batch_size * launch_dims[0], *launch_dims[1:])
 
-                launch_bounds = _build_launch_bounds(launch_dims, self.kernel.adj.kernel_dim)
+                # Revalidate here because vmap can grow the leading extent at runtime.
+                launch_bounds = _build_kernel_launch_bounds(launch_dims, self.kernel, block_dim)
 
                 if platform == _FFI_PLATFORM_CPU:
                     hooks = module_exec.get_kernel_hooks(self.kernel)

--- a/warp/native/builtin.h
+++ b/warp/native/builtin.h
@@ -1946,14 +1946,6 @@ inline CUDA_CALLABLE int block_dim()
 
 template <int N> inline CUDA_CALLABLE int tid(size_t index, const launch_bounds_t<N>& bounds)
 {
-    // For the 1-D tid() we need to warn the user if we're about to provide a truncated index
-    // Only do this in _DEBUG when called from device to avoid excessive register allocation
-#if defined(_DEBUG) || !defined(__CUDA_ARCH__)
-    if (index > 2147483647) {
-        printf("Warp warning: tid() is returning an overflowed int\n");
-    }
-#endif
-
     launch_coord_t coord = launch_coord(index, bounds);
     return static_cast<int>(coord.i);
 }

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -28,6 +28,7 @@ os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
 ARRAY_SIZE = 1024 * 1024
 TILE_STORE_SIZE = 64
 JAX_TILE_BLOCK_DIM = 64
+JAX_SCALAR_TID_DISABLED = False
 
 
 # Keep test kernels at module scope. Function-local @wp.kernel definitions mark
@@ -78,6 +79,13 @@ def inc_1d_kernel(x: wp.array[float], y: wp.array[float]):
 def inc_2d_kernel(x: wp.array2d[float], y: wp.array2d[float]):
     i, j = wp.tid()
     y[i, j] = x[i, j] + 1.0
+
+
+@wp.kernel
+def compile_time_dead_scalar_tid_kernel(x: wp.array[float], y: wp.array[float]):
+    if JAX_SCALAR_TID_DISABLED:
+        i = wp.tid()
+        y[i] = x[i]
 
 
 @wp.kernel
@@ -520,6 +528,123 @@ def test_jax_kernel_launch_dims(test, device, use_ffi=False):
 
     assert_np_equal(result_1d, expected_1d)
     assert_np_equal(result_2d, expected_2d)
+
+
+def test_jax_kernel_rejects_oversized_scalar_tid_launch_dims(test, device, use_ffi=False):
+    """Reject oversized scalar ``wp.tid()`` dimensions during legacy lowering."""
+    jax = _import_jax()
+    jp = _import_jax_numpy()
+    jax_kernel = _get_experimental_custom_call_jax_kernel()
+    jax_inc = jax_kernel(inc_1d_kernel, launch_dims=(2**31 + 1,), quiet=True)
+
+    @jax.jit
+    def run():
+        return jax_inc(jp.ones(1, dtype=jp.float32))
+
+    with jax.default_device(wp.device_to_jax(device)):
+        with test.assertRaisesRegex(
+            ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+        ):
+            run.lower()
+
+
+def test_ffi_jax_kernel_rejects_oversized_explicit_scalar_tid_launch_dims(test, device):
+    """Reject explicit oversized scalar ``wp.tid()`` dimensions during tracing."""
+    jp = _import_jax_numpy()
+    # Keep output allocation small so it cannot mask the launch-dimension error.
+    jax_inc = wp.jax_kernel(
+        inc_1d_kernel,
+        launch_dims=(2**31 + 1,),
+        output_dims=1,
+    )
+
+    @jax.jit
+    def run():
+        return jax_inc(jp.ones(1, dtype=jp.float32))
+
+    with jax.default_device(wp.device_to_jax(device)):
+        with test.assertRaisesRegex(
+            ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+        ):
+            run.lower()
+
+
+def test_ffi_jax_kernel_rejects_oversized_inferred_scalar_tid_launch_dims(test, device):
+    """Reject inferred oversized scalar ``wp.tid()`` dimensions during tracing."""
+    jp = _import_jax_numpy()
+    # Keep output allocation small so it cannot mask the launch-dimension error.
+    jax_inc = wp.jax_kernel(inc_1d_kernel, output_dims=1)
+
+    @jax.jit
+    def run(x):
+        return jax_inc(x)
+
+    # Trace the oversized input shape without allocating its storage.
+    abstract_input = jax.ShapeDtypeStruct((2**31 + 1,), jp.float32)
+    with jax.default_device(wp.device_to_jax(device)):
+        with test.assertRaisesRegex(
+            ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+        ):
+            run.lower(abstract_input)
+
+
+def test_jax_kernel_accepts_oversized_compile_time_dead_scalar_tid_launch_dims(test, device, use_ffi=False):
+    """Accept oversized launches when codegen removes scalar ``wp.tid()``."""
+    jp = _import_jax_numpy()
+    if use_ffi:
+        jax_noop = wp.jax_kernel(
+            compile_time_dead_scalar_tid_kernel,
+            launch_dims=(2**31 + 1,),
+            output_dims=1,
+            module_preload_mode=wp.JaxModulePreloadMode.NONE,
+        )
+    else:
+        jax_kernel = _get_experimental_custom_call_jax_kernel()
+        jax_noop = jax_kernel(
+            compile_time_dead_scalar_tid_kernel,
+            launch_dims=(2**31 + 1,),
+            quiet=True,
+        )
+
+    @jax.jit
+    def run():
+        return jax_noop(jp.ones(1, dtype=jp.float32))
+
+    with jax.default_device(wp.device_to_jax(device)):
+        test.assertIsNotNone(run.lower())
+
+
+def test_ffi_jax_kernel_validates_all_target_block_dims_during_tracing(test, device):
+    """Validate platform-neutral tracing against CPU and CUDA block sizes."""
+    from warp._src.jax import ffi as ffi_module  # noqa: PLC0415
+
+    jp = _import_jax_numpy()
+    configured_block_dim = 64
+    jax_noop = wp.jax_kernel(
+        compile_time_dead_scalar_tid_kernel,
+        launch_dims=(2**31 + 1,),
+        output_dims=1,
+        block_dim=configured_block_dim,
+        module_preload_mode=wp.JaxModulePreloadMode.NONE,
+    )
+
+    def run():
+        return jax_noop(jp.ones(1, dtype=jp.float32))
+
+    with (
+        warnings.catch_warnings(),
+        mock.patch.object(
+            ffi_module,
+            "_build_kernel_launch_bounds",
+            wraps=ffi_module._build_kernel_launch_bounds,
+        ) as build_bounds,
+    ):
+        warnings.simplefilter("ignore", DeprecationWarning)
+        lowered = jax.jit(run, device=wp.device_to_jax(device)).lower()
+
+    test.assertIsNotNone(lowered)
+    observed_block_dims = {call.args[2] for call in build_bounds.call_args_list}
+    test.assertEqual(observed_block_dims, {1, configured_block_dim})
 
 
 # =========================================================================================================
@@ -3033,6 +3158,7 @@ else:
                 test_jax_kernel_vecmat,
                 test_jax_kernel_multiarg,
                 test_jax_kernel_launch_dims,
+                test_jax_kernel_accepts_oversized_compile_time_dead_scalar_tid_launch_dims,
             )
             backend_neutral_ffi_tests = (
                 *jax_kernel_ffi_tests,
@@ -3046,6 +3172,9 @@ else:
                 test_ffi_jax_kernel_scale_vec_static,
                 test_ffi_jax_kernel_launch_dims_default,
                 test_ffi_jax_kernel_launch_dims_custom,
+                test_ffi_jax_kernel_validates_all_target_block_dims_during_tracing,
+                test_ffi_jax_kernel_rejects_oversized_explicit_scalar_tid_launch_dims,
+                test_ffi_jax_kernel_rejects_oversized_inferred_scalar_tid_launch_dims,
                 # callables
                 test_ffi_jax_callable_scale_constant,
                 test_ffi_jax_callable_scale_static,
@@ -3133,6 +3262,8 @@ else:
                 test_jax_kernel_vecmat,
                 test_jax_kernel_multiarg,
                 test_jax_kernel_launch_dims,
+                test_jax_kernel_rejects_oversized_scalar_tid_launch_dims,
+                test_jax_kernel_accepts_oversized_compile_time_dead_scalar_tid_launch_dims,
             )
             for test_func in legacy_custom_call_tests:
                 add_function_test(

--- a/warp/tests/test_template_launch_bounds.py
+++ b/warp/tests/test_template_launch_bounds.py
@@ -3,6 +3,7 @@
 
 """Compatibility tests for launch bounds and ``wp.tid()`` mapping."""
 
+import types
 import unittest
 from unittest import mock
 
@@ -14,14 +15,87 @@ from warp._src.types import _launch_bounds_classes, launch_bounds_t
 from warp.tests.unittest_utils import *
 
 BLOCK_DIM = 64
+SCALAR_TID_MAX_EXTENT = 2**31
+SCALAR_TID_DISABLED = False
 TILE_M = wp.constant(8)
 TILE_N = wp.constant(4)
+
+
+class ScalarTidFlags:
+    """Provide an attribute-valued false condition for codegen constant-folding coverage."""
+
+    disabled = False
+
+
+# Exercise semantic ``tid`` detection through a resolved alias rather than ``wp.tid`` syntax.
+TID_FUNCTION = context.builtin_functions["tid"]
+# Isolate the intentionally invalid user function so its build error cannot fail the shared test module.
+ALIASED_TID_FUNCTION_MODULE = wp.Module("test_template_launch_bounds_aliased_tid_function")
 
 
 @wp.kernel
 def regular_1d_kernel(out: wp.array[int]):
     i = wp.tid()
     out[i] = i
+
+
+@wp.kernel
+def inline_tid_kernel(out: wp.array[int]):
+    out[wp.tid()] = 1
+
+
+@wp.kernel
+def static_false_scalar_tid_kernel():
+    if wp.static(False):
+        i = wp.tid()
+    j = wp.tid() if wp.static(False) else 0
+
+
+@wp.kernel
+def named_false_scalar_tid_kernel():
+    if SCALAR_TID_DISABLED:
+        i = wp.tid()
+
+
+@wp.kernel
+def attributed_false_scalar_tid_kernel():
+    if ScalarTidFlags.disabled:
+        i = wp.tid()
+
+
+@wp.kernel
+def local_false_scalar_tid_kernel():
+    disabled = False
+    if disabled:
+        i = wp.tid()
+
+
+@wp.kernel
+def named_false_scalar_tid_if_exp_kernel():
+    i = wp.tid() if SCALAR_TID_DISABLED else 0
+
+
+@wp.kernel
+def aliased_scalar_tid_kernel():
+    i = TID_FUNCTION()
+
+
+@wp.func(module=ALIASED_TID_FUNCTION_MODULE)
+def aliased_tid_user_function():
+    return TID_FUNCTION()
+
+
+@wp.kernel(module=ALIASED_TID_FUNCTION_MODULE)
+def aliased_tid_user_function_kernel():
+    i = aliased_tid_user_function()
+
+
+@wp.kernel
+def mixed_tid_arity_kernel(out: wp.array[int]):
+    i = wp.tid()
+    j, k = wp.tid()
+    if i == 0 and j == 0 and k == 0:
+        out[0] = 1
 
 
 def test_regular_1d(test, device):
@@ -140,6 +214,19 @@ def no_tid_kernel(out: wp.array[float], val: float):
     wp.atomic_add(out, 0, val)
 
 
+@wp.func
+def tid_name_collision_func():
+    return 0
+
+
+tid_name_collision_namespace = types.SimpleNamespace(tid=tid_name_collision_func)
+
+
+@wp.kernel
+def qualified_tid_name_collision_kernel(out: wp.array[int]):
+    out[tid_name_collision_namespace.tid()] = 1
+
+
 def test_no_tid_kernel_multidim(test, device):
     out = wp.zeros(1, dtype=float, device=device)
     wp.launch(no_tid_kernel, dim=[2, 3], inputs=[out, 1.0], device=device)
@@ -238,6 +325,245 @@ def test_build_launch_bounds_from_tuple_preserves_large_coord_mult(test, device)
     test.assertEqual(bounds.shape[0], 1)
     test.assertEqual(bounds.coord_mult, large_mult)
     test.assertEqual(bounds.size, large_mult)
+
+
+def test_scalar_tid_rejects_oversized_extent(test, device):
+    """Reject scalar thread-coordinate extents that exceed signed 32-bit range."""
+    out = wp.zeros(1, dtype=int, device=device)
+
+    with test.assertRaisesRegex(
+        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+    ):
+        wp.launch(
+            regular_1d_kernel,
+            dim=SCALAR_TID_MAX_EXTENT + 1,
+            inputs=[out],
+            device=device,
+            record_cmd=True,
+        )
+
+
+def test_inline_scalar_tid_rejects_oversized_extent(test, device):
+    """Detect scalar ``wp.tid()`` used inside an indexing expression."""
+    out = wp.zeros(1, dtype=int, device=device)
+
+    with test.assertRaisesRegex(
+        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+    ):
+        wp.launch(
+            inline_tid_kernel,
+            dim=SCALAR_TID_MAX_EXTENT + 1,
+            inputs=[out],
+            device=device,
+            record_cmd=True,
+        )
+
+
+def test_mixed_tid_arities_reject_oversized_scalar_extent(test, device):
+    """Reject oversized leading extents when any ``wp.tid()`` call is scalar."""
+    out = wp.zeros(1, dtype=int, device=device)
+
+    with test.assertRaisesRegex(
+        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+    ):
+        wp.launch(
+            mixed_tid_arity_kernel,
+            dim=(SCALAR_TID_MAX_EXTENT + 1, 1),
+            inputs=[out],
+            device=device,
+            record_cmd=True,
+        )
+
+
+def test_scalar_tid_accepts_max_extent(test, device):
+    """Accept the largest scalar thread-coordinate extent without dispatching."""
+    out = wp.zeros(1, dtype=int, device=device)
+
+    launch = wp.launch(
+        regular_1d_kernel,
+        dim=SCALAR_TID_MAX_EXTENT,
+        inputs=[out],
+        device=device,
+        record_cmd=True,
+    )
+
+    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT)
+
+
+def test_no_tid_accepts_oversized_extent(test, device):
+    """Preserve oversized no-``tid`` launch dimensions without dispatching."""
+    out = wp.zeros(1, dtype=float, device=device)
+
+    launch = wp.launch(
+        no_tid_kernel,
+        dim=SCALAR_TID_MAX_EXTENT + 1,
+        inputs=[out, 1.0],
+        device=device,
+        record_cmd=True,
+    )
+
+    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 1)
+
+
+def test_static_false_scalar_tid_accepts_oversized_extent(test, device):
+    """Ignore scalar ``wp.tid()`` calls removed by static control flow."""
+    launch = wp.launch(
+        static_false_scalar_tid_kernel,
+        dim=SCALAR_TID_MAX_EXTENT + 1,
+        device=device,
+        record_cmd=True,
+    )
+
+    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 1)
+
+
+def test_codegen_false_scalar_tid_accepts_oversized_extent(test, device):
+    """Ignore scalar ``wp.tid()`` calls removed by codegen constant propagation."""
+    kernels = (
+        named_false_scalar_tid_kernel,
+        attributed_false_scalar_tid_kernel,
+        local_false_scalar_tid_kernel,
+        named_false_scalar_tid_if_exp_kernel,
+    )
+
+    for kernel in kernels:
+        with test.subTest(kernel=kernel.key):
+            launch = wp.launch(
+                kernel,
+                dim=SCALAR_TID_MAX_EXTENT + 1,
+                device=device,
+                record_cmd=True,
+            )
+
+            test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 1)
+
+
+def test_aliased_scalar_tid_rejects_oversized_extent(test, device):
+    """Reject scalar ``wp.tid()`` reached through a resolved function alias."""
+    aliased_scalar_tid_kernel.module.get_module_hash(BLOCK_DIM)
+
+    with test.assertRaisesRegex(
+        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+    ):
+        context._build_kernel_launch_bounds(
+            SCALAR_TID_MAX_EXTENT + 1,
+            aliased_scalar_tid_kernel,
+            BLOCK_DIM,
+        )
+
+
+def test_aliased_tid_in_user_function_is_rejected(test, device):
+    """Apply the kernel-only ``tid`` rule after semantic call resolution."""
+    aliased_tid_user_function_kernel.module.get_module_hash(BLOCK_DIM)
+
+    with test.assertRaisesRegex(
+        context.WarpCodegenError,
+        r"tid\(\) may only be called from a Warp kernel",
+    ):
+        context._build_kernel_launch_bounds(
+            SCALAR_TID_MAX_EXTENT + 1,
+            aliased_tid_user_function_kernel,
+            BLOCK_DIM,
+        )
+
+
+def test_scalar_tid_empty_dim_uses_padded_extent(test, device):
+    """Preserve the launch-bound padding behavior for an empty dimension."""
+    regular_1d_kernel.module.get_module_hash(BLOCK_DIM)
+
+    bounds = context._build_kernel_launch_bounds((), regular_1d_kernel, BLOCK_DIM)
+
+    test.assertEqual(bounds.size, 1)
+
+
+def test_small_launch_skips_exact_scalar_tid_resolution(test, device):
+    """Keep exact metadata codegen off the ordinary small-launch path."""
+    regular_1d_kernel.module.get_module_hash(BLOCK_DIM)
+
+    with mock.patch.object(
+        regular_1d_kernel.module,
+        "_get_kernel_scalar_tid_extent_limit",
+        wraps=regular_1d_kernel.module._get_kernel_scalar_tid_extent_limit,
+    ) as get_limit:
+        bounds = context._build_kernel_launch_bounds(1, regular_1d_kernel, BLOCK_DIM)
+
+    test.assertEqual(bounds.size, 1)
+    get_limit.assert_not_called()
+
+
+def test_launch_set_dim_accepts_compile_time_dead_scalar_tid(test, device):
+    """Use exact scalar-``tid`` metadata when resizing a recorded launch."""
+    launch = wp.launch(
+        named_false_scalar_tid_kernel,
+        dim=SCALAR_TID_MAX_EXTENT + 1,
+        device=device,
+        record_cmd=True,
+    )
+
+    launch.set_dim(SCALAR_TID_MAX_EXTENT + 2)
+
+    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 2)
+
+
+def test_qualified_tid_name_collision_accepts_oversized_extent(test, device):
+    """Preserve oversized launches for qualified non-builtin functions named ``tid``."""
+    out = wp.zeros(1, dtype=int, device=device)
+
+    try:
+        launch = wp.launch(
+            qualified_tid_name_collision_kernel,
+            dim=SCALAR_TID_MAX_EXTENT + 1,
+            inputs=[out],
+            device=device,
+            record_cmd=True,
+        )
+    except ValueError as error:
+        test.fail(f"Qualified non-builtin function was mistaken for wp.tid(): {error}")
+
+    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 1)
+
+
+def test_scalar_tid_validates_retained_extent(test, device):
+    """Validate the retained scalar extent instead of the total launch size."""
+    out = wp.zeros(1, dtype=int, device=device)
+
+    launch = wp.launch(
+        regular_1d_kernel,
+        dim=(SCALAR_TID_MAX_EXTENT, 2),
+        inputs=[out],
+        device=device,
+        record_cmd=True,
+    )
+    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT * 2)
+    test.assertEqual(launch.bounds.coord_mult, 2)
+
+    with test.assertRaisesRegex(
+        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+    ):
+        wp.launch(
+            regular_1d_kernel,
+            dim=(SCALAR_TID_MAX_EXTENT + 1, 2),
+            inputs=[out],
+            device=device,
+            record_cmd=True,
+        )
+
+
+def test_launch_set_dim_validates_scalar_tid_extent(test, device):
+    """Keep the last valid recorded bounds after scalar extent rejection."""
+    out = wp.zeros(1, dtype=int, device=device)
+    launch = wp.launch(regular_1d_kernel, dim=1, inputs=[out], device=device, record_cmd=True)
+
+    launch.set_dim(SCALAR_TID_MAX_EXTENT)
+    last_valid_bounds = launch.bounds
+
+    with test.assertRaisesRegex(
+        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+    ):
+        launch.set_dim(SCALAR_TID_MAX_EXTENT + 1)
+
+    test.assertIs(launch.bounds, last_valid_bounds)
+    test.assertIs(launch.params[0], last_valid_bounds)
 
 
 def test_launch_normalizes_dim_once(test, device):
@@ -423,6 +749,96 @@ add_function_test(
     "test_build_launch_bounds_from_tuple_preserves_large_coord_mult",
     test_build_launch_bounds_from_tuple_preserves_large_coord_mult,
     devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_scalar_tid_rejects_oversized_extent",
+    test_scalar_tid_rejects_oversized_extent,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_inline_scalar_tid_rejects_oversized_extent",
+    test_inline_scalar_tid_rejects_oversized_extent,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_mixed_tid_arities_reject_oversized_scalar_extent",
+    test_mixed_tid_arities_reject_oversized_scalar_extent,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_scalar_tid_accepts_max_extent",
+    test_scalar_tid_accepts_max_extent,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_no_tid_accepts_oversized_extent",
+    test_no_tid_accepts_oversized_extent,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_static_false_scalar_tid_accepts_oversized_extent",
+    test_static_false_scalar_tid_accepts_oversized_extent,
+    devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_codegen_false_scalar_tid_accepts_oversized_extent",
+    test_codegen_false_scalar_tid_accepts_oversized_extent,
+    devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_aliased_scalar_tid_rejects_oversized_extent",
+    test_aliased_scalar_tid_rejects_oversized_extent,
+    devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_aliased_tid_in_user_function_is_rejected",
+    test_aliased_tid_in_user_function_is_rejected,
+    devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_scalar_tid_empty_dim_uses_padded_extent",
+    test_scalar_tid_empty_dim_uses_padded_extent,
+    devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_small_launch_skips_exact_scalar_tid_resolution",
+    test_small_launch_skips_exact_scalar_tid_resolution,
+    devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_launch_set_dim_accepts_compile_time_dead_scalar_tid",
+    test_launch_set_dim_accepts_compile_time_dead_scalar_tid,
+    devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_qualified_tid_name_collision_accepts_oversized_extent",
+    test_qualified_tid_name_collision_accepts_oversized_extent,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_scalar_tid_validates_retained_extent",
+    test_scalar_tid_validates_retained_extent,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_launch_set_dim_validates_scalar_tid_extent",
+    test_launch_set_dim_validates_scalar_tid_extent,
+    devices=devices,
 )
 add_function_test(
     TestTemplateLaunchBounds,


### PR DESCRIPTION
## Description

Prevent scalar `wp.tid()` coordinates from wrapping when a kernel's retained one-dimensional launch extent exceeds `2**31`. These launches now raise a `ValueError` before dispatch, including recorded launches and JAX lowering, while multidimensional and no-`tid` launches retain their existing behavior.

Scalar `wp.tid()` returns a signed 32-bit coordinate, but the host previously accepted extents whose coordinates exceeded that range. The new limit is derived during kernel reference analysis and ignores calls removed by static control flow, so validation reflects the generated kernel body rather than source syntax.

APIC graph save/load behavior for otherwise valid folded bounds is tracked separately in [GH-1800](https://github.com/NVIDIA/warp/issues/1800). In particular, this change does not alter APIC serialization of `coord_mult` for `dim=(2**31, 2)`.

## Changes

- Record whether generated kernel code uses scalar `wp.tid()` and validate its retained launch extent when building or resizing launch bounds.
- Apply the same validation to direct launches, recorded launches, JAX FFI, and legacy JAX custom calls.
- Remove the native post-dispatch warning, add a no-`tid` launch benchmark, and add a changelog fragment.
- Cover the signed 32-bit boundary, folded dimensions, mixed `wp.tid()` arities, static-dead calls, recorded command updates, and JAX tracing.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

- Verified the static-dead `wp.tid()` regression test failed before the reachability fix and passes afterward.
- Ran all 76 launch-bounds tests on CPU and two CUDA devices.
- Ran the oversized-dimension JAX tests with current JAX and JAX 0.7.2, covering FFI and legacy lowering.
- Ran the full Warp suite: 15,267 tests passed with 32 expected skips.
- Ran all applicable pre-commit hooks.

## Bug fix

Before this change, the recorded launch below was accepted even though dispatch could produce scalar thread coordinates outside the signed 32-bit range. It now raises a `ValueError` before dispatch.

```python
import warp as wp


@wp.kernel
def scalar_tid_kernel():
    i = wp.tid()


wp.launch(
    scalar_tid_kernel,
    dim=2**31 + 1,
    device="cpu",
    record_cmd=True,
)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * One-dimensional kernels using scalar `wp.tid()` now reject launch extents larger than `2**31` with a clear `ValueError`, preventing thread-coordinate overflow.
  * Validation is consistent across standard, JAX custom-call, and FFI launches, including recorded launch dimension updates.
  * Oversized launches remain supported when scalar `wp.tid()` usage is absent or removed during compilation.
* **Documentation**
  * Documented the scalar thread-index launch limit and error behavior.
* **Tests**
  * Added coverage for boundary conditions, aliases, dead code, multidimensional launches, and JAX integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->