### PR TITLE
Fix FEM dynamic cache identities

### DIFF
--- a/changelog/1866.fixed.md
+++ b/changelog/1866.fixed.md
@@ -1,0 +1,1 @@
+Prevent implicit fields, hexahedral meshes, and point-basis spaces with distinct evaluation functions or options from reusing incompatible generated code.

--- a/warp/_src/fem/field/field.py
+++ b/warp/_src/fem/field/field.py
@@ -345,6 +345,11 @@ class ImplicitField(GeometryField):
         self._func_arg = self.EvalArg()
         self.values = values
 
+        func_key = self._func.native_func
+        grad_key = self._grad_func.native_func if self._grad_func is not None else "None"
+        div_key = self._div_func.native_func if self._div_func is not None else "None"
+        self._name = f"Implicit_{self.domain.name}_{self.degree}_{self.EvalArg.key}_{func_key}_{grad_key}_{div_key}"
+
         cache.setup_dynamic_attributes(self)
 
     @property
@@ -384,8 +389,8 @@ class ImplicitField(GeometryField):
 
     @property
     def name(self) -> str:
-        """Unique name encoding the domain and argument structure."""
-        return f"Implicit_{self.domain.name}_{self.degree}_{self.EvalArg.key}"
+        """Unique name encoding the domain, argument structure, and evaluation functions."""
+        return self._name
 
     def gradient_valid(self) -> bool:
         """Whether gradient evaluation is available."""

--- a/warp/_src/fem/geometry/hexmesh.py
+++ b/warp/_src/fem/geometry/hexmesh.py
@@ -181,7 +181,7 @@ class Hexmesh(Geometry):
             hex_vertex_indices: warp array of shape (num_hexes, 8) containing vertex indices for each hex
                 following standard ordering (bottom face vertices in counter-clockwise order, then similarly for upper face)
             positions: warp array of shape (num_vertices, 3) containing 3d position for each vertex
-            assume_parallelepiped: If true, assume that all cells are parallelepipeds (cheaper position/gradient evaluations)
+            assume_parallelepiped_cells: If true, assume that all cells are parallelepipeds (cheaper position/gradient evaluations)
             build_bvh: Whether to also build the hex BVH, which is necessary for the global ``fem.lookup`` operator
             temporary_store: shared pool from which to allocate temporary arrays
             cell_env: Optional per-cell environment indices. If provided, ``env_count`` must also be provided.
@@ -225,6 +225,12 @@ class Hexmesh(Geometry):
     @property
     def scalar_type(self):
         return self._scalar_type
+
+    @property
+    def name(self) -> str:
+        """Unique name including the cell evaluation mode."""
+        evaluation_mode = "parallelepiped" if self.parallelepiped_cells else "general"
+        return f"{super().name}_{evaluation_mode}"
 
     def cell_count(self):
         """Number of cells in the mesh."""

--- a/warp/_src/fem/space/point_basis_space.py
+++ b/warp/_src/fem/space/point_basis_space.py
@@ -197,6 +197,10 @@ class PointBasisSpace(BasisSpace):
             use_evaluation_point_index=use_evaluation_point_index,
         )
 
+        kernel_key = self.kernel_func.native_func
+        grad_key = self.kernel_grad_func.native_func if self.kernel_grad_func is not None else "None"
+        self._name = f"{self._topology.name}_{kernel_key}_{grad_key}_{self._distance_space}"
+
         cache.setup_dynamic_attributes(self)
         self._kernel_arg = self.ValueStruct()
         self.kernel_values = kernel_values or {}
@@ -216,7 +220,7 @@ class PointBasisSpace(BasisSpace):
     @property
     def name(self):
         """Unique name of the basis space."""
-        return f"{self._topology.name}_{self.kernel_func.key}_{self._distance_space}"
+        return self._name
 
     @property
     def value(self) -> ShapeFunction.Value:

--- a/warp/tests/fem/aux_test_function_cache_1.py
+++ b/warp/tests/fem/aux_test_function_cache_1.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provide same-named Warp functions for FEM evaluator-cache identity tests.
+
+This module is paired with ``aux_test_function_cache_2``. Matching function
+names intentionally return different values so tests detect evaluator reuse
+across distinct Warp function identities.
+"""
+
+import warp as wp
+
+
+# Unique modules give the paired implicit functions matching Warp keys and
+# module names but distinct native identities.
+@wp.func(module="unique")
+def implicit_func(x: wp.vec2):
+    return 1.0
+
+
+@wp.func(module="unique")
+def implicit_grad_func(x: wp.vec2):
+    return wp.vec2(3.0, 4.0)
+
+
+@wp.func(module="unique")
+def implicit_div_func(x: wp.vec2):
+    return 5.0
+
+
+# Distinct explicit shared modules exercise named-module identity separately
+# from the unique-module case above.
+@wp.func(module="warp.tests.fem.function.cache.module")
+def point_kernel_func(squared_dist: float, point_index: int):
+    return 1.0
+
+
+@wp.func(module="warp.tests.fem.function.cache.module")
+def point_kernel_grad_func(squared_dist: float, point_index: int):
+    return 0.0

--- a/warp/tests/fem/aux_test_function_cache_2.py
+++ b/warp/tests/fem/aux_test_function_cache_2.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provide same-named Warp functions for FEM evaluator-cache identity tests.
+
+This module is paired with ``aux_test_function_cache_1``. Matching function
+names intentionally return different values so tests detect evaluator reuse
+across distinct Warp function identities.
+"""
+
+import warp as wp
+
+
+# Unique modules give the paired implicit functions matching Warp keys and
+# module names but distinct native identities.
+@wp.func(module="unique")
+def implicit_func(x: wp.vec2):
+    return 2.0
+
+
+@wp.func(module="unique")
+def implicit_grad_func(x: wp.vec2):
+    return wp.vec2(7.0, 8.0)
+
+
+@wp.func(module="unique")
+def implicit_div_func(x: wp.vec2):
+    return 6.0
+
+
+# Distinct explicit shared modules exercise named-module identity separately
+# from the unique-module case above.
+@wp.func(module="warp_tests_fem_function_cache_module")
+def point_kernel_func(squared_dist: float, point_index: int):
+    return 2.0
+
+
+@wp.func(module="warp_tests_fem_function_cache_module")
+def point_kernel_grad_func(squared_dist: float, point_index: int):
+    return 1.0

--- a/warp/tests/fem/test_fem_field.py
+++ b/warp/tests/fem/test_fem_field.py
@@ -8,6 +8,8 @@ import numpy as np
 
 import warp as wp
 import warp.fem as fem
+import warp.tests.fem.aux_test_function_cache_1 as function_cache_module_1
+import warp.tests.fem.aux_test_function_cache_2 as function_cache_module_2
 from warp.fem.linalg import spherical_part
 from warp.fem.utils import (
     grid_to_hexes,
@@ -79,6 +81,42 @@ def aniso_bicubic_grad(x: wp.vec2, scale: wp.vec2):
 
 
 @wp.func
+def _implicit_constant_one(x: wp.vec2):
+    return 1.0
+
+
+@wp.func
+def _implicit_constant_two(x: wp.vec2):
+    return 2.0
+
+
+def _make_deferred_static_implicit_func(values):
+    @wp.func(name="deferred_static_implicit_func", module="unique")
+    def implicit_func(x: wp.vec2):
+        result = 0.0
+        for i in range(wp.static(len(values))):
+            result += wp.static(values[i])
+        return result
+
+    return implicit_func
+
+
+@wp.func
+def _implicit_constant_gradient(x: wp.vec2):
+    return wp.vec2(3.0, 4.0)
+
+
+@wp.func
+def _implicit_vector_constant(x: wp.vec2):
+    return wp.vec2(1.0, 2.0)
+
+
+@wp.func
+def _implicit_constant_divergence(x: wp.vec2):
+    return 5.0
+
+
+@wp.func
 def _expect_near(a: Any, b: Any, tol: float):
     wp.expect_near(a, b, tol)
 
@@ -121,6 +159,11 @@ def _expect_tangential_continuity(s: fem.Sample, domain: fem.Domain, field: fem.
 
     _expect_near(in_t, out_t, 0.0001)
     return 0.0
+
+
+@fem.integrand
+def _div_field(s: fem.Sample, p: fem.Field):
+    return fem.div(p, s)
 
 
 @fem.integrand
@@ -212,6 +255,206 @@ def test_dof_mapper(test, device):
             # Check that value is unitary for Frobenius norm 0.5 * |tau:tau|
             frob_norm2 = 0.5 * wp.ddot(mat, mat)
             test.assertAlmostEqual(frob_norm2, 1.0, places=6)
+
+
+def test_implicit_field_function_identity(test, device):
+    """Verify that implicit fields with different functions do not share evaluators."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2))
+        domain = fem.Cells(geo)
+        space = fem.make_polynomial_space(geo)
+        dest = fem.make_discrete_field(space)
+
+        # Keep every structural cache input equal so only the value function distinguishes the fields.
+        field_one = fem.ImplicitField(domain, func=_implicit_constant_one)
+        field_two = fem.ImplicitField(domain, func=_implicit_constant_two)
+
+        fem.interpolate(field_one, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.ones(9))
+
+        fem.interpolate(field_two, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.full(9, 2.0))
+
+
+def test_implicit_field_function_module_identity(test, device):
+    """Verify that same-named functions from different modules do not share evaluators."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2))
+        domain = fem.Cells(geo)
+        dest = fem.make_polynomial_space(geo).make_field()
+
+        # The paired functions share a Warp key and module name but have distinct native identities.
+        field_one = fem.ImplicitField(domain, func=function_cache_module_1.implicit_func)
+        field_two = fem.ImplicitField(domain, func=function_cache_module_2.implicit_func)
+
+        fem.interpolate(field_one, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.ones(9))
+
+        fem.interpolate(field_two, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.full(9, 2.0))
+
+
+def test_implicit_field_deferred_static_identity(test, device):
+    """Verify that deferred static values distinguish implicit field evaluators."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2))
+        domain = fem.Cells(geo)
+        dest = fem.make_polynomial_space(geo).make_field()
+
+        field_one = fem.ImplicitField(domain, func=_make_deferred_static_implicit_func([1.0, 2.0]))
+        field_two = fem.ImplicitField(domain, func=_make_deferred_static_implicit_func([10.0, 20.0]))
+
+        fem.interpolate(field_one, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.full(9, 3.0))
+
+        fem.interpolate(field_two, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.full(9, 30.0))
+
+
+def test_implicit_field_gradient_module_identity(test, device):
+    """Verify that same-named gradients from different modules do not share evaluators."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2))
+        domain = fem.Cells(geo)
+        dest = fem.make_polynomial_space(geo, dtype=wp.vec2).make_field()
+
+        # Keep the value function fixed so only the gradient function changes the cache identity.
+        field_one = fem.ImplicitField(
+            domain,
+            func=_implicit_constant_one,
+            grad_func=function_cache_module_1.implicit_grad_func,
+            degree=4,
+        )
+        field_two = fem.ImplicitField(
+            domain,
+            func=_implicit_constant_one,
+            grad_func=function_cache_module_2.implicit_grad_func,
+            degree=4,
+        )
+
+        fem.interpolate(grad_field, fields={"p": field_one}, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.tile((3.0, 4.0), (9, 1)))
+
+        fem.interpolate(grad_field, fields={"p": field_two}, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.tile((7.0, 8.0), (9, 1)))
+
+
+def test_implicit_field_divergence_module_identity(test, device):
+    """Verify that same-named divergences from different modules do not share evaluators."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2))
+        domain = fem.Cells(geo)
+        dest = fem.make_polynomial_space(geo).make_field()
+
+        # Keep the value function fixed so only the divergence function changes the cache identity.
+        field_one = fem.ImplicitField(
+            domain,
+            func=_implicit_vector_constant,
+            div_func=function_cache_module_1.implicit_div_func,
+            degree=4,
+        )
+        field_two = fem.ImplicitField(
+            domain,
+            func=_implicit_vector_constant,
+            div_func=function_cache_module_2.implicit_div_func,
+            degree=4,
+        )
+
+        fem.interpolate(_div_field, fields={"p": field_one}, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.full(9, 5.0))
+
+        fem.interpolate(_div_field, fields={"p": field_two}, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.full(9, 6.0))
+
+
+def test_implicit_field_does_not_share_gradient(test, device):
+    """Verify that a gradientless field still rejects gradient evaluation."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2))
+        domain = fem.Cells(geo)
+        vec_space = fem.make_polynomial_space(geo, dtype=wp.vec2)
+        dest = fem.make_discrete_field(vec_space)
+
+        # Build the gradient-capable field first to expose cache contamination in the later field.
+        field_with_gradient = fem.ImplicitField(
+            domain,
+            func=_implicit_constant_one,
+            grad_func=_implicit_constant_gradient,
+            degree=1,
+        )
+        field_without_gradient = fem.ImplicitField(domain, func=_implicit_constant_one, degree=1)
+
+        fem.interpolate(grad_field, fields={"p": field_with_gradient}, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.tile((3.0, 4.0), (9, 1)))
+
+        with test.assertRaisesRegex(TypeError, r"Operator `grad` is not defined"):
+            fem.interpolate(grad_field, fields={"p": field_without_gradient}, dest=dest)
+
+
+def test_implicit_field_does_not_drop_gradient(test, device):
+    """Verify that a later gradient-capable field still evaluates its gradient."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2))
+        domain = fem.Cells(geo)
+        vec_space = fem.make_polynomial_space(geo, dtype=wp.vec2)
+        dest = fem.make_discrete_field(vec_space)
+
+        # Prime the cache without a gradient, then evaluate a later field through interpolation.
+        fem.ImplicitField(domain, func=_implicit_constant_two, degree=2)
+        field_with_gradient = fem.ImplicitField(
+            domain,
+            func=_implicit_constant_two,
+            grad_func=_implicit_constant_gradient,
+            degree=2,
+        )
+
+        fem.interpolate(grad_field, fields={"p": field_with_gradient}, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.tile((3.0, 4.0), (9, 1)))
+
+
+def test_implicit_field_does_not_share_divergence(test, device):
+    """Verify that a divergence-free field still rejects divergence evaluation."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2))
+        domain = fem.Cells(geo)
+        space = fem.make_polynomial_space(geo)
+        dest = fem.make_discrete_field(space)
+
+        # Build the divergence-capable field first to expose cache contamination in the later field.
+        field_with_divergence = fem.ImplicitField(
+            domain,
+            func=_implicit_vector_constant,
+            div_func=_implicit_constant_divergence,
+            degree=3,
+        )
+        field_without_divergence = fem.ImplicitField(domain, func=_implicit_vector_constant, degree=3)
+
+        fem.interpolate(_div_field, fields={"p": field_with_divergence}, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.full(9, 5.0))
+
+        with test.assertRaisesRegex(TypeError, r"Operator `div` is not defined"):
+            fem.interpolate(_div_field, fields={"p": field_without_divergence}, dest=dest)
+
+
+def test_implicit_field_does_not_drop_divergence(test, device):
+    """Verify that a later divergence-capable field still evaluates its divergence."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2))
+        domain = fem.Cells(geo)
+        space = fem.make_polynomial_space(geo)
+        dest = fem.make_discrete_field(space)
+
+        # Prime the cache without divergence, then evaluate a later field through interpolation.
+        fem.ImplicitField(domain, func=_implicit_vector_constant, degree=5)
+        field_with_divergence = fem.ImplicitField(
+            domain,
+            func=_implicit_vector_constant,
+            div_func=_implicit_constant_divergence,
+            degree=5,
+        )
+
+        fem.interpolate(_div_field, fields={"p": field_with_divergence}, dest=dest)
+        assert_np_equal(dest.dof_values.numpy(), np.full(9, 5.0))
 
 
 def test_implicit_fields(test, device):
@@ -487,6 +730,57 @@ class TestFemField(unittest.TestCase):
 
 add_function_test(TestFemField, "test_vector_spaces", test_vector_spaces, devices=devices)
 add_function_test(TestFemField, "test_dof_mapper", test_dof_mapper)
+add_function_test(
+    TestFemField, "test_implicit_field_function_identity", test_implicit_field_function_identity, devices=devices
+)
+add_function_test(
+    TestFemField,
+    "test_implicit_field_function_module_identity",
+    test_implicit_field_function_module_identity,
+    devices=devices,
+)
+add_function_test(
+    TestFemField,
+    "test_implicit_field_deferred_static_identity",
+    test_implicit_field_deferred_static_identity,
+    devices=devices,
+)
+add_function_test(
+    TestFemField,
+    "test_implicit_field_gradient_module_identity",
+    test_implicit_field_gradient_module_identity,
+    devices=devices,
+)
+add_function_test(
+    TestFemField,
+    "test_implicit_field_divergence_module_identity",
+    test_implicit_field_divergence_module_identity,
+    devices=devices,
+)
+add_function_test(
+    TestFemField,
+    "test_implicit_field_does_not_share_gradient",
+    test_implicit_field_does_not_share_gradient,
+    devices=devices,
+)
+add_function_test(
+    TestFemField,
+    "test_implicit_field_does_not_drop_gradient",
+    test_implicit_field_does_not_drop_gradient,
+    devices=devices,
+)
+add_function_test(
+    TestFemField,
+    "test_implicit_field_does_not_share_divergence",
+    test_implicit_field_does_not_share_divergence,
+    devices=devices,
+)
+add_function_test(
+    TestFemField,
+    "test_implicit_field_does_not_drop_divergence",
+    test_implicit_field_does_not_drop_divergence,
+    devices=devices,
+)
 add_function_test(TestFemField, "test_implicit_fields", test_implicit_fields)
 add_function_test(
     TestFemField,

--- a/warp/tests/fem/test_fem_geometry.py
+++ b/warp/tests/fem/test_fem_geometry.py
@@ -15,6 +15,10 @@ from warp.fem.utils import grid_to_hexes, grid_to_quads, grid_to_tets, grid_to_t
 from warp.tests.unittest_utils import *
 
 
+class _CacheIdentityHexmesh(fem.Hexmesh):
+    """Provide an isolated evaluator-cache namespace for cache identity tests."""
+
+
 def _gen_trimesh(Nx, Ny):
     x = np.linspace(0.0, 1.0, Nx + 1)
     y = np.linspace(0.0, 1.0, Ny + 1)
@@ -68,6 +72,11 @@ def _test_geo_cells(
     cell_measures: wp.array[float],
 ):
     wp.atomic_add(cell_measures, s.element_index, fem.measure(domain, s) * s.qp_weight)
+
+
+@fem.integrand(kernel_options={"enable_backward": False})
+def _cell_position(s: fem.Sample, domain: fem.Domain):
+    return domain(s)
 
 
 @fem.integrand(kernel_options={"enable_backward": False, "max_unroll": 2})
@@ -344,6 +353,37 @@ def test_hex_mesh(test, device):
 
     assert_np_equal(side_measures.numpy(), np.full(side_measures.shape, 1.0 / (N**2)), tol=1.0e-4)
     assert_np_equal(cell_measures.numpy(), np.full(cell_measures.shape, 1.0 / (N**3)), tol=1.0e-4)
+
+
+def test_hex_mesh_evaluation_mode_identity(test, device):
+    """Verify that Hexmesh evaluation modes do not share cached evaluators."""
+    with wp.ScopedDevice(device):
+        # Distort vertex 6 so the general trilinear center differs from the parallelepiped shortcut.
+        positions = wp.array(
+            [
+                (0.0, 0.0, 0.0),
+                (1.0, 0.0, 0.0),
+                (1.0, 1.0, 0.0),
+                (0.0, 1.0, 0.0),
+                (0.0, 0.0, 1.0),
+                (1.0, 0.0, 1.0),
+                (2.0, 2.0, 2.0),
+                (0.0, 1.0, 1.0),
+            ],
+            dtype=wp.vec3,
+            device=device,
+        )
+        vertex_indices = wp.array([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=int, device=device)
+
+        # Prime the isolated cache namespace with the shortcut before constructing the general mesh.
+        _CacheIdentityHexmesh(vertex_indices, positions, assume_parallelepiped_cells=True)
+        general_mesh = _CacheIdentityHexmesh(vertex_indices, positions, assume_parallelepiped_cells=False)
+
+        quadrature = fem.RegularQuadrature(fem.Cells(general_mesh), order=0)
+        sampled_position = wp.empty(1, dtype=wp.vec3, device=device)
+        fem.interpolate(_cell_position, dest=sampled_position, at=quadrature)
+
+        np.testing.assert_allclose(sampled_position.numpy(), [[0.625, 0.625, 0.625]])
 
 
 def test_nanogrid(test, device):
@@ -880,6 +920,9 @@ add_function_test(TestFemGeometry, "test_mesh_guess_lookup_radius", test_mesh_gu
 add_function_test(TestFemGeometry, "test_grid_3d", test_grid_3d, devices=devices)
 add_function_test(TestFemGeometry, "test_tet_mesh", test_tet_mesh, devices=devices)
 add_function_test(TestFemGeometry, "test_hex_mesh", test_hex_mesh, devices=devices)
+add_function_test(
+    TestFemGeometry, "test_hex_mesh_evaluation_mode_identity", test_hex_mesh_evaluation_mode_identity, devices=devices
+)
 add_function_test(TestFemGeometry, "test_nanogrid", test_nanogrid, devices=cuda_devices)
 add_function_test(TestFemGeometry, "test_nanogrid_rebuild", test_nanogrid_rebuild, devices=devices)
 add_function_test(

--- a/warp/tests/fem/test_fem_quadrature.py
+++ b/warp/tests/fem/test_fem_quadrature.py
@@ -7,6 +7,8 @@ import numpy as np
 
 import warp as wp
 import warp.fem as fem
+import warp.tests.fem.aux_test_function_cache_1 as function_cache_module_1
+import warp.tests.fem.aux_test_function_cache_2 as function_cache_module_2
 from warp._src.fem.geometry.element import LinearEdge, Polynomial, Triangle
 from warp._src.fem.operator import element_partition_index, node_partition_index
 from warp.fem import Coords, Domain, Field, Sample, div, integrand
@@ -183,6 +185,86 @@ def test_point_basis(test, device):
         np.array([ref_grad, -ref_grad], dtype=float),
         rtol=1.0e-6,
     )
+
+
+def test_point_basis_gradient_identity(test, device):
+    """Verify that point bases with different gradient functions do not share evaluators."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(1))
+        quadrature = fem.RegularQuadrature(fem.Cells(geo), order=0)
+        kernel_values = {"radius": 1.0}
+
+        # Prime the cache with a gradient-capable basis before constructing its gradientless sibling.
+        fem.PointBasisSpace(
+            quadrature,
+            kernel_func=_rbf_kernel_func,
+            kernel_grad_func=_rbf_kernel_grad_func,
+            kernel_values=kernel_values,
+        )
+        basis_without_gradient = fem.PointBasisSpace(
+            quadrature,
+            kernel_func=_rbf_kernel_func,
+            kernel_values=kernel_values,
+        )
+
+        point_field = fem.make_collocated_function_space(basis_without_gradient).make_field()
+        point_field.dof_values.fill_(1.0)
+        dest = fem.make_polynomial_space(geo, dtype=wp.vec2).make_field()
+        fem.interpolate(grad_field, fields={"p": point_field}, dest=dest)
+
+        np.testing.assert_array_equal(dest.dof_values.numpy(), np.zeros((4, 2)))
+
+
+def test_point_basis_kernel_module_identity(test, device):
+    """Verify that same-named kernels from different modules do not share evaluators."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(1))
+        quadrature = fem.RegularQuadrature(fem.Cells(geo), order=0)
+
+        basis_one = fem.PointBasisSpace(quadrature, kernel_func=function_cache_module_1.point_kernel_func)
+        basis_two = fem.PointBasisSpace(quadrature, kernel_func=function_cache_module_2.point_kernel_func)
+        dest = fem.make_polynomial_space(geo).make_field()
+
+        # Unit dofs make each result depend only on the selected constant-valued kernel.
+        point_field_one = fem.make_collocated_function_space(basis_one).make_field()
+        point_field_one.dof_values.fill_(1.0)
+        fem.interpolate(point_field_one, dest=dest)
+        np.testing.assert_array_equal(dest.dof_values.numpy(), np.ones(4))
+
+        point_field_two = fem.make_collocated_function_space(basis_two).make_field()
+        point_field_two.dof_values.fill_(1.0)
+        fem.interpolate(point_field_two, dest=dest)
+        np.testing.assert_array_equal(dest.dof_values.numpy(), np.full(4, 2.0))
+
+
+def test_point_basis_gradient_module_identity(test, device):
+    """Verify that same-named gradient kernels from different modules do not share evaluators."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(1))
+        quadrature = fem.RegularQuadrature(fem.Cells(geo), order=0)
+
+        basis_one = fem.PointBasisSpace(
+            quadrature,
+            kernel_func=function_cache_module_1.point_kernel_func,
+            kernel_grad_func=function_cache_module_1.point_kernel_grad_func,
+        )
+        basis_two = fem.PointBasisSpace(
+            quadrature,
+            kernel_func=function_cache_module_1.point_kernel_func,
+            kernel_grad_func=function_cache_module_2.point_kernel_grad_func,
+        )
+        dest = fem.make_polynomial_space(geo, dtype=wp.vec2).make_field()
+
+        # Unit dofs make the zero/nonzero result depend only on the selected gradient function.
+        point_field_one = fem.make_collocated_function_space(basis_one).make_field()
+        point_field_one.dof_values.fill_(1.0)
+        fem.interpolate(grad_field, fields={"p": point_field_one}, dest=dest)
+        np.testing.assert_array_equal(dest.dof_values.numpy(), np.zeros((4, 2)))
+
+        point_field_two = fem.make_collocated_function_space(basis_two).make_field()
+        point_field_two.dof_values.fill_(1.0)
+        fem.interpolate(grad_field, fields={"p": point_field_two}, dest=dest)
+        test.assertGreater(np.linalg.norm(dest.dof_values.numpy()), 0.0)
 
 
 def test_particle_quadratures(test, device):
@@ -379,11 +461,28 @@ class TestFemQuadrature(unittest.TestCase):
     pass
 
 
+devices = get_test_devices()
+
 add_function_test(TestFemQuadrature, "test_regular_quadrature", test_regular_quadrature)
 add_function_test(TestFemQuadrature, "test_nodal_quadrature", test_nodal_quadrature)
 add_function_test(TestFemQuadrature, "test_particle_quadratures", test_particle_quadratures)
 add_function_test(TestFemQuadrature, "test_gimp_quadrature", test_gimp_quadrature)
 add_function_test(TestFemQuadrature, "test_point_basis", test_point_basis)
+add_function_test(
+    TestFemQuadrature, "test_point_basis_gradient_identity", test_point_basis_gradient_identity, devices=devices
+)
+add_function_test(
+    TestFemQuadrature,
+    "test_point_basis_kernel_module_identity",
+    test_point_basis_kernel_module_identity,
+    devices=devices,
+)
+add_function_test(
+    TestFemQuadrature,
+    "test_point_basis_gradient_module_identity",
+    test_point_basis_gradient_module_identity,
+    devices=devices,
+)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2, failfast=True)


### PR DESCRIPTION
## Description

FEM caches dynamically generated evaluators under object-derived names. `ImplicitField`, `Hexmesh`, and `PointBasisSpace` omitted function identities or evaluation options from those names, allowing distinct objects to reuse incompatible generated code. Depending on construction order, this could produce incorrect values, expose unsupported gradients or divergences, or suppress supported ones.

Closes #1866.

## Changes

- Add an identifier-safe cache key derived from a Warp function’s global identity.
- Include value, gradient, and divergence functions in `ImplicitField` cache identities.
- Include the cell evaluation mode in `Hexmesh` cache identities.
- Include kernel and optional gradient functions in `PointBasisSpace` cache identities.
- Add CPU and CUDA regressions covering observable interpolation behavior, both optional-function construction orders, same-named functions from different modules, and distinct Hexmesh evaluation modes.
- Correct the `Hexmesh` constructor parameter name in its docstring.
- Add a changelog fragment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

- Temporarily restored the old `ImplicitField` cache identity and confirmed the four construction-order regressions detect the bug through user-facing behavior: unsupported gradient or divergence operations are wrongly accepted, while supported operations are wrongly rejected.
- Restored the fix and ran all 22 `TestFemField` tests successfully on CPU and CUDA.
- Verified the new Hexmesh and point-basis cache regressions on CPU and CUDA in targeted FEM geometry and quadrature runs.
- Ran the changed-file pre-commit hooks successfully.
- No graph-capture tests were added. The full test suite was not run because validation was limited to the affected FEM components.

## Bug fix

```python
import numpy as np

import warp as wp
import warp.fem as fem


@wp.func
def constant_one(x: wp.vec2):
    return 1.0


@wp.func
def constant_two(x: wp.vec2):
    return 2.0


geometry = fem.Grid2D(res=wp.vec2i(2))
domain = fem.Cells(geometry)
destination = fem.make_polynomial_space(geometry).make_field()

fem.interpolate(fem.ImplicitField(domain, func=constant_one), dest=destination)
fem.interpolate(fem.ImplicitField(domain, func=constant_two), dest=destination)

# Before this fix, the second field could reuse the first field's evaluator.
np.testing.assert_array_equal(destination.dof_values.numpy(), np.full(9, 2.0))
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incompatible evaluator reuse in finite element workflows.
  * Improved cache separation for implicit fields with different evaluation functions or options.
  * Ensured point-basis spaces distinguish evaluators with different gradients, modules, or configurations.
  * Distinguished hexahedral mesh evaluation modes to prevent incorrect results when switching between parallelepiped and general-cell handling.

* **Documentation**
  * Updated hexahedral mesh constructor documentation to reflect the current evaluation-mode option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->