### PR TITLE
Expose CUDA kernel resource queries

### DIFF
--- a/changelog/1805.added.md
+++ b/changelog/1805.added.md
@@ -1,0 +1,1 @@
+Add `wp.get_cuda_kernel_properties()` to report per-thread CUDA register use and local-memory size for compiled kernel variants in a dictionary.

--- a/docs/api_reference/warp.rst
+++ b/docs/api_reference/warp.rst
@@ -298,6 +298,7 @@ Kernel Execution
    Kernel
    Launch
    Module
+   get_cuda_kernel_properties
    get_suggested_block_size
    launch
    launch_tiled

--- a/docs/user_guide/execution_and_performance/profiling.rst
+++ b/docs/user_guide/execution_and_performance/profiling.rst
@@ -390,6 +390,26 @@ is handled when ``cuProfilerStop`` is called.  The CUDA API does not guarantee t
 Consult the profiler's documentation to determine whether explicit synchronization is needed to include work that is
 still in flight.
 
+Checking CUDA kernel resource use
+---------------------------------
+
+When tuning a CUDA kernel, use :func:`warp.get_cuda_kernel_properties` to inspect properties of a compiled CUDA
+function without starting with a profiler. Pass ``block_dim`` explicitly to inspect the same module variant that a
+launch uses:
+
+.. code-block:: python
+
+   properties = wp.get_cuda_kernel_properties(kernel, device=device, block_dim=128)
+   print(properties["register_count"])
+   print(properties["local_memory_size"])
+
+``register_count`` is the number of registers CUDA allocates to each thread. ``local_memory_size`` is the local-memory
+size in bytes used by each thread, including thread-local storage and register spills. Future Warp releases may add
+keys to the returned dictionary.
+
+These values may change with the GPU, CUDA toolchain, Warp version, compiler options, or block dimension. For an
+occupancy-based recommendation, use :func:`warp.get_suggested_block_size`.
+
 Nsight Compute Profiling
 ------------------------
 

--- a/warp/__init__.py
+++ b/warp/__init__.py
@@ -327,6 +327,7 @@ from warp._src.context import Module as Module
 
 from warp._src.context import launch as launch
 from warp._src.context import launch_tiled as launch_tiled
+from warp._src.context import get_cuda_kernel_properties as get_cuda_kernel_properties
 from warp._src.context import get_suggested_block_size as get_suggested_block_size
 from warp._src.context import synchronize as synchronize
 

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -116,6 +116,7 @@ from warp._src.context import Launch as Launch
 from warp._src.context import Module as Module
 from warp._src.context import launch as launch
 from warp._src.context import launch_tiled as launch_tiled
+from warp._src.context import get_cuda_kernel_properties as get_cuda_kernel_properties
 from warp._src.context import get_suggested_block_size as get_suggested_block_size
 from warp._src.context import synchronize as synchronize
 from warp._src.tape import Tape as Tape

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -3223,6 +3223,24 @@ class ModuleExec:
                 pass
 
     # lookup and cache kernel entry points
+    def _get_forward_cuda_kernel(self, kernel):
+        """Return the forward CUDA function without initializing launch hooks.
+
+        CUDA function-property queries use this path instead of ``get_kernel_hooks()`` so that inspection does not
+        configure dynamic shared-memory or thread-block cluster attributes. The caller must retain this ``ModuleExec``
+        while using the returned raw CUDA function handle.
+        """
+        name = kernel._mangled_name
+        if name is None:
+            name = kernel.get_mangled_name()
+
+        hooks = self.kernel_hooks.get(name)
+        if hooks is not None:
+            return hooks.forward
+
+        forward_name = name + "_cuda_kernel_forward"
+        return runtime.core.wp_cuda_get_kernel(self.device.context, self.handle, forward_name.encode("utf-8"))
+
     def get_kernel_hooks(self, kernel) -> KernelHooks:
         # Key by the mangled name (compiled-symbol identity), not kernel.adj, which pinned one
         # Adjoint per closure-recreated kernel -- a leak the live-kernel WeakSet can't reclaim.
@@ -7479,6 +7497,14 @@ class Runtime:
             ]
             self.core.wp_cuda_get_kernel_static_shared_memory.restype = ctypes.c_int
 
+            self.core.wp_cuda_get_kernel_properties.argtypes = [
+                ctypes.c_void_p,
+                ctypes.c_void_p,
+                ctypes.POINTER(ctypes.c_int),
+                ctypes.c_int,
+            ]
+            self.core.wp_cuda_get_kernel_properties.restype = ctypes.c_bool
+
             self.core.wp_cuda_set_kernel_cluster_attrs.argtypes = [
                 ctypes.c_void_p,  # kernel (CUfunction)
                 ctypes.c_int,  # cx
@@ -11163,6 +11189,112 @@ def launch_tiled(*args, **kwargs):
     return launch(*args, **kwargs)
 
 
+def _resolve_cuda_kernel_forward_entry_point(kernel, device, block_dim, api_name):
+    """Resolve the forward CUDA kernel entry point used by property queries.
+
+    Public CUDA kernel-property APIs use this helper to validate their shared
+    arguments and load the requested block-dimension module variant. It
+    returns the ``ModuleExec`` with the raw ``CUfunction`` handle so the
+    caller can keep the owning module loaded until the CUDA property query
+    completes.
+    """
+    init()
+
+    if not isinstance(kernel, Kernel):
+        raise TypeError(f"{api_name}() expected a wp.Kernel, got {type(kernel)}")
+
+    if kernel.is_generic:
+        raise RuntimeError(
+            f"{api_name}() requires a concrete overload of generic kernel '{kernel.key}'; "
+            "create one with wp.overload() and pass the returned kernel"
+        )
+
+    device = runtime.get_device(device)
+    if not device.is_cuda:
+        raise RuntimeError(f"{api_name}() requires a CUDA device, got '{device}'")
+
+    if block_dim is None:
+        resolved_block_dim = kernel.module.options["block_dim"]
+    else:
+        if isinstance(block_dim, bool):
+            raise ValueError(f"block_dim must be a positive integer, got {block_dim!r}")
+        try:
+            resolved_block_dim = operator.index(block_dim)
+        except TypeError:
+            raise ValueError(f"block_dim must be a positive integer, got {block_dim!r}") from None
+        if resolved_block_dim <= 0:
+            raise ValueError(f"block_dim must be a positive integer, got {block_dim!r}")
+
+    try:
+        module_exec = kernel.module.load(device, resolved_block_dim)
+    except Exception as error:
+        raise RuntimeError(
+            f"Failed to load CUDA kernel '{kernel.key}' on device '{device}' with block_dim={resolved_block_dim}"
+        ) from error
+
+    if module_exec is None:
+        raise RuntimeError(
+            f"Failed to load CUDA kernel '{kernel.key}' on device '{device}' with block_dim={resolved_block_dim}"
+        )
+
+    forward_handle = module_exec._get_forward_cuda_kernel(kernel)
+    if forward_handle is None:
+        raise RuntimeError(
+            f"Failed to load forward CUDA kernel '{kernel.key}' on device '{device}' "
+            f"with block_dim={resolved_block_dim}"
+        )
+
+    return device, module_exec, forward_handle, resolved_block_dim
+
+
+_CUDA_KERNEL_PROPERTY_KEYS = ("register_count", "local_memory_size")
+
+
+def get_cuda_kernel_properties(
+    kernel,
+    device: DeviceLike = None,
+    block_dim: int | None = None,
+) -> dict[str, int]:
+    """Return properties of a compiled CUDA kernel.
+
+    The result contains ``"register_count"`` in registers per thread and
+    ``"local_memory_size"`` in bytes per thread. Values may vary with the
+    device, CUDA toolchain, Warp version, compilation options, and
+    ``block_dim``. Future Warp releases may add keys.
+
+    Args:
+        kernel: A concrete ``@wp.kernel``-decorated kernel or explicitly
+            constructed :class:`warp.Kernel`. For a generic kernel, pass an
+            overload returned by :func:`warp.overload`.
+        device: The target CUDA device. If ``None``, use the default device,
+            which must be CUDA.
+        block_dim: Threads per block for the compiled variant. If ``None``,
+            use the kernel module default.
+
+    Returns:
+        The complete dictionary of exposed CUDA kernel properties.
+
+    Raises:
+        TypeError: If kernel is not a Warp kernel.
+        ValueError: If block_dim is not a positive integer.
+        RuntimeError: If validation, loading, or the native batch fails.
+    """
+    device, _module_exec, forward_handle, resolved_block_dim = _resolve_cuda_kernel_forward_entry_point(
+        kernel, device, block_dim, "get_cuda_kernel_properties"
+    )
+    property_count = len(_CUDA_KERNEL_PROPERTY_KEYS)
+    property_values = (ctypes.c_int * property_count)()
+
+    if not runtime.core.wp_cuda_get_kernel_properties(device.context, forward_handle, property_values, property_count):
+        err = runtime.get_error_string()
+        raise RuntimeError(
+            f"Failed to query CUDA kernel properties for kernel '{kernel.key}' "
+            f"on device '{device}' with block_dim={resolved_block_dim}: {err}"
+        )
+
+    return dict(zip(_CUDA_KERNEL_PROPERTY_KEYS, property_values, strict=True))
+
+
 def get_suggested_block_size(kernel, device: DeviceLike = None) -> tuple[int, int]:
     """Suggest a CUDA block size that maximizes occupancy for a kernel.
 
@@ -11199,9 +11331,10 @@ def get_suggested_block_size(kernel, device: DeviceLike = None) -> tuple[int, in
             wp.launch(saxpy, dim=n, inputs=[2.0, x, y], block_dim=block_size)
 
     Args:
-        kernel: A :class:`warp.Kernel` object, created with ``@wp.kernel`` or
-            the :class:`warp.Kernel` constructor.
-        device: The target device. If ``None``, uses the current CUDA device.
+        kernel: A concrete :class:`warp.Kernel` object, created with
+            ``@wp.kernel`` or the :class:`warp.Kernel` constructor. For a
+            generic kernel, pass an overload returned by :func:`warp.overload`.
+        device: The target device. If ``None``, uses the default device.
             For CPU devices, returns ``(1, 1)``.
 
     Returns:
@@ -11212,7 +11345,8 @@ def get_suggested_block_size(kernel, device: DeviceLike = None) -> tuple[int, in
 
     Raises:
         TypeError: If ``kernel`` is not a Warp kernel.
-        RuntimeError: If the CUDA occupancy query fails.
+        RuntimeError: If ``kernel`` is a generic kernel parent on a CUDA
+            device or the CUDA occupancy query fails.
     """
     init()
 
@@ -11223,6 +11357,12 @@ def get_suggested_block_size(kernel, device: DeviceLike = None) -> tuple[int, in
 
     if not device.is_cuda:
         return (1, 1)
+
+    if kernel.is_generic:
+        raise RuntimeError(
+            f"get_suggested_block_size() requires a concrete overload of generic kernel '{kernel.key}'; "
+            "create one with wp.overload() and pass the returned kernel"
+        )
 
     module = kernel.module
     module_exec = module.load(device)

--- a/warp/native/warp.cpp
+++ b/warp/native/warp.cpp
@@ -1266,6 +1266,10 @@ WP_API bool wp_cuda_get_suggested_block_size(
 WP_API int wp_cuda_get_max_shared_memory(void* context) { return 0; }
 WP_API bool wp_cuda_configure_kernel_shared_memory(void* kernel, int size) { return false; }
 WP_API int wp_cuda_get_kernel_static_shared_memory(void* context, void* kernel) { return -1; }
+WP_API bool wp_cuda_get_kernel_properties(void* context, void* kernel, int* properties, int property_count)
+{
+    return false;
+}
 WP_API bool wp_cuda_set_kernel_cluster_attrs(void* kernel, int cx, int cy, int cz) { return false; }
 WP_API int wp_cuda_get_max_cluster_dim(void* context, void* kernel, int block_dim, int dynamic_smem_bytes) { return 1; }
 

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -5400,19 +5400,42 @@ bool wp_cuda_configure_kernel_shared_memory(void* kernel, int size)
     return true;
 }
 
-int wp_cuda_get_kernel_static_shared_memory(void* context, void* kernel)
+static int get_cuda_kernel_attribute(void* context, void* kernel, CUfunction_attribute attribute)
 {
     if (!kernel)
         return -1;
 
     ContextGuard guard(context);
 
-    int static_smem_bytes = 0;
-    CUresult res = cuFuncGetAttribute_f(&static_smem_bytes, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, (CUfunction)kernel);
-    if (res != CUDA_SUCCESS)
+    int value = 0;
+    if (!check_cu(cuFuncGetAttribute_f(&value, attribute, (CUfunction)kernel)))
         return -1;
 
-    return static_smem_bytes;
+    return value;
+}
+
+int wp_cuda_get_kernel_static_shared_memory(void* context, void* kernel)
+{
+    return get_cuda_kernel_attribute(context, kernel, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES);
+}
+
+bool wp_cuda_get_kernel_properties(void* context, void* kernel, int* properties, int property_count)
+{
+    constexpr int kernel_property_count = 2;
+    if (!kernel || !properties || property_count != kernel_property_count)
+        return false;
+
+    ContextGuard guard(context);
+    int queried_properties[kernel_property_count] = {};
+
+    if (!check_cu(cuFuncGetAttribute_f(&queried_properties[0], CU_FUNC_ATTRIBUTE_NUM_REGS, (CUfunction)kernel)))
+        return false;
+    if (!check_cu(cuFuncGetAttribute_f(&queried_properties[1], CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES, (CUfunction)kernel)))
+        return false;
+
+    properties[0] = queried_properties[0];
+    properties[1] = queried_properties[1];
+    return true;
 }
 
 bool wp_cuda_set_kernel_cluster_attrs(void* kernel, int cx, int cy, int cz)

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -904,6 +904,9 @@ WP_API bool wp_cuda_configure_kernel_shared_memory(void* kernel, int size);
 // Returns -1 if the kernel handle is null or the driver query fails. The dynamic shared
 // memory a kernel can be configured for is wp_cuda_get_max_shared_memory() minus this value.
 WP_API int wp_cuda_get_kernel_static_shared_memory(void* context, void* kernel);
+// Query all public properties for a loaded CUDA function in one batch.
+// Returns false without publishing partial results.
+WP_API bool wp_cuda_get_kernel_properties(void* context, void* kernel, int* properties, int property_count);
 // Set CUDA Thread Block Cluster attributes on a loaded kernel function.
 // For total cluster size > 8 (non-portable range), enables
 // CU_FUNC_NON_PORTABLE_CLUSTER_SIZE_ALLOWED. Sizes <= 8 are no-ops at this

--- a/warp/tests/cuda/test_kernel_attributes.py
+++ b/warp/tests/cuda/test_kernel_attributes.py
@@ -1,0 +1,516 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the public CUDA kernel property query.
+
+The tests cover the complete property dictionary, argument validation, module
+variant selection, lazy compilation, errors, side effects, and module lifetime.
+"""
+
+import unittest
+import weakref
+from typing import Any
+from unittest import mock
+
+import warp as wp
+import warp._src.context as warp_context
+from warp.tests.unittest_utils import add_function_test, get_selected_cuda_test_devices
+
+ATTRIBUTE_BLOCK_DIM = 64
+
+
+@wp.kernel(enable_backward=False)
+def attribute_kernel(out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = float(tid)
+
+
+@wp.kernel(enable_backward=False, module="unique")
+def lazy_attribute_kernel(out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = float(tid) + 1.0
+
+
+@wp.kernel(cluster_dim=2, enable_backward=False, module="unique")
+def inspection_attribute_kernel(out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = float(tid) + 2.0
+
+
+@wp.kernel(enable_backward=False)
+def generic_attribute_kernel(out: wp.array[Any]):
+    tid = wp.tid()
+    out[tid] = out[tid]
+
+
+generic_float_attribute_kernel = wp.overload(generic_attribute_kernel, [wp.array[float]])
+
+
+def constructor_kernel_func(out: wp.array[float]):
+    tid = wp.tid()
+    out[tid] = float(tid)
+
+
+def test_cuda_kernel_public_properties(test, device):
+    properties = wp.get_cuda_kernel_properties(attribute_kernel, device=device, block_dim=ATTRIBUTE_BLOCK_DIM)
+    test.assertEqual(set(properties), {"register_count", "local_memory_size"})
+    test.assertIsInstance(properties["register_count"], int)
+    test.assertIsInstance(properties["local_memory_size"], int)
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+    test.assertEqual(
+        properties,
+        wp.get_cuda_kernel_properties(
+            attribute_kernel,
+            device=device,
+            block_dim=ATTRIBUTE_BLOCK_DIM,
+        ),
+    )
+
+
+def test_cuda_kernel_properties_use_one_native_batch(test, device):
+    expected_forward = object()
+    module_exec = mock.Mock()
+    module_exec._get_forward_cuda_kernel.return_value = expected_forward
+
+    def query(context, forward, values, count):
+        test.assertEqual(context, device.context)
+        test.assertIs(forward, expected_forward)
+        test.assertEqual(count, 2)
+        values[0] = 17
+        values[1] = 23
+        return True
+
+    with (
+        mock.patch.object(attribute_kernel.module, "load", return_value=module_exec),
+        mock.patch.object(
+            warp_context.runtime.core,
+            "wp_cuda_get_kernel_properties",
+            side_effect=query,
+        ) as native_query,
+    ):
+        properties = wp.get_cuda_kernel_properties(attribute_kernel, device=device, block_dim=ATTRIBUTE_BLOCK_DIM)
+
+    test.assertEqual(properties, {"register_count": 17, "local_memory_size": 23})
+    native_query.assert_called_once()
+    module_exec._get_forward_cuda_kernel.assert_called_once_with(attribute_kernel)
+
+
+def test_cuda_kernel_properties_loads_requested_variant(test, device):
+    """Verify that an explicit block dimension selects the matching module variant."""
+    attribute_kernel.module.unload()
+
+    properties = wp.get_cuda_kernel_properties(
+        attribute_kernel,
+        device=device,
+        block_dim=ATTRIBUTE_BLOCK_DIM,
+    )
+
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+    module_exec = attribute_kernel.module.execs[(device.context, ATTRIBUTE_BLOCK_DIM)]
+    test.assertEqual(module_exec.block_dim, ATTRIBUTE_BLOCK_DIM)
+
+
+def test_cuda_kernel_properties_accepts_index_block_dim(test, device):
+    """Verify that resource queries resolve indexable block dimensions."""
+
+    class IndexableBlockDim:
+        def __index__(self):
+            return ATTRIBUTE_BLOCK_DIM
+
+    attribute_kernel.module.unload()
+    block_dim = IndexableBlockDim()
+
+    properties = wp.get_cuda_kernel_properties(
+        attribute_kernel,
+        device=device,
+        block_dim=block_dim,
+    )
+
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+    module_exec = attribute_kernel.module.execs[(device.context, ATTRIBUTE_BLOCK_DIM)]
+    test.assertEqual(module_exec.block_dim, ATTRIBUTE_BLOCK_DIM)
+
+
+def test_cuda_kernel_properties_uses_module_default(test, device):
+    """Verify that an omitted block dimension selects the module default variant."""
+    attribute_kernel.module.unload()
+    default_block_dim = attribute_kernel.module.options["block_dim"]
+
+    properties = wp.get_cuda_kernel_properties(attribute_kernel, device=device)
+
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+    module_exec = attribute_kernel.module.execs[(device.context, default_block_dim)]
+    test.assertEqual(module_exec.block_dim, default_block_dim)
+
+
+def test_cuda_kernel_properties_compiles_lazily(test, device):
+    """Verify that a resource query compiles a kernel before its first launch."""
+    lazy_attribute_kernel.module.unload()
+    exec_key = (device.context, ATTRIBUTE_BLOCK_DIM)
+    test.assertNotIn(exec_key, lazy_attribute_kernel.module.execs)
+
+    properties = wp.get_cuda_kernel_properties(
+        lazy_attribute_kernel,
+        device=device,
+        block_dim=ATTRIBUTE_BLOCK_DIM,
+    )
+
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+    test.assertIn(exec_key, lazy_attribute_kernel.module.execs)
+
+
+def test_cuda_kernel_properties_avoids_shared_memory_configuration(test, device):
+    """Verify that a fresh resource query avoids shared-memory configuration."""
+    attribute_kernel.module.unload()
+
+    with mock.patch.object(
+        warp_context.runtime.core,
+        "wp_cuda_configure_kernel_shared_memory",
+        wraps=warp_context.runtime.core.wp_cuda_configure_kernel_shared_memory,
+    ) as configure_shared_memory:
+        properties = wp.get_cuda_kernel_properties(
+            attribute_kernel,
+            device=device,
+            block_dim=ATTRIBUTE_BLOCK_DIM,
+        )
+
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+    configure_shared_memory.assert_not_called()
+
+
+def test_cuda_kernel_properties_avoids_cluster_configuration(test, device):
+    """Verify that a fresh resource query avoids cluster configuration."""
+    if device.arch < 90:
+        test.skipTest("CUDA thread block clusters require sm_90 or newer.")
+
+    compile_arch = max((arch for arch in wp.get_cuda_supported_archs() if 90 <= arch <= device.arch), default=None)
+    if compile_arch is None:
+        test.skipTest("NVRTC has no cluster-capable target for this device.")
+
+    original_arch = wp.config.ptx_target_arch
+    test.addCleanup(setattr, wp.config, "ptx_target_arch", original_arch)
+    wp.config.ptx_target_arch = compile_arch
+    inspection_attribute_kernel.module.unload()
+
+    with mock.patch.object(
+        warp_context.runtime.core,
+        "wp_cuda_set_kernel_cluster_attrs",
+        wraps=warp_context.runtime.core.wp_cuda_set_kernel_cluster_attrs,
+    ) as set_cluster_attrs:
+        properties = wp.get_cuda_kernel_properties(
+            inspection_attribute_kernel,
+            device=device,
+            block_dim=ATTRIBUTE_BLOCK_DIM,
+        )
+
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+    set_cluster_attrs.assert_not_called()
+
+
+def test_cuda_kernel_properties_accepts_constructor_kernel(test, device):
+    """Verify that resource queries accept an explicitly constructed Warp kernel."""
+    kernel = wp.Kernel(func=constructor_kernel_func)
+
+    properties = wp.get_cuda_kernel_properties(
+        kernel,
+        device=device,
+        block_dim=ATTRIBUTE_BLOCK_DIM,
+    )
+
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+
+
+def test_cuda_kernel_properties_accept_generic_overload(test, device):
+    """Verify that resource queries accept a concrete generic-kernel overload."""
+    properties = wp.get_cuda_kernel_properties(
+        generic_float_attribute_kernel,
+        device=device,
+        block_dim=ATTRIBUTE_BLOCK_DIM,
+    )
+
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+
+
+def test_cuda_kernel_properties_reject_invalid_block_dim(test, device):
+    """Verify that resource queries reject non-positive and non-integral block dimensions."""
+    invalid_block_dims = (True, 0, -1, 1.5, "64")
+
+    with mock.patch.object(attribute_kernel.module, "load", wraps=attribute_kernel.module.load) as load:
+        for block_dim in invalid_block_dims:
+            with test.subTest(block_dim=block_dim):
+                with test.assertRaisesRegex(ValueError, "block_dim must be a positive integer"):
+                    wp.get_cuda_kernel_properties(attribute_kernel, device=device, block_dim=block_dim)
+
+    load.assert_not_called()
+
+
+def test_cuda_kernel_properties_accepts_zero_local_memory(test, device):
+    """Verify that zero local-memory bytes is treated as a valid driver result."""
+
+    def query_zero(_context, _forward, values, count):
+        test.assertEqual(count, 2)
+        values[0] = 7
+        values[1] = 0
+        return True
+
+    with mock.patch.object(warp_context.runtime.core, "wp_cuda_get_kernel_properties", side_effect=query_zero):
+        result = wp.get_cuda_kernel_properties(
+            attribute_kernel,
+            device=device,
+            block_dim=ATTRIBUTE_BLOCK_DIM,
+        )
+
+    test.assertEqual(result, {"register_count": 7, "local_memory_size": 0})
+
+
+def test_cuda_kernel_properties_report_load_failure(test, device):
+    """Verify that module-load failures identify the kernel, device, and block dimension."""
+    with (
+        mock.patch.object(attribute_kernel.module, "load", side_effect=RuntimeError("mock load failure")),
+        test.assertRaisesRegex(
+            RuntimeError,
+            rf"Failed to load CUDA kernel '{attribute_kernel.key}'.*{device}.*block_dim={ATTRIBUTE_BLOCK_DIM}",
+        ),
+    ):
+        wp.get_cuda_kernel_properties(
+            attribute_kernel,
+            device=device,
+            block_dim=ATTRIBUTE_BLOCK_DIM,
+        )
+
+
+def test_cuda_kernel_properties_report_missing_hook(test, device):
+    """Verify that a missing forward hook produces a contextual runtime error."""
+    module_exec = mock.Mock()
+    module_exec._get_forward_cuda_kernel.return_value = None
+
+    with (
+        mock.patch.object(attribute_kernel.module, "load", return_value=module_exec),
+        test.assertRaisesRegex(
+            RuntimeError,
+            rf"Failed to load forward CUDA kernel '{attribute_kernel.key}'.*{device}.*block_dim={ATTRIBUTE_BLOCK_DIM}",
+        ),
+    ):
+        wp.get_cuda_kernel_properties(
+            attribute_kernel,
+            device=device,
+            block_dim=ATTRIBUTE_BLOCK_DIM,
+        )
+
+
+def test_cuda_kernel_properties_use_forward_entry_point(test, device):
+    """Verify that resource queries pass the forward CUDA entry point to the driver."""
+    forward_handle = object()
+    backward_handle = object()
+    module_exec = mock.Mock()
+    module_exec._get_forward_cuda_kernel.return_value = forward_handle
+
+    def query(context, forward, values, count):
+        test.assertEqual(context, device.context)
+        test.assertIs(forward, forward_handle)
+        test.assertEqual(count, 2)
+        values[0] = 7
+        values[1] = 0
+        return True
+
+    with (
+        mock.patch.object(attribute_kernel.module, "load", return_value=module_exec),
+        mock.patch.object(
+            warp_context.runtime.core, "wp_cuda_get_kernel_properties", side_effect=query
+        ) as native_query,
+    ):
+        result = wp.get_cuda_kernel_properties(attribute_kernel, device=device, block_dim=ATTRIBUTE_BLOCK_DIM)
+
+    test.assertEqual(result, {"register_count": 7, "local_memory_size": 0})
+    native_query.assert_called_once()
+    test.assertIsNot(native_query.call_args.args[1], backward_handle)
+    module_exec._get_forward_cuda_kernel.assert_called_once_with(attribute_kernel)
+
+
+def test_cuda_kernel_properties_retain_module_exec(test, device):
+    """Verify that resource queries retain the loaded module during the native call."""
+    attribute_kernel.module.unload()
+    module_exec = attribute_kernel.module.load(device, ATTRIBUTE_BLOCK_DIM)
+    module_exec_ref = weakref.ref(module_exec)
+    del module_exec
+
+    def unload_during_query(_context, _forward, values, count):
+        attribute_kernel.module.unload()
+        test.assertIsNotNone(module_exec_ref())
+        test.assertEqual(count, 2)
+        values[0] = 7
+        values[1] = 0
+        return True
+
+    with mock.patch.object(
+        warp_context.runtime.core,
+        "wp_cuda_get_kernel_properties",
+        side_effect=unload_during_query,
+    ):
+        properties = wp.get_cuda_kernel_properties(attribute_kernel, device=device, block_dim=ATTRIBUTE_BLOCK_DIM)
+
+    test.assertGreater(properties["register_count"], 0)
+    test.assertGreaterEqual(properties["local_memory_size"], 0)
+    test.assertIsNone(module_exec_ref())
+
+
+def test_cuda_kernel_properties_report_driver_failure(test, device):
+    """Verify that failed driver queries preserve the CUDA error text."""
+
+    def fail_partial(_context, _forward, values, _count):
+        values[0] = 7
+        return False
+
+    with (
+        mock.patch.object(
+            warp_context.runtime.core,
+            "wp_cuda_get_kernel_properties",
+            side_effect=fail_partial,
+        ),
+        mock.patch.object(warp_context.runtime, "get_error_string", return_value="mock CUDA error"),
+        test.assertRaisesRegex(RuntimeError, "Failed to query CUDA kernel properties.*mock CUDA error"),
+    ):
+        wp.get_cuda_kernel_properties(attribute_kernel, device=device, block_dim=ATTRIBUTE_BLOCK_DIM)
+
+
+devices = get_selected_cuda_test_devices()
+
+
+class TestCudaKernelProperties(unittest.TestCase):
+    def test_cuda_kernel_properties_reject_generic_parent(self):
+        """Verify that resource queries require a concrete generic-kernel overload."""
+        with self.assertRaisesRegex(RuntimeError, "requires a concrete overload.*wp.overload"):
+            wp.get_cuda_kernel_properties(generic_attribute_kernel)
+
+    def test_cuda_kernel_properties_reject_non_kernel(self):
+        """Verify that resource queries reject undecorated callables and strings."""
+
+        def undecorated_kernel():
+            return None
+
+        for invalid_kernel in (undecorated_kernel, "not a kernel"):
+            with self.subTest(invalid_kernel=invalid_kernel):
+                with self.assertRaisesRegex(TypeError, "expected a wp.Kernel"):
+                    wp.get_cuda_kernel_properties(invalid_kernel)
+
+    def test_cuda_kernel_properties_reject_cpu(self):
+        """Verify that CUDA resource queries reject CPU devices."""
+        with self.assertRaisesRegex(RuntimeError, "requires a CUDA device"):
+            wp.get_cuda_kernel_properties(attribute_kernel, device="cpu")
+
+
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_public_properties",
+    test_cuda_kernel_public_properties,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_use_one_native_batch",
+    test_cuda_kernel_properties_use_one_native_batch,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_loads_requested_variant",
+    test_cuda_kernel_properties_loads_requested_variant,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_accepts_index_block_dim",
+    test_cuda_kernel_properties_accepts_index_block_dim,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_uses_module_default",
+    test_cuda_kernel_properties_uses_module_default,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_compiles_lazily",
+    test_cuda_kernel_properties_compiles_lazily,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_avoids_shared_memory_configuration",
+    test_cuda_kernel_properties_avoids_shared_memory_configuration,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_avoids_cluster_configuration",
+    test_cuda_kernel_properties_avoids_cluster_configuration,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_accepts_constructor_kernel",
+    test_cuda_kernel_properties_accepts_constructor_kernel,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_accept_generic_overload",
+    test_cuda_kernel_properties_accept_generic_overload,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_reject_invalid_block_dim",
+    test_cuda_kernel_properties_reject_invalid_block_dim,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_accepts_zero_local_memory",
+    test_cuda_kernel_properties_accepts_zero_local_memory,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_report_load_failure",
+    test_cuda_kernel_properties_report_load_failure,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_report_missing_hook",
+    test_cuda_kernel_properties_report_missing_hook,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_use_forward_entry_point",
+    test_cuda_kernel_properties_use_forward_entry_point,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_retain_module_exec",
+    test_cuda_kernel_properties_retain_module_exec,
+    devices=devices,
+)
+add_function_test(
+    TestCudaKernelProperties,
+    "test_cuda_kernel_properties_report_driver_failure",
+    test_cuda_kernel_properties_report_driver_failure,
+    devices=devices,
+)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/warp/tests/cuda/test_occupancy.py
+++ b/warp/tests/cuda/test_occupancy.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from typing import Any
 
 import numpy as np
 
@@ -25,6 +26,12 @@ def bounded_kernel(a: wp.array[float]):
 def lazy_kernel(a: wp.array[float]):
     tid = wp.tid()
     a[tid] = float(tid) + 1.0
+
+
+@wp.kernel
+def generic_kernel(a: wp.array[Any]):
+    tid = wp.tid()
+    a[tid] = a[tid]
 
 
 def test_suggested_block_size_basic(test, device):
@@ -78,14 +85,22 @@ def test_suggested_block_size_kernel_constructor(test, device):
     test.assertGreater(min_grid_size, 0)
 
 
+def test_suggested_block_size_rejects_generic_parent(test, device):
+    """Generic kernel parents produce an actionable overload-selection error."""
+    with test.assertRaisesRegex(RuntimeError, "requires a concrete overload.*wp.overload"):
+        wp.get_suggested_block_size(generic_kernel, device)
+
+
 devices = get_selected_cuda_test_devices()
 
 
 class TestOccupancy(unittest.TestCase):
     def test_suggested_block_size_cpu(self):
         """CPU fallback returns (1, 1)."""
-        result = wp.get_suggested_block_size(simple_kernel, "cpu")
-        self.assertEqual(result, (1, 1))
+        for kernel in (simple_kernel, generic_kernel):
+            with self.subTest(kernel=kernel.key):
+                result = wp.get_suggested_block_size(kernel, "cpu")
+                self.assertEqual(result, (1, 1))
 
 
 add_function_test(TestOccupancy, "test_suggested_block_size_basic", test_suggested_block_size_basic, devices=devices)
@@ -111,6 +126,12 @@ add_function_test(
     TestOccupancy,
     "test_suggested_block_size_kernel_constructor",
     test_suggested_block_size_kernel_constructor,
+    devices=devices,
+)
+add_function_test(
+    TestOccupancy,
+    "test_suggested_block_size_rejects_generic_parent",
+    test_suggested_block_size_rejects_generic_parent,
     devices=devices,
 )
 

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -101,6 +101,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.cuda.test_clang_cuda import TestClangCUDA
     from warp.tests.cuda.test_cluster_dim import TestClusterDim
     from warp.tests.cuda.test_cuda_arch_suffix import TestCudaArchSuffix
+    from warp.tests.cuda.test_kernel_attributes import TestCudaKernelProperties
     from warp.tests.cuda.test_mempool import TestMempool
     from warp.tests.cuda.test_multigpu import TestMultiGPU
     from warp.tests.cuda.test_occupancy import TestOccupancy
@@ -392,6 +393,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestMultiGPU,
         TestNoise,
         TestOccupancy,
+        TestCudaKernelProperties,
         TestOperators,
         TestOptions,
         TestOverwrite,


### PR DESCRIPTION
## Description

Add `wp.get_cuda_kernel_register_count()` and `wp.get_cuda_kernel_local_memory_size()` so users can inspect per-thread resource use for compiled CUDA kernels directly from Warp. This makes it easier to compare compiled variants when investigating register pressure, local-memory use, or block-dimension choices.

The APIs return the properties reported by CUDA for the selected device and block-dimension variant without launching or configuring the kernel. The local-memory result covers all thread-local storage reported by CUDA, not only register spills.

Closes #1805.

## Changes

- Add public Python APIs and type stubs for querying register count and local-memory size.
- Query `CU_FUNC_ATTRIBUTE_NUM_REGS` and `CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES` through the CUDA driver.
- Compile and load the requested kernel variant lazily, and keep its module alive until the driver query finishes.
- Document the APIs in the API reference and profiling guide, with self-contained examples in their docstrings.
- Add CUDA tests covering public behavior, variant selection, validation, error reporting, side effects, and module lifetime.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

All tests in `warp/tests/cuda/test_kernel_attributes.py` passed. They cover public queries, device and block-dimension variant selection, lazy compilation, explicitly constructed kernels, invalid inputs, CUDA errors, and module retention during concurrent unload.

The changed-file pre-commit checks passed. The Sphinx HTML documentation build also completed successfully and resolved the new API references.

## New feature / enhancement

```python
import warp as wp


@wp.kernel
def increment(values: wp.array[float]):
    i = wp.tid()
    values[i] += 1.0


register_count = wp.get_cuda_kernel_register_count(increment, device="cuda:0", block_dim=256)
local_memory_bytes = wp.get_cuda_kernel_local_memory_size(increment, device="cuda:0", block_dim=256)

print(f"Registers per thread: {register_count}")
print(f"Local memory per thread: {local_memory_bytes} bytes")
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public APIs to report CUDA kernel register usage and per-thread local-memory consumption.
  * Supports selecting compiled kernel variants and block dimensions when retrieving resource metrics.
  * Added guidance for evaluating kernel resource usage and choosing occupancy-based block sizes.
  * Improved validation for kernel types, devices, overloads, and block dimensions.

* **Documentation**
  * Added API reference entries and changelog coverage for CUDA kernel introspection.

* **Tests**
  * Added comprehensive coverage for resource queries, validation, compilation behavior, device handling, and failure cases.
  * Added validation for occupancy queries involving generic kernels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->