### PR TITLE
Parallelize documentation doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1006,7 +1006,7 @@ jobs:
   # against a real GPU. PR-style branches gate on the same filter as the GPU test
   # rows, plus a docs/** filter for RST-only doctest changes.
   test-warp-doctest:
-    runs-on: linux-amd64-gpu-l4-latest-1
+    runs-on: linux-amd64-gpu-rtxpro6000-latest-1
     needs: [build-warp, gpu-changes]
     if: |
       github.repository == 'NVIDIA/warp' && (
@@ -1073,7 +1073,7 @@ jobs:
         run: uv run --extra docs python -c "import warp as wp; wp.print_diagnostics(); assert wp.get_cuda_devices(), 'No CUDA device visible to Warp'"
 
       - name: Run doctest
-        run: uv run --extra docs build_docs.py --doctest --no-html --warnings-as-errors
+        run: uv run --extra docs build_docs.py --doctest --doctest-jobs 2 --no-html --warnings-as-errors
 
   build-docs:
     if: github.event_name != 'schedule' || github.repository == 'NVIDIA/warp'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -294,7 +294,7 @@ doctest:
     - df -h
     - !reference [.snippets, move-linux-x86_64-binaries]
   script:
-    - uv run --extra docs build_docs.py --doctest --no-html --warnings-as-errors
+    - uv run --extra docs build_docs.py --doctest --doctest-jobs 2 --no-html --warnings-as-errors
 
 # The only purpose of this job is to make sure documentation can be built on Windows.
 # The output does not get published anywhere, but the website can be viewed in the

--- a/build_docs.py
+++ b/build_docs.py
@@ -1,61 +1,76 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from __future__ import annotations
+
 import argparse
 import logging
 import os
+import re
 import shutil
+import subprocess
+import sys
+from pathlib import Path
 
 import warp  # ensure all API functions are loaded  # noqa: F401
 from warp._src.context import export_stubs
 
-parser = argparse.ArgumentParser(
-    description="Warp Sphinx Documentation Builder",
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-)
-parser.add_argument(
-    "--html",
-    action=argparse.BooleanOptionalAction,
-    default=True,
-    help="Build HTML documentation",
-)
-parser.add_argument(
-    "--doctest",
-    action=argparse.BooleanOptionalAction,
-    default=False,
-    help="Run doctest tests of code blocks",
-)
-parser.add_argument(
-    "--warnings-as-errors",
-    action=argparse.BooleanOptionalAction,
-    default=False,
-    help=(
-        "Treat Sphinx warnings as errors (passes -W). Off by default so local "
-        "builds stay lenient (e.g. unreachable intersphinx inventories when "
-        "offline do not abort the build). CI/CD opts in to enforce strictness."
-    ),
-)
-parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
-
-args = parser.parse_args()
-
-# Validate argument combinations
-if not args.html and not args.doctest:
-    parser.error("At least one of --html or --doctest must be enabled")
-
-# Configure logging
-log_level = logging.DEBUG if args.verbose else logging.INFO
-logging.basicConfig(
-    level=log_level,
-    format="[%(asctime)s] %(levelname)s: %(message)s",
-    datefmt="%H:%M:%S",
-    handlers=[logging.StreamHandler()],
-)
 logger = logging.getLogger(__name__)
+
+_DOCS_SOURCES_PREPARED_ENV = "WARP_DOCS_SOURCES_PREPARED"
+_EXCLUDED_DOCS_DIRECTORIES = frozenset(("_build", "_src", "_templates", "superpowers"))
+_DOCTEST_DIRECTIVE_RE = re.compile(r"^\s*\.\.\s+(?:doctest|testcode)::", re.MULTILINE)
+_DOCTEST_PROMPT_RE = re.compile(r"^\s*>>>\s", re.MULTILINE)
+
+
+def positive_int(value: str) -> int:
+    """Parse a positive integer command-line value."""
+    parsed_value = int(value)
+    if parsed_value < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed_value
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the command-line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Warp Sphinx Documentation Builder",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--html",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Build HTML documentation",
+    )
+    parser.add_argument(
+        "--doctest",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Run doctest tests of code blocks",
+    )
+    parser.add_argument(
+        "--doctest-jobs",
+        type=positive_int,
+        default=1,
+        help="Number of concurrent Sphinx doctest processes",
+    )
+    parser.add_argument(
+        "--warnings-as-errors",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Treat Sphinx warnings as errors (passes -W). Off by default so local "
+            "builds stay lenient (e.g. unreachable intersphinx inventories when "
+            "offline do not abort the build). CI/CD opts in to enforce strictness."
+        ),
+    )
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose logging")
+    return parser
 
 
 def format_file_with_ruff(file_path):
-    """Format file with ruff using pre-commit for version consistency."""
+    """Format a file with Ruff using pre-commit for version consistency."""
     try:
         import pre_commit.main  # noqa: PLC0415
 
@@ -82,32 +97,49 @@ def format_file_with_ruff(file_path):
                     f"File was modified but still has issues (exit code {result})"
                 )
         else:
-            # Exit code > 1: Unexpected error
             raise RuntimeError(f"pre-commit formatting failed for {file_path} with exit code {result}")
     except ImportError as err:
         raise ImportError(
-            f"Could not format {file_path}: pre-commit not available. "
+            "Could not format generated stubs: pre-commit is not available. "
             "Install with 'pip install warp-lang[docs]' or equivalent."
         ) from err
 
 
-def build_sphinx_docs(source_dir, output_dir, builder="html", warnings_as_errors=False):
+def sphinx_args(
+    source_dir: Path,
+    output_dir: Path,
+    builder: str,
+    warnings_as_errors: bool = False,
+    config_overrides: tuple[str, ...] = (),
+) -> list[str]:
+    """Build a Sphinx argument list."""
+    args = ["-j", "auto", "-b", builder]
+    if warnings_as_errors:
+        args.insert(0, "-W")
+    for config_override in config_overrides:
+        args.extend(("-D", config_override))
+    args.extend((os.fspath(source_dir), os.fspath(output_dir)))
+    return args
+
+
+def build_sphinx_docs(
+    source_dir: Path,
+    output_dir: Path,
+    builder: str = "html",
+    warnings_as_errors: bool = False,
+) -> None:
     """Build Sphinx documentation programmatically."""
     logger.info(f"Building {builder} documentation: {source_dir} -> {output_dir}")
     try:
         from sphinx.cmd.build import build_main  # noqa: PLC0415
 
-        # Clean previous output
-        if os.path.exists(output_dir):
+        if output_dir.exists():
             logger.debug(f"Cleaning previous output directory: {output_dir}")
             shutil.rmtree(output_dir)
 
-        # sphinx-build [-W] -j auto -b <builder> source_dir output_dir
-        sphinx_args = ["-j", "auto", "-b", builder, source_dir, output_dir]
-        if warnings_as_errors:
-            sphinx_args.insert(0, "-W")
-        logger.debug(f"Running sphinx-build {' '.join(sphinx_args)}")
-        result = build_main(sphinx_args)
+        args = sphinx_args(source_dir, output_dir, builder, warnings_as_errors)
+        logger.debug(f"Running sphinx-build {' '.join(args)}")
+        result = build_main(args)
         if result != 0:
             raise RuntimeError(f"Sphinx build failed with exit code {result}")
 
@@ -115,34 +147,204 @@ def build_sphinx_docs(source_dir, output_dir, builder="html", warnings_as_errors
 
     except ImportError as err:
         raise ImportError(
-            "Could not build docs: sphinx not available. Install with 'pip install warp-lang[docs]' or equivalent."
+            "Could not build docs: Sphinx is not available. Install with 'pip install warp-lang[docs]' or equivalent."
         ) from err
 
 
-base_path = os.path.dirname(os.path.realpath(__file__))
+def discover_documentation_sources(source_dir: Path) -> tuple[Path, ...]:
+    """Return all Sphinx source files that are eligible for doctesting."""
+    sources = []
+    for path in source_dir.rglob("*"):
+        if not path.is_file() or path.suffix not in (".md", ".rst"):
+            continue
+        relative_path = path.relative_to(source_dir)
+        if any(part in _EXCLUDED_DOCS_DIRECTORIES for part in relative_path.parts):
+            continue
+        sources.append(path)
+    return tuple(sorted(sources))
 
-logger.info("Starting Warp documentation build")
 
-# generate stubs for autocomplete
-logger.info("Generating API stubs for autocomplete")
-with open(os.path.join(base_path, "warp", "__init__.pyi"), "w", encoding="utf-8") as stub_file:
-    export_stubs(stub_file)
+def estimate_doctest_weight(path: Path) -> int:
+    """Estimate a source file's doctest cost for deterministic sharding."""
+    source = path.read_text(encoding="utf-8")
+    weight = len(_DOCTEST_DIRECTIVE_RE.findall(source)) + len(_DOCTEST_PROMPT_RE.findall(source))
 
-# code formatting of __init__.pyi
-logger.info("Formatting __init__.pyi (a 'Failed' message in the output below is expected)")
-format_file_with_ruff(os.path.join(base_path, "warp", "__init__.pyi"))
+    # Autosummary pages contain directives rather than their extracted docstrings,
+    # so their doctests are not visible until Sphinx reads the document.
+    if "_generated" in path.parts:
+        weight += 1
 
-source_dir = os.path.join(base_path, "docs")
+    return max(1, weight)
 
-if args.html:
-    # Build HTML docs
-    html_output_dir = os.path.join(base_path, "docs", "_build", "html")
-    build_sphinx_docs(source_dir, html_output_dir, "html", warnings_as_errors=args.warnings_as_errors)
 
-if args.doctest:
-    # Run doctest
-    logger.info("Running doctest...")
-    doctest_output_dir = os.path.join(base_path, "docs", "_build", "doctest")
-    build_sphinx_docs(source_dir, doctest_output_dir, "doctest", warnings_as_errors=args.warnings_as_errors)
+def partition_doctest_sources(sources: tuple[Path, ...], job_count: int) -> tuple[tuple[Path, ...], ...]:
+    """Partition Sphinx sources into deterministic, approximately balanced shards."""
+    if job_count < 1:
+        raise ValueError("job_count must be at least 1")
+    if job_count > len(sources):
+        raise ValueError("job_count cannot exceed the number of documentation sources")
 
-logger.info("Documentation build completed successfully")
+    weighted_sources = sorted(
+        ((estimate_doctest_weight(source), source) for source in sources),
+        key=lambda item: (-item[0], os.fspath(item[1])),
+    )
+    shards: list[list[Path]] = [[] for _ in range(job_count)]
+    shard_weights = [0] * job_count
+
+    for weight, source in weighted_sources:
+        shard_index = min(range(job_count), key=lambda index: (shard_weights[index], index))
+        shards[shard_index].append(source)
+        shard_weights[shard_index] += weight
+
+    for index, (shard, weight) in enumerate(zip(shards, shard_weights, strict=True), start=1):
+        shard.sort()
+        logger.info(
+            "Planned doctest shard %d/%d with %d sources and estimated weight %d",
+            index,
+            job_count,
+            len(shard),
+            weight,
+        )
+
+    return tuple(tuple(shard) for shard in shards)
+
+
+def combine_doctest_output(output_dir: Path, job_count: int) -> None:
+    """Combine per-shard Sphinx summaries into the conventional output file."""
+    combined_output = output_dir / "output.txt"
+    with combined_output.open("w", encoding="utf-8") as output_file:
+        for shard_index in range(job_count):
+            shard_output = output_dir / f"shard-{shard_index}" / "output.txt"
+            output_file.write(f"Doctest shard {shard_index + 1}/{job_count}\n")
+            output_file.write("=" * 24 + "\n")
+            if shard_output.exists():
+                output_file.write(shard_output.read_text(encoding="utf-8"))
+            else:
+                output_file.write("No Sphinx doctest output was produced.\n")
+            output_file.write("\n")
+
+
+def run_parallel_doctests(
+    source_dir: Path,
+    output_dir: Path,
+    job_count: int,
+    warnings_as_errors: bool,
+    sources_prepared: bool,
+) -> None:
+    """Run filename-sharded Sphinx doctests in concurrent subprocesses."""
+    if output_dir.exists():
+        logger.debug(f"Cleaning previous output directory: {output_dir}")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+
+    if not sources_prepared:
+        preparation_output = output_dir / "prepare"
+        build_sphinx_docs(source_dir, preparation_output, "dummy")
+        shutil.rmtree(preparation_output)
+
+    sources = discover_documentation_sources(source_dir)
+    if not sources:
+        raise RuntimeError(f"No Sphinx sources found under {source_dir}")
+    shards = partition_doctest_sources(sources, job_count)
+    assigned_sources = [source for shard in shards for source in shard]
+    if len(assigned_sources) != len(sources) or set(assigned_sources) != set(sources):
+        raise RuntimeError("Doctest sharding must assign every documentation source exactly once")
+
+    processes: list[tuple[int, subprocess.Popen]] = []
+    for shard_index, shard in enumerate(shards):
+        shard_output = output_dir / f"shard-{shard_index}"
+        cache_path = output_dir / "warp-cache" / f"shard-{shard_index}"
+        manifest_path = output_dir / f"shard-{shard_index}.txt"
+        cache_path.mkdir(parents=True)
+        manifest_path.write_text(
+            "\n".join(path.relative_to(source_dir).with_suffix("").as_posix() for path in shard) + "\n",
+            encoding="utf-8",
+        )
+
+        env = os.environ.copy()
+        env[_DOCS_SOURCES_PREPARED_ENV] = "1"
+        env["WARP_CACHE_PATH"] = os.fspath(cache_path)
+        command = [
+            sys.executable,
+            "-m",
+            "sphinx",
+            *sphinx_args(
+                source_dir,
+                shard_output,
+                "doctest-shard",
+                warnings_as_errors,
+                (f"warp_doctest_shard_manifest={manifest_path}",),
+            ),
+        ]
+        logger.info("Starting doctest shard %d/%d", shard_index + 1, job_count)
+        processes.append((shard_index, subprocess.Popen(command, env=env)))
+
+    failed_shards = []
+    for shard_index, process in processes:
+        result = process.wait()
+        if result == 0:
+            logger.info("Doctest shard %d/%d completed successfully", shard_index + 1, job_count)
+        else:
+            failed_shards.append((shard_index, result))
+            logger.error("Doctest shard %d/%d failed with exit code %d", shard_index + 1, job_count, result)
+
+    combine_doctest_output(output_dir, job_count)
+    if failed_shards:
+        failed_summary = ", ".join(f"{index + 1} (exit code {result})" for index, result in failed_shards)
+        raise RuntimeError(f"Sphinx doctest shard(s) failed: {failed_summary}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Build the requested Warp documentation outputs."""
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    if not args.html and not args.doctest:
+        parser.error("At least one of --html or --doctest must be enabled")
+    if not args.doctest and args.doctest_jobs != 1:
+        parser.error("--doctest-jobs requires --doctest")
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="[%(asctime)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+        handlers=[logging.StreamHandler()],
+    )
+
+    base_path = Path(__file__).resolve().parent
+    source_dir = base_path / "docs"
+
+    logger.info("Starting Warp documentation build")
+    logger.info("Generating API stubs for autocomplete")
+    stub_path = base_path / "warp" / "__init__.pyi"
+    with stub_path.open("w", encoding="utf-8") as stub_file:
+        export_stubs(stub_file)
+
+    logger.info("Formatting __init__.pyi (a 'Failed' message in the output below is expected)")
+    format_file_with_ruff(os.fspath(stub_path))
+
+    sources_prepared = False
+    if args.html:
+        html_output_dir = source_dir / "_build" / "html"
+        build_sphinx_docs(source_dir, html_output_dir, "html", warnings_as_errors=args.warnings_as_errors)
+        sources_prepared = True
+
+    if args.doctest:
+        logger.info("Running doctest...")
+        doctest_output_dir = source_dir / "_build" / "doctest"
+        if args.doctest_jobs == 1:
+            build_sphinx_docs(source_dir, doctest_output_dir, "doctest", warnings_as_errors=args.warnings_as_errors)
+        else:
+            run_parallel_doctests(
+                source_dir,
+                doctest_output_dir,
+                args.doctest_jobs,
+                args.warnings_as_errors,
+                sources_prepared,
+            )
+
+    logger.info("Documentation build completed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/_ext/wp_doctest.py
+++ b/docs/_ext/wp_doctest.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import sphinx.util.logging
+from sphinx.ext.doctest import DocTestBuilder
+
+logger = sphinx.util.logging.getLogger(__name__)
+
+
+class ShardedDocTestBuilder(DocTestBuilder):
+    """Run doctests only for documents named in a shard manifest."""
+
+    name = "doctest-shard"
+
+    def write_documents(self, docnames: set[str]) -> None:
+        manifest = Path(self.config.warp_doctest_shard_manifest)
+        if not manifest.is_file():
+            raise RuntimeError(f"Doctest shard manifest does not exist: {manifest}")
+
+        selected_docnames = set(manifest.read_text(encoding="utf-8").splitlines())
+        unknown_docnames = selected_docnames - self.env.found_docs
+        if unknown_docnames:
+            logger.warning("doctest shard contains unknown documents: %s", ", ".join(sorted(unknown_docnames)))
+
+        super().write_documents(docnames & selected_docnames)
+
+
+def setup(app):
+    """Register the sharded doctest builder."""
+    app.add_config_value("warp_doctest_shard_manifest", "", "env", types=frozenset({str}))
+    app.add_builder(ShardedDocTestBuilder)
+    return {"parallel_read_safe": True}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ _RE_WP_DOT = re.compile(r"\bwp\.")
 
 HERE = os.path.dirname(__file__)
 WARP_PATH = os.path.realpath(os.path.join(HERE, ".."))
+_DOCS_SOURCES_PREPARED = os.environ.get("WARP_DOCS_SOURCES_PREPARED") == "1"
 
 sys.path.insert(0, WARP_PATH)
 sys.path.insert(0, os.path.join(HERE, "_ext"))
@@ -77,6 +78,7 @@ extensions = [
     "sphinx_copybutton",  # Adds a copy button to code blocks.
     # Local extensions, from `docs/_ext`.
     "wp_builtin_tags",  # Renders the property tags of the built-ins.
+    "wp_doctest",  # Runs selected doctest documents in isolated subprocess shards.
 ]
 
 # Generate targets for Markdown headings through level 2 so standard fragment
@@ -293,6 +295,10 @@ else:
 
 # -- sphinx.ext.autosummary --------------------------------------------------
 
+# Parallel doctest workers share a prepared source tree and must not rewrite
+# autosummary pages while other workers are reading them.
+autosummary_generate = not _DOCS_SOURCES_PREPARED
+
 # Document imported classes and functions.
 autosummary_imported_members = True
 
@@ -459,6 +465,9 @@ sphinx.ext.autosummary.generate.AutosummaryRenderer = AutosummaryRenderer
 
 
 # -- sphinx.ext.doctest ------------------------------------------------------
+
+# Keep CI logs focused on failures and the final per-shard summaries.
+doctest_show_successes = False
 
 # Code to run for every doctest block.
 doctest_global_setup = """
@@ -814,6 +823,8 @@ def resolve_public_builtin_aliases(app, env, node, contnode):
 
 def generate_reference_docs(app):
     """Generate API and language reference .rst files before Sphinx reads sources."""
+    if _DOCS_SOURCES_PREPARED:
+        return
     docs.generate_reference.run()
 
 


### PR DESCRIPTION
## Description

Sphinx's doctest builder executes examples serially even when the documentation build uses `-j auto`. This leaves the GPU doctest job running mostly on one process.

This PR adds an opt-in `--doctest-jobs` setting and uses two workers in CI. Both workers remain inside the existing job and share the same GPU. The local default remains one worker.

The GitHub doctest job also moves from the L4 runner to an RTX PRO 6000 runner.

## Changes

- Prepare generated reference pages once, then split documentation sources deterministically between doctest workers.
- Verify that every discovered source is assigned to exactly one shard before starting the workers.
- Give each worker separate output and Warp cache directories, then combine their summaries.
- Use a shard-aware Sphinx builder so each document executes exactly once while all documents are still parsed for warnings.
- Run two workers in both GitHub and GitLab CI.
- Hide successful doctest details to keep CI logs manageable.

No changelog fragment is needed because this only changes CI and documentation tooling.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

I first ran the full doctest suite serially with only one RTX PRO 6000 visible. It completed 138 tests with no failures in about 8 minutes and 9 seconds.

I then ran the same suite with two workers on the same single visible GPU. The workers completed 71 and 67 tests, for the same total of 138 tests with no failures, in about 3 minutes and 15 seconds. This confirms that sharding neither skips nor duplicates tests and reduced local turnaround by roughly 60 percent.

I also built the HTML documentation with warnings treated as errors and ran the repository's pre-commit checks on all changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation builds are more configurable, with improved support for strict warning handling.
  * Successful doctest output is now less verbose, making build results easier to review.

* **Tests**
  * Documentation doctests now run in parallel, helping shorten validation time.
  * Doctest workloads are distributed across jobs for more balanced execution.
  * CI documentation checks now use updated GPU infrastructure for improved build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->