### PR TITLE
Raise on array_scan device failures

### DIFF
--- a/changelog/1894.fixed.md
+++ b/changelog/1894.fixed.md
@@ -1,0 +1,1 @@
+Make `wp.utils.array_scan()` raise a `RuntimeError` with the CUDA error when a device scan fails, instead of returning with unwritten or partially written output.

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -6865,6 +6865,7 @@ class Runtime:
                 ctypes.c_int,
                 ctypes.c_bool,
             ]
+            self.core.wp_array_scan_int_device.restype = ctypes.c_bool
             self.core.wp_array_scan_int64_device.argtypes = [
                 ctypes.c_uint64,
                 ctypes.c_uint64,
@@ -6874,6 +6875,7 @@ class Runtime:
                 ctypes.c_int,
                 ctypes.c_bool,
             ]
+            self.core.wp_array_scan_int64_device.restype = ctypes.c_bool
             self.core.wp_array_scan_float_device.argtypes = [
                 ctypes.c_uint64,
                 ctypes.c_uint64,
@@ -6883,6 +6885,7 @@ class Runtime:
                 ctypes.c_int,
                 ctypes.c_bool,
             ]
+            self.core.wp_array_scan_float_device.restype = ctypes.c_bool
             self.core.wp_array_scan_double_device.argtypes = [
                 ctypes.c_uint64,
                 ctypes.c_uint64,
@@ -6892,6 +6895,7 @@ class Runtime:
                 ctypes.c_int,
                 ctypes.c_bool,
             ]
+            self.core.wp_array_scan_double_device.restype = ctypes.c_bool
 
             self.core.wp_radix_sort_pairs_int_host.argtypes = [
                 ctypes.c_uint64,

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -138,7 +138,11 @@ def array_scan(in_array: wp.array, out_array: wp.array, inclusive: bool = True) 
         else:
             raise RuntimeError(f"Unsupported data type: {type_repr(in_array.dtype)}")
 
-    native_func(in_array.ptr, out_array.ptr, in_array.size, in_stride, out_stride, type_length, inclusive)
+    status = native_func(in_array.ptr, out_array.ptr, in_array.size, in_stride, out_stride, type_length, inclusive)
+
+    # Only the CUDA implementations return a status.
+    if in_array.device.is_cuda and not status:
+        raise RuntimeError(runtime.get_error_string())
 
 
 def radix_sort_pairs(

--- a/warp/native/apic.cu
+++ b/warp/native/apic.cu
@@ -544,26 +544,31 @@ static bool apic_replay_ops_into_cuda_capture(
             // g_apic_state is null during rebuild, so these execute (not record)
             // on the capture stream set as current above. Same entry points
             // wp.utils.array_scan() dispatches to.
+            bool scan_ok;
             if (rec->dtype == APIC_TYPE_INT32)
-                wp_array_scan_int_device(
+                scan_ok = wp_array_scan_int_device(
                     reinterpret_cast<uint64_t>(src), reinterpret_cast<uint64_t>(dst), static_cast<int>(rec->length),
                     rec->in_stride, rec->out_stride, rec->type_len, rec->inclusive != 0
                 );
             else if (rec->dtype == APIC_TYPE_INT64)
-                wp_array_scan_int64_device(
+                scan_ok = wp_array_scan_int64_device(
                     reinterpret_cast<uint64_t>(src), reinterpret_cast<uint64_t>(dst), static_cast<int>(rec->length),
                     rec->in_stride, rec->out_stride, rec->type_len, rec->inclusive != 0
                 );
             else if (rec->dtype == APIC_TYPE_FLOAT32)
-                wp_array_scan_float_device(
+                scan_ok = wp_array_scan_float_device(
                     reinterpret_cast<uint64_t>(src), reinterpret_cast<uint64_t>(dst), static_cast<int>(rec->length),
                     rec->in_stride, rec->out_stride, rec->type_len, rec->inclusive != 0
                 );
             else
-                wp_array_scan_double_device(
+                scan_ok = wp_array_scan_double_device(
                     reinterpret_cast<uint64_t>(src), reinterpret_cast<uint64_t>(dst), static_cast<int>(rec->length),
                     rec->in_stride, rec->out_stride, rec->type_len, rec->inclusive != 0
                 );
+            if (!scan_ok) {
+                // The scan has already recorded the CUDA reason; do not overwrite it.
+                success = false;
+            }
             break;
         }
 

--- a/warp/native/scan.cu
+++ b/warp/native/scan.cu
@@ -72,7 +72,7 @@ template <typename T> struct cub_strided_iterator {
 }  // anonymous namespace
 
 template <typename T>
-void scan_device(
+bool scan_device(
     const T* values_in, T* values_out, int n, int in_byte_stride, int out_byte_stride, int type_length, bool inclusive
 )
 {
@@ -91,28 +91,40 @@ void scan_device(
     cub_strided_iterator<const T> values_in_iter { values_in, in_stride };
     cub_strided_iterator<T> values_out_iter { values_out, out_stride };
 
+    // Stop if CUB cannot size its temporary storage; otherwise the scan could
+    // continue without valid temporary storage.
     if (inclusive) {
-        check_cuda(cub::DeviceScan::InclusiveSum(NULL, scan_temp_size, values_in_iter, values_out_iter, n, stream));
+        if (!check_cuda(
+                cub::DeviceScan::InclusiveSum(NULL, scan_temp_size, values_in_iter, values_out_iter, n, stream)
+            ))
+            return false;
     } else {
-        check_cuda(cub::DeviceScan::ExclusiveSum(NULL, scan_temp_size, values_in_iter, values_out_iter, n, stream));
+        if (!check_cuda(
+                cub::DeviceScan::ExclusiveSum(NULL, scan_temp_size, values_in_iter, values_out_iter, n, stream)
+            ))
+            return false;
     }
 
     void* temp_buffer = wp_alloc_device(WP_CURRENT_CONTEXT, scan_temp_size, "(native:scan)");
+    // wp_alloc_device() already records the CUDA error.
+    if (scan_temp_size > 0 && !temp_buffer)
+        return false;
 
     // scan each scalar component independently
-    for (int k = 0; k < type_length; ++k) {
+    bool success = true;
+    for (int k = 0; k < type_length && success; ++k) {
         cub_strided_iterator<const T> values_in_iter { values_in + k, in_stride };
         cub_strided_iterator<T> values_out_iter { values_out + k, out_stride };
         size_t temp_storage_bytes = scan_temp_size;
 
         if (inclusive) {
-            check_cuda(
+            success = check_cuda(
                 cub::DeviceScan::InclusiveSum(
                     temp_buffer, temp_storage_bytes, values_in_iter, values_out_iter, n, stream
                 )
             );
         } else {
-            check_cuda(
+            success = check_cuda(
                 cub::DeviceScan::ExclusiveSum(
                     temp_buffer, temp_storage_bytes, values_in_iter, values_out_iter, n, stream
                 )
@@ -121,19 +133,20 @@ void scan_device(
     }
 
     wp_free_device(WP_CURRENT_CONTEXT, temp_buffer);
+    return success;
 }
 
-template <typename T> void scan_device(const T* values_in, T* values_out, int n, bool inclusive)
+template <typename T> bool scan_device(const T* values_in, T* values_out, int n, bool inclusive)
 {
-    scan_device(values_in, values_out, n, sizeof(T), sizeof(T), 1, inclusive);
+    return scan_device(values_in, values_out, n, sizeof(T), sizeof(T), 1, inclusive);
 }
 
-template void scan_device(const int*, int*, int, bool);
-template void scan_device(const int64_t*, int64_t*, int, bool);
-template void scan_device(const float*, float*, int, bool);
-template void scan_device(const double*, double*, int, bool);
+template bool scan_device(const int*, int*, int, bool);
+template bool scan_device(const int64_t*, int64_t*, int, bool);
+template bool scan_device(const float*, float*, int, bool);
+template bool scan_device(const double*, double*, int, bool);
 
-template void scan_device(const int*, int*, int, int, int, int, bool);
-template void scan_device(const int64_t*, int64_t*, int, int, int, int, bool);
-template void scan_device(const float*, float*, int, int, int, int, bool);
-template void scan_device(const double*, double*, int, int, int, int, bool);
+template bool scan_device(const int*, int*, int, int, int, int, bool);
+template bool scan_device(const int64_t*, int64_t*, int, int, int, int, bool);
+template bool scan_device(const float*, float*, int, int, int, int, bool);
+template bool scan_device(const double*, double*, int, int, int, int, bool);

--- a/warp/native/scan.h
+++ b/warp/native/scan.h
@@ -14,9 +14,9 @@ void scan_host(
     int type_length,
     bool inclusive = true
 );
-template <typename T> void scan_device(const T* values_in, T* values_out, int n, bool inclusive = true);
+template <typename T> bool scan_device(const T* values_in, T* values_out, int n, bool inclusive = true);
 template <typename T>
-void scan_device(
+bool scan_device(
     const T* values_in,
     T* values_out,
     int n,

--- a/warp/native/warp.cpp
+++ b/warp/native/warp.cpp
@@ -1276,25 +1276,29 @@ WP_API int wp_cuda_get_max_cluster_dim(void* context, void* kernel, int block_di
 WP_API void wp_cuda_set_context_restore_policy(bool always_restore) { }
 WP_API int wp_cuda_get_context_restore_policy() { return false; }
 
-WP_API void wp_array_scan_int_device(
+WP_API bool wp_array_scan_int_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 )
 {
+    return false;
 }
-WP_API void wp_array_scan_int64_device(
+WP_API bool wp_array_scan_int64_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 )
 {
+    return false;
 }
-WP_API void wp_array_scan_float_device(
+WP_API bool wp_array_scan_float_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 )
 {
+    return false;
 }
-WP_API void wp_array_scan_double_device(
+WP_API bool wp_array_scan_double_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 )
 {
+    return false;
 }
 
 WP_API bool wp_cuda_graphics_map(void* context, void* resource) { return false; }

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -2403,36 +2403,36 @@ static void apic_capture_array_scan_device(
     );
 }
 
-void wp_array_scan_int_device(
+bool wp_array_scan_int_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 )
 {
     apic_capture_array_scan_device(in, out, len, in_stride, out_stride, type_len, APIC_TYPE_INT32, inclusive);
-    scan_device((const int*)in, (int*)out, len, in_stride, out_stride, type_len, inclusive);
+    return scan_device((const int*)in, (int*)out, len, in_stride, out_stride, type_len, inclusive);
 }
 
-void wp_array_scan_int64_device(
+bool wp_array_scan_int64_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 )
 {
     apic_capture_array_scan_device(in, out, len, in_stride, out_stride, type_len, APIC_TYPE_INT64, inclusive);
-    scan_device((const int64_t*)in, (int64_t*)out, len, in_stride, out_stride, type_len, inclusive);
+    return scan_device((const int64_t*)in, (int64_t*)out, len, in_stride, out_stride, type_len, inclusive);
 }
 
-void wp_array_scan_float_device(
+bool wp_array_scan_float_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 )
 {
     apic_capture_array_scan_device(in, out, len, in_stride, out_stride, type_len, APIC_TYPE_FLOAT32, inclusive);
-    scan_device((const float*)in, (float*)out, len, in_stride, out_stride, type_len, inclusive);
+    return scan_device((const float*)in, (float*)out, len, in_stride, out_stride, type_len, inclusive);
 }
 
-void wp_array_scan_double_device(
+bool wp_array_scan_double_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 )
 {
     apic_capture_array_scan_device(in, out, len, in_stride, out_stride, type_len, APIC_TYPE_FLOAT64, inclusive);
-    scan_device((const double*)in, (double*)out, len, in_stride, out_stride, type_len, inclusive);
+    return scan_device((const double*)in, (double*)out, len, in_stride, out_stride, type_len, inclusive);
 }
 
 int wp_cuda_driver_version()

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -446,16 +446,16 @@ WP_API void wp_array_scan_double_host(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 );
 
-WP_API void wp_array_scan_int_device(
+WP_API bool wp_array_scan_int_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 );
-WP_API void wp_array_scan_int64_device(
+WP_API bool wp_array_scan_int64_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 );
-WP_API void wp_array_scan_float_device(
+WP_API bool wp_array_scan_float_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 );
-WP_API void wp_array_scan_double_device(
+WP_API bool wp_array_scan_double_device(
     uint64_t in, uint64_t out, int len, int in_stride, int out_stride, int type_len, bool inclusive
 );
 

--- a/warp/tests/test_utils.py
+++ b/warp/tests/test_utils.py
@@ -9,7 +9,9 @@ import subprocess
 import sys
 import unittest
 import warnings
+from unittest.mock import patch
 
+from warp._src import context as _context
 from warp._src import logger as _logger
 from warp._src.logger import log_warning
 from warp.tests.unittest_utils import *
@@ -185,6 +187,18 @@ def test_array_scan_error_unsupported_dtype(test, device):
     with test.assertRaisesRegex(
         RuntimeError,
         r"Unsupported data type: vec3h$",
+    ):
+        wp.utils.array_scan(values, result, True)
+
+
+def test_array_scan_error_device_failure_is_reported(test, device):
+    """A failed device scan raises instead of leaving the output silently unwritten."""
+    values = wp.zeros(16, dtype=wp.int32, device=device)
+    result = wp.zeros(16, dtype=wp.int32, device=device)
+
+    with (
+        patch.object(_context.runtime.core, "wp_array_scan_int_device", lambda *args: False),
+        test.assertRaises(RuntimeError),
     ):
         wp.utils.array_scan(values, result, True)
 
@@ -904,6 +918,7 @@ def parenthesized_multiline_lambda():
 
 
 devices = get_test_devices()
+cuda_devices = get_cuda_test_devices()
 
 
 class TestUtils(unittest.TestCase):
@@ -1252,6 +1267,12 @@ add_function_test(
     TestUtils, "test_array_inner_error_unsupported_dtype", test_array_inner_error_unsupported_dtype, devices=devices
 )
 add_function_test(TestUtils, "test_array_cast", test_array_cast, devices=devices)
+add_function_test(
+    TestUtils,
+    "test_array_scan_error_device_failure_is_reported",
+    test_array_scan_error_device_failure_is_reported,
+    devices=cuda_devices,
+)
 add_function_test(
     TestUtils,
     "test_array_cast_error_unsupported_partial_cast",


### PR DESCRIPTION
## Description

`wp.utils.array_scan()` can return normally having left its output array unwritten on CUDA devices. `scan_device` discards the result of every `check_cuda` call and returns `void`, so a CUDA failure while sizing CUB's temporary storage, allocating it, or running the scan is recorded in Warp's error string and then dropped. The caller sees a
successful call and a wrong result.

This is silent data corruption rather than a crash, which is what makes it hard to diagnose from the caller's side. Downstream code that validates its inputs raises a *plausible domain error* on the bad data, so the failure presents as a bug in the caller rather than a CUDA fault, and the only evidence is a line on stderr that nothing correlates with the result. Note this is not limited to out-of-memory: any CUDA error reached inside `scan_device`, including one already pending on the context from earlier work, is swallowed the same way.

We hit this in a molecular-simulation workload where a corrupted prefix sum inside a neighbor-list build surfaced as a legitimate-looking overflow error.

The asymmetry this fixes: Warp's *Python* allocators already check and raise (`Failed to allocate {size_in_bytes} bytes...` in `warp/_src/context.py`), so `wp.zeros()` fails loudly on OOM. Only the native internal path was silent.

Closes #1894

## Changes

**`warp/native/scan.cu`** — `scan_device` returns `bool` and checks all three failure sites rather than only the allocation:

- The CUB sizing call is the first domino. If it fails, `scan_temp_size` stays at its `0` initializer, so the allocation then asks for zero bytes and *succeeds*, and the scan runs with no temporary storage. Guarding only the allocation does not catch this — it is the path our reproducer actually takes.
- The allocation is guarded only when a nonzero size was requested, and the error string `wp_alloc_device` already recorded is left intact rather than overwritten.
- The per-component loop accumulates status and exits early; `temp_buffer` is still freed on every path.

**Propagation** — `warp/native/scan.h`, `warp/native/warp.h`, and the four `wp_array_scan_*_device` definitions in `warp/native/warp.cu`. The `WP_ENABLE_CUDA=0` stubs in `warp/native/warp.cpp` return `bool`/`false` so CPU-only builds still compile.

**`warp/_src/context.py`** — declares `restype = ctypes.c_bool` for the four device functions. It was previously unset, so ctypes was reading the return as `c_int`.

**`warp/_src/utils.py`** — `array_scan()` raises `RuntimeError(runtime.get_error_string())` on device failure, matching the existing convention used elsewhere in `warp/_src/context.py`.

**Not changed:** `scan_host` still returns `void`. `warp/native/scan.cpp` allocates nothing and has no CUDA status to report, so a `bool` there would always be `true`. Happy to make it symmetric if you would prefer that for the shared Python call site.

**Not in scope:** `radix_sort_pairs` looks like the same shape — native half returns `void`, status dropped. Left out deliberately; glad to follow up.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

Built from source and tested on an NVIDIA H100 80GB HBM3 (CUDA Toolkit 12.9, driver 13.0), via `build_lib.py --quick --no-use-libmathdx`.

1. **Reproduced the bug first, on 1.17.0 from PyPI.** With the device filled so CUB's temporary storage cannot be sized, `array_scan()` returned normally and the output array was left as zeros instead of `[1, 2, 3, ...]`. Warp's own stderr showed `Warp CUDA error 101: invalid device ordinal (in function scan_device, scan.cu:95)` followed by `Warp CUDA error 2: out of memory (... scan.cu:109)` — with no failure at the allocation in between, which is what redirected the fix from a null check to checking every status.

2. **Red/green on the new test.** `test_array_scan_error_device_failure_is_reported` stubs the FFI entry point to report failure and asserts `array_scan()` raises. Reverting only the Python-side check makes it fail with `AssertionError: RuntimeError not raised`; with the change it passes.

3. **No regression.** All 16 `array_scan` tests in `warp/tests/test_utils.py` pass on `cuda:0` and `cpu`. An ordinary scan of 65536 ones still yields `[1..8]` at the head and `65536` at the tail.

4. **The failure now surfaces.** The same filled-device scenario raises `RuntimeError: Warp CUDA error 101: invalid device ordinal (in function scan_device, scan.cu:98)` instead of returning a zeroed buffer, raised by the guard on the sizing call.

5. **CPU-only build.** macOS aarch64 with `WP_ENABLE_CUDA=0` and `-Werror` compiles `warp.cpp` and links `libwarp.dylib` with all four device scan symbols present.

**Coverage limitation.** The new test covers the propagation path deterministically and needs no GPU, but the native guards themselves are only exercised by the hardware reproducer below, which fills an 80 GB device and is not CI material. I could not find an existing way to inject a failure into a *native internal* allocation: `set_device_allocator` is a Python-layer hook, and `wp_alloc_device_default` calls `cudaMalloc` directly with only `g_alloc_tracker` observing. If you would like an injectable allocation-failure path so this class of bug becomes testable in CI, I am glad to do that as a separate PR — it seemed too much of an API decision to fold in here.

## Bug fix

Minimal reproducer **without** this PR applied. Requires a GPU you can fill; the point is to make CUB's temporary storage unsizeable while the scan operands are already resident.

```python
import numpy as np
import warp as wp

wp.init()
device = wp.get_device("cuda:0")

# Plain cudaMalloc fails cleanly when the device is full; the async mempool can
# satisfy a small late request out of reserve.
if wp.is_mempool_supported(device):
    wp.set_mempool_enabled(device, False)

n = 1 << 20
values = wp.array(np.ones(n, dtype=np.int32), device=device)
out = wp.zeros(n, dtype=wp.int32, device=device)

# Fill the device, halving the request whenever one fails.
hogs = []
size_bytes = 1 << 30
while size_bytes >= 4096:
    try:
        hogs.append(wp.zeros(size_bytes // 4, dtype=wp.int32, device=device))
    except RuntimeError:
        size_bytes //= 2

wp.utils.array_scan(values, out, inclusive=True)  # returns normally, no exception

hogs.clear()
print(out.numpy()[:8])  # [0 0 0 0 0 0 0 0], expected [1 2 3 4 5 6 7 8]
```

With this PR, `array_scan()` raises `RuntimeError` carrying the CUDA reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CUDA array scans now report device-side failures instead of silently returning incomplete output.
  * Clear `RuntimeError` messages are raised when temporary storage sizing, allocation, or scan execution fails.
  * CUDA scan replay now detects and preserves scan failures.

* **Tests**
  * Added coverage to verify that CUDA array-scan errors are surfaced correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->