### PR TITLE
Warn about CUDA texture CUBIN risk

### DIFF
--- a/changelog/1811.changed.md
+++ b/changelog/1811.changed.md
@@ -1,0 +1,2 @@
+Warn when CUDA 12.9 may generate incorrect optimized ``sm_120`` CUBIN code
+for ``Texture2D`` or ``Texture3D`` sampling.

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -4065,6 +4065,23 @@ class Module:
         if opt != 3 and not is_cpu and runtime.toolkit_version is not None and runtime.toolkit_version < (12, 9):
             log_warning("Optimization level other than 3 has no effect on CUDA versions prior to 12.9.", once=True)
 
+        if (
+            not is_cpu
+            and runtime.toolkit_version == (12, 9)
+            and output_arch == 120
+            and output_name.endswith(".cubin")
+            and opt != 0
+            and "wp::texture_sample<" in source_str
+            and ("wp::texture2d_t" in source_str or "wp::texture3d_t" in source_str)
+        ):
+            log_warning(
+                "CUDA 12.9 may generate incorrect optimized sm_120 CUBIN code for Texture2D or Texture3D sampling "
+                "when texture handles vary across lanes. Explicit mip-level sampling may also be affected. Upgrade to "
+                "an R580-or-newer driver and use automatic/PTX output, use a CUDA 13.x Warp build, or set the module "
+                "optimization level to 0.",
+                once=True,
+            )
+
         source_code_path = os.path.join(build_dir, f"{module_name_short}.{source_code_ext}")
         try:
             with open(source_code_path, "w") as source_file:

--- a/warp/tests/cuda/test_texture.py
+++ b/warp/tests/cuda/test_texture.py
@@ -3,6 +3,8 @@
 
 """Unit tests for 1D, 2D, and 3D texture functionality on both CPU and CUDA devices."""
 
+import contextlib
+import io
 import os
 import tempfile
 import unittest
@@ -2837,25 +2839,32 @@ class TestTexture(unittest.TestCase):
     def test_cuda_12_9_texture_cubin_warning(self):
         module = wp.get_module(__name__)
         options = module.resolve_options(wp.config) | {"optimization_level": 3}
+        stderr = io.StringIO()
+        saved_warnings = wp._src.logger._warnings_seen.copy()
+        wp._src.logger._warnings_seen.clear()
 
-        with (
-            tempfile.TemporaryDirectory() as tmpdir,
-            patch.object(wp.config, "cuda_arch_suffix", None),
-            patch.object(wp._src.context.runtime, "toolkit_version", (12, 9)),
-            patch.object(wp._src.context.runtime, "get_nvrtc_pch_dir", return_value=None),
-            patch("warp._src.build.build_cuda"),
-            patch("warp._src.context.log_warning") as mock_log_warning,
-        ):
-            module._compile(
-                device=None,
-                output_dir=os.path.join(tmpdir, "module"),
-                output_name="module.sm120.cubin",
-                output_arch=120,
-                options=options,
-            )
+        try:
+            with (
+                tempfile.TemporaryDirectory() as tmpdir,
+                contextlib.redirect_stderr(stderr),
+                patch.object(wp.config, "cuda_arch_suffix", None),
+                patch.object(wp._src.context.runtime, "toolkit_version", (12, 9)),
+                patch.object(wp._src.context.runtime, "get_nvrtc_pch_dir", return_value=None),
+                patch("warp._src.build.build_cuda"),
+            ):
+                for output_dir in ("module_a", "module_b"):
+                    module._compile(
+                        device=None,
+                        output_dir=os.path.join(tmpdir, output_dir),
+                        output_name="module.sm120.cubin",
+                        output_arch=120,
+                        options=options,
+                    )
+        finally:
+            wp._src.logger._warnings_seen.clear()
+            wp._src.logger._warnings_seen.update(saved_warnings)
 
-        mock_log_warning.assert_called_once()
-        self.assertIn("CUDA 12.9", mock_log_warning.call_args.args[0])
+        self.assertEqual(stderr.getvalue().count("CUDA 12.9 may generate"), 1)
 
 
 # Register tests - textures work on both CPU and CUDA devices

--- a/warp/tests/cuda/test_texture.py
+++ b/warp/tests/cuda/test_texture.py
@@ -3,7 +3,10 @@
 
 """Unit tests for 1D, 2D, and 3D texture functionality on both CPU and CUDA devices."""
 
+import os
+import tempfile
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 
@@ -2831,7 +2834,28 @@ def test_texture_mipmap_invalid_levels(test, device):
 
 
 class TestTexture(unittest.TestCase):
-    pass
+    def test_cuda_12_9_texture_cubin_warning(self):
+        module = wp.get_module(__name__)
+        options = module.resolve_options(wp.config) | {"optimization_level": 3}
+
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch.object(wp.config, "cuda_arch_suffix", None),
+            patch.object(wp._src.context.runtime, "toolkit_version", (12, 9)),
+            patch.object(wp._src.context.runtime, "get_nvrtc_pch_dir", return_value=None),
+            patch("warp._src.build.build_cuda"),
+            patch("warp._src.context.log_warning") as mock_log_warning,
+        ):
+            module._compile(
+                device=None,
+                output_dir=os.path.join(tmpdir, "module"),
+                output_name="module.sm120.cubin",
+                output_arch=120,
+                options=options,
+            )
+
+        mock_log_warning.assert_called_once()
+        self.assertIn("CUDA 12.9", mock_log_warning.call_args.args[0])
 
 
 # Register tests - textures work on both CPU and CUDA devices


### PR DESCRIPTION
## Description

Adds a targeted warning when Warp compiles an optimized CUDA 12.9 `sm_120` CUBIN module that contains `Texture2D` or `Texture3D` sampling. This configuration can produce incorrect samples when texture handles vary across lanes, including explicit mip-level sampling, so affected users now receive actionable alternatives instead of silently incorrect results.

Related to #1811.

## Changes

- Detect the affected toolkit, architecture, output format, optimization level, and generated texture-sampling code inline at module compile time.
- Emit one process-wide warning with PTX, driver/toolkit, and optimization alternatives.
- Add one compile-path warning test to the existing texture suite while retaining its functional coverage of lane-varying `Texture2D` and `Texture3D` handles and explicit mip-level sampling.
- Add an issue-linked changelog fragment for the new diagnostic.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

- Ran the focused warning test using real texture-module CUDA code generation.
- Ran all 212 tests in the existing texture test module across CPU and two `sm_120` CUDA devices.
- Rebuilt Warp with CUDA 12.9 and verified optimized CUBIN emits the warning while PTX and CUBIN at optimization level 0 remain silent, then restored the CUDA 13.0 build.
- Ran the repository pre-commit checks for all changed files.
- GitHub workflows will provide full-suite validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning for CUDA 12.9 builds that may produce incorrect optimized `sm_120` CUBIN code when sampling `Texture2D` or `Texture3D` textures.
  * The warning is shown once and includes available workarounds involving drivers, output formats, toolkit versions, and optimization settings.

* **Documentation**
  * Documented the CUDA 12.9 texture sampling compatibility issue and its workarounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
