### PR TITLE
Find MSVC from Visual Studio Build Tools installations

### DIFF
--- a/changelog/1892.fixed.md
+++ b/changelog/1892.fixed.md
@@ -1,0 +1,3 @@
+Find MSVC from Visual Studio Build Tools installations when building from
+source by passing `-products *` to `vswhere.exe`, which excludes Build Tools
+from its results by default.

--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -187,8 +187,12 @@ def find_host_compiler(host_arch: Architecture | None = None) -> str:
             if host_arch == "aarch64"
             else "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"
         )
+        # -products * includes Build Tools installations, which vswhere
+        # excludes by default (it only reports Community/Professional/Enterprise).
         vs_path = (
-            run_cmd(f'"{vswhere_path}" -latest -requires {component} -property installationPath').decode().rstrip()
+            run_cmd(f'"{vswhere_path}" -latest -products * -requires {component} -property installationPath')
+            .decode()
+            .rstrip()
         )
         vsvars_path, vsvars_arguments = _msvc_environment_script(vs_path, host_arch)
 


### PR DESCRIPTION
## Description

Closes #1892.

Building from source on a machine with only Visual Studio Build Tools (no full Visual Studio IDE) fails with `Warp build error: Could not find MSVC compiler`, even though a working MSVC toolchain is installed. `find_host_compiler()` queries `vswhere.exe` without `-products *`, and vswhere excludes Build Tools products from its results by default (it only reports Community/Professional/Enterprise). Build Tools is the usual MSVC install on CI and headless build machines, so those machines cannot build Warp without manually passing `--msvc-path`/`--sdk-path`.

This is a different failure mode from #1235, which reports the same user-visible error. In #1235 `vswhere.exe` itself is missing from the default location and cannot be run; here it runs and exits 0, but its result set is empty because of the default product filter. This PR does not implement the multi-location vswhere lookup proposed in #1235, and does not fix it.

Prepared with Claude Code (agent-assisted); all changes and validation below were run locally.

## Changes

- Pass `-products *` in the `vswhere.exe` invocation in `find_host_compiler()`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes. (No unit test: this is build-machinery behavior, which `AGENTS.md` keeps out of `warp/tests/`; verified directly as described below.)
- [x] The documentation is up to date with these changes. (n/a)
- [x] I added a changelog fragment if this change affects users.

## Validation summary

All on Windows 11 with only VS 2022 Build Tools installed (no full Visual Studio):

- Verified the current invocation `vswhere.exe -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath` prints nothing, while the same command with `-products *` prints the Build Tools installation path.
- Verified on the target branch, in a clean environment (no `VCINSTALLDIR`/`VCToolsVersion`, no `cl.exe` on `PATH`), that `build_lib.py --no-cuda` fails with "Could not find MSVC compiler". With this change, `find_host_compiler()` locates the Build Tools install, runs `vcvars64.bat`, and returns a working `cl.exe`.
- Verified a full `build_lib.py --no-cuda` build via pure auto-discovery succeeds with this change, and the resulting `warp.dll`/`warp-clang.dll` pass `warp/tests/test_codegen.py` (Ran 111 tests, OK, fresh kernel cache).

One behavior note: on a machine that has both a full Visual Studio and a *newer* Build Tools install, `-latest` may now select the Build Tools install where it previously selected the full VS. Both provide the same MSVC toolchain.

## Bug fix

Repro: install only "Visual Studio Build Tools 2022" with the C++ workload, then run `python build_lib.py --no-cuda` on a machine without a full Visual Studio → `Warp build error: Could not find MSVC compiler`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows source builds now detect required MSVC components from Visual Studio Build Tools installations.

* **Documentation**
  * Added a changelog entry documenting the updated Visual Studio discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->