### PR TITLE
Rebuild Trimesh2D after edge flips in the elastic shape optimization example (GH-1804)

### DIFF
--- a/changelog/1804.fixed.md
+++ b/changelog/1804.fixed.md
@@ -1,0 +1,3 @@
+Fix stale `Trimesh2D` side topology and BVH in the FEM elastic shape
+optimization example by rebuilding the geometry after Delaunay edge flips, so
+that side quadrature and `fem.lookup` use the updated connectivity.

--- a/warp/examples/fem/example_elastic_shape_optimization.py
+++ b/warp/examples/fem/example_elastic_shape_optimization.py
@@ -337,13 +337,14 @@ class Example:
     def _rebuild_fem_structures(self, degree):
         """Build all geometry-dependent FEM objects from scratch.
 
-        Called once from ``__init__``.  Creates geometry objects, boundary
-        subdomains, Dirichlet projectors, and function spaces.
+        Called from ``__init__`` and after each ``remesh()``.  Creates
+        geometry objects, boundary subdomains, Dirichlet projectors, and
+        function spaces.
         """
 
         if self._use_deformed_geo:
             self._build_deformed_geo()
-        elif not hasattr(self, "_geo"):
+        else:
             self._geo = fem.Trimesh2D(
                 tri_vertex_indices=self._tri_vertex_indices, positions=self._vertex_positions, build_bvh=True
             )
@@ -377,9 +378,8 @@ class Example:
     def _rebuild_spaces(self, degree):
         """Rebuild function spaces, fields, and test/trial functions.
 
-        Called after edge flips update ``tri_vertex_indices`` in-place.
-        Reuses the existing geometry objects (avoids non-deterministic topology
-        rebuild) and boundary subdomains (unaffected by interior edge flips).
+        Called from ``_rebuild_fem_structures`` with freshly rebuilt geometry
+        objects and boundary subdomains.
         """
 
         self._u_space = fem.make_polynomial_space(self._geo, degree=degree, dtype=wp.vec2)
@@ -438,13 +438,27 @@ class Example:
         # Write back updated connectivity in-place
         wp.copy(src=wp.array(tri_np, dtype=int), dest=self._tri_vertex_indices)
 
-        # Rebuild spaces and fields on the existing geometry.
-        # We intentionally avoid recreating the Trimesh2D objects: edge flips
-        # only affect interior edges, so boundary structures and projectors
-        # remain valid; and re-running _build_topology() would introduce
-        # non-deterministic edge ordering that perturbs the boundary projector
-        # enough to visibly affect the displacement on ill-conditioned systems.
+        # Recreate the geometry and everything built from it. Although only
+        # interior edges are flipped, a flip also moves the two triangles'
+        # outer edges between them, so the Trimesh2D's cached edge-to-triangle
+        # mapping -- and the triangle BVH used by `fem.lookup` -- go stale
+        # even for edges that were not themselves flipped. Rebuilding the
+        # geometry refreshes this topology so that side quadrature keeps
+        # evaluating at the correct locations.
+        # The flipper rejects flips that would degenerate the reference mesh,
+        # so `_start_geo` can be rebuilt with the same connectivity. The
+        # degree-1 fixed-vertex projector only depends on the left/right
+        # boundary vertex sets, which edge flips never change, so it remains
+        # valid without a rebuild.
+        self._start_geo = fem.Trimesh2D(
+            tri_vertex_indices=self._tri_vertex_indices, positions=self._initial_positions, build_bvh=True
+        )
         self._rebuild_fem_structures(self._degree)
+
+        # Node ordering may change with the rebuilt topology; refresh the
+        # start-geometry node positions used for rendering.
+        start_space = fem.make_polynomial_space(self._start_geo, degree=self._degree, dtype=wp.vec2)
+        self._start_node_positions = start_space.node_positions()
 
     def step(self):
         # Forward step, record adjoint tape for forces


### PR DESCRIPTION
## Description

Closes #1804.

`Example.remesh()` in `warp/examples/fem/example_elastic_shape_optimization.py`
flips edges in-place in `_tri_vertex_indices` and deliberately skipped rebuilding
the `fem.Trimesh2D` objects, on this premise:

> ```
> # We intentionally avoid recreating the Trimesh2D objects: edge flips
> # only affect interior edges, so boundary structures and projectors
> # remain valid; ...
> ```

That premise does not hold. For a flipped pair `t = (a, b, c)` / `n = (a, d, b)`
sharing edge `a-b`, the flip produces `t = (a, d, c)` / `n = (b, c, d)`: the
*unflipped* outer edges `b-c` and `a-d` migrate between the two triangles.
`Trimesh2D` builds `_edge_vertex_indices` / `_edge_tri_indices` once in
`__init__`, so after a flip the cached mapping still claims a migrated edge
belongs to its old triangle. `Trimesh2D._edge_to_tri_coords()` then fails to
match the edge endpoints against the triangle's vertices, falls through its
`if/elif/else`, and silently assigns quadrature coordinates to the wrong vertex
slot — side integrals are evaluated at wrong locations with no error. The
triangle BVH (used by `fem.lookup` in the example's `symmetrize_field`) is also
built once from the original triangles and goes stale the same way.

This PR makes `remesh()` recreate the geometry (with a fresh BVH via
`build_bvh=True`) and everything derived from it, and fixes the misleading
comment.

Alternatives considered:

- **Refresh side topology in place on `Trimesh2D`** (the "cleaner fix" floated
  in the issue). There is no existing topology-refresh API to reuse
  (`Geometry.update_bvh()` only refits an existing BVH, which is insufficient
  after a connectivity change), so this would be new library surface designed
  around one example's needs. Left for a follow-up if maintainers want it.
- **Only refresh `_edge_tri_indices` for migrated edges.** Fragile: flips can
  cascade over multiple passes, and the interior edge list itself is stale
  (flipped edges no longer exist). Rebuilding is the supported path and its
  cost is negligible at the example's remesh cadence (see below).

## Changes

- `Example.remesh()`: after writing back the flipped connectivity, rebuild
  `_start_geo` from the flipped connectivity and the initial positions (the
  flipper already rejects flips that would degenerate the reference mesh,
  precisely so this is valid), then rebuild the FEM structures, then refresh
  `_start_node_positions` (node ordering can change with rebuilt topology).
- `Example._rebuild_fem_structures()`: always recreate `self._geo`
  (previously guarded by `hasattr`, which made remesh reuse the stale
  geometry). The deformed-geometry variant goes through
  `_build_deformed_geo()`, which now wraps the rebuilt `_start_geo`.
- The degree-1 fixed-vertex projector is intentionally *not* rebuilt: its
  nodes are the mesh vertices and it depends only on the left/right boundary
  vertex sets, which edge flips never change (a comment documents this).
- Replace the incorrect comment with one describing the migrated-edge
  mechanism.
- Changelog fragment `changelog/1804.fixed.md`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (Example-only fix; the
      example's harness entry in `warp/tests/fem/test_fem_examples.py` covers
      it on CUDA CI. Repro evidence below.)
- [x] The documentation is up to date with these changes. (No doc changes
      needed; the fix corrects in-code comments.)
- [x] I added a changelog fragment if this change affects users.

## Validation summary

All validation on CPU (`"cpu"` device, macOS arm64). The change is pure Python
topology/bookkeeping — nothing device-specific — but I could not run the CUDA
path locally.

**Minimal repro (red):** on `main`, a 2-triangle mesh (`A=(0,0)`, `B=(2,0)`,
`C=(1,1)`, `D=(1,-0.5)`; triangles `(A,B,C)`, `(A,D,B)`) put through the
example's own `delaunay_edge_flip` (one flip, `A-B -> C-D`) leaves the
pre-flip `Trimesh2D` with 4 stale `_edge_tri_indices` entries — including the
two *boundary* edges `A-D` and `B-C` — and the boundary integral of a P1 field
with dof `(0, 1, 10, 100)` evaluates to **126.504553** against the analytic
value **127.211658** (error 7.1e-1). A `Trimesh2D` rebuilt from the flipped
connectivity gives 127.211660 (error 1.4e-6, float32).

**Example-level repro (red):** instantiating `Example` on `main`, perturbing
the interior vertices into a non-Delaunay state, and calling the example's own
`remesh()` (3 flips) leaves `example._geo` with **12** stale
`_edge_tri_indices` entries, and the integral of a random P1 field over all
mesh sides differs from a rebuilt reference geometry by **9.05e-2**
(9.28141300 vs 9.37189502). In this run the migrated edges are interior
diagonals; the boundary case is covered by the minimal repro above.

**With the fix (green):** the same example-level repro reports **0** stale
entries and the all-sides integral matches the rebuilt reference exactly
(9.37189502 vs 9.37189502, difference 0.0). The post-remesh `step()` runs and
returns a finite loss. The deformed-geometry variant (`mesh="deformed"`) was
exercised through the same perturb → `remesh()` → `step()` → `render()`
sequence: 0 stale entries in the rebuilt `_start_geo`, all stages OK.

**Cost:** `remesh()` goes from ~7 ms to ~9 ms at the default resolution
(res=25, degree 1, CPU), i.e. ~2 ms for the geometry rebuild, against a ~2-3 s
optimization step and a 10-iteration remesh cadence.

**Example still runs:** `uv run warp/examples/fem/example_elastic_shape_optimization.py
--device cpu --headless --num-iters 20` completes cleanly (exit 0). Over 100
iterations with the default remesh cadence the loss is identical to `main`
(constant 0.118115417659 on both) — see note below.

**Existing tests:** `uv run warp/tests/fem/test_fem_geometry.py` — 15 tests,
OK (4 skipped, CUDA-only nanogrid). `uv run warp/tests/fem/test_fem_integrate.py`
— 12 tests, OK (3 skipped). `uv run warp/tests/fem/test_fem_examples.py` — 23
tests, all skipped on CPU (the example tests are CUDA-gated), hence the direct
headless run above.

**Note (pre-existing, untouched):** while validating I noticed that on `main`
the optimization never actually moves the vertices on this build:
`_vertex_positions_scalar = wp.array(self._vertex_positions, dtype=wp.float32).flatten()`
allocates a copy (different `ptr`), so Adam updates never reach
`_vertex_positions` — and the position gradient itself is zero after
`tape.backward()`. Both observations reproduce identically with and without
this PR (loss trace bit-identical to `main`), so flips currently never trigger
organically; the repros above drive `remesh()` directly. This looks like a
separate bug worth its own issue; this PR deliberately does not touch it.

## Bug fix

Minimal code that demonstrates the issue WITHOUT this PR applied:

```python
import numpy as np
import warp as wp
import warp.fem as fem
from warp.examples.fem.example_elastic_shape_optimization import delaunay_edge_flip


@fem.integrand
def field_form(s: fem.Sample, domain: fem.Domain, f: fem.Field):
    return f(s)


# Two CCW triangles sharing edge A-B; D lies inside the circumcircle of
# (A, B, C), so the example's flipper flips A-B -> C-D.
positions_np = np.array([[0.0, 0.0], [2.0, 0.0], [1.0, 1.0], [1.0, -0.5]], dtype=np.float32)
tri_np = np.array([[0, 1, 2], [0, 3, 1]], dtype=np.int64)

positions = wp.array(positions_np, dtype=wp.vec2)
tri_vidx = wp.array(tri_np, dtype=int)
geo = fem.Trimesh2D(tri_vertex_indices=tri_vidx, positions=positions)

flipped_np, _ = delaunay_edge_flip(positions_np, tri_np.copy())
wp.copy(src=wp.array(flipped_np, dtype=int), dest=tri_vidx)  # in-place, as remesh() does

# Boundary edge B-C is cached as belonging to a triangle that no longer contains B:
print(geo.edge_vertex_indices.numpy()[3], "->", geo.tri_vertex_indices.numpy()[geo.edge_tri_indices.numpy()[3][0]])
# [1 2] -> [0 3 2]

# Boundary integral of the P1 field with dof (0, 1, 10, 100); analytic value 127.2117:
space = fem.make_polynomial_space(geo, degree=1, dtype=float)
f = fem.make_discrete_field(space=space)
f.dof_values = wp.array(np.array([0.0, 1.0, 10.0, 100.0]), dtype=float)
print(fem.integrate(field_form, fields={"f": f.trace()}, domain=fem.BoundarySides(geo), output_dtype=float))
# 126.50455  (wrong; a rebuilt Trimesh2D gives 127.21166)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved elastic shape optimization after mesh remeshing.
  * Rebuilt geometry, topology, and spatial data consistently after mesh connectivity changes.
  * Kept finite-element calculations, quadrature, and rendered node positions aligned with the updated mesh.
  * Added support for repeated mesh rebuilds during optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->