### PR TITLE
Fix FEM shape optimization not moving vertices [GH-1832]

### DIFF
--- a/changelog/1832.fixed.md
+++ b/changelog/1832.fixed.md
@@ -1,0 +1,2 @@
+Fix `fem/example_elastic_shape_optimization.py` not moving its vertices on CPU devices: the Adam optimizer was given detached
+copies of the vertex positions and gradients rather than zero-copy views, so the shape and the loss stayed at their initial values for every iteration.

--- a/warp/examples/fem/example_elastic_shape_optimization.py
+++ b/warp/examples/fem/example_elastic_shape_optimization.py
@@ -291,9 +291,9 @@ class Example:
         self.renderer = fem_example_utils.Plot()
 
         # Initialize Adam optimizer
-        # Current implementation assumes scalar arrays, so cast our vec2 arrays to scalars
-        self._vertex_positions_scalar = wp.array(self._vertex_positions, dtype=wp.float32).flatten()
-        self._vertex_positions_scalar.grad = wp.array(self._vertex_positions.grad, dtype=wp.float32).flatten()
+        # Warp's Adam optimizer currently only supports scalar arrays, so create a
+        # flattened scalar view of the vec2 vertex positions.
+        self._vertex_positions_scalar = self._vertex_positions.view(wp.float32).flatten()
         self.optimizer = Adam([self._vertex_positions_scalar], lr=lr)
 
         self._rebuild_fem_structures(degree)


### PR DESCRIPTION
## Description

`warp/examples/fem/example_elastic_shape_optimization.py` runs its whole optimization loop without ever moving a vertex. The loss is bit-identical on every iteration, the arch shape the example advertises never forms, and `remesh()` never finds an edge worth flipping because the mesh it is handed is the starting mesh.

Adam has no `vec2` kernel, so the example builds a scalar view of its `vec2` position array to hand to the optimizer. It built that view with `wp.array(other_array, dtype=...)`, which copies. So the optimizer read a gradient buffer that nothing writes to, and wrote its updates into positions that nothing reads.

This is the example a reader lands on from `docs/domain_modules/fem.rst` and from the shape-optimization tile in `README.md`, so what it demonstrates right now is a loop that does nothing.

closes #1832

## Changes

`warp/examples/fem/example_elastic_shape_optimization.py`

- Build the optimizer's scalar parameter with `view(wp.float32).flatten()` instead of `wp.array(..., dtype=wp.float32).flatten()`. Both calls are zero-copy.
- Drop the separate `_vertex_positions_scalar.grad = ...` line. `view()` already carries the gradient array through as a view of `_vertex_positions.grad`, and `flatten()` does the same, so assigning it again is redundant once the parent is a real view.

`warp/tests/fem/test_fem_examples.py`

- Add `test_elastic_shape_optimization_moves_vertices`, an in-process test that asserts the optimizer parameter aliases the position array and that one `step()` moves at least one vertex.
- Register it on `get_test_devices(mode="basic")` so it runs on CPU as well as CUDA, and adjust the module docstring, which said all example tests were CUDA-only.

`changelog/1832.fixed.md`

- New fragment.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Correcting the issue

The issue reports two independent defects. The first is right. The second is not, and it is worth saying so, because a reader who believes it will go looking for a bug in `warp.fem` autodiff that is not there.

> 2. **The position gradient is zero.** After `tape.backward(loss)`, the gradient with respect to the positions array is identically zero in this setup, so even an in-place update would currently be a no-op.

The gradient is not zero. Measured on `main` at 608094fc, CPU, `resolution=8`, by instrumenting `wp.Tape.backward`, `Adam.step` and `wp.Tape.zero`:

```
A  max|positions.grad| right after tape.backward   : 0.13600475
B  max|positions.grad| after projector+symmetrize  : 0.07234181
C  max|grad| Adam actually receives                : 0.00000000   <-- fed from the copy
D  max|param change| Adam applied to its buffer    : 0.00000000
F  max|positions.grad| before tape.zero()          : 0.07234181
G  max|positions.grad| after  tape.zero()          : 0.00000000   <-- what a caller sees post-step
```

`step()` ends with `tape.zero()`, which clears `_vertex_positions.grad`. Anyone who reads the gradient after `step()` returns, which is the natural place to look, reads zeros. That is a measurement artifact, not a missing derivative.

Shape derivatives through a `Trimesh2D` work fine on their own. Integrating `1.0` over the unit square split into two triangles gives an area of 1.0 and `d(area)/d(positions)` of `±0.5` per vertex, which is correct.

So there is one defect here, not two, and the aliasing fix is sufficient. That also matches the issue's own observation that the two behaviours reproduce identically with and without the fix for #1804.

## Bug fix

Before this PR, with `main` at 608094fc:

```python
import numpy as np
import warp as wp
from warp.examples.fem.example_elastic_shape_optimization import Example

with wp.ScopedDevice("cpu"):
    example = Example(quiet=True, degree=1, resolution=25, mesh="tri", lr=1.0e-3)
    start = example._vertex_positions.numpy().copy()
    for i in range(5):
        loss = example.step()
        moved = np.abs(example._vertex_positions.numpy() - start).max()
        print(f"iter {i}: loss={loss:.12f}  max|dx|={moved:.3e}")
```

```
iter 0: loss=0.118115417659  max|dx|=0.000e+00
iter 1: loss=0.118115417659  max|dx|=0.000e+00
iter 2: loss=0.118115417659  max|dx|=0.000e+00
iter 3: loss=0.118115417659  max|dx|=0.000e+00
iter 4: loss=0.118115417659  max|dx|=0.000e+00
```

With this PR, same script, 120 iterations with the default remesh interval:

```
iter   0: loss=0.1181149557  max|dx|=1.000047e-03
iter  20: loss=0.0981881991  max|dx|=2.216834e-02
iter  40: loss=0.0896228105  max|dx|=4.048952e-02
iter  60: loss=0.0869978070  max|dx|=4.689008e-02
iter  80: loss=0.0853810534  max|dx|=4.902768e-02
iter 119: loss=0.0837662965  max|dx|=5.207330e-02
```

Both `--mesh tri` and `--mesh deformed` were broken, and both now produce identical trajectories, which is what you would expect given the two parametrizations describe the same positions.

## Behavioural difference

The example now does real work where it previously did none, so it is slower per iteration and its output changes. Nothing else in the repository imports this module, and no test asserts on its numbers, so the blast radius is the example itself and its own test.

One thing I did not change. `remesh()` starts flipping edges once the vertices move, which is the behaviour it was written for but has apparently never had. Edge flips mutate `_tri_vertex_indices` in place, and #1804 reports that `Trimesh2D` side topology goes stale afterwards. That is a separate bug with its own open issue, and this PR neither fixes nor worsens it. It is now reachable through the default settings, where before the frozen mesh hid it.

## Validation summary

Verified on Linux (WSL2, Ubuntu 26.04) against a CPU-only build of `main` at 608094fc, `python build_lib.py --no-cuda`. I have no NVIDIA GPU, so nothing here was executed on CUDA. The new test is registered for CUDA devices too and I could not run that variant.

Red/green on the new test:

- With the fix, `test_elastic_shape_optimization_moves_vertices_cpu` passes in 3.6s.
- With the test kept and the one-line source change stashed, it fails on the first assertion: `AssertionError: 153768448 != 140138112`.
- With the two pointer assertions also removed, so only the behavioural assertion remains, it still fails: `AssertionError: np.float32(0.0) not greater than 0.0`. Each half of the test catches the bug on its own.

Full default suite on this branch, `python -m warp.tests`:

```
Ran 3683 tests in 572.387s
OK (skipped=523)
```

Of the 523 skips, 505 are CUDA or multi-device tests that this machine has no hardware for. The other 18 are environment gaps rather than device gaps: 10 skip on `JAX version too old`, 3 want a `warp-clang` built with `--sanitize=address`, 2 are Windows-only path checks, and one each for missing `rmm`, missing `torch`, and an insufficient-free-memory guard.

FEM suite alone, `python -m warp.tests -s autodetect -p 'test_fem*.py'`, run three ways:

- Pristine checkout, warm kernel cache: `Ran 98 tests` / `OK (skipped=34)`.
- This branch, warm kernel cache: `Ran 99 tests` / `OK (skipped=34)`. The extra test is the new one.
- This branch, cold kernel cache: `Ran 99 tests` / `OK (skipped=34)`.

Lint and format, at the versions pinned in `.pre-commit-config.yaml`:

- `ruff 0.16.5 check` on both changed Python files: `All checks passed!`
- `ruff 0.16.5 format --check`: `2 files already formatted`
- `typos 1.50.0` on all three changed files: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed CPU-based vertex movement during elastic shape optimization.
  - Vertex positions and gradients now remain linked correctly, allowing Adam updates to change the shape and reduce the loss.

- **Documentation**
  - Added a changelog entry describing the CPU optimization fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->