### PR TITLE
bvh: fix block-collective divergence in compute_total_bounds (GH-1601)

### DIFF
--- a/warp/native/bvh.cu
+++ b/warp/native/bvh.cu
@@ -459,22 +459,28 @@ __global__ void compute_total_bounds(
 
     const int tid = blockStart + threadIdx.x;
 
+    // BlockReduce::Reduce() and __syncthreads() are block-wide collectives, so every thread
+    // in the block must reach them, including the tail threads with tid >= num_items.
+    // Out-of-range lanes contribute neutral values, which Reduce() ignores through numValid.
+    vec3 lower = vec3(FLT_MAX);
+    vec3 upper = vec3(-FLT_MAX);
+
     if (tid < num_items) {
-        vec3 lower = item_lowers[tid];
-        vec3 upper = item_uppers[tid];
+        lower = item_lowers[tid];
+        upper = item_uppers[tid];
+    }
 
-        vec3 block_upper = BlockReduce(temp_storage).Reduce(upper, Vec3Max, numValid);
+    vec3 block_upper = BlockReduce(temp_storage).Reduce(upper, Vec3Max, numValid);
 
-        // sync threads because second reduce uses same temp storage as first
-        __syncthreads();
+    // sync threads because second reduce uses same temp storage as first
+    __syncthreads();
 
-        vec3 block_lower = BlockReduce(temp_storage).Reduce(lower, Vec3Min, numValid);
+    vec3 block_lower = BlockReduce(temp_storage).Reduce(lower, Vec3Min, numValid);
 
-        if (threadIdx.x == 0) {
-            // write out block results, expanded by the radius
-            atomic_max(total_upper, block_upper);
-            atomic_min(total_lower, block_lower);
-        }
+    if (threadIdx.x == 0) {
+        // write out block results, expanded by the radius
+        atomic_max(total_upper, block_upper);
+        atomic_min(total_lower, block_lower);
     }
 }
 


### PR DESCRIPTION
Fixes #1601.

## Problem

`compute_total_bounds` (`warp/native/bvh.cu`) performs two `cub::BlockReduce::Reduce()` calls and a `__syncthreads()` **inside** `if (tid < num_items)`:

```cuda
if (tid < num_items) {
    vec3 lower = item_lowers[tid];
    vec3 upper = item_uppers[tid];
    vec3 block_upper = BlockReduce(temp_storage).Reduce(upper, Vec3Max, numValid);
    __syncthreads();
    vec3 block_lower = BlockReduce(temp_storage).Reduce(lower, Vec3Min, numValid);
    ...
}
```

`BlockReduce::Reduce` and `__syncthreads()` are block-wide collectives: **every** thread of the block must reach them. When `num_items` is not a multiple of the block size, the tail lanes (`tid >= num_items`) skip the branch, so the collectives run with only part of the block participating — undefined behavior (barrier/shuffle divergence, flagged by `compute-sanitizer --tool synccheck`). It triggers on any GPU LBVH build whose item count is not a multiple of the block size, e.g. `wp.Bvh` / `wp.Mesh` with 300 primitives.

## Fix

Hoist the loads and both `Reduce()` calls + `__syncthreads()` out of the branch. Out-of-range lanes carry neutral sentinels (`lower = vec3(FLT_MAX)`, `upper = vec3(-FLT_MAX)`) which `Reduce()` already ignores through the existing `numValid` count; only the final `atomic_max`/`atomic_min` writes stay under `threadIdx.x == 0`. No behavior change for in-range data.

## Testing

The changed kernel compiles cleanly. I can't run the full CUDA test suite on my dev box, so I have not executed a GPU run here; the change is a pure control-flow hoist that makes the block collectives uniform, and out-of-range lanes are neutralized via the pre-existing `numValid`. A maintainer run of the BVH/mesh tests (e.g. `warp/tests/test_bvh.py`, `test_mesh.py`) with a non-multiple-of-256 primitive count under `compute-sanitizer --tool synccheck` should show the divergence gone.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounds calculation reliability for workloads whose data does not evenly fill processing blocks.
  * Prevented incorrect results and synchronization issues during parallel bounds reduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->