### PR TITLE
Support native Windows linking from wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,13 +128,181 @@ jobs:
         env:
           WARP_CACHE_PATH: ${{ runner.temp }}/warp-cache-${{ matrix.artifact-name }}
         run: uv run build_lib.py ${{ matrix.build-args }}
-      
+
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ${{ matrix.artifact-name }}
           path: warp/bin/
           retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
+
+  build-windows-wheels:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
+    name: build-windows-wheel (${{ matrix.platform }})
+    needs: build-warp
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    env:
+      UV_PYTHON: ${{ matrix.python_request || '3.12' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2022
+            platform: windows-x86_64-cuda12
+            build_artifact_name: build-artifact-windows-cuda12
+            wheel_artifact_name: wheel-artifact-windows-x86_64-cuda12
+            wheel_platform: windows-x86_64
+            wheel_tag: win_amd64
+          - os: windows-2022
+            platform: windows-x86_64-cuda13
+            build_artifact_name: build-artifact-windows-cuda13
+            wheel_artifact_name: wheel-artifact-windows-x86_64-cuda13
+            wheel_platform: windows-x86_64
+            wheel_tag: win_amd64
+          - os: windows-11-arm
+            platform: windows-aarch64-cpu
+            python_request: cpython-3.12-windows-aarch64-none
+            build_artifact_name: build-artifact-windows-aarch64-cpu
+            wheel_artifact_name: wheel-artifact-windows-aarch64-cpu
+            wheel_platform: windows-aarch64
+            wheel_tag: win_arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          version: "0.12.7"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Download Warp build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: ${{ matrix.build_artifact_name }}
+          path: warp/bin/
+
+      - name: Build Windows wheel
+        shell: pwsh
+        run: |
+          uv build --wheel --out-dir _build/wheel -C--build-option=-P${{ matrix.wheel_platform }}
+          $wheels = @(Get-ChildItem -Path _build/wheel -Filter *.whl)
+          if ($wheels.Count -ne 1) {
+            throw "Expected one wheel, found $($wheels.Count)"
+          }
+          $expectedSuffix = "-${{ matrix.wheel_tag }}.whl"
+          if (-not $wheels[0].Name.EndsWith($expectedSuffix)) {
+            throw "Expected wheel tag ${{ matrix.wheel_tag }}, found $($wheels[0].Name)"
+          }
+
+      - name: Upload Windows wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.wheel_artifact_name }}
+          path: _build/wheel/*.whl
+          if-no-files-found: error
+          retention-days: ${{ github.repository == 'NVIDIA/warp' && 7 || 1 }}
+
+  test-windows-import-libraries:
+    if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'
+    name: test-windows-import-libraries (${{ matrix.platform }})
+    needs: build-windows-wheels
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    env:
+      UV_PYTHON: ${{ matrix.python_request || '3.12' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2022
+            platform: windows-x86_64-cuda12
+            wheel_artifact_name: wheel-artifact-windows-x86_64-cuda12
+            python_machine: amd64
+          - os: windows-2022
+            platform: windows-x86_64-cuda13
+            wheel_artifact_name: wheel-artifact-windows-x86_64-cuda13
+            python_machine: amd64
+          - os: windows-11-arm
+            platform: windows-aarch64-cpu
+            python_request: cpython-3.12-windows-aarch64-none
+            wheel_artifact_name: wheel-artifact-windows-aarch64-cpu
+            python_machine: arm64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          version: "0.12.7"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Download Windows wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: ${{ matrix.wheel_artifact_name }}
+          path: _build/wheel/
+
+      - name: Install Windows wheel
+        shell: pwsh
+        run: |
+          $wheels = @(Get-ChildItem -Path _build/wheel -Filter *.whl)
+          if ($wheels.Count -ne 1) {
+            throw "Expected one wheel, found $($wheels.Count)"
+          }
+          $wheelPath = $wheels[0].FullName
+          uv pip install --target _build/wheel-install $wheelPath
+
+      - name: Test installed Windows wheel
+        env:
+          WARP_CACHE_PATH: ${{ runner.temp }}/warp-cache-${{ matrix.platform }}-wheel
+        working-directory: _build/wheel-install
+        shell: pwsh
+        run: |
+          @'
+          import platform
+
+          import warp as wp
+
+          wp.init()
+          info = wp.print_diagnostics()
+          assert info["warp_python"] == info["warp_native"], info
+          assert info["warp_clang"].split()[0] == info["warp_python"], info
+          machine = platform.machine().lower()
+          assert machine == "${{ matrix.python_machine }}", machine
+          '@ | uv run --no-project python -
+
+      - name: Test Windows import libraries
+        shell: pwsh
+        run: |
+          cmake `
+            -S tools/ci/windows_import_library_smoke `
+            -B _build/windows-import-library-smoke `
+            -DWARP_PACKAGE_ROOT:PATH="$env:GITHUB_WORKSPACE/_build/wheel-install/warp"
+          if ($LASTEXITCODE -ne 0) {
+            throw "CMake configuration failed with exit code $LASTEXITCODE"
+          }
+          cmake --build _build/windows-import-library-smoke --config Release
+          if ($LASTEXITCODE -ne 0) {
+            throw "CMake build failed with exit code $LASTEXITCODE"
+          }
+          ctest `
+            --test-dir _build/windows-import-library-smoke `
+            --build-config Release `
+            --output-on-failure
       
   build-warp-python-free-threaded:
     if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -68,7 +68,9 @@ jobs:
         run: |
           source "${HOME}/conda/etc/profile.d/conda.sh"
           conda activate
+          # api.h owns WP_API; avoid Cppcheck's invalid WP_API=1 configuration.
           cppcheck \
+            -UWP_API \
             --inline-suppr \
             --cppcheck-build-dir=_build/.cppcheck \
             --enable=warning \
@@ -85,7 +87,9 @@ jobs:
         run: |
           source "${HOME}/conda/etc/profile.d/conda.sh"
           conda activate
+          # Keep this configuration in sync with the gating command above.
           cppcheck \
+            -UWP_API \
             --inline-suppr \
             --cppcheck-build-dir=_build/.cppcheck \
             --enable=warning \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -389,6 +389,7 @@ cppcheck:
     - cppcheck_exit_code=0
     - >-
       cppcheck
+      -UWP_API
       --inline-suppr
       --cppcheck-build-dir=_build/.cppcheck
       --enable=warning
@@ -403,6 +404,7 @@ cppcheck:
     # Pass 2: For the Code Quality report.
     - >-
       cppcheck
+      -UWP_API
       --inline-suppr
       --cppcheck-build-dir=_build/.cppcheck
       --enable=warning

--- a/.gitlab/ci/common.yml
+++ b/.gitlab/ci/common.yml
@@ -105,7 +105,9 @@ default:
   move-windows-binaries-to-platform-dir:
     - mkdir -p warp/bin/windows-x86_64
     - mv warp/bin/warp.dll warp/bin/windows-x86_64/
+    - mv warp/bin/warp.lib warp/bin/windows-x86_64/
     - mv warp/bin/warp-clang.dll warp/bin/windows-x86_64/
+    - mv warp/bin/warp-clang.lib warp/bin/windows-x86_64/
   
   move-macos-binaries-to-platform-dir:
     - mkdir -p warp/bin/macos-aarch64
@@ -154,6 +156,7 @@ default:
       - warp/native/exports.h
       - warp/native/version.h
       - warp/bin/**/*.dll
+      - warp/bin/**/*.lib
       - warp/bin/**/*.so
       - warp/bin/**/*.dylib
       - VERSION.md

--- a/.gitlab/ci/debug-build-and-test.yml
+++ b/.gitlab/ci/debug-build-and-test.yml
@@ -144,7 +144,9 @@ create pypi wheels:
     # Move binaries into platform-specific folders. Already done in the build jobs for Linux.
     - mkdir -p warp/bin/windows-x86_64
     - mv warp/bin/warp.dll warp/bin/windows-x86_64/
+    - mv warp/bin/warp.lib warp/bin/windows-x86_64/
     - mv warp/bin/warp-clang.dll warp/bin/windows-x86_64/
+    - mv warp/bin/warp-clang.lib warp/bin/windows-x86_64/
   script:
     - uv build --wheel -C--build-option=-Pwindows-x86_64
     - uv build --wheel -C--build-option=-Plinux-x86_64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ endif()
 # builds that need the full CUDA compatibility policy.
 set(WARP_ENABLE_CUDA_COMPATIBILITY_VALUE 0)
 
+target_compile_definitions(warp PRIVATE WP_BUILD_DLL)
 target_compile_definitions(
     warp
     PRIVATE
@@ -396,6 +397,7 @@ if(WARP_BUILD_CLANG)
         warp-clang
         PRIVATE "$<$<AND:$<PLATFORM_ID:Linux>,$<COMPILE_LANG_AND_ID:CXX,GNU>>:-fabi-version=13>"
     )
+    target_compile_definitions(warp-clang PRIVATE WP_BUILD_DLL)
     target_compile_definitions(
         warp-clang
         PRIVATE

--- a/changelog/1888.added.md
+++ b/changelog/1888.added.md
@@ -1,0 +1,3 @@
+Ship `warp.lib` and `warp-clang.lib` in Windows wheels and add `warp_clang.h` so native C++ applications can link to
+Warp and warp-clang without resolving each entry point manually. Keep the native headers, import libraries, and DLLs on
+the same Warp release.

--- a/design/windows-import-libraries.md
+++ b/design/windows-import-libraries.md
@@ -1,0 +1,387 @@
+# Windows import libraries
+
+**Status**: Proposed
+
+**Issue**: [GH-1888](https://github.com/NVIDIA/warp/issues/1888)
+
+## Motivation
+
+Warp's Windows builds produce `warp.dll` and `warp-clang.dll`. The Microsoft
+linker also creates the corresponding `warp.lib` and `warp-clang.lib` import
+libraries, but Windows wheels leave the `.lib` files out. Native applications
+that use Warp from a wheel must therefore open each DLL and resolve every entry
+point with `LoadLibrary()` and `GetProcAddress()`.
+
+The C++ controller runtime proposed in
+[Newton PR #4068](https://github.com/newton-physics/newton/pull/4068) shows the
+cost of that omission. It has platform-specific library helpers, two function
+pointer tables, and a lookup for every Warp entry point it calls. If Warp ships
+the import libraries, the controller can link to those functions directly and
+drop most of that code.
+
+An import library does not put Warp's implementation into the application. It
+records the DLL and symbol names for the Windows loader. This is more convenient
+for callers, but it does not make the native ABI stable. Removing or renaming a
+symbol can stop the process before `main()`. Changing a function signature
+without changing its C symbol name is worse: the process may start, then behave
+incorrectly or crash when the application calls the function. For now, native
+linking requires an exact version match.
+
+Linux and macOS do not need companion import libraries because their linkers
+consume `.so` and `.dylib` files directly. The header and version rules in this
+design apply on all platforms. Only the new packaged binaries are specific to
+Windows.
+
+## Requirements
+
+| ID | Requirement | Priority | Notes |
+| --- | --- | --- | --- |
+| R1 | Ship `warp.lib` and `warp-clang.lib` alongside their DLLs in Windows wheels. | Must | Applies to every Windows architecture for which a wheel is constructed. |
+| R2 | Make Windows import-library output paths deterministic in the native build. | Must | The import libraries remain beside the DLLs under `warp/bin`. |
+| R3 | Provide correct export annotations for native-library builds and import annotations for consumers. | Must | Generated JIT modules must retain their existing export behavior. |
+| R4 | Provide declarations for the `warp-clang` CPU-module entry points needed by APIC consumers. | Must | Keep the header narrow and mark the interface experimental. |
+| R5 | Require headers, import libraries, DLLs, and APIC artifacts from the same Warp release. | Must | No backward or forward native ABI guarantee is introduced. |
+| R6 | Fail Windows wheel construction when any required DLL or import library is absent. | Must | Prevent a partial package from silently reaching a release. |
+| R7 | Compile, link, and run a native consumer against both import libraries in Windows CI. | Must | The smoke test must not require a GPU. |
+| R8 | Preserve existing Python native-library loading and non-Windows packaging. | Must | Python continues loading the shared libraries by explicit path. |
+| R9 | Update the C++ APIC examples to demonstrate direct native linking and version checks. | Must | The examples remain self-contained rather than depending on a packaged CMake configuration. |
+
+**Non-goals**:
+
+- Defining a backward- or forward-compatible native ABI.
+- Defining cross-version compatibility for `.wrp` files or their companion
+  module artifacts.
+- Adding a stable entry-point query function or a generated function table.
+- Adding versioned DLL filenames.
+- Adding a packaged CMake configuration or official umbrella CMake target.
+- Adding delay-load behavior for `warp-clang.dll`.
+- Updating downstream consumers such as Newton in the Warp change.
+
+## Design
+
+### Approach
+
+Warp packages conventional Microsoft import libraries and treats native
+linking as an exact-version workflow. The build already creates the files. The
+remaining work is to give them predictable output paths, put them in Windows
+wheels, declare the small `warp-clang` surface needed by APIC consumers, and
+use the result in Warp's C++ APIC examples and a native smoke test.
+
+Applications check versions before making other native calls. Those checks can
+catch a mismatched DLL only after the Windows loader has started the process.
+They cannot recover from a missing load-time import.
+
+### Native API visibility
+
+`warp/native/api.h` becomes the single home for `WP_API`, which is currently
+defined in more than one native header. `warp.h`, `crt.h`, `apic.h`, and the new
+`warp_clang.h` use that definition.
+
+Keeping the visibility macro in a small standalone header lets each native API
+header declare imported or exported symbols without including unrelated Warp
+runtime, APIC, or CRT declarations. It also keeps the producer-versus-consumer
+rule consistent across those independently usable headers.
+
+On Windows:
+
+- A native DLL build defines `WP_BUILD_DLL`, so `WP_API` expands to
+  `__declspec(dllexport)`.
+- A generated JIT module defines `WP_NO_CRT` and keeps the export annotation
+  used today for JIT-visible entry points.
+- A normal consumer gets `__declspec(dllimport)`.
+- CUDA device code gets no DLL annotation.
+
+On Linux and macOS, `WP_API` keeps default symbol visibility. The
+`build_lib.py` and top-level CMake builds define `WP_BUILD_DLL` for both `warp`
+and `warp-clang`. Treating `WP_NO_CRT` as an export case preserves the current
+behavior of generated CPU and CUDA modules.
+
+### `warp-clang` header
+
+`warp/native/warp_clang.h` declares the four CPU-module functions needed by a
+standalone APIC consumer:
+
+- `wp_load_obj()`
+- `wp_unload_obj()`
+- `wp_lookup()`
+- `wp_warp_clang_version()`
+
+The header uses the C ABI and includes both the common visibility definition
+and the generated Warp version. Its comments identify the interface as
+experimental and require an exactly matching Warp release. Internal compiler
+entry points such as `wp_compile_cpp()` and `wp_compile_cuda()` remain out of
+the consumer header.
+
+This is enough for Newton PR #4068. `warp.h` and `apic.h` already declare every
+core and APIC function used by the proposed controller runtime. The controller
+copies only `wp_load_obj()` and `wp_lookup()` from
+`warp/native/clang/clang.cpp`.
+
+### Downstream fit: Newton
+
+The proposed `FindWarp.cmake` in draft Newton PR #4068 locates `warp.dll` and
+`warp-clang.dll`, then passes both absolute paths to `controller.cpp`. It does
+not create linkable targets. The controller opens the libraries and resolves
+their entry points at runtime.
+
+Once the wheel contains import libraries, Newton can keep its discovery module
+and create ordinary CMake imported targets. On Windows, each target sets the
+DLL as `IMPORTED_LOCATION` and its `.lib` as `IMPORTED_IMPLIB`. Because
+`newton_controllers` is a static library, it links those targets publicly so
+the final executable inherits the native dependencies. Newton may link the
+shared libraries directly on Linux and macOS or keep its current runtime loader
+there. Nothing in this Warp change forces that choice.
+
+Direct linking removes `dynamic_library.cpp`, `dynamic_library.hpp`, the
+absolute-path compile definitions, both function pointer tables, the symbol
+resolver, and the copied `warp-clang` declarations from the proposed Newton
+runtime. Its CUDA and CPU graph-loading paths stay as they are. The same is true
+of CPU module registration; neither part exists to work around Windows DLL
+loading.
+
+Newton currently calls `wp_init(nullptr)`, which disables Warp's core-library
+version check. It should call `wp_init(WP_VERSION_STRING)` instead. Before the
+first CPU-module operation, it should also compare
+`wp_warp_clang_version()` with `WP_VERSION_STRING`.
+
+### C++ reference examples
+
+The existing CUDA and CPU APIC examples demonstrate the supported native
+linking pattern without introducing a packaged CMake configuration. Their
+CMake files define local imported shared targets. On Windows, each target uses
+the DLL as `IMPORTED_LOCATION` and the matching import library as
+`IMPORTED_IMPLIB`; a post-build command copies the required DLLs beside the
+executable. Linux and macOS link their shared libraries directly.
+
+The CUDA example links `Warp::runtime` and passes `WP_VERSION_STRING` to
+`wp_init()`. The CPU example also links `Warp::clang`, includes
+`warp_clang.h`, and calls `wp_load_obj()` and `wp_lookup()` directly. This
+replaces its platform-specific `LoadLibrary()`/`GetProcAddress()` and
+`dlopen()`/`dlsym()` code. It checks both the core runtime and `warp-clang`
+versions before loading a graph or its CPU modules.
+
+The CPU example's Makefile follows the same dependency model. It links both
+shared libraries on Linux and macOS, links both import libraries on Windows,
+and stages both Windows DLLs beside the executable.
+
+### Build artifacts
+
+The Windows `link.exe` command passes an explicit `/IMPLIB` path based on the
+DLL output path. Building `warp.dll` writes `warp.lib`, and building
+`warp-clang.dll` writes `warp-clang.lib`. Both files go in `warp/bin` beside the
+DLLs. The linker-generated `.exp` files stay as build intermediates and are not
+distributed.
+
+The top-level CMake build already sends archive outputs to `warp/bin`, so its
+Windows output remains consistent with `build_lib.py`.
+
+### Wheel packaging
+
+The platform metadata in `setup.py` accepts more than one native-library
+extension for a platform. Windows recognizes `.dll` and `.lib`. Linux and
+macOS continue to recognize only `.so` and `.dylib`.
+
+A Windows wheel requires all four files:
+
+- `warp.dll`
+- `warp.lib`
+- `warp-clang.dll`
+- `warp-clang.lib`
+
+Wheel construction fails if any one is missing. GitLab's Windows wheel-staging
+helpers move the complete set into the platform directory before building the
+wheel. The existing `native/*.h` package-data rule already covers `api.h` and
+`warp_clang.h`.
+
+### Consumer compatibility contract
+
+Native consumers compile and deploy one matched set of Warp artifacts. On
+Windows, that set contains the headers, import libraries, and DLLs from the
+same release. A standalone APIC application also uses `.wrp` files and module
+artifacts produced by that release.
+
+Before other native calls, the application:
+
+1. Calls `wp_init(WP_VERSION_STRING)` instead of passing a null expected
+   version.
+2. Compares `wp_warp_clang_version()` with `WP_VERSION_STRING` before loading
+   CPU modules.
+
+These checks produce a controlled error when the loader finds a mismatched
+library that still exports the requested symbols. They cannot help when a DLL
+or symbol is missing, since Windows may reject the process before `main()`.
+They also cannot make an incompatible function signature safe. The
+documentation states those limits and tells applications to put the matching
+DLLs beside the executable or configure the DLL search path deliberately.
+
+A normal link to `warp-clang.lib` makes `warp-clang.dll` a startup dependency,
+even when an application eventually uses only CUDA APIC graphs. Both DLLs are
+included in the same Warp Windows distribution package, such as a wheel or
+conda package, but remain separate libraries. The first version of this
+feature accepts that dependency instead of adding MSVC delay-load
+configuration and failure hooks.
+
+### Continuous integration
+
+`tools/ci/windows_import_library_smoke/` contains a `CMakeLists.txt` and one
+C++ source file. The project:
+
+- Finds the native headers and both import libraries under a supplied Warp
+  package root.
+- Includes `warp.h`, `apic.h`, and `warp_clang.h`.
+- Calls `wp_init()`, creates and destroys an APIC state, and keeps references
+  to the object-loading functions so the executable imports the native symbols
+  used by APIC consumers.
+- Calls `wp_version()` and `wp_warp_clang_version()` directly.
+- Compares both results with `WP_VERSION_STRING`, using distinct nonzero exit
+  codes for mismatches.
+- Copies both DLLs beside the executable and registers it with CTest.
+
+The program calls `wp_init()`, which safely continues when CUDA initialization
+is unavailable, so the smoke test does not need a GPU. After the GitHub
+`build-warp` matrix uploads its artifacts, the `build-windows-wheels` matrix
+downloads each Windows artifact, builds a wheel, checks its platform tag, and
+uploads it separately. A downstream Windows job installs each wheel into a
+clean directory, confirms that Python can initialize Warp with matching
+native-library versions and architecture, then configures, builds, and runs the
+CMake smoke project against that installed package. The matrices cover the
+Windows x86-64 CUDA 12 and CUDA 13 artifacts and the Windows ARM64 CPU artifact.
+
+Keeping wheel construction separate from consumer validation ensures a CMake,
+Python, or smoke-test failure cannot suppress the wheel artifact. A link or
+runtime failure still fails CI. These checks belong to build and packaging
+validation, not the core Python test suite, so they add no test under
+`warp/tests`. The package-time file check separately protects GitLab wheel
+builds.
+
+### Alternatives considered
+
+#### Stable entry-point query
+
+Warp could export one stable function that resolves the rest of the API by
+name. Applications could then diagnose missing optional functions and choose
+their own compatibility behavior. They would still need function tables and
+per-symbol resolution, which is most of the code GH-1888 aims to remove. A
+query API can be considered later, after Warp defines its native ABI goals.
+
+#### Versioned DLL filenames
+
+Putting an API or release version in each DLL name would stop an application
+from loading a differently named release by accident. It would also require
+changes to Python loading, native builds, wheels, examples, deployment, and
+downstream build systems. A changed signature behind an unchanged C symbol
+would remain incompatible.
+
+#### Continue explicit runtime loading
+
+`LoadLibrary()` and `GetProcAddress()` let applications report their own loader
+errors and load `warp-clang` only when needed. The cost is repeated platform
+code, function pointer tables, and symbol resolution in every consumer. That
+is the code GH-1888 removes.
+
+#### Package a CMake configuration
+
+Official imported targets could hide filenames and usage requirements from
+consumers such as Newton. They would also create a broader build-system API
+than this fix needs. A CMake package can be evaluated separately once native
+linking has real downstream use.
+
+## Testing strategy
+
+Verification covers each affected layer:
+
+1. Rebuild Warp after changing native visibility and linker options.
+2. Run targeted formatting and static checks on the changed files.
+3. Build Windows x86-64 and ARM64 wheels and check their platform tags.
+4. Install each wheel into a clean directory and confirm that Python
+   initialization reports matching `warp` and `warp-clang` versions and the
+   expected machine architecture.
+5. Build and run the CMake smoke consumer against each installed wheel.
+
+The smoke program initializes Warp, checks the two version functions, creates
+and destroys an APIC state, and references each function in `warp_clang.h`. If
+the process starts, Windows found both DLLs and resolved the imports used by a
+native APIC consumer. Matching return values show that both libraries agree
+with the headers used to compile the program. Existing APIC tests continue to
+cover broader APIC behavior.
+
+## Future work: relocatable Linux native consumers
+
+Investigate a relocatable Linux consumer recipe separately from this Windows
+packaging change. Prefer improving the consuming targets and deployment
+instructions before changing the identity of Warp's shared libraries. An
+executable that records an absolute dependency on a wheel's installation path
+can stop working when that installation moves. This is distinct from Python's
+normal loading path: `Runtime` in `warp/_src/context.py` locates both libraries
+inside the installed package and opens them by explicit path.
+
+### Investigation results
+
+A focused investigation used the Linux x86-64 `build_lib.py` outputs for
+`1.18.0.dev3`, glibc 2.35, GCC 11.4, and CMake 4.3.3. Both libraries lacked
+`DT_SONAME`. The SONAME experiments used temporary library copies with
+`patchelf --set-soname warp.so` and `patchelf --set-soname warp-clang.so`;
+these were metadata experiments, not validation of a changed release build.
+
+| Configuration | Observed result |
+| --- | --- |
+| Existing libraries, absolute `IMPORTED_LOCATION` | The executable recorded absolute `DT_NEEDED` paths. Moving the package broke startup even with `LD_LIBRARY_PATH` pointing at its new location. |
+| Existing libraries, GNU filename linking (`-l:warp.so`, `-l:warp-clang.so`) | The executable recorded library basenames. A moved application bundle ran from an unrelated working directory using `$ORIGIN/../lib` RUNPATH, with no `LD_LIBRARY_PATH`. |
+| Copies with basename SONAMEs, absolute `IMPORTED_LOCATION` | New executables recorded the SONAMEs and passed the same relocation checks. |
+| Existing libraries, `IMPORTED_NO_SONAME TRUE` | CMake generated `-lwarp` and `-lwarp-clang`, which failed because the files lack the conventional `lib` prefix. This property alone was insufficient. |
+| Python with existing or SONAME-modified copies | Package initialization, version checks, and a JIT-compiled kernel on CPU and both available CUDA devices passed before and after moving the copied package trees. |
+| Previously linked executable, libraries replaced by SONAME-modified copies | It still ran at the original path, but still failed after relocation. Changing library metadata does not rewrite an existing executable's dependencies. |
+
+The native probes called both version functions, initialized Warp, and created
+and destroyed an APIC state. These checks establish the narrower loading and
+relocation behavior; they do not replace full runtime or APIC replay coverage.
+A minimal CMake `SHARED` target using Warp's output naming emitted a SONAME by
+default, so a future change must inspect actual outputs from both native build
+paths and installed wheels rather than assume they have identical metadata.
+
+### Compatibility risks
+
+Adding a SONAME affects dependency selection as well as relocation. In small
+ELF fixtures representing two installations, a host first opened library A by
+absolute path with `RTLD_LOCAL`, then opened a plugin linked against B. When
+both libraries advertised the same SONAME, the plugin reused A. With an
+absolute dependency and no SONAME, it used B. Explicitly opening B by full path
+still returned B in both cases. This demonstrates an additional alias used by
+the loader, not a failure of ordinary Python package loading.
+
+Filename linking also needs a deliberate deployment policy. In the fixtures,
+`LD_LIBRARY_PATH` could override a plugin's RUNPATH and select another
+installation for either kind of basename dependency. Loading A with
+`RTLD_GLOBAL` could also redirect the plugin's function calls even without a
+SONAME change. Neither alternative should promise isolation between Warp
+versions in one process; mixed-release use remains unsupported.
+
+The GNU linker documents both
+[SONAME-based dependency selection and exact-filename linking](https://sourceware.org/binutils/docs/ld/Options.html).
+CMake documents its platform-dependent handling of
+[imported libraries without a SONAME](https://cmake.org/cmake/help/latest/prop_tgt/IMPORTED_NO_SONAME.html).
+The observed failures and successes above are specific to the tested Linux
+toolchain, not evidence for macOS install-name behavior or other ELF loaders.
+
+### Suggested follow-up
+
+1. Develop and test a Linux consumer recipe that links the existing filenames
+   from one selected Warp package. For bundled applications, stage the matched
+   libraries and use a runtime search path relative to the executable. State
+   how environment overrides and preloaded libraries affect selection; a
+   relative RUNPATH is not an isolation guarantee. Keep GNU linker options
+   scoped to toolchains that support them.
+2. Validate the recipe against installed wheels: inspect `DT_NEEDED` and
+   RUNPATH, remove the original package location, move the deployment, and run
+   it from an unrelated directory. Cover native CPU-module loading and APIC
+   replay as well as initialization, Python CPU/CUDA execution, alternate
+   library search paths, and host/plugin load order.
+3. Consider a SONAME policy only as a separate native-build change if consumer
+   guidance proves insufficient. Compare `build_lib.py` and CMake outputs,
+   actual rebuilt wheels, existing executables, and supported Linux
+   architectures/toolchains. The passing Python probes here support further
+   evaluation but do not establish compatibility across those combinations.
+
+This follow-up should improve standalone deployment without making changes
+to normal Python loading or non-Windows library metadata a prerequisite for
+shipping Windows import libraries.

--- a/docs/user_guide/programming_model/cpp_cuda_workflows.rst
+++ b/docs/user_guide/programming_model/cpp_cuda_workflows.rst
@@ -659,12 +659,87 @@ The C++ integration examples intentionally use a small native surface:
   Warp's generated type support.
 - ``warp/native/warp.h`` declares the core Warp C API exported by the native
   library.
+- ``warp/native/warp_clang.h`` declares the experimental CPU module loading and
+  symbol lookup API exported by ``warp-clang``.
 - ``warp/native/apic.h`` declares the APIC graph loading and replay API used by
   ``.wrp`` graph consumers.
 
 Other files in ``warp/native/`` implement Warp's runtime and kernel support
 library. They are useful when inspecting generated code, but the examples above
 are the recommended starting points for native host integration.
+
+.. _native_library_linking:
+
+Native Library Linking and Version Checks
+-----------------------------------------
+
+Windows wheels include ``warp.lib`` beside ``warp.dll`` and
+``warp-clang.lib`` beside ``warp-clang.dll``. Link against the ``.lib`` import
+libraries and deploy the corresponding DLLs. On Linux and macOS, link directly
+to the Warp and warp-clang shared libraries.
+
+Warp does not currently provide an official ``find_package()`` configuration.
+A consuming CMake project that knows the wheel's package location can define
+ordinary imported targets. For example, the Windows targets can be defined as:
+
+.. code:: cmake
+
+    set(WARP_PACKAGE_ROOT ".../site-packages/warp")
+
+    add_library(Warp::runtime SHARED IMPORTED)
+    set_target_properties(Warp::runtime PROPERTIES
+        IMPORTED_LOCATION "${WARP_PACKAGE_ROOT}/bin/warp.dll"
+        IMPORTED_IMPLIB "${WARP_PACKAGE_ROOT}/bin/warp.lib"
+        INTERFACE_INCLUDE_DIRECTORIES "${WARP_PACKAGE_ROOT}/native"
+    )
+
+    add_library(Warp::clang SHARED IMPORTED)
+    set_target_properties(Warp::clang PROPERTIES
+        IMPORTED_LOCATION "${WARP_PACKAGE_ROOT}/bin/warp-clang.dll"
+        IMPORTED_IMPLIB "${WARP_PACKAGE_ROOT}/bin/warp-clang.lib"
+        INTERFACE_INCLUDE_DIRECTORIES "${WARP_PACKAGE_ROOT}/native"
+    )
+
+    target_link_libraries(my_app PRIVATE Warp::runtime Warp::clang)
+
+On Linux and macOS, set ``IMPORTED_LOCATION`` to the corresponding ``.so`` or
+``.dylib`` file and omit ``IMPORTED_IMPLIB``.
+
+The native C APIs and ``.wrp`` format do not currently guarantee backward or
+forward compatibility across Warp releases. Build and deploy a native
+application with the headers, DLLs or other shared libraries, Windows import
+libraries, ``.wrp`` files, and companion module artifacts from the same Warp
+release. Mixing these artifacts across releases is unsupported, even when a
+particular combination happens to work. Check both linked libraries during
+startup before loading a graph or CPU module:
+
+.. code:: cpp
+
+    #include "warp.h"
+    #include "warp_clang.h"
+
+    #include <cstring>
+
+    if (wp_init(WP_VERSION_STRING) != 0)
+        return 1;
+    if (std::strcmp(wp_warp_clang_version(), WP_VERSION_STRING) != 0)
+        return 2;
+
+These checks detect a library that reports a different Warp release, but they
+do not establish a stable ABI:
+
+- The Windows loader may reject a missing DLL or symbol before ``main()``, so
+  runtime version checks cannot recover from that failure.
+- An unchanged C symbol with a changed signature remains unsafe despite the
+  version checks.
+- Put the matching DLLs beside the executable or configure the DLL search path
+  deliberately.
+- Linking ``warp-clang.lib`` makes ``warp-clang.dll`` a startup dependency,
+  even for a process that later replays only CUDA graphs.
+- Both DLLs are included in the same Warp Windows distribution package, such
+  as a wheel or conda package, but remain separate libraries.
+- CPU APIC callers should include ``warp_clang.h`` instead of copying the
+  ``wp_load_obj()`` and ``wp_lookup()`` declarations from ``clang.cpp``.
 
 Related Topics
 --------------

--- a/docs/user_guide/runtime.rst
+++ b/docs/user_guide/runtime.rst
@@ -2214,6 +2214,9 @@ declared in `warp/native/apic.h <https://github.com/NVIDIA/warp/blob/main/warp/n
     // Release the loaded graph and its associated allocations.
     void wp_apic_destroy_graph(APICGraph* graph);
 
+For native library headers, build-system setup, platform-specific linking,
+deployment, and version compatibility, see :ref:`native_library_linking`.
+
 Two reference C++ examples ship with Warp under ``warp/examples/cpp/``. Both
 implement the same interactive 2-D wave simulation visualized with GLFW/OpenGL,
 and both take their captured ``.wrp`` file from a Python ``capture_wave.py``

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ class Platform(NamedTuple):
     os: str
     arch: str
     fancy_name: str
-    extension: str
+    extensions: tuple[str, ...]
     tag: str
 
     def name(self) -> str:
@@ -69,11 +69,11 @@ class Platform(NamedTuple):
 
 
 platforms = [
-    Platform("windows", "x86_64", "Windows x86-64", ".dll", "win_amd64"),
-    Platform("windows", "aarch64", "Windows ARM64", ".dll", "win_arm64"),
-    Platform("linux", "x86_64", "Linux x86-64", ".so", "manylinux_2_28_x86_64"),
-    Platform("linux", "aarch64", "Linux AArch64", ".so", "manylinux_2_34_aarch64"),
-    Platform("macos", "aarch64", "macOS ARM64", ".dylib", "macosx_11_0_arm64"),
+    Platform("windows", "x86_64", "Windows x86-64", (".dll", ".lib"), "win_amd64"),
+    Platform("windows", "aarch64", "Windows ARM64", (".dll", ".lib"), "win_arm64"),
+    Platform("linux", "x86_64", "Linux x86-64", (".so",), "manylinux_2_28_x86_64"),
+    Platform("linux", "aarch64", "Linux AArch64", (".so",), "manylinux_2_34_aarch64"),
+    Platform("macos", "aarch64", "macOS ARM64", (".dylib",), "macosx_11_0_arm64"),
 ]
 
 
@@ -89,7 +89,7 @@ def detect_warp_libraries():
     warp_bin = pathlib.Path("warp/bin")
     for file in warp_bin.rglob("*.*"):
         for p in platforms:
-            if os.path.splitext(file.name)[1] == p.extension:
+            if os.path.splitext(file.name)[1] in p.extensions:
                 # If this is a local build, assume we want a wheel for this machine's architecture
                 if file.parent.name == "bin" and p.os == machine_os() and p.arch == machine_architecture():
                     detected_libraries.add(Library(file.name, "bin/", p))
@@ -186,6 +186,14 @@ class BinaryDistribution(setuptools.Distribution):
         return True
 
 
+WINDOWS_REQUIRED_LIBRARIES = {
+    "warp.dll",
+    "warp.lib",
+    "warp-clang.dll",
+    "warp-clang.lib",
+}
+
+
 def get_warp_libraries(platform):
     libraries = []
     for library in detected_libraries:
@@ -196,6 +204,12 @@ def get_warp_libraries(platform):
                 shutil.copyfile(src, dst)
 
             libraries.append("bin/" + library.file)
+
+    if platform.os == "windows":
+        found = {pathlib.PurePosixPath(path).name for path in libraries}
+        missing = sorted(WINDOWS_REQUIRED_LIBRARIES - found)
+        if missing:
+            raise RuntimeError(f"Missing required {platform.fancy_name} native libraries: {', '.join(missing)}")
 
     return libraries
 

--- a/tools/ci/windows_import_library_smoke/CMakeLists.txt
+++ b/tools/ci/windows_import_library_smoke/CMakeLists.txt
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.24)
+project(windows_import_library_smoke LANGUAGES CXX)
+
+if(NOT WIN32)
+    message(FATAL_ERROR "The Windows import-library smoke test requires Windows")
+endif()
+
+set(WARP_PACKAGE_ROOT "" CACHE PATH "Path to the Warp Python package directory")
+if(NOT WARP_PACKAGE_ROOT)
+    message(FATAL_ERROR "Set WARP_PACKAGE_ROOT to the directory containing native/ and bin/")
+endif()
+
+get_filename_component(WARP_PACKAGE_ROOT "${WARP_PACKAGE_ROOT}" ABSOLUTE)
+set(WARP_NATIVE_DIR "${WARP_PACKAGE_ROOT}/native")
+set(WARP_BIN_DIR "${WARP_PACKAGE_ROOT}/bin")
+
+foreach(required_file
+    "${WARP_NATIVE_DIR}/apic.h"
+    "${WARP_NATIVE_DIR}/warp.h"
+    "${WARP_NATIVE_DIR}/warp_clang.h"
+    "${WARP_BIN_DIR}/warp.dll"
+    "${WARP_BIN_DIR}/warp.lib"
+    "${WARP_BIN_DIR}/warp-clang.dll"
+    "${WARP_BIN_DIR}/warp-clang.lib"
+)
+    if(NOT EXISTS "${required_file}")
+        message(FATAL_ERROR "Required Warp package file not found: ${required_file}")
+    endif()
+endforeach()
+
+add_library(Warp::runtime SHARED IMPORTED)
+set_target_properties(Warp::runtime PROPERTIES
+    IMPORTED_LOCATION "${WARP_BIN_DIR}/warp.dll"
+    IMPORTED_IMPLIB "${WARP_BIN_DIR}/warp.lib"
+    INTERFACE_INCLUDE_DIRECTORIES "${WARP_NATIVE_DIR}"
+)
+
+add_library(Warp::clang SHARED IMPORTED)
+set_target_properties(Warp::clang PROPERTIES
+    IMPORTED_LOCATION "${WARP_BIN_DIR}/warp-clang.dll"
+    IMPORTED_IMPLIB "${WARP_BIN_DIR}/warp-clang.lib"
+    INTERFACE_INCLUDE_DIRECTORIES "${WARP_NATIVE_DIR}"
+)
+
+add_executable(windows_import_library_smoke main.cpp)
+target_compile_features(windows_import_library_smoke PRIVATE cxx_std_17)
+target_link_libraries(windows_import_library_smoke PRIVATE Warp::runtime Warp::clang)
+
+add_custom_command(TARGET windows_import_library_smoke POST_BUILD
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+        "$<TARGET_FILE:Warp::runtime>"
+        "$<TARGET_FILE_DIR:windows_import_library_smoke>"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+        "$<TARGET_FILE:Warp::clang>"
+        "$<TARGET_FILE_DIR:windows_import_library_smoke>"
+)
+
+enable_testing()
+add_test(NAME windows_import_library_smoke COMMAND windows_import_library_smoke)

--- a/tools/ci/windows_import_library_smoke/main.cpp
+++ b/tools/ci/windows_import_library_smoke/main.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "apic.h"
+#include "warp.h"
+#include "warp_clang.h"
+
+#include <cstring>
+#include <iostream>
+
+int main()
+{
+    if (wp_init(WP_VERSION_STRING) != 0) {
+        const char* error = wp_get_error_string();
+        std::cerr << "Failed to initialize Warp: " << (error == nullptr ? "<null>" : error) << '\n';
+        return 1;
+    }
+
+    const char* runtime_version = wp_version();
+    if (runtime_version == nullptr || std::strcmp(runtime_version, WP_VERSION_STRING) != 0) {
+        std::cerr << "warp version mismatch: expected " << WP_VERSION_STRING << ", got "
+                  << (runtime_version == nullptr ? "<null>" : runtime_version) << '\n';
+        return 2;
+    }
+
+    const char* clang_version = wp_warp_clang_version();
+    if (clang_version == nullptr || std::strcmp(clang_version, WP_VERSION_STRING) != 0) {
+        std::cerr << "warp-clang version mismatch: expected " << WP_VERSION_STRING << ", got "
+                  << (clang_version == nullptr ? "<null>" : clang_version) << '\n';
+        return 3;
+    }
+
+    APICState* state = wp_apic_create_state();
+    if (state == nullptr) {
+        std::cerr << "Failed to create an APIC state\n";
+        return 4;
+    }
+    wp_apic_destroy_state(state);
+
+    // Volatile reads keep optimized builds linked to every function declared
+    // by warp_clang.h without requiring an object-file fixture.
+    volatile auto load_obj = &wp_load_obj;
+    volatile auto unload_obj = &wp_unload_obj;
+    volatile auto lookup = &wp_lookup;
+    if (load_obj == nullptr || unload_obj == nullptr || lookup == nullptr) {
+        std::cerr << "A warp-clang import resolved to null\n";
+        return 5;
+    }
+
+    return 0;
+}

--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -631,6 +631,7 @@ def build_dll_for_arch(
 
         nvcc_opts = [
             *gencode_opts,
+            "-DWP_BUILD_DLL",
             "-t0",  # multithreaded compilation
             "--extended-lambda",
             "-diag-suppress=221",  # suppress "floating-point value does not fit" warning from INFINITY macro in CUDA headers
@@ -644,6 +645,7 @@ def build_dll_for_arch(
         clang_opts = [
             *clang_arch_flags,
             "-std=c++17",
+            "-DWP_BUILD_DLL",
             "-xcuda",
             f'--cuda-path="{cuda_home}"',
             "-D_GLIBCXX_USE_CXX11_ABI=0",
@@ -700,7 +702,7 @@ def build_dll_for_arch(
             iter_dbg = "_ITERATOR_DEBUG_LEVEL=2"
             debug = "_DEBUG"
 
-        cpp_flags = f'/nologo /std:c++17 /GR- /EHsc {runtime} /D "{debug}" /D "{cuda_enabled}" /D "{mathdx_enabled}" /D "{cuda_compat_enabled}" /D "{iter_dbg}" /I"{native_dir}" {includes} '
+        cpp_flags = f'/nologo /std:c++17 /GR- /EHsc {runtime} /D "WP_BUILD_DLL" /D "{debug}" /D "{cuda_enabled}" /D "{mathdx_enabled}" /D "{cuda_compat_enabled}" /D "{iter_dbg}" /I"{native_dir}" {includes} '
 
         if args.mode == "debug":
             cpp_flags += "/FS /Zi /Od /D WP_ENABLE_DEBUG=1"
@@ -801,7 +803,8 @@ def build_dll_for_arch(
                 print(f"build took {elapsed:.2f} ms ({args.jobs:d} workers)")
 
         with ScopedTimer("link", active=args.verbose):
-            link_cmd = f'"{host_linker}" {" ".join(linkopts + libs)} /out:"{dll_path}"'
+            implib_path = os.path.splitext(dll_path)[0] + ".lib"
+            link_cmd = f'"{host_linker}" {" ".join(linkopts + libs)} /out:"{dll_path}" /IMPLIB:"{implib_path}"'
             run_cmd(link_cmd)
 
     else:
@@ -826,7 +829,7 @@ def build_dll_for_arch(
             else:
                 version = ""
 
-        cpp_flags = f'-Werror -Wuninitialized {version} --std=c++17 -fno-rtti -D{cuda_enabled} -D{mathdx_enabled} -D{cuda_compat_enabled} -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -D_GLIBCXX_USE_CXX11_ABI=0 -I"{native_dir}" {includes} '
+        cpp_flags = f'-Werror -Wuninitialized {version} --std=c++17 -fno-rtti -DWP_BUILD_DLL -D{cuda_enabled} -D{mathdx_enabled} -D{cuda_compat_enabled} -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -D_GLIBCXX_USE_CXX11_ABI=0 -I"{native_dir}" {includes} '
 
         if mode == "debug":
             cpp_flags += "-Og -g -D_DEBUG -DWP_ENABLE_DEBUG=1"

--- a/warp/examples/cpp/02_apic_visualization/CMakeLists.txt
+++ b/warp/examples/cpp/02_apic_visualization/CMakeLists.txt
@@ -50,30 +50,52 @@ if(NOT DEFINED WARP_BIN_DIR)
 endif()
 get_filename_component(WARP_BIN_ABS "${WARP_BIN_DIR}" ABSOLUTE)
 
-# Try to find warp library
-find_library(WARP_LIB
-    NAMES warp warp.so warp.dll
-    HINTS ${WARP_BIN_ABS}
-    PATHS ENV WARP_PATH
-    PATH_SUFFIXES bin lib
-)
+if(WIN32)
+    find_file(WARP_LIBRARY
+        NAMES warp.dll
+        HINTS ${WARP_BIN_ABS}
+        PATHS ENV WARP_PATH
+        PATH_SUFFIXES bin
+    )
+    find_library(WARP_IMPLIB
+        NAMES warp
+        HINTS ${WARP_BIN_ABS}
+        PATHS ENV WARP_PATH
+        PATH_SUFFIXES bin lib
+    )
+    if(NOT WARP_LIBRARY OR NOT WARP_IMPLIB)
+        message(FATAL_ERROR
+            "Could not find warp.dll and warp.lib\n"
+            "Hints searched: ${WARP_BIN_ABS}\n"
+            "Set WARP_BIN_DIR to the directory containing both files")
+    endif()
 
-if(NOT WARP_LIB)
-    message(FATAL_ERROR
-        "Could not find Warp library (warp.dll / warp.so / libwarp.dylib)\n"
-        "Hints searched: ${WARP_BIN_ABS}\n"
-        "Set WARP_BIN_DIR to the directory containing the warp library")
+    add_library(Warp::runtime SHARED IMPORTED)
+    set_target_properties(Warp::runtime PROPERTIES
+        IMPORTED_LOCATION "${WARP_LIBRARY}"
+        IMPORTED_IMPLIB "${WARP_IMPLIB}"
+        INTERFACE_INCLUDE_DIRECTORIES "${WARP_INCLUDE}"
+    )
+else()
+    find_library(WARP_LIBRARY
+        NAMES warp warp.so
+        HINTS ${WARP_BIN_ABS}
+        PATHS ENV WARP_PATH
+        PATH_SUFFIXES bin lib
+    )
+    if(NOT WARP_LIBRARY)
+        message(FATAL_ERROR
+            "Could not find Warp library (warp.so / libwarp.dylib)\n"
+            "Hints searched: ${WARP_BIN_ABS}\n"
+            "Set WARP_BIN_DIR to the directory containing the Warp library")
+    endif()
+
+    add_library(Warp::runtime SHARED IMPORTED)
+    set_target_properties(Warp::runtime PROPERTIES
+        IMPORTED_LOCATION "${WARP_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${WARP_INCLUDE}"
+    )
 endif()
-
-# Wrap the resolved library path in an IMPORTED target so CMake passes the
-# full path to the linker verbatim. Otherwise CMake converts an absolute
-# path like /path/to/warp.so to "-L/path/to -lwarp", which fails on Linux
-# because the library lacks the conventional lib<name>.so prefix.
-add_library(warp::runtime UNKNOWN IMPORTED)
-set_target_properties(warp::runtime PROPERTIES
-    IMPORTED_LOCATION "${WARP_LIB}"
-    IMPORTED_NO_SONAME TRUE
-)
 
 # Fetch GLFW and GLAD
 include(FetchContent)
@@ -126,12 +148,6 @@ endif()
 # Set C++ standard
 target_compile_features(02_apic_visualization PRIVATE cxx_std_17)
 
-# Add includes
-# Use SYSTEM to suppress warnings from external headers
-target_include_directories(02_apic_visualization SYSTEM PRIVATE
-    ${WARP_INCLUDE}
-)
-
 # Link libraries
 target_link_libraries(02_apic_visualization
     CUDA::cuda_driver
@@ -139,22 +155,24 @@ target_link_libraries(02_apic_visualization
     OpenGL::GL
     glfw
     glad
-    warp::runtime
+    Warp::runtime
 )
 
 # On Windows, copy the warp DLL to the output directory
 if(WIN32)
-    get_filename_component(WARP_LIB_DIR "${WARP_LIB}" DIRECTORY)
     add_custom_command(TARGET 02_apic_visualization POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${WARP_LIB_DIR}/warp.dll"
+            "${WARP_LIBRARY}"
             "$<TARGET_FILE_DIR:02_apic_visualization>"
         COMMENT "Copying warp.dll to output directory"
     )
 endif()
 
 message(STATUS "Warp include: ${WARP_INCLUDE}")
-message(STATUS "Warp library: ${WARP_LIB}")
+message(STATUS "Warp library: ${WARP_LIBRARY}")
+if(WIN32)
+    message(STATUS "Warp import library: ${WARP_IMPLIB}")
+endif()
 message(STATUS "CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")
 
 # Add headless smoke test (uses --smoke to skip GUI; needs a CUDA-capable runtime).

--- a/warp/examples/cpp/02_apic_visualization/README.md
+++ b/warp/examples/cpp/02_apic_visualization/README.md
@@ -45,6 +45,10 @@ This example runs from within the Warp repository.
 - **Build System**: GNU Make (Unix/Linux) or CMake 3.20+ (cross-platform)
 - **Note**: macOS is **not supported** (CUDA not available on macOS)
 
+On Windows, keep `warp.dll` and `warp.lib` from the same Warp build together in
+`warp/bin`. CMake links the import library and copies the DLL beside the example
+executable.
+
 **Setup:**
 
 Clone and build Warp:
@@ -164,6 +168,12 @@ The C++ program loads the saved APIC representation, reconstructs a CUDA graph, 
 #include "aot.h"   // Warp AOT utilities
 #include "warp.h"  // Warp C API
 #include "apic.h"  // APIC graph loading and execution
+#include "version.h"
+
+// Reject a native library from a different Warp release.
+if (wp_init(WP_VERSION_STRING) != 0) {
+    return 1;
+}
 
 // Load the saved APIC representation
 APICGraph* graph = wp_apic_load_graph(context, "generated/wave_sim", 0);  // 0 = CUDA

--- a/warp/examples/cpp/02_apic_visualization/main.cu
+++ b/warp/examples/cpp/02_apic_visualization/main.cu
@@ -44,6 +44,7 @@
 #include "aot.h"  // Warp AOT utilities (includes CUDA)
 #include "warp.h" // Warp C API
 #include "apic.h" // APIC graph loading and execution
+#include "version.h"  // WP_VERSION_STRING
 
 #include <cmath>
 #include <cstdio>
@@ -299,7 +300,10 @@ int main(int argc, char** argv)
 
     // Initialize Warp runtime (wp_init returns 0 on success)
     printf("Initializing Warp runtime...\n");
-    wp_init(nullptr);
+    if (wp_init(WP_VERSION_STRING) != 0) {
+        fprintf(stderr, "Failed to initialize Warp: %s\n", wp_get_error_string());
+        return 1;
+    }
 
     // Load APIC graph
     printf("\nLoading APIC graph from: %s\n", graph_path);

--- a/warp/examples/cpp/03_apic_visualization_cpu/CMakeLists.txt
+++ b/warp/examples/cpp/03_apic_visualization_cpu/CMakeLists.txt
@@ -19,10 +19,11 @@ if(NOT DEFINED WARP_NATIVE_DIR)
 endif()
 
 get_filename_component(WARP_INCLUDE "${WARP_NATIVE_DIR}" ABSOLUTE)
-if(NOT EXISTS "${WARP_INCLUDE}/builtin.h")
+if(NOT EXISTS "${WARP_INCLUDE}/builtin.h" OR NOT EXISTS "${WARP_INCLUDE}/warp_clang.h")
     message(FATAL_ERROR
         "Could not find Warp native directory at: ${WARP_INCLUDE}\n"
-        "Set WARP_NATIVE_DIR to override (e.g., cmake -DWARP_NATIVE_DIR=/path/to/warp/native)")
+        "Expected builtin.h and warp_clang.h. Set WARP_NATIVE_DIR to override\n"
+        "(e.g., cmake -DWARP_NATIVE_DIR=/path/to/warp/native)")
 endif()
 
 # Find Warp library
@@ -31,29 +32,81 @@ if(NOT DEFINED WARP_BIN_DIR)
 endif()
 get_filename_component(WARP_BIN_ABS "${WARP_BIN_DIR}" ABSOLUTE)
 
-find_library(WARP_LIB
-    NAMES warp warp.so warp.dll
-    HINTS ${WARP_BIN_ABS}
-    PATHS ENV WARP_PATH
-    PATH_SUFFIXES bin lib
-)
+if(WIN32)
+    find_file(WARP_LIBRARY
+        NAMES warp.dll
+        HINTS ${WARP_BIN_ABS}
+        PATHS ENV WARP_PATH
+        PATH_SUFFIXES bin
+    )
+    find_library(WARP_IMPLIB
+        NAMES warp
+        HINTS ${WARP_BIN_ABS}
+        PATHS ENV WARP_PATH
+        PATH_SUFFIXES bin lib
+    )
+    find_file(WARP_CLANG_LIBRARY
+        NAMES warp-clang.dll
+        HINTS ${WARP_BIN_ABS}
+        PATHS ENV WARP_PATH
+        PATH_SUFFIXES bin
+    )
+    find_library(WARP_CLANG_IMPLIB
+        NAMES warp-clang
+        HINTS ${WARP_BIN_ABS}
+        PATHS ENV WARP_PATH
+        PATH_SUFFIXES bin lib
+    )
+    if(NOT WARP_LIBRARY OR NOT WARP_IMPLIB OR NOT WARP_CLANG_LIBRARY OR NOT WARP_CLANG_IMPLIB)
+        message(FATAL_ERROR
+            "Could not find warp.dll, warp.lib, warp-clang.dll, and warp-clang.lib\n"
+            "Hints searched: ${WARP_BIN_ABS}\n"
+            "Set WARP_BIN_DIR to the directory containing all four files")
+    endif()
 
-if(NOT WARP_LIB)
-    message(FATAL_ERROR
-        "Could not find Warp library (warp.dll / warp.so / libwarp.dylib)\n"
-        "Hints searched: ${WARP_BIN_ABS}\n"
-        "Set WARP_BIN_DIR to the directory containing the warp library")
+    add_library(Warp::runtime SHARED IMPORTED)
+    set_target_properties(Warp::runtime PROPERTIES
+        IMPORTED_LOCATION "${WARP_LIBRARY}"
+        IMPORTED_IMPLIB "${WARP_IMPLIB}"
+        INTERFACE_INCLUDE_DIRECTORIES "${WARP_INCLUDE}"
+    )
+    add_library(Warp::clang SHARED IMPORTED)
+    set_target_properties(Warp::clang PROPERTIES
+        IMPORTED_LOCATION "${WARP_CLANG_LIBRARY}"
+        IMPORTED_IMPLIB "${WARP_CLANG_IMPLIB}"
+        INTERFACE_INCLUDE_DIRECTORIES "${WARP_INCLUDE}"
+    )
+else()
+    find_library(WARP_LIBRARY
+        NAMES warp warp.so
+        HINTS ${WARP_BIN_ABS}
+        PATHS ENV WARP_PATH
+        PATH_SUFFIXES bin lib
+    )
+    find_library(WARP_CLANG_LIBRARY
+        NAMES warp-clang warp-clang.so
+        HINTS ${WARP_BIN_ABS}
+        PATHS ENV WARP_PATH
+        PATH_SUFFIXES bin lib
+    )
+    if(NOT WARP_LIBRARY OR NOT WARP_CLANG_LIBRARY)
+        message(FATAL_ERROR
+            "Could not find the Warp and warp-clang shared libraries\n"
+            "Hints searched: ${WARP_BIN_ABS}\n"
+            "Set WARP_BIN_DIR to the directory containing both libraries")
+    endif()
+
+    add_library(Warp::runtime SHARED IMPORTED)
+    set_target_properties(Warp::runtime PROPERTIES
+        IMPORTED_LOCATION "${WARP_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${WARP_INCLUDE}"
+    )
+    add_library(Warp::clang SHARED IMPORTED)
+    set_target_properties(Warp::clang PROPERTIES
+        IMPORTED_LOCATION "${WARP_CLANG_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${WARP_INCLUDE}"
+    )
 endif()
-
-# Wrap the resolved library path in an IMPORTED target so CMake passes the
-# full path to the linker verbatim. Otherwise CMake converts an absolute
-# path like /path/to/warp.so to "-L/path/to -lwarp", which fails on Linux
-# because the library lacks the conventional lib<name>.so prefix.
-add_library(warp::runtime UNKNOWN IMPORTED)
-set_target_properties(warp::runtime PROPERTIES
-    IMPORTED_LOCATION "${WARP_LIB}"
-    IMPORTED_NO_SONAME TRUE
-)
 
 # Fetch GLFW and GLAD
 include(FetchContent)
@@ -100,33 +153,34 @@ add_executable(03_apic_visualization_cpu main.cpp)
 
 target_compile_features(03_apic_visualization_cpu PRIVATE cxx_std_17)
 
-target_include_directories(03_apic_visualization_cpu SYSTEM PRIVATE
-    ${WARP_INCLUDE}
-)
-
 target_link_libraries(03_apic_visualization_cpu
     OpenGL::GL
     glfw
     glad
-    warp::runtime
+    Warp::runtime
+    Warp::clang
 )
 
 # On Windows, copy the warp DLLs to the output directory
 if(WIN32)
-    get_filename_component(WARP_LIB_DIR "${WARP_LIB}" DIRECTORY)
     add_custom_command(TARGET 03_apic_visualization_cpu POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${WARP_LIB_DIR}/warp.dll"
+            "${WARP_LIBRARY}"
             "$<TARGET_FILE_DIR:03_apic_visualization_cpu>"
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${WARP_LIB_DIR}/warp-clang.dll"
+            "${WARP_CLANG_LIBRARY}"
             "$<TARGET_FILE_DIR:03_apic_visualization_cpu>"
         COMMENT "Copying warp.dll and warp-clang.dll to output directory"
     )
 endif()
 
 message(STATUS "Warp include: ${WARP_INCLUDE}")
-message(STATUS "Warp library: ${WARP_LIB}")
+message(STATUS "Warp library: ${WARP_LIBRARY}")
+message(STATUS "warp-clang library: ${WARP_CLANG_LIBRARY}")
+if(WIN32)
+    message(STATUS "Warp import library: ${WARP_IMPLIB}")
+    message(STATUS "warp-clang import library: ${WARP_CLANG_IMPLIB}")
+endif()
 
 # Add headless smoke test (uses --smoke to skip GUI).
 # PASS_REGULAR_EXPRESSION asserts the iteration count actually ran — guards against

--- a/warp/examples/cpp/03_apic_visualization_cpu/Makefile
+++ b/warp/examples/cpp/03_apic_visualization_cpu/Makefile
@@ -57,13 +57,15 @@ CXX_FLAGS := -std=c++17 \
              -Wall
 
 # Platform-specific linker flags
+STAGED_RUNTIME_LIBS :=
 ifeq ($(UNAME_S),Linux)
-    LDFLAGS := -ldl -lGL -lglfw -L$(WARP_LIB) -l:warp.so -Wl,-rpath,$(WARP_LIB)
+    LDFLAGS := -lGL -lglfw -L$(WARP_LIB) -l:warp.so -l:warp-clang.so -Wl,-rpath,$(WARP_LIB)
 else ifeq ($(UNAME_S),Darwin)
-    LDFLAGS := -ldl -framework OpenGL -lglfw -L$(WARP_LIB) -lwarp -Wl,-rpath,$(WARP_LIB)
+    LDFLAGS := -framework OpenGL -lglfw -L$(WARP_LIB) -lwarp -lwarp-clang -Wl,-rpath,$(WARP_LIB)
 else
     # Windows (MinGW/Cygwin)
-    LDFLAGS := -lopengl32 -lglfw3 -L$(WARP_LIB) -lwarp
+    LDFLAGS := -lopengl32 -lglfw3 $(WARP_LIB)/warp.lib $(WARP_LIB)/warp-clang.lib
+    STAGED_RUNTIME_LIBS := warp.dll warp-clang.dll
 endif
 
 # Sentinel file to track graph generation
@@ -71,7 +73,14 @@ GRAPH_SENTINEL := generated/.graph_captured
 
 # Default target - build everything
 .PHONY: all
-all: $(TARGET)
+all: $(TARGET) $(STAGED_RUNTIME_LIBS)
+
+# Keep Windows runtime libraries beside the executable and refresh them when
+# the corresponding Warp build outputs change.
+ifneq ($(STAGED_RUNTIME_LIBS),)
+$(STAGED_RUNTIME_LIBS): %: $(WARP_LIB)/%
+	cp "$<" "$@"
+endif
 
 # Generate APIC graph (dependency for target)
 $(GRAPH_SENTINEL): capture_wave.py
@@ -134,7 +143,7 @@ check-glfw:
 
 # Build only the C++ program (assumes graph and glad already exist)
 .PHONY: cpp
-cpp: $(SOURCES)
+cpp: $(SOURCES) $(STAGED_RUNTIME_LIBS)
 	@if [ ! -d "$(WARP_INCLUDE)" ]; then \
 		echo "Error: Warp native directory not found at: $(WARP_INCLUDE)"; \
 		exit 1; \
@@ -166,7 +175,7 @@ capture:
 # Clean build artifacts
 .PHONY: clean
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGET) $(STAGED_RUNTIME_LIBS)
 	@echo "Cleaned build artifacts"
 
 # Clean everything including generated files

--- a/warp/examples/cpp/03_apic_visualization_cpu/README.md
+++ b/warp/examples/cpp/03_apic_visualization_cpu/README.md
@@ -26,7 +26,8 @@ the CPU, but it still needs the `warp-clang` library and the companion
 
 - `capture_wave.py` — Python script that captures the wave simulation graph on CPU
 - `main.cpp` — C++ program (pure C++, no CUDA) with OpenGL visualization
-- `Makefile` / `CMakeLists.txt` — Build systems (Make for Unix, CMake for cross-platform; both fetch glad v2 and link `warp.so` directly)
+- `Makefile` / `CMakeLists.txt` — Build systems (Make for Unix, CMake for
+  cross-platform; both link the Warp and `warp-clang` shared libraries)
 - `generated/` — Directory containing generated files:
   - `wave_sim.wrp` — Serialized APIC graph representation
   - `wave_sim_modules/` — Compiled CPU modules (.o files)
@@ -38,10 +39,10 @@ the CPU, but it still needs the `warp-clang` library and the companion
 - **Python 3.10+** with Warp installed
 - **CMake 3.20+**
 - **OpenGL 3.3** support
-- **Warp native library** (`warp.dll` on Windows, `warp.so` on Linux,
-  `libwarp.dylib` on macOS)
-- **Warp LLVM library** (`warp-clang.dll` on Windows, `warp-clang.so` on
-  Linux, `libwarp-clang.dylib` on macOS) for CPU JIT
+- **Warp native library** (`warp.dll` and `warp.lib` on Windows, `warp.so` on
+  Linux, or `libwarp.dylib` on macOS)
+- **Warp LLVM library** (`warp-clang.dll` and `warp-clang.lib` on Windows,
+  `warp-clang.so` on Linux, or `libwarp-clang.dylib` on macOS) for CPU JIT
 
 The generated `wave_sim_modules/` directory must be available next to the
 `.wrp` graph for replay.
@@ -129,9 +130,12 @@ wp_apic_destroy_graph(graph);
 ```
 
 CPU replay also needs kernel function pointers from the companion `.o` files.
-The example loads each object with `warp-clang`, resolves the recorded forward
-and backward symbols, and registers them with `wp_apic_register_loaded_cpu_kernel()`
-using the recorded kernel key and module hash.
+The example includes `warp_clang.h` and links `warp-clang`, then loads each
+object with `wp_load_obj()`, resolves the recorded forward and backward symbols
+with `wp_lookup()`, and registers them with
+`wp_apic_register_loaded_cpu_kernel()` using the recorded kernel key and module
+hash. Before loading the graph, it verifies that both native libraries match
+the version declared by the installed headers.
 
 ## Current Limitations
 

--- a/warp/examples/cpp/03_apic_visualization_cpu/main.cpp
+++ b/warp/examples/cpp/03_apic_visualization_cpu/main.cpp
@@ -26,6 +26,7 @@
 
 #include "apic.h"  // APIC graph loading and execution
 #include "warp.h"  // Warp C API
+#include "warp_clang.h"  // CPU module loading
 
 #include <cmath>
 #include <cstdio>
@@ -38,7 +39,6 @@
 #include <windows.h>
 #else
 #include <dirent.h>
-#include <dlfcn.h>
 #endif
 // clang-format on
 
@@ -244,39 +244,6 @@ void update_vertices(float* vertices, const float* heights, int width, int heigh
 // CPU module loading via warp-clang
 // ---------------------------------------------------------------------------
 
-// Function pointers loaded from warp-clang shared library
-typedef int (*wp_load_obj_fn)(const char* object_file, const char* module_name, bool use_legacy_linker);
-typedef uint64_t (*wp_lookup_fn)(const char* dll_name, const char* function_name);
-
-static wp_load_obj_fn g_wp_load_obj = nullptr;
-static wp_lookup_fn g_wp_lookup = nullptr;
-
-bool load_warp_clang()
-{
-#ifdef _WIN32
-    HMODULE lib = LoadLibraryA("warp-clang.dll");
-    if (!lib) {
-        fprintf(stderr, "Failed to load warp-clang.dll\n");
-        return false;
-    }
-    g_wp_load_obj = (wp_load_obj_fn)GetProcAddress(lib, "wp_load_obj");
-    g_wp_lookup = (wp_lookup_fn)GetProcAddress(lib, "wp_lookup");
-#else
-    const char* lib_name = "warp-clang.so";
-#ifdef __APPLE__
-    lib_name = "libwarp-clang.dylib";
-#endif
-    void* lib = dlopen(lib_name, RTLD_NOW);
-    if (!lib) {
-        fprintf(stderr, "Failed to load %s: %s\n", lib_name, dlerror());
-        return false;
-    }
-    g_wp_load_obj = (wp_load_obj_fn)dlsym(lib, "wp_load_obj");
-    g_wp_lookup = (wp_lookup_fn)dlsym(lib, "wp_lookup");
-#endif
-    return g_wp_load_obj && g_wp_lookup;
-}
-
 bool load_cpu_modules(APICGraph* graph, const char* modules_dir)
 {
     // Load all .o files from the modules directory and resolve kernel functions
@@ -301,7 +268,7 @@ bool load_cpu_modules(APICGraph* graph, const char* modules_dir)
         std::string stem = filename.substr(0, filename.size() - 2);  // Remove .o
         std::string handle = "wp_apic_" + stem;
 
-        if (g_wp_load_obj(path.c_str(), handle.c_str(), false) != 0) {
+        if (wp_load_obj(path.c_str(), handle.c_str(), false) != 0) {
             fprintf(stderr, "Failed to load CPU module: %s\n", path.c_str());
             FindClose(hFind);
             return false;
@@ -325,7 +292,7 @@ bool load_cpu_modules(APICGraph* graph, const char* modules_dir)
         std::string stem = filename.substr(0, filename.size() - 2);
         std::string handle = "wp_apic_" + stem;
 
-        if (g_wp_load_obj(path.c_str(), handle.c_str(), false) != 0) {
+        if (wp_load_obj(path.c_str(), handle.c_str(), false) != 0) {
             fprintf(stderr, "Failed to load CPU module: %s\n", path.c_str());
             closedir(dir);
             return false;
@@ -362,11 +329,11 @@ bool load_cpu_modules(APICGraph* graph, const char* modules_dir)
         void* fwd_fn = nullptr;
         void* bwd_fn = nullptr;
         for (const auto& h : candidate_handles) {
-            uint64_t fn = g_wp_lookup(h.c_str(), fwd_name);
+            uint64_t fn = wp_lookup(h.c_str(), fwd_name);
             if (fn) {
                 fwd_fn = reinterpret_cast<void*>(fn);
                 if (bwd_name)
-                    bwd_fn = reinterpret_cast<void*>(g_wp_lookup(h.c_str(), bwd_name));
+                    bwd_fn = reinterpret_cast<void*>(wp_lookup(h.c_str(), bwd_name));
                 break;
             }
         }
@@ -397,12 +364,17 @@ int main(int argc, char** argv)
 
     // Initialize Warp runtime
     printf("Initializing Warp runtime...\n");
-    wp_init(nullptr);
+    if (wp_init(WP_VERSION_STRING) != 0) {
+        fprintf(stderr, "Failed to initialize Warp: %s\n", wp_get_error_string());
+        return 1;
+    }
 
-    // Load warp-clang for CPU JIT
-    printf("Loading warp-clang...\n");
-    if (!load_warp_clang()) {
-        fprintf(stderr, "warp-clang is required for CPU graph execution\n");
+    const char* warp_clang_version = wp_warp_clang_version();
+    if (warp_clang_version == nullptr || strcmp(warp_clang_version, WP_VERSION_STRING) != 0) {
+        fprintf(
+            stderr, "warp-clang version mismatch: expected %s, got %s\n", WP_VERSION_STRING,
+            warp_clang_version == nullptr ? "<null>" : warp_clang_version
+        );
         return 1;
     }
 

--- a/warp/examples/cpp/README.md
+++ b/warp/examples/cpp/README.md
@@ -108,6 +108,11 @@ my_kernel_cuda_kernel_forward<<<grid, block>>>(dim, arr_x);
 
 Examples `02` and `03` use `wp.capture_begin(..., apic=True)` and `wp.capture_save()` to write a `.wrp` file plus a companion `_modules` directory. The standalone C++ application loads both artifacts through the APIC API. The CUDA example reconstructs a CUDA graph for replay; the CPU example directly interprets the recorded operation stream.
 
+Both examples link Warp's native shared libraries directly. Their CMake files
+model Windows DLLs and import libraries as imported shared targets, while the
+CPU example uses `warp_clang.h` and links `warp-clang` for module loading and
+symbol lookup.
+
 ## Key Concepts
 
 ### Warp AOT Header

--- a/warp/native/api.h
+++ b/warp/native/api.h
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Define WP_BUILD_DLL only when building Warp's native shared libraries.
+// Windows consumers leave it undefined so WP_API imports Warp's symbols.
+
+#ifndef WP_API
+#if defined(__CUDA_ARCH__)
+#define WP_API
+#elif defined(_WIN32)
+#if defined(WP_BUILD_DLL) || defined(WP_NO_CRT)
+#define WP_API __declspec(dllexport)
+#else
+#define WP_API __declspec(dllimport)
+#endif
+#else
+#define WP_API __attribute__((visibility("default")))
+#endif
+#endif  // WP_API

--- a/warp/native/apic.h
+++ b/warp/native/apic.h
@@ -20,18 +20,11 @@
 // WP_API export macro and `wp_` name prefix; internal helpers live in
 // apic_internal.h.
 
+#include "api.h"
 #include "apic_types.h"
 
 #include <stddef.h>
 #include <stdint.h>
-
-#ifndef WP_API
-#ifdef _WIN32
-#define WP_API __declspec(dllexport)
-#else
-#define WP_API __attribute__((visibility("default")))
-#endif
-#endif
 
 extern "C" {
 

--- a/warp/native/clang/clang.cpp
+++ b/warp/native/clang/clang.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "../native/crt.h"
-#include "../version.h"
+#include "../warp_clang.h"
 #include <clang/Basic/DiagnosticOptions.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/TextDiagnosticPrinter.h>

--- a/warp/native/crt.h
+++ b/warp/native/crt.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "api.h"
+
 // This file declares a subset of the C runtime (CRT) functions and macros for
 // use by compute kernel modules. There are three environments in which this
 // file gets included:
@@ -14,18 +16,6 @@
 //   the compiler library instead (clang.dll).
 // - Warp runtime (!WP_NO_CRT). When building warp.dll it's fine to include the
 //   standard C library headers, and it avoids mismatched redefinitions.
-
-#ifndef WP_API
-#if !defined(__CUDA_ARCH__)
-#if defined(_WIN32)
-#define WP_API __declspec(dllexport)
-#else
-#define WP_API __attribute__ ((visibility ("default")))
-#endif
-#else
-#define WP_API
-#endif
-#endif  // WP_API
 
 #if !defined(__CUDA_ARCH__)
 

--- a/warp/native/warp.h
+++ b/warp/native/warp.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "api.h"
+
 // defines all crt + builtin types
 #include "builtin.h"
 

--- a/warp/native/warp_clang.h
+++ b/warp/native/warp_clang.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api.h"
+#include "version.h"
+
+#include <cstdint>
+
+// This native C ABI is experimental. Use this header only with warp-clang from
+// the exact same Warp release.
+extern "C" {
+
+WP_API int wp_load_obj(const char* object_file, const char* module_name, bool use_legacy_linker);
+WP_API int wp_unload_obj(const char* module_name);
+WP_API uint64_t wp_lookup(const char* module_name, const char* function_name);
+WP_API const char* wp_warp_clang_version();
+
+}  // extern "C"


### PR DESCRIPTION
## Description

Warp's Windows builds already produce `warp.lib` and `warp-clang.lib`, but the wheels currently omit them. Native C++ applications that start from a wheel must open both DLLs and resolve every entry point with `LoadLibrary()` and `GetProcAddress()`.

[newton-physics/newton#4068](https://github.com/newton-physics/newton/pull/4068) has this workaround in its standalone APIC controller runtime. Shipping the import libraries lets Newton link to Warp normally and remove the loader helpers, function pointer tables, and copied `warp-clang` declarations.

This PR packages both import libraries and adds two public headers. `api.h` gives the native headers one definition of `WP_API`, with the correct export annotation for Warp builds and import annotation for Windows consumers. The narrow, experimental `warp_clang.h` declares the CPU module entry points used by standalone APIC applications. Linux and macOS still package their existing `.so` and `.dylib` binaries rather than import libraries, but the new headers and version rules apply there too.

Import libraries do not make Warp's native ABI stable. Consumers must use headers, libraries, DLLs, and APIC artifacts from the same Warp release. Runtime checks can diagnose a version mismatch only after the Windows loader starts the process. A missing symbol can still prevent startup, and changing a function signature without changing its C symbol remains unsafe. A stable entry-point query API is outside the scope of this PR.

Closes #1888.

## Changes

- Emit `warp.lib` and `warp-clang.lib` at deterministic paths and package them beside their DLLs in Windows wheels.
- Add `api.h` for shared import and export annotations, plus the experimental `warp_clang.h` header for the CPU module functions used by APIC consumers.
- Fail Windows wheel construction if a required DLL or import library is missing.
- Update the CUDA and CPU APIC C++ examples to link the native libraries directly, check their versions, and stage the required DLLs on Windows. The CPU example no longer uses explicit symbol lookup.
- Build Windows x86-64 CUDA 12, x86-64 CUDA 13, and ARM64 CPU wheels in a dedicated job and upload each wheel before native consumer validation starts.
- Install each built wheel in a clean directory, then build and run a CMake smoke consumer against the installed package. The smoke test links both import libraries, calls both version functions directly, and does not need a GPU.
- Keep wheel construction separate from CMake validation so a consumer build failure does not suppress the wheel artifact.
- Document native linking and the same-release artifact requirement in the user guide and design note, with a changelog fragment for the packaged import libraries.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

1. Rebuilt Warp's native libraries on Linux after changing the visibility and linker definitions.
2. Ran the full Warp test suite on CPU and CUDA. All 8,773 tests passed, with 49 skipped.
3. Ran the targeted pre-commit checks, `git diff --check`, and the documentation build successfully.
4. GitHub CI builds the Windows wheels first, then installs and tests each wheel in a separate native consumer job. This machine is Linux, so the PR supplies the Windows link-and-run validation.

## New feature / enhancement

A Windows consumer can create ordinary imported CMake targets from the files installed by the wheel:

```cmake
set(WARP_PACKAGE_ROOT ".../site-packages/warp")

add_library(Warp::runtime SHARED IMPORTED)
set_target_properties(Warp::runtime PROPERTIES
    IMPORTED_LOCATION "${WARP_PACKAGE_ROOT}/bin/warp.dll"
    IMPORTED_IMPLIB "${WARP_PACKAGE_ROOT}/bin/warp.lib"
    INTERFACE_INCLUDE_DIRECTORIES "${WARP_PACKAGE_ROOT}/native"
)

add_library(Warp::clang SHARED IMPORTED)
set_target_properties(Warp::clang PROPERTIES
    IMPORTED_LOCATION "${WARP_PACKAGE_ROOT}/bin/warp-clang.dll"
    IMPORTED_IMPLIB "${WARP_PACKAGE_ROOT}/bin/warp-clang.lib"
    INTERFACE_INCLUDE_DIRECTORIES "${WARP_PACKAGE_ROOT}/native"
)

target_link_libraries(my_app PRIVATE Warp::runtime Warp::clang)
```

The application should check both native library versions before loading an APIC graph or CPU module:

```cpp
#include "warp.h"
#include "warp_clang.h"

#include <cstring>

if (wp_init(WP_VERSION_STRING) != 0)
    return 1;

const char* warp_clang_version = wp_warp_clang_version();
if (warp_clang_version == nullptr || std::strcmp(warp_clang_version, WP_VERSION_STRING) != 0)
    return 2;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Windows wheels now include native import libraries for Warp and Warp-Clang, enabling direct C++ linking.
  - Added an experimental native C API for module loading, symbol lookup, and Warp-Clang version checks.
  - Added CMake support for embedding Warp with platform-specific native library deployment.

- **Documentation**
  - Expanded guidance for native linking, runtime deployment, version matching, compatibility requirements, and the experimental C API.

- **Testing**
  - Added Windows validation for import libraries, DLL packaging, native linking, and runtime version compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
