### PR TITLE
Fix svd2 U/V for scaled orthogonal inputs (GH-1734)

### DIFF
--- a/changelog/1734.fixed.md
+++ b/changelog/1734.fixed.md
@@ -1,0 +1,2 @@
+Fix `wp.svd2()` returning identity singular vectors for scaled orthogonal
+inputs such as rotations, reflections, and negative multiples of the identity.

--- a/warp/native/svd.h
+++ b/warp/native/svd.h
@@ -520,12 +520,27 @@ inline CUDA_CALLABLE void _svd_2( // input A
 
     // Step 3: Singular values
     if (discriminant == Type(0)) {
-        // Duplicate eigenvalue, A ~ s Id
+        // Duplicate eigenvalue, ATA = lambda Id, so A = s Q with Q orthogonal
+        // (any scaled rotation or reflection, not just a scaled identity)
         s1 = s2 = sqrt(Type(0.5) * trace);
-        u11 = v11 = Type(1);
-        u12 = v12 = Type(0);
-        u21 = v21 = Type(0);
-        u22 = v22 = Type(1);
+        v11 = Type(1);
+        v12 = Type(0);
+        v21 = Type(0);
+        v22 = Type(1);
+        if (s1 == Type(0)) {
+            // A = 0
+            u11 = Type(1);
+            u12 = Type(0);
+            u21 = Type(0);
+            u22 = Type(1);
+        } else {
+            // A / s is exactly orthogonal, so U = A / s, V = Id reconstructs A
+            Type inv_sigma = Type(1) / s1;
+            u11 = a11 * inv_sigma;
+            u12 = a12 * inv_sigma;
+            u21 = a21 * inv_sigma;
+            u22 = a22 * inv_sigma;
+        }
         return;
     }
 

--- a/warp/tests/matrix/test_mat.py
+++ b/warp/tests/matrix/test_mat.py
@@ -933,6 +933,12 @@ def test_svd_2D(test, device, dtype, register_kernels=False):
                 np.array([[1.0, 1.0], [-1.0, -1.0]]),
                 np.array([[3.0, 0.0], [4.0, 5.0]]),
                 np.eye(2) + tol * np.array([[1.0, 1.0], [-1.0, -1.0]]),
+                # scaled orthogonal inputs hit the repeated-singular-value path (GH-1734)
+                np.array([[0.0, -1.0], [1.0, 0.0]]),  # rotation by 90 degrees
+                np.array([[np.cos(0.5), -np.sin(0.5)], [np.sin(0.5), np.cos(0.5)]]),  # rotation by 0.5 rad
+                2.0 * np.array([[np.cos(0.5), -np.sin(0.5)], [np.sin(0.5), np.cos(0.5)]]),  # scaled rotation
+                -np.eye(2),  # negative scaled identity
+                np.array([[1.0, 0.0], [0.0, -1.0]]),  # reflection
             ],
         ),
         axis=0,


### PR DESCRIPTION
## Description

`wp.svd2()` returns `U = V = identity` for any scaled orthogonal input `A = s * R` (rotations,
reflections, negative multiples of the identity), which reconstructs `A` only when `A` is a
non-negative multiple of the identity. The singular values are correct; only the singular vectors
are wrong, silently — no error, no NaN. Downstream users of 2D polar decomposition, co-rotational
strain, and rotation extraction get a wrong rotation with no diagnostic.

Root cause: the repeated-singular-value special case added by the fix for #679 (`svd2` returning
NaN on `diag(2, 2)`) assumes that a duplicate eigenvalue of `AᵀA` means `A` is a scaled identity.
The condition that actually reaches that branch is `AᵀA = λI` (`discriminant == 0` requires both
`ATA11 == ATA22` and `ATA12 == 0`), which characterizes the whole scaled-orthogonal family: columns
of `A` orthogonal with equal norm `σ = sqrt(λ)`.

The fix uses exactly that property: for `λ > 0`, `A / σ` is exactly orthogonal, so returning
`U = A / σ`, `Σ = σI`, `V = I` reconstructs `A` while keeping `U` orthogonal and preserving the
existing sign convention `det(U) = sign(det(A))`, `det(V) = +1`. `A = 0` keeps `U = V = I`, `Σ = 0`.
The #679 case (`A = sI`, `s > 0`) returns identical results to before by construction
(`A / σ = I`).

Closes #1734.

## Changes

- `warp/native/svd.h`: in `_svd_2`'s duplicate-eigenvalue branch, return `U = A / σ` (with an
  `A = 0` guard) instead of unconditionally `U = I`; `V = I` unchanged. Header code shared by all
  scalar types and both devices.
- `warp/tests/matrix/test_mat.py`: add five scaled-orthogonal matrices (rot 90°, rot 0.5,
  `2·rot 0.5`, `-I`, reflection `diag(1, -1)`) to `test_svd_2D`'s hand-built edge-case list, which
  already asserts `U·diag(σ)·Vᵀ = A`, orthogonality of `U` and `V`, and gradients.
- `changelog/1734.fixed.md`: changelog fragment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

Validated on macOS arm64, CPU device, native library built from source with `build_lib.py`
(CPU-only build; formatting via `uvx pre-commit run`, all hooks pass).

- **Red:** with only the new test matrices applied, `warp/tests/matrix/test_mat.py` fails at
  `test_svd_2Dfloat16_cpu` — the mismatching elements are exactly the new rotation/reflection
  entries (max absolute error 2.0, the `-I` case).
- **Green:** with the fix, the full module passes: `Ran 69 tests ... OK`, including
  `test_svd_2D{float16,float32,float64}_cpu` with the new cases and the existing gradient checks.
- **Reproducer sweep** (float32 and float64 kernels, CPU), max `|U·diag(σ)·Vᵀ − A|`:

  | Input | Before | After (f32) | After (f64) |
  | --- | --- | --- | --- |
  | `rot(90°)` | 1.0 | 0.0 | 0.0 |
  | `-I` | 2.0 | 0.0 | 0.0 |
  | `diag(1, -1)` | 2.0 | 0.0 | 0.0 |
  | `rot(0.5)` | 0.479 | 0.0 | 0.0 |
  | `2·rot(0.5)` | 0.959 | 0.0 | 0.0 |
  | `rot(π/4)` | 0.707 | 0.0 | 0.0 |
  | `I`, `5I`, `diag(2, 2)` (#679) | 0.0 | 0.0 | 0.0 |
  | zero matrix | 0.0 | 0.0 | 0.0 |
  | `I + 1e-7·offset` (near-repeated) | 7.1e-15 | 7.1e-15 | 1.1e-16 |

  `U` stays orthogonal to ≤ 1.4e-7 (f32) / 2.2e-16 (f64), singular values match NumPy throughout,
  no NaNs, and the near-repeated-singular-value input still takes the general path unchanged.

- **Not run:** CUDA. No NVIDIA GPU is available on this machine. The changed code is
  device-independent header code (`_svd_2` template in `svd.h`) with no device-specific branches,
  compiled identically for both backends; the issue reports the same wrong output on CUDA for the
  inputs whose intermediates land exactly on zero, which this change corrects by the same math.

## Bug fix

Minimal reproducer without this PR (from #1734):

```python
import numpy as np
import warp as wp


@wp.kernel
def decompose(a: wp.array[wp.mat22], rec: wp.array[wp.mat22], sigma: wp.array[wp.vec2]):
    tid = wp.tid()
    U, s, V = wp.svd2(a[tid])
    sigma[tid] = s
    rec[tid] = U * wp.diag(s) * wp.transpose(V)


a = wp.array([wp.mat22(0.0, -1.0, 1.0, 0.0)], dtype=wp.mat22)  # 90-degree rotation
rec = wp.zeros(1, dtype=wp.mat22)
sigma = wp.zeros(1, dtype=wp.vec2)
wp.launch(decompose, dim=1, inputs=[a], outputs=[rec, sigma])

print(sigma.numpy()[0])                              # [1. 1.]  <- correct
print(rec.numpy()[0])                                # [[1. 0.] [0. 1.]]  <- should be the input
print(np.abs(rec.numpy()[0] - a.numpy()[0]).max())   # 1.0 without this PR, 0.0 with it
```

---

Noting that #1734 is self-assigned — if a fix is already underway in-house, happy to close this in its favor or rework it to match; the added test matrices may be useful either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected 2D SVD results for scaled rotations, reflections, and negative identity matrices.
  * Improved handling of zero and repeated singular values to ensure accurate matrix reconstruction.

* **Tests**
  * Added coverage for orthogonal and scaled-orthogonal matrix cases.

* **Documentation**
  * Added a changelog entry describing the SVD correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->