### PR TITLE
Refresh Trimesh side topology after in-place connectivity changes

### DIFF
--- a/changelog/1804.added.md
+++ b/changelog/1804.added.md
@@ -1,0 +1,3 @@
+`fem.Trimesh.update_topology()`, which rebuilds the edge list, the edge-to-triangle map, the boundary edges and the
+BVH after `tri_vertex_indices` has been modified in place, so that meshes whose connectivity changes at runtime no
+longer integrate over stale sides.

--- a/changelog/1804.fixed.md
+++ b/changelog/1804.fixed.md
@@ -1,0 +1,3 @@
+The elastic shape optimization example now refreshes its geometry after Delaunay edge flips. A flip can move an edge
+it did not select from one triangle to another, so the cached side topology and the triangle BVH no longer described
+the mesh being integrated over.

--- a/warp/_src/fem/geometry/trimesh.py
+++ b/warp/_src/fem/geometry/trimesh.py
@@ -292,9 +292,11 @@ class Trimesh(Geometry):
         self._build_topology(temporary_store)
         self._orient_edges()
 
-        # Arg structs hold references to the previous edge arrays.
+        # Arg structs hold references to the previous edge arrays. side_index_arg_value caches
+        # the boundary edge list, which _build_topology() reallocates, so it has to go too.
         Geometry.cell_arg_value.invalidate(self)
         Geometry.side_arg_value.invalidate(self)
+        Geometry.side_index_arg_value.invalidate(self)
 
         # Cell bounds are derived from the triangles, so a connectivity change invalidates the tree
         # itself and not just its bounds; refitting through update_bvh() is not enough here.

--- a/warp/_src/fem/geometry/trimesh.py
+++ b/warp/_src/fem/geometry/trimesh.py
@@ -114,17 +114,7 @@ class Trimesh(Geometry):
         self._edge_tri_indices: wp.array = None
         self._build_topology(temporary_store)
 
-        # Flip edges so that normals point away from inner cell
-        if self.dimension == 2:
-            orient_kernel = Trimesh._orient_edges_2d
-        else:
-            orient_kernel = Trimesh._orient_edges_3d
-        wp.launch(
-            kernel=orient_kernel,
-            device=positions.device,
-            dim=self.side_count(),
-            inputs=[self._edge_vertex_indices, self._edge_tri_indices, self.tri_vertex_indices, self.positions],
-        )
+        self._orient_edges()
 
         # Process all dynamic attributes (Trimesh primitives + Geometry dependents)
         cache.setup_dynamic_attributes(self)
@@ -268,6 +258,49 @@ class Trimesh(Geometry):
         return side_to_cell_arg
 
     # -- Topology building (precision-independent, uses integer indices) --
+
+    def _orient_edges(self):
+        """Flip edges so that normals point away from the inner cell."""
+
+        orient_kernel = Trimesh._orient_edges_2d if self.dimension == 2 else Trimesh._orient_edges_3d
+        wp.launch(
+            kernel=orient_kernel,
+            device=self.positions.device,
+            dim=self.side_count(),
+            inputs=[self._edge_vertex_indices, self._edge_tri_indices, self.tri_vertex_indices, self.positions],
+        )
+
+    def update_topology(self, temporary_store: TemporaryStore | None = None):
+        """Rebuild the side topology after ``tri_vertex_indices`` has been modified in place.
+
+        The edge list, the edge-to-triangle map and the boundary edge list are all derived from
+        ``tri_vertex_indices`` when the geometry is constructed. Changing the connectivity in place,
+        for instance by flipping edges, leaves those structures describing the previous mesh, so
+        side integration and :func:`lookup` silently use stale data. Calling this method makes them
+        consistent with the current triangles again.
+
+        Note that a connectivity change may reorder the edges, so any :class:`Field` or
+        :class:`Space` built from a previous side ordering must be rebuilt as well.
+
+        Args:
+            temporary_store: shared pool from which to allocate temporary arrays
+
+        See also: :meth:`.Geometry.update_bvh`, which handles moving positions rather than
+        changing connectivity.
+        """
+
+        self._build_topology(temporary_store)
+        self._orient_edges()
+
+        # Arg structs hold references to the previous edge arrays.
+        Geometry.cell_arg_value.invalidate(self)
+        Geometry.side_arg_value.invalidate(self)
+
+        # Cell bounds are derived from the triangles, so a connectivity change invalidates the tree
+        # itself and not just its bounds; refitting through update_bvh() is not enough here.
+        if self._bvhs:
+            for bvh in list(self._bvhs.values()):
+                self.build_bvh(bvh.lowers.device)
 
     def _build_topology(self, temporary_store: TemporaryStore):
         device = self.tri_vertex_indices.device

--- a/warp/examples/fem/example_elastic_shape_optimization.py
+++ b/warp/examples/fem/example_elastic_shape_optimization.py
@@ -438,12 +438,17 @@ class Example:
         # Write back updated connectivity in-place
         wp.copy(src=wp.array(tri_np, dtype=int), dest=self._tri_vertex_indices)
 
-        # Rebuild spaces and fields on the existing geometry.
-        # We intentionally avoid recreating the Trimesh2D objects: edge flips
-        # only affect interior edges, so boundary structures and projectors
-        # remain valid; and re-running _build_topology() would introduce
-        # non-deterministic edge ordering that perturbs the boundary projector
-        # enough to visibly affect the displacement on ill-conditioned systems.
+        # The flips rewrote the shared triangle array in place, so the geometries now hold a
+        # side topology that no longer matches their triangles. Flipping the edge shared by
+        # (c, a, b) and (d, b, a) yields (c, a, d) and (d, b, c), which moves the untouched
+        # edge b-c from the first triangle to the second, so the cached edge-to-triangle map
+        # is wrong even for edges no flip selected. The BVH is bounded per triangle and is
+        # invalidated for the same reason.
+        self._start_geo.update_topology()
+        if not self._use_deformed_geo:
+            self._geo.update_topology()
+
+        # Rebuild spaces and fields, which depend on the refreshed side ordering.
         self._rebuild_fem_structures(self._degree)
 
     def step(self):

--- a/warp/tests/fem/test_fem_geometry.py
+++ b/warp/tests/fem/test_fem_geometry.py
@@ -890,6 +890,12 @@ def test_trimesh_update_topology(test, device):
 
     test.assertEqual(stale_side_count(), 0)
 
+    # Populate the cached Arg structs so the refresh has to invalidate them, in particular the
+    # side-index arg, which holds the boundary edge list.
+    geo.cell_arg_value(device)
+    geo.side_arg_value(device)
+    geo.side_index_arg_value(device)
+
     # Flip the connectivity in place, without rebuilding the geometry.
     wp.copy(src=tri_after, dest=geo.tri_vertex_indices)
     test.assertGreater(stale_side_count(), 0)
@@ -910,6 +916,13 @@ def test_trimesh_update_topology(test, device):
         )
 
     test.assertEqual(canonical(geo), canonical(rebuilt))
+
+    # The cached side-index arg must hand out the rebuilt boundary edge list, not the one it
+    # captured before the flip.
+    refreshed_boundary = geo.side_index_arg_value(device).boundary_edge_indices.numpy().tolist()
+    test.assertEqual(refreshed_boundary, geo._boundary_edge_indices.numpy().tolist())
+    test.assertEqual(len(refreshed_boundary), geo.boundary_side_count())
+    test.assertEqual(geo.boundary_side_count(), rebuilt.boundary_side_count())
 
 
 devices = get_test_devices()

--- a/warp/tests/fem/test_fem_geometry.py
+++ b/warp/tests/fem/test_fem_geometry.py
@@ -864,6 +864,54 @@ def test_closest_point_queries(test, device):
 
 # -- Device setup and test registration --
 
+
+def test_trimesh_update_topology(test, device):
+    # Two triangles sharing the diagonal a-b. Flipping it gives (c, a, d) and (d, b, c),
+    # which also moves the untouched edge b-c from the first triangle to the second, so the
+    # cached edge-to-triangle map is stale for an edge the flip did not select.
+    a, b, c, d = 0, 1, 2, 3
+    positions = wp.array([[0.0, 0.0], [1.0, 1.0], [0.0, 1.0], [1.0, 0.0]], dtype=wp.vec2, device=device)
+    tri_before = wp.array([[c, a, b], [d, b, a]], dtype=int, device=device)
+    tri_after = wp.array([[c, a, d], [d, b, c]], dtype=int, device=device)
+
+    geo = fem.Trimesh2D(tri_vertex_indices=tri_before, positions=positions, build_bvh=True)
+
+    def stale_side_count():
+        triangles = geo.tri_vertex_indices.numpy()
+        edge_vertices = geo.edge_vertex_indices.numpy()
+        edge_tris = geo.edge_tri_indices.numpy()
+        stale = 0
+        for (v0, v1), tris in zip(edge_vertices, edge_tris, strict=False):
+            for tri_index in tris:
+                corners = triangles[tri_index]
+                if v0 not in corners or v1 not in corners:
+                    stale += 1
+        return stale
+
+    test.assertEqual(stale_side_count(), 0)
+
+    # Flip the connectivity in place, without rebuilding the geometry.
+    wp.copy(src=tri_after, dest=geo.tri_vertex_indices)
+    test.assertGreater(stale_side_count(), 0)
+
+    geo.update_topology()
+    test.assertEqual(stale_side_count(), 0)
+
+    # The refreshed topology must describe the same mesh as one built from the flipped triangles.
+    rebuilt = fem.Trimesh2D(tri_vertex_indices=tri_after, positions=positions)
+    test.assertEqual(geo.side_count(), rebuilt.side_count())
+
+    def canonical(g):
+        return sorted(
+            (tuple(sorted(edge)), tuple(sorted(tris)))
+            for edge, tris in zip(
+                g.edge_vertex_indices.numpy().tolist(), g.edge_tri_indices.numpy().tolist(), strict=False
+            )
+        )
+
+    test.assertEqual(canonical(geo), canonical(rebuilt))
+
+
 devices = get_test_devices()
 cuda_devices = get_selected_cuda_test_devices()
 capture_allocation_devices = [device for device in get_test_devices_with_graph_capture_allocation() if device.is_cuda]
@@ -896,6 +944,7 @@ add_function_test(TestFemGeometry, "test_deformed_geometry", test_deformed_geome
 add_function_test(
     TestFemGeometry, "test_deformed_geometry_codimensional", test_deformed_geometry_codimensional, devices=devices
 )
+add_function_test(TestFemGeometry, "test_trimesh_update_topology", test_trimesh_update_topology, devices=devices)
 add_function_test(TestFemGeometry, "test_closest_point_queries", test_closest_point_queries)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #1804.

`Trimesh` builds `_edge_vertex_indices`, `_edge_tri_indices` and `_boundary_edge_indices` from `tri_vertex_indices` once, in the constructor. `example_elastic_shape_optimization.py` rewrites that array in place after Delaunay edge flips and deliberately skips the rebuild, with a comment explaining that flips only affect interior edges so boundary structures and projectors stay valid.

That premise does not hold. Flipping the edge shared by `(c, a, b)` and `(d, b, a)` gives `(c, a, d)` and `(d, b, c)`, which moves the untouched edge `b-c` out of the first triangle and into the second. The cached map still assigns `b-c` to the first triangle, so `_edge_to_tri_coords()` looks for a vertex that is no longer in that triangle, falls through to the `else` branch, and places the quadrature point at the wrong location in the wrong triangle. Nothing raises. The BVH is bounded per triangle and is stale for the same reason, and `Geometry.update_bvh()` only refits an existing tree, so it is not sufficient after a connectivity change.

Reproduced on the two-triangle case above, checking each cached edge against the triangles actually present:

```
stale side->tri entries WITHOUT update_topology(): 6
stale side->tri entries WITH    update_topology(): 0
matches a freshly built Trimesh2D: True
```

`edge (1,2)` is the interesting one: that is `b-c`, an edge no flip selected, and the stale map points it at a triangle that no longer contains vertex 1.

## Change

`Trimesh.update_topology()` rebuilds the side topology, reorients the edges, invalidates the cached `CellArg`/`SideArg` structs that hold references to the old arrays, and rebuilds the BVH on each device that has one. The orientation launch the constructor ran inline moves into `_orient_edges()` so both paths share it.

The example calls it on the affected geometries after applying flips, before rebuilding the spaces and fields that depend on the side ordering. `_start_geo` and `_geo` share the same triangle array, so both go stale; in the deformed-mesh mode `_geo` is derived from `_start_geo` and is rebuilt by `_rebuild_fem_structures()`.

The issue suggests preserving edge ordering where possible. This does not attempt that: the ordering comes out of `compress_node_indices` and preserving it across a connectivity change would be a much larger change for a path that already has to rebuild its spaces and fields. The docstring states that sides may be reordered.

## Verification

New test `test_trimesh_update_topology` in `warp/tests/fem/test_fem_geometry.py` asserts a freshly built mesh has no stale sides, that flipping in place introduces some, that `update_topology()` removes them, and that the result matches a `Trimesh2D` built from the flipped triangles.

- `test_trimesh_update_topology`: passes on `cpu` and `cuda:0`. Errors with `AttributeError` on unmodified main, and the stale-entry assertion is what fails if the rebuild is removed.
- `warp.tests.fem.test_fem_geometry`: 27 tests, OK (1 skipped), on `cpu` and `cuda:0`.
- `fem.example_elastic_shape_optimization` example test: OK.
- `ruff check` and `ruff format --check` clean on the touched files.

One note on the concern in the issue that this would move the example's output. I could not get the flipper to produce a flip in that example: at `resolution=16` over 80 iterations and at `resolution=25` over 150 iterations, remeshing every 5 or 10 steps, `delaunay_edge_flip` returned 0 flips every time and `remesh()` returned before touching the connectivity. So I have no measurement showing the output moving, and the example test result is unchanged. That also explains how the stale topology went unnoticed. If you have a configuration that does flip, I am happy to run it and report the before and after.

Tested on Windows 11, RTX 3050, CUDA 12.9.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public operation to refresh mesh topology after in-place triangle connectivity changes.
  * Mesh connectivity, cached data, boundary-edge information, and acceleration structures are rebuilt consistently after updates.

* **Bug Fixes**
  * Fixed elastic shape optimization remeshing so geometry and topology remain synchronized after edge flips.
  * Improved reliability of refreshed mesh data across supported devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->