### PR TITLE
Harden MEMTILE replay span validation

### DIFF
--- a/changelog/1883.fixed.md
+++ b/changelog/1883.fixed.md
@@ -1,0 +1,1 @@
+Reject `.wrp` capture files containing MEMTILE byte spans that overflow during validation.

--- a/warp/native/apic.cpp
+++ b/warp/native/apic.cpp
@@ -27,7 +27,7 @@
 #include <climits>
 #include <cmath>
 #include <cstddef>  // offsetof
-#include <cstdint>  // SIZE_MAX
+#include <cstdint>  // UINT64_MAX
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -1405,20 +1405,6 @@ static bool apic_is_radix_dtype(uint8_t dtype)
         || dtype == APIC_TYPE_INT64 || dtype == APIC_TYPE_UINT64 || dtype == APIC_TYPE_FLOAT64;
 }
 
-// Checked multiply: writes a*b to *out and returns true, or returns false if
-// the product would overflow size_t. Replay computes byte spans as products of
-// record fields (count, stride, nnz, block size, scalar size) and trusts the
-// validator, so a corrupt/oversized .wrp could otherwise wrap a span to a small
-// value that passes resolve_ptr's bounds check while the host op reads/writes
-// far more. The validator uses this to reject such records up front.
-static bool apic_mul_check(uint64_t a, uint64_t b, uint64_t* out)
-{
-    if (b != 0 && a > (SIZE_MAX / b))
-        return false;
-    *out = a * b;
-    return true;
-}
-
 static bool apic_add_check(uint64_t a, uint64_t b, uint64_t* out)
 {
     if (a > UINT64_MAX - b)
@@ -1591,6 +1577,11 @@ bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t o
             const APICMemtileRecord* rec = reinterpret_cast<const APICMemtileRecord*>(ptr);
             if (op_start + sizeof(APICMemtileRecord) + rec->srcsize > op_end) {
                 fprintf(stderr, "APIC: Error - memtile inline data overflow at operation %u\n", i);
+                return false;
+            }
+            uint64_t total_bytes;
+            if (!apic_mul_check(rec->count, rec->srcsize, &total_bytes)) {
+                fprintf(stderr, "Warp APIC error: memtile span overflow at operation %u\n", i);
                 return false;
             }
             break;
@@ -2243,7 +2234,11 @@ static bool apic_cpu_replay_stream(
         case APIC_OP_MEMTILE: {
             const APICMemtileRecord* rec = reinterpret_cast<const APICMemtileRecord*>(ptr);
             const void* value = ptr + sizeof(APICMemtileRecord);
-            uint64_t total_bytes = rec->count * rec->srcsize;
+            uint64_t total_bytes;
+            if (!apic_mul_check(rec->count, rec->srcsize, &total_bytes)) {
+                fprintf(stderr, "Warp APIC error: memtile span overflow at operation %u\n", i);
+                return false;
+            }
             void* dst = resolve_ptr(rec->region_id, rec->offset, total_bytes);
             if (!dst) {
                 fprintf(stderr, "APIC: Error - memtile pointer resolution failed at operation %u\n", i);

--- a/warp/native/apic.cu
+++ b/warp/native/apic.cu
@@ -516,7 +516,12 @@ static bool apic_replay_ops_into_cuda_capture(
         case APIC_OP_MEMTILE: {
             const APICMemtileRecord* rec = reinterpret_cast<const APICMemtileRecord*>(ptr);
             const void* value = ptr + sizeof(APICMemtileRecord);
-            uint64_t total_bytes = rec->count * rec->srcsize;
+            uint64_t total_bytes;
+            if (!apic_mul_check(rec->count, rec->srcsize, &total_bytes)) {
+                wp::set_error_string("APIC memtile: span overflow at operation %u", i);
+                success = false;
+                break;
+            }
             void* dst = apic_resolve_region_ptr(graph, rec->region_id, rec->offset, total_bytes);
             if (!dst) {
                 wp::set_error_string("APIC memtile: failed to resolve region (op %u)", i);

--- a/warp/native/apic_internal.h
+++ b/warp/native/apic_internal.h
@@ -24,6 +24,15 @@
 #include <cudaTypedefs.h>
 #endif
 
+// Checked multiplication for byte spans derived from serialized records.
+inline bool apic_mul_check(uint64_t a, uint64_t b, uint64_t* out)
+{
+    if (b != 0 && a > (SIZE_MAX / b))
+        return false;
+    *out = a * b;
+    return true;
+}
+
 // Byte size of a scalar APICType value: 4 for the 32-bit members, 8 for the
 // 64-bit members, 0 for an unrecognized/unset value. Shared by the array_scan
 // and radix/segmented sort capture and replay paths (apic.cpp and warp.cpp).

--- a/warp/native/apic_types.h
+++ b/warp/native/apic_types.h
@@ -286,6 +286,7 @@ struct APICMemtileRecord {
     uint64_t count;  // number of elements
     // followed by srcsize bytes of inline value data
 };  // 32 bytes fixed
+static_assert(sizeof(APICMemtileRecord) == 32, "APICMemtileRecord must remain 32 bytes");
 
 // In-graph allocation (fixed size)
 struct APICAllocRecord {

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -86,6 +86,11 @@ _APIC_MEMORY_REGION_RECORD = struct.Struct("<IIQB7x")
 # APICCondRecord: operation type/size, condition region/padding/offset, then each
 # branch's byte size and operation count.
 _APIC_COND_RECORD = struct.Struct("<IIiIQIIII")
+
+# APICMemtileRecord: operation type/size, destination region, inline value size,
+# destination offset, and repetition count.
+_APIC_MEMTILE_RECORD = struct.Struct("<IIiIQQ")
+_APIC_OP_MEMTILE = 10
 _APIC_UINT32 = struct.Struct("<I")  # One serialized uint32_t.
 
 
@@ -218,6 +223,29 @@ def _corrupt_apic_empty_branch_count(path, branch_name):
         wrp_file.write(_APIC_COND_RECORD.pack(*conditional))
 
 
+def _corrupt_apic_memtile_count_to_overflow(path):
+    """Make a four-byte MEMTILE record's destination span overflow uint64_t."""
+    with open(path, "r+b") as wrp_file:
+        wrp_data = wrp_file.read()
+        section_offset, section_size = _find_apic_section(wrp_data, _APIC_SECTION_OPERATIONS)
+
+        if section_size < _APIC_UINT32.size + _APIC_MEMTILE_RECORD.size:
+            raise ValueError("WRP operations section has no MEMTILE record")
+
+        operation_count = _APIC_UINT32.unpack_from(wrp_data, section_offset)[0]
+        if operation_count != 1:
+            raise ValueError("Expected exactly one operation")
+
+        memtile_offset = section_offset + _APIC_UINT32.size
+        memtile = list(_APIC_MEMTILE_RECORD.unpack_from(wrp_data, memtile_offset))
+        if memtile[0] != _APIC_OP_MEMTILE or memtile[3] != 4:
+            raise ValueError("Expected a four-byte MEMTILE operation")
+
+        memtile[5] = 1 << 62
+        wrp_file.seek(memtile_offset)
+        wrp_file.write(_APIC_MEMTILE_RECORD.pack(*memtile))
+
+
 def test_save_apic_false_error(test, device):
     """capture_save() should raise when apic=False."""
     n = 64
@@ -294,6 +322,20 @@ def test_capture_load_rejects_empty_conditional_branches_with_operations(test, d
                     wp.capture_load(path, device=device)
             finally:
                 wp_context.runtime.core.wp_set_error_output_enabled(saved_error_output_enabled)
+
+
+def test_capture_load_rejects_memtile_span_overflow(test, device):
+    """Reject a MEMTILE whose byte-span multiplication overflows."""
+    values = wp.zeros(4, dtype=wp.float32, device=device)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "memtile_span_overflow.wrp")
+        with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+            values.fill_(42.0)
+        wp.capture_save(capture.graph, path, outputs={"values": values})
+        _corrupt_apic_memtile_count_to_overflow(path)
+
+        _assert_apic_load_rejected(test, path, device, r"operation stream failed validation")
 
 
 def test_capture_load_rejects_malformed_memory_regions(test, device):
@@ -3156,6 +3198,12 @@ add_function_test(
 )
 add_function_test(
     TestApic,
+    "test_capture_load_rejects_memtile_span_overflow",
+    test_capture_load_rejects_memtile_span_overflow,
+    devices=[d for d in devices if d.is_cpu],
+)
+add_function_test(
+    TestApic,
     "test_capture_load_rejects_malformed_memory_regions",
     test_capture_load_rejects_malformed_memory_regions,
     devices=[d for d in devices if d.is_cpu],
@@ -3235,9 +3283,7 @@ add_function_test(
     test_cpu_graph_replay_after_array_refs_released,
     devices=[d for d in devices if d.is_cpu],
 )
-add_function_test(
-    TestApic, "test_save_load_fill", test_save_load_fill, devices=get_cuda_test_devices()
-)  # CPU: wp_memtile_host not recorded
+add_function_test(TestApic, "test_save_load_fill", test_save_load_fill, devices=devices)
 add_function_test(
     TestApic, "test_save_load_alloc_only", test_save_load_alloc_only, devices=devices_with_graph_capture_allocation
 )


### PR DESCRIPTION
## Description

`wp.capture_load()` validates byte spans before replaying operations from `.wrp` files. MEMTILE was an exception: its `count * srcsize` calculation could wrap, allowing an invalid span to pass the region bounds check.

This PR makes MEMTILE use checked multiplication like the other replay operations. Invalid files are rejected during loading, while valid `.wrp` files behave as before.

Closes #1883

## Changes

- Validate MEMTILE byte spans before replay.
- Keep the same overflow guard in the CPU and CUDA replay paths.
- Report rejected spans with a Warp APIC diagnostic.
- Add regression coverage for an overflowing serialized MEMTILE count.
- Run the existing fill round-trip test on both CPU and CUDA.
- Add a changelog fragment for the fix.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

The regression test saves a valid CPU capture containing `array.fill_()`, changes the serialized MEMTILE count so its byte-span calculation overflows, and loads the resulting file.

- Verified that the regression test fails on the target branch because `wp.capture_load()` does not reject the invalid span.
- Verified that the test passes with this change and the file is rejected during validation.
- Ran all 136 tests in `warp/tests/test_apic.py` on CPU and CUDA.
- Rebuilt the native library with CUDA Toolkit 12.8.
- Ran pre-commit checks on all changed files.
- Rendered the pending Towncrier entries and verified the GH-1883 changelog link.

## Bug fix

A `.wrp` file containing a MEMTILE operation with an overflowing `count * srcsize` span can pass operation-stream validation. The new regression reproduces this by modifying the count in an otherwise valid capture file and then calling `wp.capture_load()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Capture loading now rejects MEMTILE records whose calculated byte spans exceed validation limits.
  * CPU and CUDA replay safely detect oversized MEMTILE operations and report errors instead of processing invalid data.
  * Capture save/load behavior is now covered across all configured devices.

* **Tests**
  * Added coverage for corrupted captures with overflowing MEMTILE destination spans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->