### PR TITLE
Reject invalid FEM mesh vertex indices

### DIFF
--- a/changelog/1873.fixed.md
+++ b/changelog/1873.fixed.md
@@ -1,0 +1,1 @@
+Reject out-of-range vertex indices when constructing FEM meshes.

--- a/warp/_src/fem/geometry/hexmesh.py
+++ b/warp/_src/fem/geometry/hexmesh.py
@@ -16,7 +16,7 @@ from warp._src.fem.types import (
     Coords,
     ElementIndex,
 )
-from warp._src.fem.utils import compress_node_indices, host_read_at_index, masked_indices
+from warp._src.fem.utils import compress_node_indices, host_read_at_index, masked_indices, validate_node_indices
 from warp._src.types import type_scalar_type
 from warp._src.utils import array_scan
 
@@ -618,6 +618,10 @@ class Hexmesh(Geometry):
 
     def _build_topology(self, temporary_store: TemporaryStore):
         device = self.hex_vertex_indices.device
+
+        validate_node_indices(
+            self.vertex_count(), self.hex_vertex_indices, index_name="Vertex", temporary_store=temporary_store
+        )
 
         vertex_hex_offsets, vertex_hex_indices = compress_node_indices(
             self.vertex_count(), self.hex_vertex_indices, temporary_store=temporary_store

--- a/warp/_src/fem/geometry/quadmesh.py
+++ b/warp/_src/fem/geometry/quadmesh.py
@@ -16,7 +16,7 @@ from warp._src.fem.types import (
     ElementIndex,
     make_coords,
 )
-from warp._src.fem.utils import compress_node_indices, host_read_at_index, masked_indices
+from warp._src.fem.utils import compress_node_indices, host_read_at_index, masked_indices, validate_node_indices
 from warp._src.types import type_scalar_type
 from warp._src.utils import array_scan
 
@@ -256,6 +256,10 @@ class Quadmesh(Geometry):
 
     def _build_topology(self, temporary_store: TemporaryStore):
         device = self.quad_vertex_indices.device
+
+        validate_node_indices(
+            self.vertex_count(), self.quad_vertex_indices, index_name="Vertex", temporary_store=temporary_store
+        )
 
         vertex_quad_offsets, vertex_quad_indices = compress_node_indices(
             self.vertex_count(), self.quad_vertex_indices, temporary_store=temporary_store

--- a/warp/_src/fem/geometry/tetmesh.py
+++ b/warp/_src/fem/geometry/tetmesh.py
@@ -15,7 +15,7 @@ from warp._src.fem.types import (
     OUTSIDE,
     ElementIndex,
 )
-from warp._src.fem.utils import compress_node_indices, host_read_at_index, masked_indices
+from warp._src.fem.utils import compress_node_indices, host_read_at_index, masked_indices, validate_node_indices
 from warp._src.types import type_scalar_type
 from warp._src.utils import array_scan
 
@@ -382,6 +382,10 @@ class Tetmesh(Geometry):
 
     def _build_topology(self, temporary_store: TemporaryStore):
         device = self.tet_vertex_indices.device
+
+        validate_node_indices(
+            self.vertex_count(), self.tet_vertex_indices, index_name="Vertex", temporary_store=temporary_store
+        )
 
         vertex_tet_offsets, vertex_tet_indices = compress_node_indices(
             self.vertex_count(), self.tet_vertex_indices, temporary_store=temporary_store

--- a/warp/_src/fem/geometry/trimesh.py
+++ b/warp/_src/fem/geometry/trimesh.py
@@ -16,7 +16,7 @@ from warp._src.fem.types import (
     ElementIndex,
     make_coords,
 )
-from warp._src.fem.utils import compress_node_indices, host_read_at_index, masked_indices
+from warp._src.fem.utils import compress_node_indices, host_read_at_index, masked_indices, validate_node_indices
 from warp._src.types import type_scalar_type
 from warp._src.utils import array_scan
 
@@ -271,6 +271,10 @@ class Trimesh(Geometry):
 
     def _build_topology(self, temporary_store: TemporaryStore):
         device = self.tri_vertex_indices.device
+
+        validate_node_indices(
+            self.vertex_count(), self.tri_vertex_indices, index_name="Vertex", temporary_store=temporary_store
+        )
 
         vertex_tri_offsets, vertex_tri_indices = compress_node_indices(
             self.vertex_count(), self.tri_vertex_indices, temporary_store=temporary_store

--- a/warp/_src/fem/utils.py
+++ b/warp/_src/fem/utils.py
@@ -83,7 +83,8 @@ def compress_node_indices(
      - the ``unique_node_count`` array containing the number of unique node indices
      - the ``unique_node_indices`` array containing the sorted list of unique node indices (i.e. the list of indices i for which ``node_offsets[i] < node_offsets[i+1]``)
 
-    Node indices equal to :data:`NULL_NODE_INDEX` will be ignored.
+    Node indices equal to :data:`NULL_NODE_INDEX`, as well as other indices outside the range
+    ``[0, node_count)``, will be ignored.
 
     If the ``node_offsets``, ``sorted_array_indices``, ``unique_node_count`` and ``unique_node_indices`` arrays are provided and adequately shaped, they will be used to store the results instead of creating new arrays.
     """
@@ -101,7 +102,7 @@ def compress_node_indices(
         wp.launch(
             kernel=_prepare_node_sort_kernel,
             dim=index_count,
-            inputs=[node_indices.flatten(), sorted_node_indices, sorted_array_indices, indices_per_element],
+            inputs=[node_count, node_indices.flatten(), sorted_node_indices, sorted_array_indices, indices_per_element],
         )
 
         # Sort indices
@@ -150,6 +151,51 @@ def compress_node_indices(
             return node_offsets, sorted_array_indices
 
         return node_offsets, sorted_array_indices, unique_node_count, unique_node_indices
+
+
+def validate_node_indices(
+    node_count: int,
+    node_indices: wp.array[int],
+    index_name: str = "Node",
+    temporary_store: cache.TemporaryStore | None = None,
+) -> None:
+    """Validate that all node indices are in bounds.
+
+    Args:
+        node_count: Number of available nodes.
+        node_indices: Warp array containing the indices to validate.
+        index_name: Name used to identify an index in error messages.
+        temporary_store: Shared pool from which to allocate temporary arrays.
+
+    Raises:
+        ValueError: If ``node_indices`` contains a value outside ``[0, node_count)``.
+    """
+
+    index_count = node_indices.size
+    if index_count == 0:
+        return
+
+    invalid_array_index = cache.borrow_temporary(temporary_store, shape=(1,), dtype=int, device=node_indices.device)
+    try:
+        invalid_array_index.fill_(index_count)
+
+        wp.launch(
+            kernel=_find_invalid_node_index,
+            dim=index_count,
+            inputs=[node_count, node_indices.flatten(), invalid_array_index],
+            device=node_indices.device,
+        )
+
+        first_invalid = int(host_read_at_index(invalid_array_index, temporary_store=temporary_store))
+    finally:
+        invalid_array_index.release()
+
+    if first_invalid < index_count:
+        invalid_value = int(host_read_at_index(node_indices.flatten(), first_invalid, temporary_store=temporary_store))
+        raise ValueError(
+            f"{index_name} index {invalid_value} at flattened array index {first_invalid} "
+            f"is out of bounds; expected a value in [0, {node_count})"
+        )
 
 
 def host_read_at_index(array: wp.array, index: int = -1, temporary_store: cache.TemporaryStore = None) -> int:
@@ -214,6 +260,7 @@ def masked_indices(
 
 @wp.kernel
 def _prepare_node_sort_kernel(
+    node_count: int,
     node_indices: wp.array(dtype=int),
     sort_keys: wp.array(dtype=int),
     sort_values: wp.array(dtype=int),
@@ -221,8 +268,20 @@ def _prepare_node_sort_kernel(
 ):
     i = wp.tid()
     node = node_indices[i]
-    sort_keys[i] = wp.where(node >= 0, node, NULL_NODE_INDEX)
+    sort_keys[i] = wp.where(node >= 0 and node < node_count, node, NULL_NODE_INDEX)
     sort_values[i] = i // divisor
+
+
+@wp.kernel
+def _find_invalid_node_index(
+    node_count: int,
+    node_indices: wp.array[int],
+    invalid_array_index: wp.array[int],
+):
+    i = wp.tid()
+    node_index = node_indices[i]
+    if node_index < 0 or node_index >= node_count:
+        wp.atomic_min(invalid_array_index, 0, i)
 
 
 @wp.kernel
@@ -240,7 +299,8 @@ def _scatter_node_counts(
         return
 
     node_index = unique_node_indices[i]
-    if node_index == NULL_NODE_INDEX:
+    if node_index < 0 or node_index >= node_counts.shape[0] - 1:
+        unique_node_indices[i] = NULL_NODE_INDEX
         wp.atomic_sub(unique_node_count, 0, 1)
         return
 

--- a/warp/tests/fem/test_fem_geometry.py
+++ b/warp/tests/fem/test_fem_geometry.py
@@ -10,6 +10,7 @@ import numpy as np
 import warp as wp
 import warp.fem as fem
 from warp._src.fem.geometry.closest_point import project_on_tet_at_origin, project_on_tri_at_origin
+from warp._src.fem.utils import compress_node_indices
 from warp.fem import Coords, Domain, Sample, integrand, make_free_sample
 from warp.fem.utils import grid_to_hexes, grid_to_quads, grid_to_tets, grid_to_tris
 from warp.tests.unittest_utils import *
@@ -240,6 +241,47 @@ def test_triangle_mesh(test, device):
 
     assert_np_equal(cell_measures.numpy(), np.full(cell_measures.shape, 0.5 / (N**2)), tol=1.0e-4)
     test.assertAlmostEqual(np.sum(side_measures.numpy()), 2 * (N + 1) + N * math.sqrt(2.0), places=4)
+
+
+def test_mesh_rejects_invalid_vertex_indices(test, device):
+    """Verify that mesh constructors reject out-of-range vertex indices."""
+    mesh_cases = (
+        ("Trimesh", fem.Trimesh2D, "tri_vertex_indices", wp.vec2, 3),
+        ("Quadmesh", fem.Quadmesh2D, "quad_vertex_indices", wp.vec2, 4),
+        ("Tetmesh", fem.Tetmesh, "tet_vertex_indices", wp.vec3, 4),
+        ("Hexmesh", fem.Hexmesh, "hex_vertex_indices", wp.vec3, 8),
+    )
+
+    for mesh_name, mesh_type, index_arg_name, position_dtype, vertex_count in mesh_cases:
+        positions = wp.zeros(vertex_count, dtype=position_dtype, device=device)
+        for invalid_index in (-1, vertex_count, (1 << 31) - 2, fem.NULL_NODE_INDEX):
+            vertex_indices = list(range(vertex_count))
+            vertex_indices[0] = invalid_index
+            connectivity = wp.array([vertex_indices], dtype=int, device=device)
+
+            with test.subTest(mesh=mesh_name, invalid_index=invalid_index):
+                with test.assertRaisesRegex(ValueError, "out of bounds"):
+                    mesh_type(**{index_arg_name: connectivity, "positions": positions})
+
+
+def test_compress_node_indices_ignores_out_of_range_values(test, device):
+    """Verify that node-index compression ignores invalid values without overrunning offsets."""
+    backing_offsets = wp.full(12, -99, dtype=int, device=device)
+    node_offsets = wp.array(ptr=backing_offsets.ptr, shape=(4,), dtype=int, device=device, copy=False)
+    node_indices = wp.array([0, 1, 2, 3, 4, 5, -1], dtype=int, device=device)
+
+    _, sorted_indices, unique_count, unique_indices = compress_node_indices(
+        3, node_indices, node_offsets=node_offsets, return_unique_nodes=True
+    )
+
+    np.testing.assert_array_equal(node_offsets.numpy(), [0, 1, 2, 3])
+    np.testing.assert_array_equal(backing_offsets.numpy()[4:], np.full(8, -99))
+    test.assertEqual(unique_count.numpy()[0], 3)
+    np.testing.assert_array_equal(unique_indices.numpy()[:3], [0, 1, 2])
+
+    sorted_indices.release()
+    unique_count.release()
+    unique_indices.release()
 
 
 def test_quad_mesh(test, device):
@@ -875,6 +917,18 @@ class TestFemGeometry(unittest.TestCase):
 
 add_function_test(TestFemGeometry, "test_grid_2d", test_grid_2d, devices=devices)
 add_function_test(TestFemGeometry, "test_triangle_mesh", test_triangle_mesh, devices=devices)
+add_function_test(
+    TestFemGeometry,
+    "test_mesh_rejects_invalid_vertex_indices",
+    test_mesh_rejects_invalid_vertex_indices,
+    devices=devices,
+)
+add_function_test(
+    TestFemGeometry,
+    "test_compress_node_indices_ignores_out_of_range_values",
+    test_compress_node_indices_ignores_out_of_range_values,
+    devices=devices,
+)
 add_function_test(TestFemGeometry, "test_quad_mesh", test_quad_mesh, devices=devices)
 add_function_test(TestFemGeometry, "test_mesh_guess_lookup_radius", test_mesh_guess_lookup_radius, devices=devices)
 add_function_test(TestFemGeometry, "test_grid_3d", test_grid_3d, devices=devices)


### PR DESCRIPTION
## Description

FEM mesh constructors previously passed connectivity arrays directly into topology construction. A vertex index outside `[0, vertex_count)` could write past temporary offset storage, return incomplete topology, crash the CPU process, or leave CUDA in an illegal memory access state.

This change validates Trimesh, Quadmesh, Tetmesh, and Hexmesh connectivity before building topology. Invalid indices raise a `ValueError` that reports the value, its location in the connectivity array, and the valid range.

Node index compression now ignores all out-of-range values without writing past its offset storage. This retains the documented handling of `NULL_NODE_INDEX`.

Closes #1873.

## Changes

- Validate vertex connectivity before constructing FEM mesh topology.
- Report the first invalid vertex index with its flattened array position and valid range.
- Keep node index compression safe for `NULL_NODE_INDEX` and other out-of-range values.
- Add CPU and CUDA regression coverage and a changelog fragment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

The original failure was reproduced against `upstream/main` in isolated processes. A large positive index caused the CPU process to exit with code 139. On CUDA, the same input produced error 700, after which later device allocations failed.

The new mesh validation and node compression regressions pass on CPU and `cuda:0`. All four targeted device cases passed.

Broader FEM caller tests, boundary-index fuzz checks, and pre-commit validation also passed.

## Bug fix

Without this change, an invalid vertex index reaches topology construction:

```python
import warp as wp
import warp.fem as fem

device = "cpu"  # Change to "cuda:0" to reproduce on CUDA.

with wp.ScopedDevice(device):
    positions = wp.zeros(3, dtype=wp.vec2)
    tri_vertex_indices = wp.array(
        [[(1 << 31) - 2, 1, 2]],
        dtype=int,
    )

    mesh = fem.Trimesh2D(
        tri_vertex_indices=tri_vertex_indices,
        positions=positions,
    )
    wp.synchronize_device()
```

With this change, construction raises a `ValueError` before building topology.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * FEM mesh construction now rejects negative or out-of-range vertex indices with a clear error.
  * Improved handling of invalid node indices during mesh connectivity processing, preventing corrupted topology data.

* **Tests**
  * Added coverage for triangle, quadrilateral, tetrahedral, and hexahedral meshes.
  * Added tests confirming invalid indices are safely ignored during node compression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->