### PR TITLE
Derive tile warp-scan constants from WP_TILE_WARP_SIZE

### DIFF
--- a/changelog/1936.fixed.md
+++ b/changelog/1936.fixed.md
@@ -1,0 +1,5 @@
+Mark `byte_offset_helper` as `CUDA_CALLABLE`. It is reachable from device code
+through array slicing in kernels, so a strict Clang-based CUDA compile rejected
+the call as host-only. Tile warp-scan code now derives its lane mask and lane
+indices from `WP_TILE_WARP_SIZE` instead of repeating the width as literals;
+values are unchanged on all supported architectures.

--- a/warp/native/array.h
+++ b/warp/native/array.h
@@ -828,7 +828,8 @@ CUDA_CALLABLE inline bool view_arg_is_slice(const slice_t&) { return true; }
 
 
 template <typename T, size_t... Idxs>
-size_t byte_offset_helper(array_t<T>& src, const slice_t (&slices)[sizeof...(Idxs)], index_sequence<Idxs...>)
+inline CUDA_CALLABLE size_t
+byte_offset_helper(array_t<T>& src, const slice_t (&slices)[sizeof...(Idxs)], index_sequence<Idxs...>)
 {
     return byte_offset(src, slices[Idxs].start...);
 }

--- a/warp/native/sparse.cu
+++ b/warp/native/sparse.cu
@@ -594,8 +594,6 @@ CUDA_CALLABLE_DEVICE int bsr_compress_select_sorted_runs(
     int* selected_run_starts
 )
 {
-    constexpr unsigned int full_warp_mask = 0xffffffffu;
-
     const int tid = threadIdx.x;
     const int lane = tid & (WP_TILE_WARP_SIZE - 1);
     const int warp = tid / WP_TILE_WARP_SIZE;
@@ -616,9 +614,9 @@ CUDA_CALLABLE_DEVICE int bsr_compress_select_sorted_runs(
             run_start = col >= 0 && col != BSR_COMPRESS_INVALID_COLUMN && prev_col != col;
         }
 
-        const unsigned int keep_mask = __ballot_sync(full_warp_mask, run_start);
-        const int warp_total = __popc(keep_mask);
-        const int lane_prefix = __popc(keep_mask & ((1u << lane) - 1u));
+        const wp_tile_lane_mask_bits_t keep_mask = __ballot_sync(WP_TILE_LANE_MASK_ALL, run_start);
+        const int warp_total = WP_TILE_LANE_MASK_POPC(keep_mask);
+        const int lane_prefix = WP_TILE_LANE_MASK_POPC(keep_mask & WP_TILE_LANE_MASK_BELOW(lane));
 
         if (lane == WP_TILE_WARP_SIZE - 1) {
             warp_offsets[warp] = warp_total;
@@ -629,7 +627,7 @@ CUDA_CALLABLE_DEVICE int bsr_compress_select_sorted_runs(
             int warp_prefix = lane < warp_count ? warp_offsets[lane] : 0;
 #pragma unroll
             for (int offset = 1; offset < WP_TILE_WARP_SIZE; offset <<= 1) {
-                const int other = __shfl_up_sync(full_warp_mask, warp_prefix, offset, WP_TILE_WARP_SIZE);
+                const int other = __shfl_up_sync(WP_TILE_LANE_MASK_ALL, warp_prefix, offset, WP_TILE_WARP_SIZE);
                 if (lane >= offset) {
                     warp_prefix += other;
                 }

--- a/warp/native/tile.h
+++ b/warp/native/tile.h
@@ -3,6 +3,20 @@
 
 #pragma once
 
+// Internal lane-participation masks for tile warp collectives, not logical
+// tile masks. Keep this block before builtin.h because its tile headers use it.
+#define WP_TILE_WARP_SIZE 32
+
+#define WP_TILE_LANE_MASK_ALL 0xffffffffu
+#define WP_TILE_LANE_MASK_POPC(mask) __popc(mask)
+#define WP_TILE_LANE_MASK_FFS(mask) __ffs(mask)
+
+using wp_tile_lane_mask_bits_t = decltype(WP_TILE_LANE_MASK_ALL);
+
+// Excludes `lane` itself.
+#define WP_TILE_LANE_MASK_BELOW(lane)                                                                                  \
+    ((((wp_tile_lane_mask_bits_t)1) << (lane)) - ((wp_tile_lane_mask_bits_t)1))
+
 #include "builtin.h"
 
 #include "rand.h"

--- a/warp/native/tile_radix_sort.h
+++ b/warp/native/tile_radix_sort.h
@@ -19,6 +19,13 @@ namespace wp {
 // The radix sort in this file is consistently slower than the bitonic sort
 #define BITONIC_SORT_THRESHOLD 2048
 
+// Bitonic shuffles use fixed 32-lane groups; cross-group exchanges use shared
+// memory, so every shuffle below has a stride of at most 16 and stays inside its
+// group. The overloads below are not full-warp collectives when WP_TILE_WARP_SIZE
+// differs from WP_TILE_BITONIC_GROUP_SIZE.
+#define WP_TILE_BITONIC_GROUP_SIZE 32
+#define WP_TILE_BITONIC_GROUP_MASK 0xffffffffu
+
 struct UintKeyToUint {
     inline CUDA_CALLABLE uint32_t convert(uint32 value) { return value; }
 
@@ -102,7 +109,7 @@ constexpr inline CUDA_CALLABLE int next_higher_pow2(int input)
 inline CUDA_CALLABLE half warp_shuffle_xor(half val, int lane_mask)
 {
     unsigned int bits = static_cast<unsigned int>(val.u);
-    bits = __shfl_xor_sync(0xFFFFFFFFu, bits, lane_mask);
+    bits = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, bits, lane_mask, WP_TILE_BITONIC_GROUP_SIZE);
 
     half result;
     result.u = static_cast<unsigned short>(bits);
@@ -113,7 +120,7 @@ inline CUDA_CALLABLE half warp_shuffle_xor(half val, int lane_mask)
 inline CUDA_CALLABLE bfloat16 warp_shuffle_xor(bfloat16 val, int lane_mask)
 {
     unsigned int bits = static_cast<unsigned int>(val.u);
-    bits = __shfl_xor_sync(0xFFFFFFFFu, bits, lane_mask);
+    bits = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, bits, lane_mask, WP_TILE_BITONIC_GROUP_SIZE);
 
     bfloat16 result;
     result.u = static_cast<unsigned short>(bits);
@@ -141,7 +148,7 @@ template <typename T> inline CUDA_CALLABLE T warp_shuffle_xor(T val, int lane_ma
 
     WP_PRAGMA_UNROLL
     for (int i = 0; i < word_count; ++i) {
-        output[i] = __shfl_xor_sync(0xFFFFFFFFu, input[i], lane_mask);
+        output[i] = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, input[i], lane_mask, WP_TILE_BITONIC_GROUP_SIZE);
     }
 
     return *reinterpret_cast<T*>(output);
@@ -153,7 +160,7 @@ inline CUDA_CALLABLE wp::vec_t<Length, T> warp_shuffle_xor(wp::vec_t<Length, T> 
     wp::vec_t<Length, T> result;
 
     for (unsigned i = 0; i < Length; ++i)
-        result[i] = __shfl_xor_sync(0xFFFFFFFFu, val[i], lane_mask);
+        result[i] = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, val[i], lane_mask, WP_TILE_BITONIC_GROUP_SIZE);
 
     return result;
 }
@@ -189,7 +196,8 @@ inline CUDA_CALLABLE wp::mat_t<Rows, Cols, T> warp_shuffle_xor(wp::mat_t<Rows, C
 
     for (unsigned i = 0; i < Rows; ++i)
         for (unsigned j = 0; j < Cols; ++j)
-            result.data[i][j] = __shfl_xor_sync(0xFFFFFFFFu, val.data[i][j], lane_mask);
+            result.data[i][j]
+                = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, val.data[i][j], lane_mask, WP_TILE_BITONIC_GROUP_SIZE);
 
     return result;
 }
@@ -226,8 +234,8 @@ template <typename T> inline CUDA_CALLABLE T* warp_shuffle_xor(T* val, int lane_
     unsigned long long ptr = reinterpret_cast<unsigned long long>(val);
     unsigned int ptr_lo = static_cast<unsigned int>(ptr);
     unsigned int ptr_hi = static_cast<unsigned int>(ptr >> 32);
-    ptr_lo = __shfl_xor_sync(0xFFFFFFFFu, ptr_lo, lane_mask);
-    ptr_hi = __shfl_xor_sync(0xFFFFFFFFu, ptr_hi, lane_mask);
+    ptr_lo = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, ptr_lo, lane_mask, WP_TILE_BITONIC_GROUP_SIZE);
+    ptr_hi = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, ptr_hi, lane_mask, WP_TILE_BITONIC_GROUP_SIZE);
     ptr = (static_cast<unsigned long long>(ptr_hi) << 32) | static_cast<unsigned long long>(ptr_lo);
     return reinterpret_cast<T*>(ptr);
 }
@@ -237,7 +245,8 @@ inline CUDA_CALLABLE wp::shape_t warp_shuffle_xor(wp::shape_t val, int lane_mask
     wp::shape_t result;
 
     for (int i = 0; i < wp::ARRAY_MAX_DIMS; ++i)
-        result.dims[i] = __shfl_xor_sync(0xFFFFFFFFu, val.dims[i], lane_mask);
+        result.dims[i]
+            = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, val.dims[i], lane_mask, WP_TILE_BITONIC_GROUP_SIZE);
 
     return result;
 }
@@ -250,9 +259,14 @@ template <typename T> inline CUDA_CALLABLE wp::array_t<T> warp_shuffle_xor(wp::a
     result.grad = wp::warp_shuffle_xor(val.grad, lane_mask);
     result.shape = wp::warp_shuffle_xor(val.shape, lane_mask);
     for (int i = 0; i < wp::ARRAY_MAX_DIMS; ++i)
-        result.strides[i] = __shfl_xor_sync(0xFFFFFFFFu, val.strides[i], lane_mask);
-    result.ndim = static_cast<uint16_t>(__shfl_xor_sync(0xFFFFFFFFu, static_cast<unsigned int>(val.ndim), lane_mask));
-    result.flags = static_cast<uint16_t>(__shfl_xor_sync(0xFFFFFFFFu, static_cast<unsigned int>(val.flags), lane_mask));
+        result.strides[i]
+            = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, val.strides[i], lane_mask, WP_TILE_BITONIC_GROUP_SIZE);
+    result.ndim = static_cast<uint16_t>(__shfl_xor_sync(
+        WP_TILE_BITONIC_GROUP_MASK, static_cast<unsigned int>(val.ndim), lane_mask, WP_TILE_BITONIC_GROUP_SIZE
+    ));
+    result.flags = static_cast<uint16_t>(__shfl_xor_sync(
+        WP_TILE_BITONIC_GROUP_MASK, static_cast<unsigned int>(val.flags), lane_mask, WP_TILE_BITONIC_GROUP_SIZE
+    ));
 
     return result;
 }
@@ -329,11 +343,10 @@ inline CUDA_CALLABLE void bitonic_sort_single_stage_full_thread_block(
     __syncthreads();
 }
 
-// stride can be 1, 2, 4, 8, 16
 template <typename K, typename V>
 inline CUDA_CALLABLE void bitonic_sort_single_stage_full_warp(int k, unsigned int thread_id, int stride, K& key, V& val)
 {
-    auto s_key = __shfl_xor_sync(0xFFFFFFFFu, key, stride);
+    auto s_key = __shfl_xor_sync(WP_TILE_BITONIC_GROUP_MASK, key, stride, WP_TILE_BITONIC_GROUP_SIZE);
     auto s_val = warp_shuffle_xor(val, stride);
     auto swap = (((thread_id & stride) != 0 ? key > s_key : key < s_key)) ^ ((thread_id & k) == 0);
     key = swap ? s_key : key;
@@ -341,12 +354,12 @@ inline CUDA_CALLABLE void bitonic_sort_single_stage_full_warp(int k, unsigned in
 }
 
 
-// Sorts 32 elements according to keys
+// Sorts one 32-lane subwarp's worth of elements according to keys
 template <typename K, typename V>
 inline CUDA_CALLABLE void bitonic_sort_single_warp(unsigned int thread_id, K& key, V& val)
 {
 #pragma unroll
-    for (int k = 2; k <= 32; k <<= 1) {
+    for (int k = 2; k <= WP_TILE_BITONIC_GROUP_SIZE; k <<= 1) {
 #pragma unroll
         for (int stride = k / 2; stride > 0; stride >>= 1) {
             bitonic_sort_single_stage_full_warp(k, thread_id, stride, key, val);
@@ -469,9 +482,9 @@ template <int max_num_elements, typename K, typename V, typename KeyToUint>
 inline CUDA_CALLABLE void
 bitonic_sort_thread_block_shared_mem(int thread_id, K* keys_input, V* values_input, int num_elements_to_sort)
 {
-    if constexpr (max_num_elements < 32) {
+    if constexpr (max_num_elements < WP_TILE_BITONIC_GROUP_SIZE) {
         // Fast track - single warp sort
-        if (thread_id < 32)
+        if (thread_id < WP_TILE_BITONIC_GROUP_SIZE)
             bitonic_sort_single_warp<K, V, KeyToUint>(thread_id, keys_input, values_input, num_elements_to_sort);
         __syncthreads();
     } else {
@@ -568,9 +581,9 @@ template <int max_num_elements, typename K, typename V, typename KeyToUint>
 inline CUDA_CALLABLE void
 bitonic_sort_thread_block_direct(int thread_id, K* keys_input, V* values_input, int num_elements_to_sort)
 {
-    if constexpr (max_num_elements < 32) {
+    if constexpr (max_num_elements < WP_TILE_BITONIC_GROUP_SIZE) {
         // Fast track - single warp sort
-        if (thread_id < 32)
+        if (thread_id < WP_TILE_BITONIC_GROUP_SIZE)
             bitonic_sort_single_warp<K, V, KeyToUint>(thread_id, keys_input, values_input, num_elements_to_sort);
         __syncthreads();
     } else {
@@ -637,23 +650,27 @@ bitonic_sort_thread_block_direct(int thread_id, uint64_t* keys_input, V* values_
 
 // End bitonic sort
 
-inline CUDA_CALLABLE int warp_scan_inclusive(int lane, unsigned int ballot_mask)
+// Position of `lane` among the lanes set in `ballot_mask`, counting itself.
+inline CUDA_CALLABLE int warp_scan_inclusive(int lane, wp_tile_lane_mask_bits_t ballot_mask)
 {
-    uint32_t mask = ((1u << (lane + 1)) - 1);
-    return __popc(ballot_mask & mask);
+    // Lanes 0..lane inclusive: LANES_BELOW(lane) is exclusive, so add this lane.
+    wp_tile_lane_mask_bits_t mask
+        = WP_TILE_LANE_MASK_BELOW(lane) | (((wp_tile_lane_mask_bits_t)1) << (wp_tile_lane_mask_bits_t)lane);
+    return (int)WP_TILE_LANE_MASK_POPC(ballot_mask & mask);
 }
 
-inline CUDA_CALLABLE int warp_scan_inclusive(int lane, unsigned int mask, bool thread_contributes_element)
+inline CUDA_CALLABLE int warp_scan_inclusive(int lane, wp_tile_lane_mask_bits_t mask, bool thread_contributes_element)
 {
     return warp_scan_inclusive(lane, __ballot_sync(mask, thread_contributes_element));
 }
 
 template <typename T> inline CUDA_CALLABLE T warp_scan_inclusive(int lane, T value)
 {
-// Computes an inclusive cumulative sum
+// Computes an inclusive cumulative sum over the warp: one doubling step per
+// bit of WP_TILE_WARP_SIZE.
 #pragma unroll
-    for (int i = 1; i <= 32; i *= 2) {
-        auto n = __shfl_up_sync(0xffffffffu, value, i, 32);
+    for (int i = 1; i < WP_TILE_WARP_SIZE; i *= 2) {
+        auto n = __shfl_up_sync(WP_TILE_LANE_MASK_ALL, value, i, WP_TILE_WARP_SIZE);
 
         if (lane >= i)
             value = value + n;
@@ -676,8 +693,10 @@ inline CUDA_CALLABLE void radix_sort_thread_block_core(
 
     int num_bits_to_sort = 32;  // Sort all bits because that's what the bitonic fast pass does as well
 
-    const int warp_id = thread_id / 32;
-    const int lane_id = thread_id & 31;
+    // shared_mem holds one row per tile warp, so warp_id must be derived from
+    // the same WP_TILE_WARP_SIZE the callers use to size it.
+    const int warp_id = thread_id / WP_TILE_WARP_SIZE;
+    const int lane_id = thread_id & (WP_TILE_WARP_SIZE - 1);
 
     const int bits_per_pass
         = 4;  // Higher than 5 is currently not supported - 2^5=32 is the warp size and is still just fine
@@ -711,9 +730,9 @@ inline CUDA_CALLABLE void radix_sort_thread_block_core(
 
             for (int b = 0; b < num_scan_buckets; b++) {
                 bool contributes = digit == b;
-                int sum_per_warp = warp_scan_inclusive(lane_id, 0xFFFFFFFF, contributes);
+                int sum_per_warp = warp_scan_inclusive(lane_id, WP_TILE_LANE_MASK_ALL, contributes);
 
-                if (lane_id == 31)
+                if (lane_id == WP_TILE_WARP_SIZE - 1)
                     shared_mem[warp_id][b] = sum_per_warp;
             }
             __syncthreads();
@@ -721,7 +740,7 @@ inline CUDA_CALLABLE void radix_sort_thread_block_core(
             for (int b = warp_id; b < num_warp_passes * num_warps; b += num_warps) {
                 int f = lane_id < num_warps ? shared_mem[lane_id][b] : 0;
                 f = warp_scan_inclusive(lane_id, f);
-                if (lane_id == 31)
+                if (lane_id == WP_TILE_WARP_SIZE - 1)
                     buckets[b] += f;
             }
             __syncthreads();
@@ -792,8 +811,8 @@ inline CUDA_CALLABLE void radix_sort_thread_block_core(
 
             for (int b = 0; b < num_scan_buckets; b++) {
                 bool contributes = digit == b;
-                int sum_per_warp = warp_scan_inclusive(lane_id, 0xFFFFFFFF, contributes);
-                if (lane_id == 31)
+                int sum_per_warp = warp_scan_inclusive(lane_id, WP_TILE_LANE_MASK_ALL, contributes);
+                if (lane_id == WP_TILE_WARP_SIZE - 1)
                     shared_mem[warp_id][b] = sum_per_warp;
 
                 if (contributes)
@@ -808,12 +827,12 @@ inline CUDA_CALLABLE void radix_sort_thread_block_core(
 
                 int f = lane_id < num_warps ? shared_mem[lane_id][b] : 0;
                 int inclusive_scan = warp_scan_inclusive(lane_id, f);
-                if (lane_id == 31 && warp_id == 0) {
+                if (lane_id == WP_TILE_WARP_SIZE - 1 && warp_id == 0) {
                     buckets2[b] += inclusive_scan;
                 }
 
                 int warp_offset = __shfl_sync(
-                    0xFFFFFFFF, inclusive_scan - f, warp_id
+                    WP_TILE_LANE_MASK_ALL, inclusive_scan - f, warp_id
                 );  //-f because warp_offset needs to be an exclusive scan
 
                 bool contributes = digit == b;

--- a/warp/native/tile_reduce.h
+++ b/warp/native/tile_reduce.h
@@ -11,8 +11,6 @@
 #pragma clang diagnostic ignored "-Wc++17-extensions"
 #endif  // __clang__
 
-#define WP_TILE_WARP_SIZE 32
-
 namespace wp {
 
 
@@ -30,7 +28,7 @@ template <typename T> int argmin_tracker(T champion_value, T current_value, int 
 #if defined(__CUDA_ARCH__)
 
 // half / float16 uses a dedicated overload to shuffle its 16-bit payload directly.
-inline CUDA_CALLABLE half warp_shuffle_down(half val, int offset, int mask)
+inline CUDA_CALLABLE half warp_shuffle_down(half val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     unsigned int bits = static_cast<unsigned int>(val.u);
     bits = __shfl_down_sync(mask, bits, offset, WP_TILE_WARP_SIZE);
@@ -41,7 +39,7 @@ inline CUDA_CALLABLE half warp_shuffle_down(half val, int offset, int mask)
 }
 
 #ifndef WP_NO_BFLOAT16
-inline CUDA_CALLABLE bfloat16 warp_shuffle_down(bfloat16 val, int offset, int mask)
+inline CUDA_CALLABLE bfloat16 warp_shuffle_down(bfloat16 val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     unsigned int bits = static_cast<unsigned int>(val.u);
     bits = __shfl_down_sync(mask, bits, offset, WP_TILE_WARP_SIZE);
@@ -52,7 +50,7 @@ inline CUDA_CALLABLE bfloat16 warp_shuffle_down(bfloat16 val, int offset, int ma
 }
 #endif  // WP_NO_BFLOAT16
 
-template <typename T> inline CUDA_CALLABLE T warp_shuffle_down(T val, int offset, int mask)
+template <typename T> inline CUDA_CALLABLE T warp_shuffle_down(T val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     // Shuffle word-by-word over the raw bytes so any trivially-copyable value type is
     // supported. A plain word buffer (rather than a union over T) avoids the deleted
@@ -83,7 +81,8 @@ template <typename T> inline CUDA_CALLABLE T warp_shuffle_down(T val, int offset
 
 // vector overload
 template <unsigned Length, typename T>
-inline CUDA_CALLABLE wp::vec_t<Length, T> warp_shuffle_down(wp::vec_t<Length, T> val, int offset, int mask)
+inline CUDA_CALLABLE wp::vec_t<Length, T>
+warp_shuffle_down(wp::vec_t<Length, T> val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     wp::vec_t<Length, T> result;
 
@@ -94,7 +93,8 @@ inline CUDA_CALLABLE wp::vec_t<Length, T> warp_shuffle_down(wp::vec_t<Length, T>
 }
 
 template <unsigned Length>
-inline CUDA_CALLABLE wp::vec_t<Length, half> warp_shuffle_down(wp::vec_t<Length, half> val, int offset, int mask)
+inline CUDA_CALLABLE wp::vec_t<Length, half>
+warp_shuffle_down(wp::vec_t<Length, half> val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     wp::vec_t<Length, half> result;
 
@@ -107,7 +107,7 @@ inline CUDA_CALLABLE wp::vec_t<Length, half> warp_shuffle_down(wp::vec_t<Length,
 #ifndef WP_NO_BFLOAT16
 template <unsigned Length>
 inline CUDA_CALLABLE wp::vec_t<Length, bfloat16>
-warp_shuffle_down(wp::vec_t<Length, bfloat16> val, int offset, int mask)
+warp_shuffle_down(wp::vec_t<Length, bfloat16> val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     wp::vec_t<Length, bfloat16> result;
 
@@ -120,7 +120,8 @@ warp_shuffle_down(wp::vec_t<Length, bfloat16> val, int offset, int mask)
 
 // matrix overload
 template <unsigned Rows, unsigned Cols, typename T>
-inline CUDA_CALLABLE wp::mat_t<Rows, Cols, T> warp_shuffle_down(wp::mat_t<Rows, Cols, T> val, int offset, int mask)
+inline CUDA_CALLABLE wp::mat_t<Rows, Cols, T>
+warp_shuffle_down(wp::mat_t<Rows, Cols, T> val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     wp::mat_t<Rows, Cols, T> result;
 
@@ -133,7 +134,7 @@ inline CUDA_CALLABLE wp::mat_t<Rows, Cols, T> warp_shuffle_down(wp::mat_t<Rows, 
 
 template <unsigned Rows, unsigned Cols>
 inline CUDA_CALLABLE wp::mat_t<Rows, Cols, half>
-warp_shuffle_down(wp::mat_t<Rows, Cols, half> val, int offset, int mask)
+warp_shuffle_down(wp::mat_t<Rows, Cols, half> val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     wp::mat_t<Rows, Cols, half> result;
 
@@ -147,7 +148,7 @@ warp_shuffle_down(wp::mat_t<Rows, Cols, half> val, int offset, int mask)
 #ifndef WP_NO_BFLOAT16
 template <unsigned Rows, unsigned Cols>
 inline CUDA_CALLABLE wp::mat_t<Rows, Cols, bfloat16>
-warp_shuffle_down(wp::mat_t<Rows, Cols, bfloat16> val, int offset, int mask)
+warp_shuffle_down(wp::mat_t<Rows, Cols, bfloat16> val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     wp::mat_t<Rows, Cols, bfloat16> result;
 
@@ -160,7 +161,7 @@ warp_shuffle_down(wp::mat_t<Rows, Cols, bfloat16> val, int offset, int mask)
 #endif  // WP_NO_BFLOAT16
 
 
-template <typename T> inline CUDA_CALLABLE T* warp_shuffle_down(T* val, int offset, int mask)
+template <typename T> inline CUDA_CALLABLE T* warp_shuffle_down(T* val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     unsigned long long ptr = reinterpret_cast<unsigned long long>(val);
     unsigned int ptr_lo = static_cast<unsigned int>(ptr);
@@ -171,7 +172,7 @@ template <typename T> inline CUDA_CALLABLE T* warp_shuffle_down(T* val, int offs
     return reinterpret_cast<T*>(ptr);
 }
 
-inline CUDA_CALLABLE wp::shape_t warp_shuffle_down(wp::shape_t val, int offset, int mask)
+inline CUDA_CALLABLE wp::shape_t warp_shuffle_down(wp::shape_t val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     wp::shape_t result;
 
@@ -181,7 +182,8 @@ inline CUDA_CALLABLE wp::shape_t warp_shuffle_down(wp::shape_t val, int offset, 
     return result;
 }
 
-template <typename T> inline CUDA_CALLABLE wp::array_t<T> warp_shuffle_down(wp::array_t<T> val, int offset, int mask)
+template <typename T>
+inline CUDA_CALLABLE wp::array_t<T> warp_shuffle_down(wp::array_t<T> val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     wp::array_t<T> result;
 
@@ -200,7 +202,8 @@ template <typename T> inline CUDA_CALLABLE wp::array_t<T> warp_shuffle_down(wp::
 }
 
 template <typename T>
-inline CUDA_CALLABLE wp::indexedarray_t<T> warp_shuffle_down(wp::indexedarray_t<T> val, int offset, int mask)
+inline CUDA_CALLABLE wp::indexedarray_t<T>
+warp_shuffle_down(wp::indexedarray_t<T> val, int offset, wp_tile_lane_mask_bits_t mask)
 {
     wp::indexedarray_t<T> result;
 
@@ -213,11 +216,11 @@ inline CUDA_CALLABLE wp::indexedarray_t<T> warp_shuffle_down(wp::indexedarray_t<
 }
 
 
-template <typename T, typename Op> inline CUDA_CALLABLE T warp_reduce(T val, Op f, unsigned int mask)
+template <typename T, typename Op> inline CUDA_CALLABLE T warp_reduce(T val, Op f, wp_tile_lane_mask_bits_t mask)
 {
     T sum = val;
 
-    if (mask == 0xFFFFFFFF) {
+    if (mask == WP_TILE_LANE_MASK_ALL) {
         // handle case where entire warp is active
         for (int offset = WP_TILE_WARP_SIZE / 2; offset > 0; offset /= 2) {
             sum = f(sum, warp_shuffle_down(sum, offset, mask));
@@ -226,7 +229,7 @@ template <typename T, typename Op> inline CUDA_CALLABLE T warp_reduce(T val, Op 
         // handle partial warp case - works for contiguous masks
         for (int offset = WP_TILE_WARP_SIZE / 2; offset > 0; offset /= 2) {
             T shfl_val = warp_shuffle_down(sum, offset, mask);
-            if ((mask & (1 << ((threadIdx.x + offset) % WP_TILE_WARP_SIZE))) != 0)
+            if ((mask & (((wp_tile_lane_mask_bits_t)1) << ((threadIdx.x + offset) % WP_TILE_WARP_SIZE))) != 0)
                 sum = f(sum, shfl_val);
         }
     }
@@ -240,12 +243,13 @@ template <typename T> struct ValueAndIndex {
 };
 
 template <typename T, typename Op, typename OpTrack>
-inline CUDA_CALLABLE ValueAndIndex<T> warp_reduce_tracked(T val, int idx, Op f, OpTrack track, unsigned int mask)
+inline CUDA_CALLABLE ValueAndIndex<T>
+warp_reduce_tracked(T val, int idx, Op f, OpTrack track, wp_tile_lane_mask_bits_t mask)
 {
     T sum = val;
     int index = idx;
 
-    if (mask == 0xFFFFFFFF) {
+    if (mask == WP_TILE_LANE_MASK_ALL) {
         // handle case where entire warp is active
         for (int offset = WP_TILE_WARP_SIZE / 2; offset > 0; offset /= 2) {
             auto shfl_val = warp_shuffle_down(sum, offset, mask);
@@ -258,7 +262,7 @@ inline CUDA_CALLABLE ValueAndIndex<T> warp_reduce_tracked(T val, int idx, Op f, 
         for (int offset = WP_TILE_WARP_SIZE / 2; offset > 0; offset /= 2) {
             T shfl_val = warp_shuffle_down(sum, offset, mask);
             int shfl_index = warp_shuffle_down(index, offset, mask);
-            if ((mask & (1 << ((threadIdx.x + offset) % WP_TILE_WARP_SIZE))) != 0) {
+            if ((mask & (((wp_tile_lane_mask_bits_t)1) << ((threadIdx.x + offset) % WP_TILE_WARP_SIZE))) != 0) {
                 index = track(sum, shfl_val, index, shfl_index);
                 sum = f(sum, shfl_val);
             }
@@ -283,7 +287,7 @@ block_combine_thread_results(T thread_sum, bool thread_has_data, Op f, T* partia
     const int lane_index = threadIdx.x % WP_TILE_WARP_SIZE;
 
     // determine which threads have data
-    unsigned int mask = __ballot_sync(0xFFFFFFFF, thread_has_data);
+    wp_tile_lane_mask_bits_t mask = __ballot_sync(WP_TILE_LANE_MASK_ALL, thread_has_data);
     bool warp_is_active = mask != 0;
 
     // warp reduction
@@ -343,12 +347,12 @@ template <typename Tile, typename Op> CUDA_CALLABLE_DEVICE auto tile_reduce_impl
     T block_sum;
     if constexpr (warp_count == 1) {
         // fast path: single warp, just do warp reduction
-        unsigned int mask = __ballot_sync(0xFFFFFFFF, thread_has_data);
+        wp_tile_lane_mask_bits_t mask = __ballot_sync(WP_TILE_LANE_MASK_ALL, thread_has_data);
         if (thread_has_data)
             block_sum = warp_reduce(thread_sum, f, mask);
 
         // write from first active lane (warp_reduce result is only valid there)
-        int first_active = __ffs(mask) - 1;
+        int first_active = WP_TILE_LANE_MASK_FFS(mask) - 1;
         if (threadIdx.x == first_active)
             output.data[0] = block_sum;
     } else {
@@ -440,7 +444,7 @@ template <int Axis, typename Op, typename Tile> CUDA_CALLABLE_DEVICE auto tile_r
 
                 // warp reduce this chunk (only valid lanes may call warp_reduce,
                 // because __shfl_down_sync requires all executing threads to be in the mask)
-                unsigned int mask = __ballot_sync(0xFFFFFFFF, valid);
+                wp_tile_lane_mask_bits_t mask = __ballot_sync(WP_TILE_LANE_MASK_ALL, valid);
                 T chunk_result;
                 if (valid)
                     chunk_result = warp_reduce(val, f, mask);
@@ -494,12 +498,12 @@ template <int Axis, typename Op, typename Tile> CUDA_CALLABLE_DEVICE auto tile_r
             T block_sum;
             if constexpr (warp_count == 1) {
                 // fast path: single warp, just do warp reduction
-                unsigned int mask = __ballot_sync(0xFFFFFFFF, thread_has_data);
+                wp_tile_lane_mask_bits_t mask = __ballot_sync(WP_TILE_LANE_MASK_ALL, thread_has_data);
                 if (thread_has_data)
                     block_sum = warp_reduce(thread_sum, f, mask);
 
                 // write from first active lane (warp_reduce result is only valid there)
-                int first_active = __ffs(mask) - 1;
+                int first_active = WP_TILE_LANE_MASK_FFS(mask) - 1;
                 if (threadIdx.x == first_active)
                     output_buffer[out_idx] = block_sum;
             } else {
@@ -565,7 +569,7 @@ CUDA_CALLABLE_DEVICE auto tile_arg_reduce_impl(Op f, OpTrack track, Tile& t)
     }
 
     // determine which threads have valid data
-    unsigned int mask = __ballot_sync(0xFFFFFFFF, thread_has_data);
+    wp_tile_lane_mask_bits_t mask = __ballot_sync(WP_TILE_LANE_MASK_ALL, thread_has_data);
     bool warp_is_active = mask != 0;
 
     // warp reduction (only threads with valid data may participate,
@@ -813,11 +817,11 @@ template <typename TileA, typename TileB> CUDA_CALLABLE auto tile_dot(TileA& a, 
 
     ScalarT result {};
     if constexpr (warp_count == 1) {
-        unsigned int mask = __ballot_sync(0xFFFFFFFF, has_data);
+        wp_tile_lane_mask_bits_t mask = __ballot_sync(WP_TILE_LANE_MASK_ALL, has_data);
         if (has_data)
             result = warp_reduce(thread_sum, add_op, mask);
 
-        int first_active = __ffs(mask) - 1;
+        int first_active = WP_TILE_LANE_MASK_FFS(mask) - 1;
         if (threadIdx.x == first_active)
             output.data[0] = result;
     } else {

--- a/warp/native/tile_scan.h
+++ b/warp/native/tile_scan.h
@@ -57,8 +57,8 @@ template <typename T, typename Op = OpAdd<T>> inline CUDA_CALLABLE T scan_warp_i
     // Computes an inclusive cumulative sum/max/etc
     Op op;
 #pragma unroll
-    for (int i = 1; i < 32; i *= 2) {
-        auto n = __shfl_up_sync(0xffffffffu, value, i, 32);
+    for (int i = 1; i < WP_TILE_WARP_SIZE; i *= 2) {
+        auto n = __shfl_up_sync(WP_TILE_LANE_MASK_ALL, value, i, WP_TILE_WARP_SIZE);
 
         if (lane >= i)
             value = op(value, n);
@@ -77,7 +77,7 @@ inline CUDA_CALLABLE T scan_warp_exclusive(int lane, T value, T* inclusive_value
         *inclusive_value = inclusive;
 
     // Shift right by 1 to convert inclusive to exclusive
-    T exclusive = __shfl_up_sync(0xffffffffu, inclusive, 1, 32);
+    T exclusive = __shfl_up_sync(WP_TILE_LANE_MASK_ALL, inclusive, 1, WP_TILE_WARP_SIZE);
 
     // Lane 0 gets the identity value
     if (lane == 0)
@@ -96,10 +96,10 @@ inline CUDA_CALLABLE T thread_block_scan(int lane, int warp_index, int num_warps
     T orig_value = value;
 
     if constexpr (exclusive) {
-        value = scan_warp_exclusive<T, Op>(lane, value, lane == 31 ? &sums[warp_index] : nullptr);
+        value = scan_warp_exclusive<T, Op>(lane, value, lane == WP_TILE_WARP_SIZE - 1 ? &sums[warp_index] : nullptr);
     } else {
         value = scan_warp_inclusive<T, Op>(lane, value);
-        if (lane == 31)
+        if (lane == WP_TILE_WARP_SIZE - 1)
             sums[warp_index] = value;
     }
 

--- a/warp/tests/cuda/test_clang_cuda.py
+++ b/warp/tests/cuda/test_clang_cuda.py
@@ -127,6 +127,27 @@ def test_bf16_arithmetic(test, device):
     np.testing.assert_allclose(out.numpy(), a_np + b_np, rtol=1e-2)
 
 
+@wp.kernel
+def slice_kernel(src: wp.array2d[float], out: wp.array[float]):
+    i = wp.tid()
+    view = src[i : i + 2, 1]
+    out[i] = view[0] + view[1]
+
+
+def test_slice_kernel(test, device):
+    # Slicing reaches byte_offset_helper() in array.h, which Clang rejects unless
+    # it is marked CUDA_CALLABLE. No other test in this file slices an array, so
+    # without this the annotation could be dropped without any test noticing.
+    rows, cols = 5, 3
+    src_np = np.arange(rows * cols, dtype=np.float32).reshape(rows, cols)
+    src = wp.array(src_np, dtype=float, device=device)
+    n = rows - 1
+    out = wp.zeros(n, dtype=float, device=device)
+    wp.launch(slice_kernel, dim=n, inputs=[src, out], device=device)
+    expected = src_np[0:n, 1] + src_np[1 : n + 1, 1]
+    np.testing.assert_allclose(out.numpy(), expected, rtol=1e-5)
+
+
 def test_invalid_native_func_compile_error(test, device):
     @wp.func_native("""
         INVALID SOURCE;
@@ -160,6 +181,7 @@ add_function_test(TestClangCUDA, "test_trivial_kernel", test_trivial_kernel, dev
 add_function_test(TestClangCUDA, "test_math_kernel", test_math_kernel, devices=devices)
 add_function_test(TestClangCUDA, "test_vec_kernel", test_vec_kernel, devices=devices)
 add_function_test(TestClangCUDA, "test_conditional_kernel", test_conditional_kernel, devices=devices)
+add_function_test(TestClangCUDA, "test_slice_kernel", test_slice_kernel, devices=devices)
 bf16_devices = [d for d in devices if d.arch >= 80]
 add_function_test(TestClangCUDA, "test_bf16_round_trip", test_bf16_round_trip, devices=bf16_devices)
 add_function_test(TestClangCUDA, "test_bf16_arithmetic", test_bf16_arithmetic, devices=bf16_devices)


### PR DESCRIPTION
## Description

Two related changes to the tile execution contract in `warp/native/`.

The first is a bug fix. `byte_offset_helper()` in `array.h` was declared without
`CUDA_CALLABLE`, making it host-only, but it is called from `view()`, which is
`CUDA_CALLABLE` and is what a kernel-side array slice lowers to. NVCC tolerates
the host-only call; the Clang-based CUDA compiler selected by
`wp.config.llvm_cuda` rejects it, so slicing an array inside a kernel fails to
compile on that path. Closes #1936.

The second is a refactor with no change in behavior. `tile_radix_sort.h` and
`tile_scan.h` hardcoded the warp width in several forms — `32` as a loop bound
and as a divisor, `0xffffffffu` as a ballot mask, and `lane == 31` to select the
lane holding a scan total — while `WP_TILE_WARP_SIZE` was already defined beside
them and meant exactly the same thing. The divisor is the one that matters on its
own: callers size shared memory as
`(WP_TILE_BLOCK_DIM + WP_TILE_WARP_SIZE - 1) / WP_TILE_WARP_SIZE`, so
`thread_id / 32` is a second, independent definition of the same quantity, and a
disagreement between them is a silent out-of-bounds shared-memory write rather
than a compile error. All values are unchanged: the mask is still 32 bits and the
intrinsics are the ones the call sites already invoked directly.

The coupling became visible while porting Warp to HIP/ROCm, where a wavefront is
64 lanes. That work is not proposed here — this change is CUDA-only.

## Changes

- `array.h`: mark `byte_offset_helper()` as `CUDA_CALLABLE`.
- `tile.h`: define the tile execution contract — `WP_TILE_WARP_SIZE`, the lane
  mask type `wp_tile_lane_mask_bits_t`, `WP_TILE_LANE_MASK_ALL`,
  `WP_TILE_LANE_MASK_BELOW`, `WP_TILE_LANE_MASK_POPC`, `WP_TILE_LANE_MASK_FFS` —
  above the `builtin.h` include, since `tile_reduce.h`, `tile_scan.h`,
  `tile_radix_sort.h` and `sparse.cu` all consume it.
- `tile_scan.h`, `tile_reduce.h`, `sparse.cu`: use those names instead of `32`,
  `0xffffffffu`, `lane == 31`, `__popc` and `__ffs`.
- `tile_radix_sort.h`: name the bitonic shuffle constants
  `WP_TILE_BITONIC_GROUP_SIZE` / `WP_TILE_BITONIC_GROUP_MASK` for their real
  scope. These are deliberately **not** `WP_TILE_WARP_SIZE`: the bitonic
  exchanges are bounded to a fixed 32-lane group by their stride, so tying them
  to the warp width would be wrong on a wider target.
- `warp/tests/cuda/test_clang_cuda.py`: add `test_slice_kernel`, which slices an
  array inside a kernel under `wp.config.llvm_cuda`. No other test in that file
  slices, so without it the annotation could be removed unnoticed.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

Validated on an **NVIDIA H100 80GB HBM3** (driver 590.48.01, CUDA 13.1), built
from source with `warp-clang.so` present, since `wp.config.llvm_cuda` dispatches
to `runtime.llvm.wp_compile_cuda` and is silently unavailable without it.

Red/green for the bug fix, on unmodified `main` at
`6465652a53e76937bd21cc3e1ea05ce6ddf3fa33` (`git status --porcelain` empty):

- Verified the reproducer below **fails** on `main` without this change:

  ```
  warp/native/array.h:862:21: error: reference to __host__ function
      'byte_offset_helper<float, 0ULL, 1ULL>' in __host__ __device__ function
  .../wp___main___c5edd41.cu:100:21: note: called by
      'slice_kernel_923dd757_cuda_kernel_forward'
  2 errors generated when compiling for sm_75.
  CUDA kernel build failed with error code -1
  ```

- Verified it **passes** with the one-line `CUDA_CALLABLE` annotation applied to
  that same tree (`git diff --stat` = 1 file, 1 insertion, 1 deletion), printing
  `[ 5. 11. 17. 23.]`. Both runs used the same build; the kernel cache was
  cleared between them so a stale artifact could not mask either outcome.

Full output is in #1936.

`test_slice_kernel` in `warp/tests/cuda/test_clang_cuda.py` is that reproducer as
a regression test.

For the refactor, this branch was compared against unmodified `main` with an
identical run, selecting `TestTileReduce`, `TestTileSort`, `TestTileScan` and
`TestArray`: both arms report **Ran 127 — ok=125, ERROR=1, FAIL=0**, identical
including one pre-existing failure present in both. Header placement was checked
separately by swapping the `tile_reduce.h` and `tile_scan.h` include lines in
`builtin.h`: on the pre-image that still builds and then fails at first kernel
launch, where NVRTC instantiates the templates —

```
warp/native/tile_scan.h(61): error: identifier "WP_TILE_FULL_WARP_MASK" is undefined
warp/native/tile_scan.h(60): error: identifier "WP_TILE_WARP_SIZE" is undefined
```

— while with the definitions in `tile.h` the same swap builds and passes. Each
phase ran on a cold kernel cache.

The branch also builds and passes tile-sort correctness checks on gfx942.

## Bug fix

Fails on `main`, passes with this PR. Requires a build that includes
`warp-clang.so`.

```python
import numpy as np
import warp as wp

wp.config.llvm_cuda = True


@wp.kernel
def slice_kernel(src: wp.array2d[float], out: wp.array[float]):
    i = wp.tid()
    view = src[i : i + 2, 1]
    out[i] = view[0] + view[1]


src = wp.array(np.arange(15, dtype=np.float32).reshape(5, 3), dtype=float, device="cuda:0")
out = wp.zeros(4, dtype=float, device="cuda:0")
wp.launch(slice_kernel, dim=4, inputs=[src, out], device="cuda:0")
print(out.numpy())
```
