### PR TITLE
Reject invalid graph coloring edge indices

### DIFF
--- a/changelog/1868.fixed.md
+++ b/changelog/1868.fixed.md
@@ -1,0 +1,1 @@
+Reject graph-coloring edges with endpoint indices outside the node range instead of allowing out-of-bounds native memory access.

--- a/warp/_src/coloring.py
+++ b/warp/_src/coloring.py
@@ -153,13 +153,18 @@ def graph_coloring_balance(
 
     node_count = node_colors.shape[0]
 
-    return runtime.core.wp_balance_coloring(
+    max_min_ratio = runtime.core.wp_balance_coloring(
         node_count,
         edges.__ctype__(),
         color_count,
         target_max_min_ratio,
         node_colors.__ctype__(),
     )
+
+    if max_min_ratio < 0.0:
+        raise RuntimeError("Graph coloring balance failed")
+
+    return max_min_ratio
 
 
 @wp.kernel

--- a/warp/native/coloring.cpp
+++ b/warp/native/coloring.cpp
@@ -49,6 +49,16 @@ struct Graph {
         for (size_t edge_idx = 0; edge_idx < edges.shape[0]; edge_idx++) {
             int e0 = *address(edges, edge_idx, 0);
             int e1 = *address(edges, edge_idx, 1);
+
+            if (e0 < 0 || e0 >= num_nodes || e1 < 0 || e1 >= num_nodes) {
+                fprintf(
+                    stderr, "Graph edge %zu has endpoints (%d, %d), but valid node indices are in the range [0, %d).\n",
+                    edge_idx, e0, e1, num_nodes
+                );
+                valid = false;
+                return;
+            }
+
             node_degrees[e0] += 1;
             node_degrees[e1] += 1;
         }
@@ -89,6 +99,7 @@ struct Graph {
     std::vector<int> graph_flatten;
     std::vector<int> node_offsets;
     std::vector<int> node_colors;
+    bool valid = true;
 };
 
 void convert_to_color_groups(
@@ -506,6 +517,10 @@ int wp_graph_coloring(int num_nodes, wp::array_t<int> edges, int algorithm, wp::
     // convert to a format that coloring algorithm can recognize
 
     Graph graph(num_nodes, edges);
+    if (!graph.valid) {
+        // Color counts are non-negative, so use -1 to signal failure.
+        return -1;
+    }
 
     int num_colors = -1;
     switch (algorithm) {
@@ -542,6 +557,11 @@ float wp_balance_coloring(
 )
 {
     Graph graph(num_nodes, edges);
+    if (!graph.valid) {
+        // Ratios are non-negative, so use -1.f to signal failure.
+        return -1.f;
+    }
+
     // copy the color info to graph
     memcpy(graph.node_colors.data(), node_colors.data, num_nodes * sizeof(int));
     if (num_colors > 1) {

--- a/warp/tests/test_coloring.py
+++ b/warp/tests/test_coloring.py
@@ -174,6 +174,28 @@ def create_lattice_grid(N):
 
 
 class TestColoring(unittest.TestCase):
+    def test_coloring_rejects_invalid_edge_indices(self):
+        """Verify graph coloring rejects edges with invalid node indices."""
+        node_colors = wp.empty(2, dtype=wp.int32, device="cpu")
+
+        for invalid_edge in ((-1, 0), (0, -1), (2, 0), (0, 2)):
+            with self.subTest(invalid_edge=invalid_edge):
+                edges = wp.array([invalid_edge], dtype=wp.int32, device="cpu")
+
+                with self.assertRaisesRegex(RuntimeError, "Graph coloring failed"):
+                    wp.utils.graph_coloring_assign(edges, node_colors)
+
+    def test_coloring_balance_rejects_invalid_edge_indices(self):
+        """Verify graph coloring balance rejects edges with invalid node indices."""
+        node_colors = wp.array([0, 1], dtype=wp.int32, device="cpu")
+
+        for invalid_edge in ((-1, 0), (0, -1), (2, 0), (0, 2)):
+            with self.subTest(invalid_edge=invalid_edge):
+                edges = wp.array([invalid_edge], dtype=wp.int32, device="cpu")
+
+                with self.assertRaisesRegex(RuntimeError, "Graph coloring balance failed"):
+                    wp.utils.graph_coloring_balance(edges, node_colors, color_count=2, target_max_min_ratio=1.1)
+
     def test_coloring_corner_case(self):
         """Test corner cases: empty graph and simple 2-node graph."""
         # Test 1: Simple 2-node graph with one edge connecting the nodes


### PR DESCRIPTION
## Description

Graph coloring trusted edge endpoints before using them to index native adjacency vectors. An endpoint outside `[0, node_count)` could cause heap corruption, a segmentation fault, or an incorrect result.

This change validates endpoints while constructing the native graph. Both coloring APIs now report invalid graph data with a Python `RuntimeError`.

Closes #1868.

## Changes

- Validate both endpoints of every edge before accessing graph storage.
- Propagate validation failures through `graph_coloring_assign()` and `graph_coloring_balance()`.
- Test negative and upper-bound indices in both endpoint positions.
- Add a changelog fragment for the fix.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

The new tests failed against `upstream/main`, where malformed edges could terminate the process through native memory corruption.

After the fix, all five tests in `warp/tests/test_coloring.py` pass. The quick native build and pre-commit checks for the changed files also pass.

## Bug fix

Before this change, the following example may abort the process:

```python
import warp as wp

edges = wp.array([[0, -1]], dtype=wp.int32, device="cpu")
node_colors = wp.empty(2, dtype=wp.int32, device="cpu")

wp.utils.graph_coloring_assign(edges, node_colors)
```

With this change, `graph_coloring_assign()` raises `RuntimeError` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graph coloring and balancing now reject edges with negative or out-of-range vertex indices.
  * Invalid graph data produces a clear runtime error instead of risking unsafe memory access.
  * Coloring operations stop safely when graph validation fails.
  * Balancing now reports failures consistently when processing invalid graph inputs.

* **Tests**
  * Added coverage for invalid edge indices during coloring and balancing operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->