### PR TITLE
Update pre-commit tooling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -277,7 +277,7 @@ SpacesInParensOptions:
   InEmptyParentheses: false
   Other:           false
 SpacesInSquareBrackets: false
-Standard:        Latest
+Standard:        c++17
 StatementAttributeLikeMacros:
   - Q_EMIT
 StatementMacros:

--- a/.claude/skills/warp-release-notes/references/feature-release-template.md
+++ b/.claude/skills/warp-release-notes/references/feature-release-template.md
@@ -237,7 +237,7 @@ shape. Example:
   out = wp.zeros(N, dtype=float, requires_grad=True)
   ...
   tape.backward()
-  print(out.grad)   # v1.12: ones, v1.13: zeros
+  print(out.grad)  # v1.12: ones, v1.13: zeros
 
   # v1.13 migration: ...
   ```

--- a/.claude/skills/warp-release-notes/references/style-rules.md
+++ b/.claude/skills/warp-release-notes/references/style-rules.md
@@ -330,7 +330,7 @@ with wp.Tape() as tape:
     wp.launch(forward_kernel, dim=N, inputs=[x], outputs=[out])
 out.grad = wp.ones_like(out)
 tape.backward()
-print(out.grad)   # v1.12: ones, v1.13: zeros
+print(out.grad)  # v1.12: ones, v1.13: zeros
 
 # v1.13 migration: keep output grads, pass fresh seeds each call
 out = wp.array(shape=N, dtype=float, requires_grad=True, retain_grad=True)

--- a/.codex/skills/warp-release-notes/references/feature-release-template.md
+++ b/.codex/skills/warp-release-notes/references/feature-release-template.md
@@ -237,7 +237,7 @@ shape. Example:
   out = wp.zeros(N, dtype=float, requires_grad=True)
   ...
   tape.backward()
-  print(out.grad)   # v1.12: ones, v1.13: zeros
+  print(out.grad)  # v1.12: ones, v1.13: zeros
 
   # v1.13 migration: ...
   ```

--- a/.codex/skills/warp-release-notes/references/style-rules.md
+++ b/.codex/skills/warp-release-notes/references/style-rules.md
@@ -330,7 +330,7 @@ with wp.Tape() as tape:
     wp.launch(forward_kernel, dim=N, inputs=[x], outputs=[out])
 out.grad = wp.ones_like(out)
 tape.backward()
-print(out.grad)   # v1.12: ones, v1.13: zeros
+print(out.grad)  # v1.12: ones, v1.13: zeros
 
 # v1.13 migration: keep output grads, pass fresh seeds each call
 out = wp.array(shape=N, dtype=float, requires_grad=True, retain_grad=True)

--- a/.github/workflows/build-llvm-sdk.yml
+++ b/.github/workflows/build-llvm-sdk.yml
@@ -365,8 +365,9 @@ jobs:
 
       - name: Install uv
         if: ${{ env.SKIP_BUILD != '1' && !startsWith(matrix.platform, 'linux') }}
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
+          version: "0.12.7"
           # This workflow runs once or twice a year; caching would only
           # churn the repository's 10 GB Actions cache quota.
           enable-cache: false

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,9 +29,9 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,9 @@ jobs:
           lfs: true
       
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
       
       - name: Set up Python
         run: uv python install
@@ -149,9 +149,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install 3.14t
@@ -238,9 +238,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install
@@ -365,9 +365,9 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install
@@ -419,9 +419,9 @@ jobs:
           lfs: true
       
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
       
       - name: Set up Python
         run: uv python install
@@ -466,9 +466,9 @@ jobs:
           lfs: true
       
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
       
       - name: Set up Python
         run: uv python install
@@ -621,9 +621,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install
@@ -707,9 +707,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install
@@ -797,9 +797,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install 3.14t
@@ -877,9 +877,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install
@@ -953,9 +953,9 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install
@@ -1055,9 +1055,9 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
 
       - name: Set up Python
         run: uv python install
@@ -1089,9 +1089,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
       - name: Set up Python
         run: uv python install
       - name: Download Warp binaries
@@ -1383,9 +1383,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
       - name: Set up Python
         run: uv python install
       - name: Run pyright on stub file

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -88,9 +88,9 @@ jobs:
           echo "metadata_only=$metadata_only" >> "$GITHUB_OUTPUT"
           echo "Doc version: $version  (metadata_only=$metadata_only)"
       - name: Install uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          version: "0.11.16"
+          version: "0.12.7"
       - name: Set up Python
         run: uv python install
       - name: Build Warp without CUDA Support

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,9 +46,9 @@ variables:
   UV_PYTHON_PREFERENCE: only-managed
   
   # Standard container images (pinned with SHA256 for supply chain security)
-  UV_TRIXIE_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-trixie@sha256:3a10099599f370305314be6af0cf18fdbc65ea5ddadb3731561dd920f1d185b8"
-  UV_TRIXIE_SLIM_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-trixie-slim@sha256:bf3ae2823f0399092f2e47ec7bae6a8e0b389d2310a9bc7f0741f0fa1629040f"
-  UV_TRIXIE_SLIM_ARM_IMAGE: "ghcr.io/astral-sh/uv:0.11.16-trixie-slim@sha256:e4e5baeeb366609825aadbe4387686c39dab036b0cc68d938fcb9a61aa05bf75"
+  UV_TRIXIE_IMAGE: "ghcr.io/astral-sh/uv:0.12.7-trixie@sha256:20cd86504a183da51c633012c37903c41c54837f0ff53f6c2298fd1f001148c9"
+  UV_TRIXIE_SLIM_IMAGE: "ghcr.io/astral-sh/uv:0.12.7-trixie-slim@sha256:bd3571a45f9fcd715ca26938a30ef0bbe85a813d4a7c3e9a7dc0e27997f1a442"
+  UV_TRIXIE_SLIM_ARM_IMAGE: "ghcr.io/astral-sh/uv:0.12.7-trixie-slim@sha256:f0c9e8c3b86decaa94dbb7e134d3a3241b7cf4c8c66da2f1bc257d8036bca972"
   MINIFORGE_IMAGE: "condaforge/miniforge3:25.11.0-0@sha256:d2fadb08950045962fd1cfb1eeb6224442027f03095862e725f4c1c7b17a3caf"
   # Stale pin, and harmless. These tags name older images that still bake in LLVM 21,
   # from before the builder image stopped shipping Clang/LLVM at all. Nothing links

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         pass_filenames: false
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.20
+    rev: v0.16.5
     hooks:
       # Run the linter.
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
       # Update the uv lockfile
       - id: uv-lock
   - repo: https://github.com/crate-ci/typos
-    rev: v1.48.0
+    rev: v1.50.0
     hooks:
       - id: typos
   - repo: https://github.com/pre-commit/mirrors-clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     hooks:
       - id: typos
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v22.1.5
+    rev: v23.1.0
     hooks:
       - id: clang-format
         types_or: [c++, c, cuda]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
       - id: ruff-format
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.11.26
+    rev: 0.12.7
     hooks:
       # Update the uv lockfile
       - id: uv-lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -440,11 +440,13 @@ from warp.tests.unittest_utils import *
 def test_amazing_code_test_one(test, device):
     pass
 
+
 devices = get_test_devices()
 
 
 class TestAmazingCode(unittest.TestCase):
     pass
+
 
 add_function_test(TestAmazingCode, "test_amazing_code_test_one", test_amazing_code_test_one, devices=devices)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,7 +263,7 @@ integration (e.g., VS Code format-on-save), install the version specified in `.p
 # Ubuntu/Debian - Install from apt.llvm.org
 # See https://apt.llvm.org/ for repository setup instructions
 # Check .pre-commit-config.yaml for the current version
-sudo apt-get install clang-format-21
+sudo apt-get install clang-format-23
 ```
 
 For other platforms, consult the LLVM documentation for installation instructions. We recommend using pre-commit

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ import numpy as np
 num_particles = 1_000_000
 dt = 0.01
 
+
 @wp.kernel
 def gravity_step(pos: wp.array[wp.vec3], vel: wp.array[wp.vec3]):
     i = wp.tid()
@@ -40,6 +41,7 @@ def gravity_step(pos: wp.array[wp.vec3], vel: wp.array[wp.vec3]):
     acc = -1000.0 / dist_sq * wp.normalize(position)  # gravitational pull toward origin
     vel[i] = vel[i] + acc * dt
     pos[i] = pos[i] + vel[i] * dt
+
 
 rng = np.random.default_rng(42)
 positions = wp.array(rng.normal(size=(num_particles, 3)), dtype=wp.vec3)

--- a/design/hardware-coherent-memory-access.md
+++ b/design/hardware-coherent-memory-access.md
@@ -414,15 +414,11 @@ Add the properties to `Device.__init__` for CUDA devices:
 
 ```python
 # Unified CPU/GPU memory access capability properties
-self.is_cpu_memory_access_from_gpu_supported = (
-    runtime.core.wp_cuda_device_get_pageable_memory_access(ordinal) > 0
-)
+self.is_cpu_memory_access_from_gpu_supported = runtime.core.wp_cuda_device_get_pageable_memory_access(ordinal) > 0
 self.is_gpu_memory_access_from_cpu_supported = (
     runtime.core.wp_cuda_device_get_direct_managed_mem_access_from_host(ordinal) > 0
 )
-self.is_cpu_gpu_atomic_supported = (
-    runtime.core.wp_cuda_device_get_host_native_atomic_supported(ordinal) > 0
-)
+self.is_cpu_gpu_atomic_supported = runtime.core.wp_cuda_device_get_host_native_atomic_supported(ordinal) > 0
 ```
 
 For the CPU device branch, set all three Python properties to `False`.
@@ -936,9 +932,7 @@ if value.device != device and warp.config.auto_prefetch:
         try:
             stream_handle = device.stream.cuda_stream if device.is_cuda else 0
             device_ordinal = device.ordinal if device.is_cuda else -1
-            runtime.core.wp_cuda_mem_prefetch_async(
-                value.ptr, value.capacity, device_ordinal, stream_handle
-            )
+            runtime.core.wp_cuda_mem_prefetch_async(value.ptr, value.capacity, device_ordinal, stream_handle)
         except Exception:
             pass  # Prefetch is best-effort
 ```
@@ -1196,9 +1190,9 @@ This phase should add public built-in allocator accessors with names based on
 memory behavior, not on historical defaults:
 
 ```python
-wp.get_cuda_device_allocator(device)      # cudaMalloc / cudaFree device memory
-wp.get_cuda_mempool_allocator(device)     # cudaMallocAsync / cudaFreeAsync pool memory
-wp.get_cuda_managed_allocator()           # cudaMallocManaged managed memory
+wp.get_cuda_device_allocator(device)  # cudaMalloc / cudaFree device memory
+wp.get_cuda_mempool_allocator(device)  # cudaMallocAsync / cudaFreeAsync pool memory
+wp.get_cuda_managed_allocator()  # cudaMallocManaged managed memory
 ```
 
 With those accessors, users can write:

--- a/design/pluggable-allocators.md
+++ b/design/pluggable-allocators.md
@@ -64,6 +64,7 @@ support named allocator types.
 ```python
 from typing import Protocol, runtime_checkable
 
+
 @runtime_checkable
 class Allocator(Protocol):
     def allocate(self, size_in_bytes: int) -> int: ...
@@ -104,6 +105,7 @@ duplication of the validation logic and error message.
 # In Device.__init__, CUDA branch, after existing allocator setup:
 self._custom_allocator = None
 
+
 # Modified get_allocator():
 def get_allocator(self, pinned: bool = False):
     if self.is_cuda:
@@ -143,6 +145,7 @@ def set_cuda_allocator(allocator: Allocator | None) -> None:
     for device in devices:
         device._custom_allocator = allocator
 
+
 def set_device_allocator(device: DeviceLike, allocator: Allocator | None) -> None:
     """Set the memory allocator for a specific CUDA device."""
     device = get_device(device)
@@ -150,6 +153,7 @@ def set_device_allocator(device: DeviceLike, allocator: Allocator | None) -> Non
         raise RuntimeError("Custom allocators are only supported on CUDA devices")
     _validate_allocator(allocator)
     device._custom_allocator = allocator
+
 
 def get_device_allocator(device: DeviceLike) -> Allocator:
     """Get the current effective memory allocator for a device."""
@@ -271,12 +275,14 @@ class RmmAllocator:
         """Return an RMM ``Stream`` wrapping the current Warp device's CUDA stream."""
         from rmm.pylibrmm.stream import Stream as RmmStream
         from warp._src.context import runtime
+
         return RmmStream(obj=runtime.get_current_cuda_device().stream)
 
     def allocate(self, size_in_bytes: int) -> int:
         if size_in_bytes == 0:
             return 0
         import rmm
+
         buf = rmm.DeviceBuffer(size=size_in_bytes, stream=self._get_rmm_stream())
         ptr = buf.ptr
         self._buffers[ptr] = buf
@@ -288,9 +294,7 @@ class RmmAllocator:
         try:
             del self._buffers[ptr]
         except KeyError:
-            raise RuntimeError(
-                f"RmmAllocator.deallocate called with unrecognized pointer {ptr:#x} ..."
-            ) from None
+            raise RuntimeError(f"RmmAllocator.deallocate called with unrecognized pointer {ptr:#x} ...") from None
 ```
 
 ##### Stream handling

--- a/design/unified-logging.md
+++ b/design/unified-logging.md
@@ -142,6 +142,7 @@ class MyLogger:
     def warning(self, message, category=None, stacklevel=1): ...
     def error(self, message): ...
 
+
 wp.set_logger(MyLogger())
 ```
 

--- a/skills/warp-compile-time-optimizer/SKILL.md
+++ b/skills/warp-compile-time-optimizer/SKILL.md
@@ -165,7 +165,7 @@ Scope the option to the measured process, before importing the library:
 ```python
 import warp as wp
 
-wp.config.enable_backward = False   # must precede the library import
+wp.config.enable_backward = False  # must precede the library import
 
 import the_library
 ```

--- a/skills/warp-compile-time-optimizer/references/mechanisms.md
+++ b/skills/warp-compile-time-optimizer/references/mechanisms.md
@@ -67,11 +67,13 @@ def run(values):
     @wp.kernel
     def first(x: wp.array[wp.float32]):
         x[wp.tid()] += 1.0
+
     wp.launch(first, dim=values.shape, inputs=[values])
 
     @wp.kernel
     def second(x: wp.array[wp.float32]):
         x[wp.tid()] *= 2.0
+
     wp.launch(second, dim=values.shape, inputs=[values])
 ```
 
@@ -153,11 +155,11 @@ late, check that one instead.
 ```python
 # Before
 wp.launch(first, ...)
-wp.set_module_options({"fast_math": True})   # invalidates the module
+wp.set_module_options({"fast_math": True})  # invalidates the module
 wp.launch(second, ...)
 
 # After
-wp.set_module_options({"fast_math": True})   # resolved before anything loads
+wp.set_module_options({"fast_math": True})  # resolved before anything loads
 wp.launch(first, ...)
 wp.launch(second, ...)
 ```
@@ -430,7 +432,7 @@ by the time your code runs, reach the module that exists instead of the default
 it was built from:
 
 ```python
-wp.get_module("pkg.module").options["enable_backward"] = False   # before it loads
+wp.get_module("pkg.module").options["enable_backward"] = False  # before it loads
 ```
 
 That is still application-scoped — it configures this process, not the library's

--- a/skills/warp-debug-gradients/references/case-studies.md
+++ b/skills/warp-debug-gradients/references/case-studies.md
@@ -21,7 +21,7 @@ per-substep states, taped each frame separately, and carried state between
 frames with:
 
 ```python
-self.states[0] = self.states[-1]   # Python REBIND, not a copy
+self.states[0] = self.states[-1]  # Python REBIND, not a copy
 ```
 
 After the first frame, `states[0]` and `states[-1]` are the same object: on
@@ -82,7 +82,7 @@ The stage looked like:
 ```python
 clamped_q = wp.zeros_like(state.particle_q, requires_grad=True)
 wp.launch(clip_kernel, dim=n, inputs=[state.particle_q], outputs=[clamped_q])
-wp.copy(state.particle_q, clamped_q)     # <- the bug
+wp.copy(state.particle_q, clamped_q)  # <- the bug
 ```
 
 `wp.copy` is differentiable and tape-recorded — but its *destination* is

--- a/skills/warp-debug-gradients/references/custom-gradients.md
+++ b/skills/warp-debug-gradients/references/custom-gradients.md
@@ -43,6 +43,7 @@ Three decorators, three distinct jobs:
   def ste_round(x: float) -> float:
       return wp.round(x)
 
+
   @wp.func_grad(ste_round)
   def adj_ste_round(x: float, adj_ret: float):
       wp.adjoint[x] += adj_ret  # identity backward; clip/scale here for variants

--- a/skills/warp-debug-gradients/references/verification.md
+++ b/skills/warp-debug-gradients/references/verification.md
@@ -8,6 +8,7 @@ anchor: "Debugging Gradients" in the Differentiability guide
 
 ```python
 import warp as wp
+
 wp.config.verify_autograd_array_access = True  # BEFORE kernels load/launch
 ```
 
@@ -60,15 +61,22 @@ forward pass**, not just a kernel:
 ```python
 import warp.autograd
 
+
 def forward(theta: wp.array, loss: wp.array):
     # run the full pipeline: inference, sim steps, loss kernel
     ...
 
+
 ok = wp.autograd.gradcheck(
-    forward, inputs=[theta], outputs=[loss],
-    eps=1e-3, atol=1e-3, rtol=1e-2,          # scale eps to the parameters
-    max_inputs_per_var=32,                    # sample large inputs
-    raise_exception=False, show_summary=True,
+    forward,
+    inputs=[theta],
+    outputs=[loss],
+    eps=1e-3,
+    atol=1e-3,
+    rtol=1e-2,  # scale eps to the parameters
+    max_inputs_per_var=32,  # sample large inputs
+    raise_exception=False,
+    show_summary=True,
 )
 ```
 
@@ -159,7 +167,7 @@ When the signature and checklist leave several candidates:
 ## Tape visualization
 
 ```python
-tape.visualize("tape.dot")   # then: dot -Tsvg tape.dot -o tape.svg
+tape.visualize("tape.dot")  # then: dot -Tsvg tape.dot -o tape.svg
 ```
 
 Arrays render green when `requires_grad=True`, grey otherwise — a fast way to

--- a/warp/examples/cpp/00_cubin_launch/README.md
+++ b/warp/examples/cpp/00_cubin_launch/README.md
@@ -94,11 +94,12 @@ The Python script compiles a SAXPY kernel to CUBIN:
 @wp.kernel
 def saxpy(alpha: wp.float32, x: wp.array(dtype=wp.float32), y: wp.array(dtype=wp.float32)):
     """SAXPY: Single-Precision A·X Plus Y
-    
+
     Computes: y = alpha * x + y
     """
     tid = wp.tid()
     y[tid] = alpha * x[tid] + y[tid]
+
 
 # Compile to CUBIN (use_ptx=False for CUBIN, strip_hash=True for predictable kernel names)
 wp.compile_aot_module("__main__", module_dir="generated/", use_ptx=False, strip_hash=True)

--- a/warp/examples/cpp/01_source_include/README.md
+++ b/warp/examples/cpp/01_source_include/README.md
@@ -117,10 +117,12 @@ def compute_loss(
     error = y_pred - y_true[tid]
     wp.atomic_add(loss, 0, error * error)
 
+
 @wp.kernel
 def update_params(learning_rate: wp.float32, grads: wp.array(dtype=wp.float32), params: wp.array(dtype=wp.float32)):
     tid = wp.tid()
     params[tid] -= learning_rate * grads[tid]
+
 
 # Generate .cu source
 wp.compile_aot_module("__main__", module_dir="generated/", strip_hash=True)

--- a/warp/examples/cpp/02_apic_visualization/README.md
+++ b/warp/examples/cpp/02_apic_visualization/README.md
@@ -115,12 +115,10 @@ wp.capture_begin(device=device, apic=True)
 for s in range(substeps):  # e.g., 16 iterations
     if s == 0:
         # First substep: apply mouse displacement
-        wp.launch(wave_displace, dim=width * height,
-                  inputs=[grid0, grid1, mouse_pos, ...])
+        wp.launch(wave_displace, dim=width * height, inputs=[grid0, grid1, mouse_pos, ...])
 
     # Every substep: integrate wave equation
-    wp.launch(wave_solve, dim=width * height,
-              inputs=[grid0, grid1, ...])
+    wp.launch(wave_solve, dim=width * height, inputs=[grid0, grid1, ...])
 
     # Swap buffers
     grid0, grid1 = grid1, grid0
@@ -128,12 +126,12 @@ for s in range(substeps):  # e.g., 16 iterations
 graph = wp.capture_end(device=device)
 
 # Save with named bindings
-wp.capture_save(graph, "generated/wave_sim",
-                inputs={"heights": grid1,
-                        "heights_prev": grid0,
-                        "mouse_pos": mouse_pos},
-                outputs={"heights_out": grid1,
-                         "heights_prev_out": grid0})
+wp.capture_save(
+    graph,
+    "generated/wave_sim",
+    inputs={"heights": grid1, "heights_prev": grid0, "mouse_pos": mouse_pos},
+    outputs={"heights_out": grid1, "heights_prev_out": grid0},
+)
 ```
 
 This creates an APIC operation stream describing 17 kernel launches (1 displacement + 16 solves). The stream and module files are later used to construct a fresh CUDA graph.

--- a/warp/examples/cpp/README.md
+++ b/warp/examples/cpp/README.md
@@ -62,10 +62,12 @@ Examples `00` and `01` follow this two-phase workflow.
 ```python
 import warp as wp
 
+
 @wp.kernel
 def my_kernel(x: wp.array(dtype=wp.float32)):
     tid = wp.tid()
     x[tid] = x[tid] * 2.0
+
 
 wp.init()
 wp.compile_aot_module("__main__", module_dir="generated/", strip_hash=True)


### PR DESCRIPTION
## Description

Updates Warp's pre-commit toolchain one dependency at a time so each behavior change and resulting formatting update remains attributable. The branch also aligns clang-format with Warp's C++17 build mode and synchronizes uv and setup-uv versions across GitHub and GitLab CI.

This draft PR is open to validate the changes across GitHub Actions before the tooling update is finalized. No changelog fragment is included because this is developer tooling and produces no user-facing Warp behavior change.

## Changes

- **Formatting policy**: Configure clang-format for C++17 and update the hook to 23.1.0.
- **Pre-commit hooks**: Update typos to 1.50.0, Ruff to 0.16.5, and uv to 0.12.7.
- **Markdown examples**: Apply Ruff 0.16.5's formatting for Python fenced code blocks.
- **CI/CD**: Pin setup-uv v10.0.1 by commit, use uv 0.12.7 across GitHub and GitLab, and refresh architecture-specific GitLab image digests.
- **Contributor documentation**: Update the optional local formatter guidance to clang-format 23.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

Ran the affected pre-commit hooks against every file changed from the current `NVIDIA/warp:main`; the generated-file, version-consistency, skill-sync, Ruff, typos, and relevant formatting checks passed. Parsed all 14 GitHub and GitLab CI YAML files and verified the branch remained clean after validation. A full Warp test suite was not run because the changes are limited to formatting, tooling configuration, CI version pins, and documentation; this draft is intended to exercise the GitHub Actions workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved formatting and readability across quick-start guides, examples, design documents, and skill references.
  - Updated contribution instructions to reference `clang-format-23`.
  - Clarified compile-time optimization examples so configuration applies consistently before module loading.
  - Expanded gradient-check examples with explicit configuration.

- **Chores**
  - Updated development tooling versions, including formatting, linting, typo checking, and environment management tools.
  - Standardized C++ formatting against C++17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->