### PR TITLE
Honor dtype in Python-scope identity builtins (GH-1839)

### DIFF
--- a/changelog/1839.fixed.md
+++ b/changelog/1839.fixed.md
@@ -1,0 +1,4 @@
+Fix `wp.quat_identity()` and `wp.transform_identity()` ignoring the requested
+`dtype` when called from the Python scope, returning float32 values instead.
+Unsupported `dtype` arguments, such as integer types, are now rejected instead
+of being silently ignored.

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -652,7 +652,13 @@ class Function:
                 default_args = {k: v for k, v in self.defaults.items() if k not in bound_args.arguments}
                 warp._src.codegen.apply_defaults(bound_args, default_args)
 
-            bound_arg_types = tuple(type(x) for x in bound_args.arguments.values())
+            # Arguments that are types themselves, such as `dtype`, are mapped
+            # onto their own identity rather than their metaclass so that
+            # calls passing different types resolve to different descriptors.
+            bound_arg_types = tuple(
+                x if isinstance(x, type) and x in warp._src.types.scalar_and_bool_types else type(x)
+                for x in bound_args.arguments.values()
+            )
 
             # For each of this function's existing overloads, we attempt to pack
             # the given arguments into the C types expected by the corresponding
@@ -771,6 +777,7 @@ class BuiltinCallDesc(NamedTuple):
     arg_types: Sequence[type]  # Types passed to `add_builtin()` or defined by the `export_func` callback.
     param_kinds: Sequence[BuiltinParamKind]  # How to pack a parameter into a C type.
     value_type: Any  # Return type.
+    c_value_type: Any  # Return type of the exported C function, which may differ from `value_type`.
 
 
 @functools.cache
@@ -843,10 +850,27 @@ def get_builtin_call_desc(
         arg_types.append(arg_type)
         param_kinds.append(param_kind)
 
-    # Retrieve the return type.
-    value_type = func.value_func(func_args, None)
+    # Retrieve the return type of the exported C function, which is only
+    # instantiated for the declared default template arguments.
+    c_value_type = func.value_func(func_args, None)
 
-    return BuiltinCallDesc(c_func, arg_types, param_kinds, value_type)
+    # Parameters stripped from the exported C signature by `export_func` are
+    # template arguments, such as `dtype`, that callers pass as types.
+    # Resolve the return type against them so that, for example,
+    # `wp.quat_identity(dtype=wp.float64)` returns a float64 quaternion (GH-1839).
+    value_type = c_value_type
+    if len(func_args) < len(func.input_types):
+        template_arg_types = dict(func_args)
+        for name, param_type in zip(func.input_types.keys(), param_types, strict=False):
+            if name in func_args or param_type is type(None):
+                continue
+            if not warp._src.types.types_equal_generic(func.input_types[name], param_type):
+                return None
+            template_arg_types[name] = param_type
+        if len(template_arg_types) > len(func_args):
+            value_type = func.value_func(template_arg_types, None)
+
+    return BuiltinCallDesc(c_func, arg_types, param_kinds, value_type, c_value_type)
 
 
 def call_builtin_from_desc(
@@ -879,7 +903,9 @@ def call_builtin_from_desc(
         else:
             raise AssertionError(f"Unexpected parameter kind value `{param_kind}`")
 
-    value_type = builtin_desc.value_type
+    # The C function only writes a value of `c_value_type`; the resolved
+    # `value_type` may differ when the caller passed template arguments.
+    value_type = builtin_desc.c_value_type
     if value_type is None:
         ret = None
     else:
@@ -902,6 +928,12 @@ def call_builtin_from_desc(
     return_value = tuple(extract_return_value(x, y, z) for x, y, z in zip(value_type, value_ctype, ret, strict=True))
     if len(return_value) == 1:
         return_value = return_value[0]
+
+    if builtin_desc.value_type is not builtin_desc.c_value_type:
+        # The exported C function is only instantiated for its default
+        # template arguments, so convert the value it wrote into the return
+        # type resolved from the caller's template arguments.
+        return builtin_desc.value_type(return_value)
 
     return return_value
 

--- a/warp/tests/test_builtins_resolution.py
+++ b/warp/tests/test_builtins_resolution.py
@@ -748,6 +748,32 @@ class TestBuiltinsResolution(unittest.TestCase):
         self.assertAlmostEqual(float(result[2]), expected_z, places=1)
         self.assertAlmostEqual(float(result[3]), expected_w, places=1)
 
+    def test_quat_identity_dtype_template_arg(self):
+        q = wp.quat_identity()
+        self.assertIs(q._wp_scalar_type_, wp.float32)
+        self.assertEqual([float(x) for x in q], [0.0, 0.0, 0.0, 1.0])
+
+        for dtype in (wp.float16, wp.float32, wp.float64):
+            q = wp.quat_identity(dtype=dtype)
+            self.assertIs(q._wp_scalar_type_, dtype)
+            self.assertEqual([float(x) for x in q], [0.0, 0.0, 0.0, 1.0])
+
+        with self.assertRaisesRegex(RuntimeError, r"^Couldn't find a function 'quat_identity' compatible"):
+            wp.quat_identity(dtype=wp.int32)
+
+    def test_transform_identity_dtype_template_arg(self):
+        t = wp.transform_identity()
+        self.assertIs(t._wp_scalar_type_, wp.float32)
+        self.assertEqual([float(x) for x in t], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+
+        for dtype in (wp.float16, wp.float32, wp.float64):
+            t = wp.transform_identity(dtype=dtype)
+            self.assertIs(t._wp_scalar_type_, dtype)
+            self.assertEqual([float(x) for x in t], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+
+        with self.assertRaisesRegex(RuntimeError, r"^Couldn't find a function 'transform_identity' compatible"):
+            wp.transform_identity(dtype=wp.int32)
+
 
 for dtype in wp._src.types.int_types:
     add_function_test(


### PR DESCRIPTION
Fixes GH-1839.

## Root cause

`wp.quat_identity()` and `wp.transform_identity()` declare `dtype` as a template argument that `export_func` strips from the exported C signature. The Python-scope call path therefore dropped it entirely: the builtin call descriptor matched any `dtype` (all dtype values collapsed to the same cache key via `type(x)`), resolved the return type from the stripped signature, and always returned float32 values — `wp.quat_identity(dtype=wp.float64)` silently returned a `quatf`, and invalid dtypes like `wp.int32` were silently accepted. An audit of the exported builtins shows these two are the only ones affected.

## Fix

In `warp/_src/context.py`:

- Map type-valued arguments (scalar/bool dtypes) onto their own identity when building the descriptor cache key, so calls passing different dtypes resolve to different descriptors.
- In `get_builtin_call_desc`, resolve the descriptor's return type against the types the caller passed for stripped template parameters, rejecting unsupported ones through the existing no-match path.
- In `call_builtin_from_desc`, unpack the C result as the exported instantiation's type and convert it to the resolved return type when they differ. Identity values are exact in every supported dtype, so the conversion is lossless.

Adds regression tests in `warp/tests/test_builtins_resolution.py` and a changelog fragment (`changelog/1839.fixed.md`).

## Verification

All executed on a Windows CPU-only build of main (6e826ae):

- Red on main: `wp.quat_identity(dtype=wp.float64)` returns float32; `dtype=wp.int32` is silently accepted.
- Green with the fix: float16/float32/float64 are honored for both builtins; `wp.int32` raises.
- Suites pass: `test_builtins_resolution` (50), `test_quat` (85), `test_spatial` (109), `test_ctypes` (18). `pre-commit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `quat_identity()` and `transform_identity()` to honor requested floating-point data types.
  - Unsupported types, including integer types, now return a clear error instead of being silently ignored.
  - Improved type handling so returned identity values use the requested scalar type.

- **Tests**
  - Added coverage for default behavior, `float16`, `float32`, and `float64` results.
  - Added validation that unsupported integer types are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->