### PR TITLE
Validate wp.tid() launch extents

### DIFF
--- a/asv/benchmarks/api/launch.py
+++ b/asv/benchmarks/api/launch.py
@@ -105,8 +105,32 @@ def k0():
 
 
 @wp.kernel
+def k0_2d():
+    _i, _j = wp.tid()
+
+
+@wp.kernel
+def k0_4d():
+    _i, _j, _k, _l = wp.tid()
+
+
+@wp.kernel
 def k0_no_tid():
     pass
+
+
+@wp.kernel
+def write_tid_2d(output: wp.array[int]):
+    i, j = wp.tid()
+    index = i * 1024 + j
+    output[index] = index
+
+
+@wp.kernel
+def write_tid_4d(output: wp.array[int]):
+    i, j, k, l = wp.tid()
+    index = ((i * 32 + j) * 32 + k) * 32 + l
+    output[index] = index
 
 
 class KernelLaunchParameters:
@@ -158,6 +182,20 @@ class KernelLaunchParameters:
     def time_direct_empty(self):
         wp.launch(k0, dim=1, inputs=[], device="cuda:0")
 
+    def time_direct_empty_2d(self):
+        """Measure host overhead for a two-dimensional kernel launch."""
+        wp.launch(k0_2d, dim=(1, 1), inputs=[], device="cuda:0")
+
+    time_direct_empty_2d.number = 2000
+    time_direct_empty_2d.repeat = 20
+
+    def time_direct_empty_4d(self):
+        """Measure host overhead for a four-dimensional kernel launch."""
+        wp.launch(k0_4d, dim=(1, 1, 1, 1), inputs=[], device="cuda:0")
+
+    time_direct_empty_4d.number = 2000
+    time_direct_empty_4d.repeat = 20
+
     def time_direct_empty_no_tid(self):
         """Measure an empty direct launch that does not consume ``wp.tid()``."""
         wp.launch(k0_no_tid, dim=1, inputs=[], device="cuda:0")
@@ -167,6 +205,38 @@ class KernelLaunchParameters:
 
     def time_struct_empty(self):
         wp.launch(ks0, dim=1, inputs=[self.s0], device="cuda:0")
+
+
+class ThreadCoordinateReconstruction:
+    """Measure device-side reconstruction of multidimensional thread coordinates."""
+
+    number = 20
+    repeat = 10
+    params = ["2d", "4d"]
+    param_names = ["rank"]
+
+    @setup_once
+    def setup(self, rank):
+        wp.init()
+        wp.load_module(device="cuda:0")
+        self.output = wp.empty(1024 * 1024, dtype=int, device="cuda:0")
+        if rank == "2d":
+            kernel = write_tid_2d
+            dim = (1024, 1024)
+        else:
+            kernel = write_tid_4d
+            dim = (32, 32, 32, 32)
+
+        self.cmd = wp.launch(kernel, dim=dim, outputs=[self.output], device="cuda:0", record_cmd=True)
+        self.cmd.launch()
+        wp.synchronize_device("cuda:0")
+
+    def teardown(self, rank):
+        wp.synchronize_device("cuda:0")
+
+    def time_cuda(self, rank):
+        self.cmd.launch()
+        wp.synchronize_device("cuda:0")
 
 
 class GraphLaunch:

--- a/changelog/1815.changed.md
+++ b/changelog/1815.changed.md
@@ -1,0 +1,1 @@
+Write APIC `.wrp` files using format version 16, which stores launch extents as unsigned 32-bit values. Readers accept versions 13 through 16 and reject high-bit launch extents from older formats because their intended values are ambiguous.

--- a/changelog/1815.fixed.md
+++ b/changelog/1815.fixed.md
@@ -1,0 +1,1 @@
+Reject launches with a nonzero thread count when any extent represented by `wp.tid()` exceeds $2^{31}$, preventing signed 32-bit thread coordinates from overflowing. Extents of exactly $2^{31}$ remain supported.

--- a/design/api-capture-and-cpu-graphs.md
+++ b/design/api-capture-and-cpu-graphs.md
@@ -332,7 +332,7 @@ Deferred compilation is not part of the stream. Missing or incompatible module b
 
 #### ``.wrp`` format
 
-The feature is experimental. The current constants in ``warp/native/apic_types.h`` define writer version 15 and a readable range of versions 13 through 15. These numbers describe the operation and metadata wire format, not the Python package version.
+The feature is experimental. The current constants in ``warp/native/apic_types.h`` define writer version 16 and a readable range of versions 13 through 16. Version 16 changes kernel launch shapes from signed to unsigned 32-bit extents; readers reject high-bit launch shapes from older formats because their intended values are ambiguous. These numbers describe the operation and metadata wire format, not the Python package version.
 
 Contributors must follow these rules:
 

--- a/docs/user_guide/limitations.rst
+++ b/docs/user_guide/limitations.rst
@@ -45,18 +45,10 @@ Kernels and User Functions
   Rebinding a function-valued local to a different function or to a non-function value is not supported.
   User functions with ``wp.Function`` parameters also cannot define custom gradient or replay functions.
 
-:func:`wp.tid() <warp._src.lang.tid>` returns signed 32-bit thread coordinates. The supported launch extents depend
-on how the kernel uses those coordinates:
-
-* The leading coordinate supports a launch extent up to :math:`2^{31}`, whose largest coordinate is
-  :math:`2^{31}-1`. Warp enforces this limit for kernels that use scalar ``wp.tid()`` and raises a ``ValueError``
-  for a larger leading extent.
-* For tuple-valued ``wp.tid()``, keep each non-leading launch dimension at or below :math:`2^{31}-1`.
-  Multidimensional launch bounds store these extents as signed 32-bit values, so an extent of exactly
-  :math:`2^{31}` can produce incorrect coordinates when an earlier dimension is greater than one. Warp does not
-  currently validate tuple-only launches: a leading extent above :math:`2^{31}` can overflow the first returned
-  coordinate, and a non-leading extent above :math:`2^{31}-1` can corrupt coordinate reconstruction. In a kernel
-  that uses both scalar and tuple-valued ``wp.tid()``, the scalar validation applies only to the leading coordinate.
+:func:`wp.tid() <warp._src.lang.tid>` returns signed 32-bit thread coordinates. In a launch with a nonzero thread
+count, the extent corresponding to each coordinate may be at most :math:`2^{31}`, so the largest coordinate is
+:math:`2^{31}-1`. Warp raises a ``ValueError`` if any such extent is larger. This limit applies to scalar and
+tuple-valued ``wp.tid()``.
 
 The total number of threads in a multidimensional grid may exceed :math:`2^{31}` when each returned coordinate stays
 within these limits. Use 64-bit arithmetic when flattening such coordinates into a linear index. See

--- a/docs/user_guide/runtime.rst
+++ b/docs/user_guide/runtime.rst
@@ -1996,7 +1996,10 @@ API Capture: Saving and Loading Graphs
     surface, the C ``wp_apic_*`` API, and the recorded operation set are all
     subject to change without a formal deprecation cycle. ``.wrp`` files written
     by one version of Warp may not be loadable by another. The current writer
-    emits format version 15, and the reader accepts versions 13 through 15.
+    emits format version 16, and the reader accepts versions 13 through 16.
+    Version 16 stores kernel launch extents as unsigned 32-bit values. Older
+    files whose launch extents have the high bit set are rejected because those
+    values overflowed the signed representation used by their format.
 
 The APIC operation stream lets Warp serialize a supported captured graph to
 disk and load it back later from another Python program or a standalone C++

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -36,7 +36,9 @@ from warp._src.types import *
 # of current compile options (block_dim) etc
 options = {}
 
-_SCALAR_TID_MAX_EXTENT = 2**31
+# wp.tid() coordinates are signed 32-bit integers. An extent of 2**31 is
+# valid because its largest coordinate is 2**31 - 1.
+_TID_MAX_EXTENT = 2**31
 
 # Extraction products shared across Adjoints of one code object, populated
 # lazily by Adjoint.__init__ (see _SharedFunctionSource).
@@ -370,19 +372,46 @@ def is_valid_cpp_identifier(value: str) -> bool:
     return _IDENTIFIER_RE.fullmatch(value) is not None
 
 
-def _is_tid_call(node, adj=None) -> bool:
-    """Return True if ``node`` is an AST call to ``wp.tid()``."""
-    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute) or node.func.attr != "tid":
+def _is_tid_call(
+    node,
+    adj=None,
+    local_variables=frozenset(),
+    tid_aliases=frozenset(),
+    callable_arg_values=None,
+) -> bool:
+    """Return whether ``node`` semantically calls ``wp.tid()``.
+
+    Args:
+        node: AST node to inspect.
+        adj: Adjoint whose scope is used to resolve the call. If omitted, only
+            direct ``wp.tid()`` and ``warp.tid()`` syntax is recognized.
+        local_variables: Names assigned in the function scope.
+        tid_aliases: Local names known to reference ``wp.tid()``.
+        callable_arg_values: Specialized function targets keyed by callable
+            parameter name.
+    """
+    if not isinstance(node, ast.Call):
         return False
 
-    receiver = node.func.value
-    if adj is not None:
-        if isinstance(receiver, ast.Name):
-            return adj.resolve_external_reference(receiver.id) is warp
-        resolved_receiver, _ = adj.resolve_static_expression(receiver, eval_types=False)
-        return resolved_receiver is warp
+    if adj is None:
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "tid":
+            return False
 
-    return isinstance(receiver, ast.Name) and receiver.id in ("wp", "warp")
+        receiver = node.func.value
+        return isinstance(receiver, ast.Name) and receiver.id in ("wp", "warp")
+
+    if isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Name):
+        receiver = adj.resolve_external_reference(node.func.value.id)
+        if receiver is warp:
+            func = warp._src.context.builtin_functions.get(node.func.attr)
+        else:
+            func = getattr(receiver, node.func.attr, None)
+    elif isinstance(node.func, ast.Name) and node.func.id in local_variables:
+        return node.func.id in tid_aliases
+    else:
+        func = resolve_reference_call_func(adj, node, callable_arg_values)
+
+    return func is warp._src.context.builtin_functions["tid"]
 
 
 def is_external_constant_params_arg(arg) -> bool:
@@ -413,7 +442,13 @@ def iter_ast_nodes_of_types(root: ast.AST, *types: type):
 
 
 def _uses_tid_call(adj) -> bool:
-    return any(_is_tid_call(node, adj) for node in iter_ast_nodes_of_types(adj.tree, ast.Call))
+    local_variables = adj.assigned_name_ids()
+    tid_aliases = resolve_reference_tid_aliases(adj, local_variables)
+    callable_arg_values = getattr(adj, "callable_arg_values", None) or {}
+    return any(
+        _is_tid_call(node, adj, local_variables, tid_aliases, callable_arg_values)
+        for node in iter_ast_nodes_of_types(adj.tree, ast.Call)
+    )
 
 
 def _is_texture_type(var_type: type) -> bool:
@@ -1526,6 +1561,47 @@ def resolve_reference_call_func(adj, call_node, callable_arg_values=None):
     return func
 
 
+def resolve_reference_tid_aliases(adj, local_variables) -> frozenset[str]:
+    """Return local names that can resolve to ``wp.tid()`` during reference scans."""
+
+    tid_func = warp._src.context.builtin_functions["tid"]
+    tid_aliases = set()
+    aliases_by_source = {}
+
+    def iter_bindings(target, value):
+        if isinstance(target, ast.Name):
+            yield target.id, value
+        elif isinstance(target, (ast.Tuple, ast.List)) and isinstance(value, (ast.Tuple, ast.List)):
+            for target_item, value_item in zip(target.elts, value.elts, strict=False):
+                yield from iter_bindings(target_item, value_item)
+
+    for node in adj.reference_nodes():
+        if not isinstance(node, ast.Assign):
+            continue
+
+        for target in node.targets:
+            for name, value_node in iter_bindings(target, node.value):
+                if isinstance(value_node, ast.Name) and value_node.id in local_variables:
+                    aliases_by_source.setdefault(value_node.id, set()).add(name)
+                else:
+                    func, path = adj.resolve_static_expression(value_node, eval_types=False)
+                    if path and func is warp:
+                        func = warp._src.context.builtin_functions.get(path[-1])
+
+                    if func is tid_func:
+                        tid_aliases.add(name)
+
+    pending = list(tid_aliases)
+    while pending:
+        source = pending.pop()
+        for name in aliases_by_source.get(source, ()):
+            if name not in tid_aliases:
+                tid_aliases.add(name)
+                pending.append(name)
+
+    return frozenset(tid_aliases)
+
+
 def iter_call_callable_arg_targets(adj, func, call_node, callable_arg_values=None):
     """Yield Warp function targets passed to ``wp.Function`` parameters.
 
@@ -1760,7 +1836,7 @@ class _SharedFunctionSource:
     and ``wp.static`` (which rewrites the tree) exclude an adjoint.
     """
 
-    __slots__ = ("assigned_name_ids", "fun_lineno", "reference_nodes", "source", "tree")
+    __slots__ = ("assigned_name_ids", "assignment_call_metadata", "fun_lineno", "reference_nodes", "source", "tree")
 
     def __init__(self, source, fun_lineno, tree):
         self.source = source
@@ -1768,6 +1844,7 @@ class _SharedFunctionSource:
         self.tree = tree
         self.reference_nodes = None
         self.assigned_name_ids = None
+        self.assignment_call_metadata = None
 
 
 def _shared_source_for_code(code):
@@ -1939,10 +2016,11 @@ class Adjoint:
         # paths do not need to coordinate deterministic internals directly.
         adj.deterministic = DeterministicCodegen(adj)
 
-        # Caches derived from the AST. Reset both if ``adj.tree`` is ever mutated
-        # after either cache is populated.
+        # Caches derived from the AST. Reset all three if ``adj.tree`` is ever
+        # mutated after any cache is populated.
         adj._reference_nodes = None
         adj._assigned_name_ids = None
+        adj._assignment_call_metadata = None
 
     # allocate extra space for a function call that requires its
     # own shared memory space, we treat shared memory as a stack
@@ -2163,7 +2241,7 @@ class Adjoint:
         adj.called_user_functions = {}
 
         # Exact launch metadata derived from calls reached by this build.
-        adj.uses_scalar_tid = False
+        adj.uses_tid = False
 
         # wp.ref[T] callees lacking a manual adjoint; rejected post-build, once used_by_backward_kernel is final
         adj.unvalidated_ref_calls = []
@@ -4425,8 +4503,8 @@ class Adjoint:
         if hasattr(node, "expects"):
             min_outputs = node.expects
 
-        if func is warp._src.context.builtin_functions["tid"] and (min_outputs is None or min_outputs <= 1):
-            adj.uses_scalar_tid = True
+        if func is warp._src.context.builtin_functions["tid"]:
+            adj.uses_tid = True
 
         # Evaluate positional arguments.
         args = []
@@ -6538,9 +6616,9 @@ class Adjoint:
         This cache assumes ``adj.tree`` is structurally final before the first call; adjoints
         whose tree is mutated (transformers, ``wp.static`` rewriting) never share it. Any new
         code that mutates ``adj.tree`` afterwards must reset ``adj._reference_nodes`` -- and
-        ``adj._shared_source.reference_nodes`` and ``assigned_name_ids`` when set, which
-        invalidates every adjoint sharing the tree -- or better, exclude the adjoint from
-        sharing like the cases above.
+        ``adj._shared_source.reference_nodes``, ``assigned_name_ids``, and
+        ``assignment_call_metadata`` when set, which invalidates every adjoint sharing the tree
+        -- or better, exclude the adjoint from sharing like the cases above.
         """
         if adj._reference_nodes is None:
             shared = adj._shared_source
@@ -6578,11 +6656,35 @@ class Adjoint:
                     shared.assigned_name_ids = adj._assigned_name_ids
         return adj._assigned_name_ids
 
+    def assignment_call_metadata(adj) -> tuple[dict[ast.Call, int], frozenset[str]]:
+        """Return direct assignment calls by unpacking arity and their bare callee names."""
+
+        if adj._assignment_call_metadata is None:
+            shared = adj._shared_source
+            if shared is not None and shared.assignment_call_metadata is not None:
+                adj._assignment_call_metadata = shared.assignment_call_metadata
+            else:
+                call_dims = {}
+                call_name_ids = set()
+                for node in adj.reference_nodes():
+                    if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+                        continue
+
+                    target = node.targets[0]
+                    call_dims[node.value] = len(target.elts) if isinstance(target, ast.Tuple) else 1
+                    if isinstance(node.value.func, ast.Name):
+                        call_name_ids.add(node.value.func.id)
+
+                adj._assignment_call_metadata = (call_dims, frozenset(call_name_ids))
+                if shared is not None:
+                    shared.assignment_call_metadata = adj._assignment_call_metadata
+        return adj._assignment_call_metadata
+
     def get_references(adj) -> tuple[dict[str, Any], dict[Any, Any], dict[warp._src.context.Function, Any]]:
         """Traverse ``adj.tree`` for referenced constants, types, and user-defined functions.
 
         As a side effect, also sets ``adj.kernel_dim`` (the thread-grid dimension inferred from
-        ``wp.tid()``) and ``adj.scalar_tid_extent_limit_candidate``. They are folded into this
+        ``wp.tid()``) and ``adj.tid_extent_limit_candidate``. They are folded into this
         traversal rather than walked separately because ``get_references`` already visits every
         ``Assign`` and runs for every adjoint during module hashing. The candidate is conservative;
         code generation records exact reachability before an oversized launch is rejected.
@@ -6597,6 +6699,12 @@ class Adjoint:
         types: dict[Struct | type, Any] = {}
         functions: dict[warp._src.context.Function, Any] = {}
         max_dim = 0  # thread-grid dimension, inferred from wp.tid() unpack arity
+        assignment_call_dims, assignment_call_name_ids = adj.assignment_call_metadata()
+        if local_variables.isdisjoint(assignment_call_name_ids):
+            tid_aliases = frozenset()
+        else:
+            tid_aliases = resolve_reference_tid_aliases(adj, local_variables)
+        tid_func = warp._src.context.builtin_functions["tid"]
         callable_arg_values = getattr(adj, "callable_arg_values", None) or {}
         # Shared single traversal (see reference_nodes()); resolved here at hash time.
         for node in adj.reference_nodes():
@@ -6614,8 +6722,15 @@ class Adjoint:
             elif isinstance(node, ast.Call):
                 if isinstance(node.func, ast.Name) and node.func.id in local_variables:
                     func = callable_arg_values.get(node.func.id)
+                    if func is None and node.func.id in tid_aliases:
+                        func = tid_func
                 else:
                     func = resolve_reference_call_func(adj, node, callable_arg_values)
+
+                if func is tid_func:
+                    call_dim = assignment_call_dims.get(node)
+                    if call_dim is not None:
+                        max_dim = max(max_dim, call_dim)
 
                 if isinstance(func, warp._src.context.Function):
                     if not func.is_builtin():
@@ -6642,11 +6757,6 @@ class Adjoint:
                     types[func] = None
 
             elif isinstance(node, ast.Assign):
-                # Infer the thread-grid dimension from `i[, j, ...] = wp.tid()` unpack arity.
-                if _is_tid_call(node.value, adj):
-                    target = node.targets[0]
-                    max_dim = max(max_dim, len(target.elts) if isinstance(target, ast.Tuple) else 1)
-
                 # A function bound to a local (`f = mod.func`) or to several locals via tuple
                 # unpacking (`f, g = mod.a, mod.b`) is referenced only through the local(s)
                 # afterwards, so it would otherwise be missed here and left out of the module
@@ -6662,11 +6772,11 @@ class Adjoint:
                         functions[rhs_func] = None
 
         adj.kernel_dim = max_dim if max_dim > 0 else 1
-        # Treat every kernel as a potential scalar-`wp.tid()` user until exact
-        # code generation proves otherwise. This conservative gate cannot miss
-        # aliases or transformer-generated calls, and only oversized leading
-        # extents pay for metadata-only code generation.
-        adj.scalar_tid_extent_limit_candidate = _SCALAR_TID_MAX_EXTENT
+        # Treat every kernel as a potential `wp.tid()` user until exact code
+        # generation proves otherwise. This conservative gate cannot miss
+        # aliases or transformer-generated calls, and only launch extents above
+        # the coordinate limit pay for metadata-only code generation.
+        adj.tid_extent_limit_candidate = _TID_MAX_EXTENT
         return constants, types, functions
 
 

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -3349,7 +3349,7 @@ class ModuleBuilder:
         kernel.adj.build(self)
         for var in (*kernel.adj.args, *kernel.adj.variables):
             self._collect_native_types(var.type)
-        self.module._cache_kernel_scalar_tid_extent_limit(kernel, self.options["block_dim"])
+        self.module._cache_kernel_tid_extent_limit(kernel, self.options["block_dim"])
 
         if kernel.adj.return_var is not None:
             raise WarpCodegenTypeError(f"'{kernel.key}': {_KERNEL_RETURN_ERROR}")
@@ -3920,7 +3920,7 @@ class Module:
         # hash data, including the module hash. Module may store multiple hashes (one per block_dim used)
         self.hashers = {}
         self.resolved_options = {}
-        self._scalar_tid_extent_limits = {}
+        self._tid_extent_limits = {}
 
         # LLVM executable modules are identified using strings.  Since it's possible for multiple
         # executable versions to be loaded at the same time, we need a way to ensure uniqueness.
@@ -4303,18 +4303,18 @@ class Module:
 
         return self.hashers[block_dim].get_hash()
 
-    def _cache_kernel_scalar_tid_extent_limit(self, kernel: Kernel, block_dim: int) -> None:
-        """Cache exact scalar ``wp.tid()`` metadata from the kernel's latest build."""
-        limit = warp._src.codegen._SCALAR_TID_MAX_EXTENT if kernel.adj.uses_scalar_tid else None
-        self._scalar_tid_extent_limits[(block_dim, kernel.hash)] = limit
+    def _cache_kernel_tid_extent_limit(self, kernel: Kernel, block_dim: int) -> None:
+        """Cache exact ``wp.tid()`` metadata from the kernel's latest build."""
+        limit = warp._src.codegen._TID_MAX_EXTENT if kernel.adj.uses_tid else None
+        self._tid_extent_limits[(block_dim, kernel.hash)] = limit
 
     @synchronized(_codegen_lock)
-    def _get_kernel_scalar_tid_extent_limit(self, kernel: Kernel, block_dim: int | None = None) -> int | None:
-        """Return exact scalar ``wp.tid()`` metadata for a module variant.
+    def _get_kernel_tid_extent_limit(self, kernel: Kernel, block_dim: int | None = None) -> int | None:
+        """Return exact ``wp.tid()`` metadata for a module variant.
 
         Held under ``_codegen_lock`` so another variant cannot rebuild the shared
         kernel adjoint between ``kernel.adj.build()`` and caching its
-        ``uses_scalar_tid`` result.
+        ``uses_tid`` result.
         """
         if block_dim is None:
             block_dim = self.options["block_dim"]
@@ -4322,12 +4322,12 @@ class Module:
         self.get_module_hash(block_dim)
         cache_key = (block_dim, kernel.hash)
 
-        if cache_key not in self._scalar_tid_extent_limits:
+        if cache_key not in self._tid_extent_limits:
             builder_options = self.resolved_options[block_dim] | {"output_arch": None}
             kernel.adj.build(None, builder_options)
-            self._cache_kernel_scalar_tid_extent_limit(kernel, block_dim)
+            self._cache_kernel_tid_extent_limit(kernel, block_dim)
 
-        return self._scalar_tid_extent_limits[cache_key]
+        return self._tid_extent_limits[cache_key]
 
     def _snapshot_deterministic_metadata(
         self, block_dim: int, options: dict, rebuild: bool
@@ -4914,7 +4914,7 @@ class Module:
         # clear hash data
         self.hashers = {}
         self.resolved_options = {}
-        self._scalar_tid_extent_limits = {}
+        self._tid_extent_limits = {}
 
         # clear build failures
         self.failed_builds = {}
@@ -10869,16 +10869,16 @@ class Launch:
             dim: The dimensions of the launch.
 
         Raises:
-            ValueError: If ``dim`` is invalid, its leading extent exceeds ``2**31`` for a kernel
-                that uses scalar ``wp.tid()``, or the resized grid is incompatible with the launch's
-                CUDA thread-block cluster configuration.
+            ValueError: If ``dim`` is invalid, a launch with a nonzero thread count has an extent
+                represented by ``wp.tid()`` greater than ``2**31``, or the resized grid is
+                incompatible with the launch's CUDA thread-block cluster configuration.
             RuntimeError: If the kernel is not grid-stride and the new dimensions exceed the lean 3D
                 grid capacity (~7e16 work items). Decorate the kernel with
                 ``@wp.kernel(grid_stride=True)`` to support launch dimensions this large.
         """
-        dim, _ = _normalize_launch_dim(dim)
-        scalar_tid_extent_limit = _resolve_kernel_scalar_tid_extent_limit(self.kernel, dim, self.block_dim)
-        new_bounds = _build_launch_bounds_from_tuple(dim, self.kernel.adj.kernel_dim, scalar_tid_extent_limit)
+        dim, total_dim_size = _normalize_launch_dim(dim)
+        _validate_kernel_tid_extents(self.kernel, dim, total_dim_size, self.block_dim)
+        new_bounds = _build_launch_bounds_from_tuple(dim, self.kernel.adj.kernel_dim)
 
         # Guard the impossible lean-grid overflow so a resize fails clearly instead of silently
         # dropping work items (matching wp.launch()).
@@ -11240,11 +11240,7 @@ def _normalize_launch_dim(dim: int | Sequence[int]) -> tuple[tuple[int, ...], in
     return dim, total
 
 
-def _build_launch_bounds_from_tuple(
-    dim: tuple[int, ...],
-    kernel_dim: int,
-    scalar_tid_extent_limit: int | None = None,
-) -> LaunchBounds:
+def _build_launch_bounds_from_tuple(dim: tuple[int, ...], kernel_dim: int) -> LaunchBounds:
     """Build launch bounds while preserving legacy ``wp.tid()`` aliasing.
 
     Missing trailing dimensions are padded with 1. Extra trailing dimensions
@@ -11254,14 +11250,6 @@ def _build_launch_bounds_from_tuple(
     padded = dim + (1,) * max(0, kernel_dim - len(dim))
     kept = padded[:kernel_dim]
     extras = padded[kernel_dim:]
-
-    if scalar_tid_extent_limit is not None and kept[0] > scalar_tid_extent_limit:
-        raise ValueError(
-            f"Warp cannot launch a kernel using scalar wp.tid() with extent {kept[0]}. "
-            f"Scalar wp.tid() returns a signed 32-bit coordinate and supports extents up to "
-            f"{scalar_tid_extent_limit}. Use a multidimensional launch and unpack wp.tid() "
-            "to index additional work items uniquely."
-        )
 
     bounds = launch_bounds_t(kept)
     if extras:
@@ -11275,14 +11263,29 @@ def _build_launch_bounds_from_tuple(
     return bounds
 
 
-def _resolve_kernel_scalar_tid_extent_limit(kernel: Kernel, dim: tuple[int, ...], block_dim: int | None) -> int | None:
-    """Resolve exact scalar ``wp.tid()`` metadata only when its candidate would reject."""
-    candidate = kernel.adj.scalar_tid_extent_limit_candidate
-    leading_extent = dim[0] if dim else 1
-    if leading_extent <= candidate:
-        return candidate
+def _validate_kernel_tid_extents(
+    kernel: Kernel,
+    dim: tuple[int, ...],
+    total_dim_size: int,
+    block_dim: int | None,
+) -> None:
+    """Validate launch extents represented by ``wp.tid()``, resolving exact metadata only when needed."""
+    candidate = kernel.adj.tid_extent_limit_candidate
+    if total_dim_size <= candidate:
+        return
 
-    return kernel.module._get_kernel_scalar_tid_extent_limit(kernel, block_dim)
+    oversized = next(
+        ((axis, extent) for axis, extent in enumerate(dim[: kernel.adj.kernel_dim]) if extent > candidate),
+        None,
+    )
+    if oversized is None or kernel.module._get_kernel_tid_extent_limit(kernel, block_dim) is None:
+        return
+
+    axis, extent = oversized
+    raise ValueError(
+        f"Warp cannot launch a kernel using wp.tid() with extent {extent} in dimension {axis}. "
+        f"wp.tid() returns signed 32-bit coordinates and supports extents up to {candidate}."
+    )
 
 
 def _build_kernel_launch_bounds(
@@ -11290,10 +11293,10 @@ def _build_kernel_launch_bounds(
     kernel: Kernel,
     block_dim: int | None = None,
 ) -> LaunchBounds:
-    """Build launch bounds using exact scalar ``wp.tid()`` metadata when required."""
-    dim, _ = _normalize_launch_dim(dim)
-    scalar_tid_extent_limit = _resolve_kernel_scalar_tid_extent_limit(kernel, dim, block_dim)
-    return _build_launch_bounds_from_tuple(dim, kernel.adj.kernel_dim, scalar_tid_extent_limit)
+    """Build launch bounds using exact ``wp.tid()`` metadata when required."""
+    dim, total_dim_size = _normalize_launch_dim(dim)
+    _validate_kernel_tid_extents(kernel, dim, total_dim_size, block_dim)
+    return _build_launch_bounds_from_tuple(dim, kernel.adj.kernel_dim)
 
 
 def launch(
@@ -11424,8 +11427,8 @@ def launch(
                     f"@wp.kernel(grid_stride=True) to launch dimensions this large."
                 )
 
-        scalar_tid_extent_limit = _resolve_kernel_scalar_tid_extent_limit(kernel, dim, block_dim)
-        bounds = _build_launch_bounds_from_tuple(dim, kernel.adj.kernel_dim, scalar_tid_extent_limit)
+        _validate_kernel_tid_extents(kernel, dim, total_dim_size, block_dim)
+        bounds = _build_launch_bounds_from_tuple(dim, kernel.adj.kernel_dim)
 
         # first param is the number of threads
         params = [bounds]

--- a/warp/_src/jax/custom_call.py
+++ b/warp/_src/jax/custom_call.py
@@ -337,8 +337,8 @@ def _create_jax_warp_primitive():
             dims = launch_dims
             warp_dims = launch_dims
 
-        # JAX 0.4.25-0.7.x uses this legacy custom-call path, so reject
-        # oversized scalar coordinates during lowering before XLA allocates outputs.
+        # JAX 0.4.25-0.7.x uses this legacy custom-call path, so validate launch
+        # extents visible through wp.tid() during lowering before XLA allocates outputs.
         _build_kernel_launch_bounds(warp_dims, wp_kernel)
 
         # Figure out the types and shapes of the input arrays.

--- a/warp/_src/jax/ffi.py
+++ b/warp/_src/jax/ffi.py
@@ -14,7 +14,7 @@ from enum import IntEnum
 from typing import Any
 
 import warp as wp
-from warp._src.codegen import _SCALAR_TID_MAX_EXTENT, get_full_arg_spec, make_full_qualified_name
+from warp._src.codegen import _TID_MAX_EXTENT, get_full_arg_spec, make_full_qualified_name
 from warp._src.context import (
     CudaMemcpyKind,
     _build_kernel_launch_bounds,
@@ -165,8 +165,8 @@ def _validate_ffi_kernel_launch_bounds(dim, kernel, block_dim=None) -> None:
     kernel.module.get_module_hash(cuda_block_dim)
     _build_kernel_launch_bounds(dim, kernel, cuda_block_dim)
 
-    leading_extent = dim[0] if dim else 1
-    if leading_extent > _SCALAR_TID_MAX_EXTENT and cuda_block_dim != 1:
+    tid_extents = dim[: kernel.adj.kernel_dim]
+    if any(extent > _TID_MAX_EXTENT for extent in tid_extents) and cuda_block_dim != 1:
         _build_kernel_launch_bounds(dim, kernel, 1)
 
 
@@ -562,7 +562,7 @@ class FfiKernel:
                         # roll batch size into the first launch dimension
                         launch_dims = (batch_size * launch_dims[0], *launch_dims[1:])
 
-                # Revalidate here because vmap can grow the leading extent at runtime.
+                # Revalidate here because vmap can grow an extent visible through wp.tid() at runtime.
                 launch_bounds = _build_kernel_launch_bounds(launch_dims, self.kernel, block_dim)
 
                 if platform == _FFI_PLATFORM_CPU:

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -2335,7 +2335,7 @@ def _make_launch_bounds_class(ndim: int):
         (ctypes.Structure,),
         {
             "_fields_": (
-                ("shape", ctypes.c_int32 * ndim),
+                ("shape", ctypes.c_uint32 * ndim),
                 ("size", ctypes.c_size_t),
                 ("coord_mult", ctypes.c_size_t),
             ),

--- a/warp/native/apic.cpp
+++ b/warp/native/apic.cpp
@@ -346,7 +346,7 @@ void apic_record_kernel_launch(
     const char* kernel_key,
     const char* module_hash,
     int is_forward,
-    const int* shape,
+    const uint32_t* shape,
     int ndim,
     uint64_t size,
     int max_blocks,
@@ -1435,7 +1435,9 @@ static bool apic_add_check(uint64_t a, uint64_t b, uint64_t* out)
 // op_type is recognized. Called once at stream-close time (end of recording
 // for live capture; after .wrp load for deserialized graphs). Replay paths
 // skip per-op bounds checks once this returns true.
-bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t operation_count, uint32_t depth)
+bool apic_validate_operation_stream(
+    const uint8_t* data, size_t size, uint32_t operation_count, uint32_t depth, uint32_t format_version
+)
 {
     // Cap conditional nesting before recursion can stack-overflow on a
     // malformed .wrp. 1024 levels is far past anything a real program will
@@ -1476,6 +1478,24 @@ bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t o
                 return false;
             }
             const APICLaunchRecord* rec = reinterpret_cast<const APICLaunchRecord*>(ptr);
+            if (format_version < APIC_UNSIGNED_LAUNCH_BOUNDS_VERSION) {
+                int ndim = rec->ndim;
+                if (ndim < 1)
+                    ndim = 1;
+                if (ndim > APIC_LAUNCH_MAX_DIMS)
+                    ndim = APIC_LAUNCH_MAX_DIMS;
+                for (int d = 0; d < ndim; d++) {
+                    if (rec->shape[d] > INT32_MAX) {
+                        fprintf(
+                            stderr,
+                            "Warp APIC error: legacy kernel launch shape overflows signed 32-bit extent at operation "
+                            "%u dimension %d\n",
+                            i, d
+                        );
+                        return false;
+                    }
+                }
+            }
             const uint8_t* var_data = ptr + sizeof(APICLaunchRecord);
             if (var_data + rec->kernel_key_len + rec->module_hash_len > op_end) {
                 fprintf(stderr, "Warp APIC error: kernel launch strings overflow at operation %u\n", i);
@@ -1878,7 +1898,9 @@ bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t o
             const uint8_t* branch_b = branch_a + rec->branch_a_size;
             // Recurse into the inner sub-streams.
             if (rec->branch_a_size > 0
-                && !apic_validate_operation_stream(branch_a, rec->branch_a_size, rec->branch_a_op_count, depth + 1)) {
+                && !apic_validate_operation_stream(
+                    branch_a, rec->branch_a_size, rec->branch_a_op_count, depth + 1, format_version
+                )) {
                 fprintf(stderr, "Warp APIC error: branch_a invalid at operation %u\n", i);
                 return false;
             }
@@ -1887,7 +1909,9 @@ bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t o
                 return false;
             }
             if (rec->branch_b_size > 0
-                && !apic_validate_operation_stream(branch_b, rec->branch_b_size, rec->branch_b_op_count, depth + 1)) {
+                && !apic_validate_operation_stream(
+                    branch_b, rec->branch_b_size, rec->branch_b_op_count, depth + 1, format_version
+                )) {
                 fprintf(stderr, "Warp APIC error: branch_b invalid at operation %u\n", i);
                 return false;
             }
@@ -2166,7 +2190,7 @@ static bool apic_cpu_replay_stream(
             memset(bounds_buf, 0, bounds_size);
             uint64_t shape_size = 1;
             for (int d = 0; d < ndim; d++)
-                reinterpret_cast<int*>(bounds_buf)[d] = rec->shape[d];
+                reinterpret_cast<uint32_t*>(bounds_buf)[d] = rec->shape[d];
             for (int d = 0; d < ndim; d++)
                 shape_size *= static_cast<uint64_t>(rec->shape[d]);
             *reinterpret_cast<size_t*>(bounds_buf + size_offset) = rec->size;
@@ -3282,7 +3306,9 @@ APICGraph* wp_apic_load_graph(void* context, const char* path, int device_type)
         memcpy(&operation_count, operations_ptr, sizeof(operation_count));
         operation_stream = operations_ptr + sizeof(operation_count);
         operation_stream_size = operations_size - sizeof(operation_count);
-        if (!apic_validate_operation_stream(operation_stream, operation_stream_size, operation_count)) {
+        if (!apic_validate_operation_stream(
+                operation_stream, operation_stream_size, operation_count, 0, header->version
+            )) {
             wp::set_error_string("Warp APIC error: operation stream failed validation");
             return nullptr;
         }

--- a/warp/native/apic.cu
+++ b/warp/native/apic.cu
@@ -366,7 +366,7 @@ static bool apic_replay_ops_into_cuda_capture(
                 memset(bounds_buf, 0, bounds_alloc_size);
 
                 uint64_t shape_size = 1;
-                int* shape_ptr = reinterpret_cast<int*>(bounds_buf);
+                uint32_t* shape_ptr = reinterpret_cast<uint32_t*>(bounds_buf);
                 for (int d = 0; d < ndim; d++) {
                     shape_ptr[d] = rec->shape[d];
                     shape_size *= static_cast<uint64_t>(rec->shape[d]);

--- a/warp/native/apic_internal.h
+++ b/warp/native/apic_internal.h
@@ -102,7 +102,7 @@ constexpr size_t launch_bounds_align8(size_t offset) { return (offset + 7) & ~si
 
 constexpr size_t launch_bounds_size_offset(int ndim)
 {
-    return launch_bounds_align8(static_cast<size_t>(ndim) * sizeof(int));
+    return launch_bounds_align8(static_cast<size_t>(ndim) * sizeof(uint32_t));
 }
 
 constexpr size_t launch_bounds_coord_mult_offset(int ndim) { return launch_bounds_size_offset(ndim) + sizeof(size_t); }
@@ -293,7 +293,7 @@ void apic_record_kernel_launch(
     const char* kernel_key,
     const char* module_hash,
     int is_forward,
-    const int* shape,
+    const uint32_t* shape,
     int ndim,
     uint64_t size,
     int max_blocks,
@@ -559,7 +559,13 @@ struct APICGraph {
 // Walk the operation byte stream once and verify that every record header,
 // variable-length payload, and op_type is within bounds. Prints a diagnostic
 // and returns false on first inconsistency. Defined in apic.cpp.
-bool apic_validate_operation_stream(const uint8_t* data, size_t size, uint32_t operation_count, uint32_t depth = 0);
+bool apic_validate_operation_stream(
+    const uint8_t* data,
+    size_t size,
+    uint32_t operation_count,
+    uint32_t depth = 0,
+    uint32_t format_version = APIC_FORMAT_VERSION
+);
 
 // ============================================================================
 // .wrp file reading helpers (pure C++, defined in apic.cpp)

--- a/warp/native/apic_types.h
+++ b/warp/native/apic_types.h
@@ -10,8 +10,9 @@
 // APIC Format Constants
 // =============================================================================
 
-#define APIC_FORMAT_VERSION 15
+#define APIC_FORMAT_VERSION 16
 #define APIC_MIN_SUPPORTED_FORMAT_VERSION 13
+#define APIC_UNSIGNED_LAUNCH_BOUNDS_VERSION 16
 #define APIC_MAGIC "WRP1"
 #define APIC_MAGIC_VALUE 0x31505257  // "WRP1" as little-endian uint32
 
@@ -174,7 +175,7 @@ struct APICLaunchRecord {
 
     // Generated kernel launch bounds (embedded). Stores the shape and dimensionality
     // used by launch_bounds_t<N>, not necessarily the original Python wp.launch() rank.
-    int32_t shape[APIC_LAUNCH_MAX_DIMS];  // Shape passed to the generated kernel entry point
+    uint32_t shape[APIC_LAUNCH_MAX_DIMS];  // Shape passed to the generated kernel entry point
     int32_t ndim;  // Kernel dimensionality used to select launch_bounds_t<N>
     uint64_t size;  // Total threads, including any folded launch axes
 

--- a/warp/native/builtin.h
+++ b/warp/native/builtin.h
@@ -1915,7 +1915,7 @@ static constexpr int LAUNCH_MAX_DIMS = 4;  // should match types.py
 template <int N> struct launch_bounds_t {
     static_assert(N > 0 && N <= LAUNCH_MAX_DIMS, "launch_bounds_t<N> only supports 1-4 dimensions");
 
-    int shape[N];
+    uint32_t shape[N];
     size_t size;
     size_t coord_mult;  // threads sharing each coord tuple; launch_coord divides linear by this before unraveling
 };

--- a/warp/native/warp.cpp
+++ b/warp/native/warp.cpp
@@ -257,7 +257,7 @@ void wp_cpu_launch_kernel(void* func, void* bounds, void* args, void* adj_args, 
     if (recording_state && apic_info) {
         // Extract shape from launch_bounds_t<N>. kernel_dim gives the exact
         // dimensionality expected by the generated kernel.
-        int shape[APIC_LAUNCH_MAX_DIMS] = {};
+        uint32_t shape[APIC_LAUNCH_MAX_DIMS] = {};
         int ndim = apic_info->kernel_dim;
         if (ndim < 1)
             ndim = 1;
@@ -266,7 +266,7 @@ void wp_cpu_launch_kernel(void* func, void* bounds, void* args, void* adj_args, 
 
         uint64_t launch_size = 0;
         if (bounds && ndim > 0) {
-            const int* bounds_shape = static_cast<const int*>(bounds);
+            const uint32_t* bounds_shape = static_cast<const uint32_t*>(bounds);
             for (int d = 0; d < ndim; d++)
                 shape[d] = bounds_shape[d];
 

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -5697,10 +5697,10 @@ size_t wp_cuda_launch_kernel(
             if (ndim > APIC_LAUNCH_MAX_DIMS)
                 ndim = APIC_LAUNCH_MAX_DIMS;
 
-            int shape[APIC_LAUNCH_MAX_DIMS] = {};
+            uint32_t shape[APIC_LAUNCH_MAX_DIMS] = {};
             uint64_t launch_size = dim;
             if (args && args[0]) {
-                const int* bounds_shape = static_cast<const int*>(args[0]);
+                const uint32_t* bounds_shape = static_cast<const uint32_t*>(args[0]);
                 for (int d = 0; d < ndim; d++)
                     shape[d] = bounds_shape[d];
 
@@ -5708,7 +5708,7 @@ size_t wp_cuda_launch_kernel(
                 const uint8_t* bounds_bytes = static_cast<const uint8_t*>(args[0]);
                 launch_size = *reinterpret_cast<const size_t*>(bounds_bytes + size_offset);
             } else {
-                shape[0] = (int)dim;
+                shape[0] = static_cast<uint32_t>(dim);
             }
 
             apic_record_kernel_launch(

--- a/warp/tests/interop/test_jax.py
+++ b/warp/tests/interop/test_jax.py
@@ -551,7 +551,25 @@ def test_jax_kernel_rejects_oversized_scalar_tid_launch_dims(test, device, use_f
 
     with jax.default_device(wp.device_to_jax(device)):
         with test.assertRaisesRegex(
-            ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+            ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 0"
+        ):
+            run.lower()
+
+
+def test_jax_kernel_rejects_oversized_tuple_tid_launch_dims(test, device, use_ffi=False):
+    """Reject oversized tuple-valued ``wp.tid()`` dimensions during legacy lowering."""
+    jax = _import_jax()
+    jp = _import_jax_numpy()
+    jax_kernel = _get_experimental_custom_call_jax_kernel()
+    jax_inc = jax_kernel(inc_2d_kernel, launch_dims=(1, 2**31 + 1), quiet=True)
+
+    @jax.jit
+    def run():
+        return jax_inc(jp.ones((1, 1), dtype=jp.float32))
+
+    with jax.default_device(wp.device_to_jax(device)):
+        with test.assertRaisesRegex(
+            ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 1"
         ):
             run.lower()
 
@@ -572,7 +590,27 @@ def test_ffi_jax_kernel_rejects_oversized_explicit_scalar_tid_launch_dims(test, 
 
     with jax.default_device(wp.device_to_jax(device)):
         with test.assertRaisesRegex(
-            ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+            ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 0"
+        ):
+            run.lower()
+
+
+def test_ffi_jax_kernel_rejects_oversized_explicit_tuple_tid_launch_dims(test, device):
+    """Reject an explicit oversized tuple-valued ``wp.tid()`` dimension during tracing."""
+    jp = _import_jax_numpy()
+    jax_inc = wp.jax_kernel(
+        inc_2d_kernel,
+        launch_dims=(1, 2**31 + 1),
+        output_dims=(1, 1),
+    )
+
+    @jax.jit
+    def run():
+        return jax_inc(jp.ones((1, 1), dtype=jp.float32))
+
+    with jax.default_device(wp.device_to_jax(device)):
+        with test.assertRaisesRegex(
+            ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 1"
         ):
             run.lower()
 
@@ -591,7 +629,24 @@ def test_ffi_jax_kernel_rejects_oversized_inferred_scalar_tid_launch_dims(test, 
     abstract_input = jax.ShapeDtypeStruct((2**31 + 1,), jp.float32)
     with jax.default_device(wp.device_to_jax(device)):
         with test.assertRaisesRegex(
-            ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+            ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 0"
+        ):
+            run.lower(abstract_input)
+
+
+def test_ffi_jax_kernel_rejects_oversized_inferred_tuple_tid_launch_dims(test, device):
+    """Reject an inferred oversized tuple-valued ``wp.tid()`` dimension during tracing."""
+    jp = _import_jax_numpy()
+    jax_inc = wp.jax_kernel(inc_2d_kernel, output_dims=(1, 1))
+
+    @jax.jit
+    def run(x):
+        return jax_inc(x)
+
+    abstract_input = jax.ShapeDtypeStruct((1, 2**31 + 1), jp.float32)
+    with jax.default_device(wp.device_to_jax(device)):
+        with test.assertRaisesRegex(
+            ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 1"
         ):
             run.lower(abstract_input)
 
@@ -3340,7 +3395,9 @@ else:
                 test_ffi_jax_kernel_launch_dims_custom,
                 test_ffi_jax_kernel_validates_all_target_block_dims_during_tracing,
                 test_ffi_jax_kernel_rejects_oversized_explicit_scalar_tid_launch_dims,
+                test_ffi_jax_kernel_rejects_oversized_explicit_tuple_tid_launch_dims,
                 test_ffi_jax_kernel_rejects_oversized_inferred_scalar_tid_launch_dims,
+                test_ffi_jax_kernel_rejects_oversized_inferred_tuple_tid_launch_dims,
                 # callables
                 test_ffi_jax_callable_scale_constant,
                 test_ffi_jax_callable_scale_static,
@@ -3442,6 +3499,7 @@ else:
                 test_jax_kernel_multiarg,
                 test_jax_kernel_launch_dims,
                 test_jax_kernel_rejects_oversized_scalar_tid_launch_dims,
+                test_jax_kernel_rejects_oversized_tuple_tid_launch_dims,
                 test_jax_kernel_accepts_oversized_compile_time_dead_scalar_tid_launch_dims,
             )
             for test_func in legacy_custom_call_tests:

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -48,6 +48,12 @@ def scale_kernel(input: wp.array[float], output: wp.array[float], s: float):
 
 
 @wp.kernel
+def scale_2d_kernel(input: wp.array2d[float], output: wp.array2d[float], s: float):
+    i, j = wp.tid()
+    output[i, j] = input[i, j] * s
+
+
+@wp.kernel
 def add_kernel(a: wp.array[float], b: wp.array[float], output: wp.array[float]):
     i = wp.tid()
     output[i] = a[i] + b[i]
@@ -58,6 +64,11 @@ def fill_reduction_inputs_kernel(a: wp.array[wp.float32], b: wp.array[wp.float32
     i = wp.tid()
     a[i] = float(i + 1)
     b[i] = float(2 * i + 1)
+
+
+@wp.kernel
+def no_tid_kernel():
+    pass
 
 
 @wp.kernel
@@ -76,6 +87,7 @@ class TestApic(unittest.TestCase):
 # Must match APICSectionType in warp/native/apic_types.h.
 _APIC_SECTION_MEMORY = 2
 _APIC_SECTION_OPERATIONS = 3
+_APIC_FORMAT_VERSION = 16
 
 # These layouts mirror the packed structs in warp/native/apic_types.h. "<"
 # selects little-endian standard sizes without implicit alignment; "4s", "i",
@@ -89,11 +101,14 @@ _APIC_SECTION_ENTRY = struct.Struct("<IIQQQ")
 
 # APICMemoryRegionRecord: ID, element size, byte size, initial-data flag, padding.
 _APIC_MEMORY_REGION_RECORD = struct.Struct("<IIQB7x")
+_APIC_OP_HEADER = struct.Struct("<II")
 
 # APICCondRecord: operation type/size, condition region/padding/offset, then each
 # branch's byte size and operation count.
 _APIC_COND_RECORD = struct.Struct("<IIiIQIIII")
 _APIC_UINT32 = struct.Struct("<I")  # One serialized uint32_t.
+_APIC_OP_KERNEL_LAUNCH = 1
+_APIC_LAUNCH_SHAPE_OFFSET = _APIC_OP_HEADER.size
 
 
 def _find_apic_section(wrp_data, requested_section_type):
@@ -160,6 +175,35 @@ def _replace_apic_section(path, requested_section_type, replacement):
         wrp_file.seek(0)
         wrp_file.write(wrp_data)
         wrp_file.truncate()
+
+
+def _set_apic_file_version(path, version):
+    """Replace the WRP header version while preserving the other prefix fields."""
+    with open(path, "r+b") as wrp_file:
+        prefix = list(_APIC_FILE_HEADER_PREFIX.unpack(wrp_file.read(_APIC_FILE_HEADER_PREFIX.size)))
+        prefix[1] = version
+        wrp_file.seek(0)
+        wrp_file.write(_APIC_FILE_HEADER_PREFIX.pack(*prefix))
+
+
+def _replace_first_apic_kernel_shape(path, extent, axis=0):
+    """Replace one extent in the first kernel launch record."""
+    operations = _read_apic_section(path, _APIC_SECTION_OPERATIONS)
+    operation_count = _APIC_UINT32.unpack_from(operations)[0]
+    offset = _APIC_UINT32.size
+    for _ in range(operation_count):
+        operation_type, operation_size = _APIC_OP_HEADER.unpack_from(operations, offset)
+        if operation_type == _APIC_OP_KERNEL_LAUNCH:
+            _APIC_UINT32.pack_into(
+                operations,
+                offset + _APIC_LAUNCH_SHAPE_OFFSET + axis * _APIC_UINT32.size,
+                extent,
+            )
+            _replace_apic_section(path, _APIC_SECTION_OPERATIONS, operations)
+            return
+        offset += operation_size
+
+    raise ValueError("Expected at least one APIC kernel launch")
 
 
 def _append_apic_memory_record(path, record_and_payload):
@@ -385,7 +429,7 @@ def test_live_hashgrid_capture_does_not_snapshot_inputs(test, device):
 
 
 def test_save_single_kernel(test, device):
-    """Capture, save to .wrp, verify file exists."""
+    """Save a kernel graph and verify its WRP file uses the current format version."""
     n = 256
     a = wp.array(np.arange(n, dtype=np.float32), device=device)
     b = wp.zeros(n, dtype=float, device=device)
@@ -401,6 +445,81 @@ def test_save_single_kernel(test, device):
         wrp_path = path + ".wrp"
         test.assertTrue(os.path.exists(wrp_path), f"WRP file not found: {wrp_path}")
         test.assertGreater(os.path.getsize(wrp_path), 0, "WRP file is empty")
+        with open(wrp_path, "rb") as wrp_file:
+            _, version, _, _, _ = _APIC_FILE_HEADER_PREFIX.unpack_from(wrp_file.read())
+        test.assertEqual(version, _APIC_FORMAT_VERSION)
+
+
+def test_load_rejects_legacy_overflowed_launch_shape(test, device):
+    """Reject ambiguous signed launch extents on every active axis in older WRP versions."""
+    a = wp.ones((1, 1), dtype=float, device=device)
+    b = wp.zeros((1, 1), dtype=float, device=device)
+
+    wp.load_module(device=device)
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        wp.launch(scale_2d_kernel, dim=(1, 1), inputs=[a, b, 1.0], device=device)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for axis in range(2):
+            path = os.path.join(tmpdir, f"legacy_overflowed_shape_axis_{axis}")
+            wp.capture_save(capture.graph, path, inputs={"a": a}, outputs={"b": b})
+            wrp_path = path + ".wrp"
+            _replace_first_apic_kernel_shape(wrp_path, 2**31, axis)
+
+            for version in range(13, _APIC_FORMAT_VERSION):
+                with test.subTest(axis=axis, version=version):
+                    _set_apic_file_version(wrp_path, version)
+                    _assert_apic_load_rejected(
+                        test,
+                        wrp_path,
+                        device,
+                        r"operation stream failed validation",
+                    )
+
+
+def test_load_accepts_supported_legacy_launch_shapes(test, device):
+    """Verify ordinary launch shapes remain loadable from every supported legacy WRP version."""
+    a = wp.ones(1, dtype=float, device=device)
+    b = wp.zeros(1, dtype=float, device=device)
+
+    wp.load_module(device=device)
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        wp.launch(scale_kernel, dim=1, inputs=[a, b, 1.0], device=device)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "legacy_launch_shape")
+        wp.capture_save(capture.graph, path, inputs={"a": a}, outputs={"b": b})
+        wrp_path = path + ".wrp"
+
+        for version in range(13, _APIC_FORMAT_VERSION):
+            with test.subTest(version=version):
+                _set_apic_file_version(wrp_path, version)
+                loaded = wp.capture_load(wrp_path, device=device)
+                try:
+                    test.assertTrue(loaded.is_loaded)
+                    wp.capture_launch(loaded)
+
+                    result = wp.empty_like(b)
+                    loaded.get_param("b", result)
+                    np.testing.assert_allclose(result.numpy(), np.ones(1, dtype=np.float32))
+                finally:
+                    # Release the LLVM module before loading the next version or
+                    # deleting its backing object file on Windows.
+                    del loaded
+
+
+def test_load_accepts_current_oversized_no_tid_launch_shape(test, device):
+    """Accept version 16 oversized extents when the kernel does not use ``wp.tid()``."""
+    wp.load_module(device=device)
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        wp.launch(no_tid_kernel, dim=2**31 + 1, device=device)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "current_oversized_no_tid_shape")
+        wp.capture_save(capture.graph, path)
+
+        loaded = wp.capture_load(path, device=device)
+        test.assertTrue(loaded.is_loaded)
 
 
 def test_save_load_round_trip(test, device):
@@ -3420,6 +3539,24 @@ add_function_test(
     "test_save_single_kernel",
     test_save_single_kernel,
     devices=devices_with_cuda_graph_module_load,
+)
+add_function_test(
+    TestApic,
+    "test_load_rejects_legacy_overflowed_launch_shape",
+    test_load_rejects_legacy_overflowed_launch_shape,
+    devices=[d for d in devices if d.is_cpu],
+)
+add_function_test(
+    TestApic,
+    "test_load_accepts_supported_legacy_launch_shapes",
+    test_load_accepts_supported_legacy_launch_shapes,
+    devices=[d for d in devices if d.is_cpu],
+)
+add_function_test(
+    TestApic,
+    "test_load_accepts_current_oversized_no_tid_launch_shape",
+    test_load_accepts_current_oversized_no_tid_launch_shape,
+    devices=[d for d in devices if d.is_cpu],
 )
 add_function_test(
     TestApic,

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -2216,6 +2216,22 @@ class TestCodeGen(unittest.TestCase):
         self.assertTrue(_is_tid_call(warp_alias_tid, fake_adj))
         self.assertFalse(_is_tid_call(other_tid, fake_adj))
 
+    def test_direct_tid_reference_scan_avoids_fallback_scans(self):
+        def direct_tid_kernel(values: wp.array2d[wp.int32]):
+            i, j = wp.tid()
+            values[i, j] = i + j
+
+        adj = codegen.Adjoint(direct_tid_kernel)
+        fallback_error = AssertionError("direct TID calls must not use fallback scans")
+
+        with (
+            mock.patch.object(codegen, "resolve_reference_tid_aliases", side_effect=fallback_error),
+            mock.patch.object(codegen, "_is_tid_call", side_effect=fallback_error),
+        ):
+            adj.get_references()
+
+        self.assertEqual(adj.kernel_dim, 2)
+
     def test_namespaced_tid_call_sets_kernel_dim(self):
         namespace = types.SimpleNamespace(warp=wp)
 

--- a/warp/tests/test_template_launch_bounds.py
+++ b/warp/tests/test_template_launch_bounds.py
@@ -15,7 +15,7 @@ from warp._src.types import _launch_bounds_classes, launch_bounds_t
 from warp.tests.unittest_utils import *
 
 BLOCK_DIM = 64
-SCALAR_TID_MAX_EXTENT = 2**31
+TID_MAX_EXTENT = 2**31
 SCALAR_TID_DISABLED = False
 TILE_M = wp.constant(8)
 TILE_N = wp.constant(4)
@@ -29,6 +29,7 @@ class ScalarTidFlags:
 
 # Exercise semantic ``tid`` detection through a resolved alias rather than ``wp.tid`` syntax.
 TID_FUNCTION = context.builtin_functions["tid"]
+TID_NAMESPACE = types.SimpleNamespace(tid=TID_FUNCTION)
 # Isolate the intentionally invalid user function so its build error cannot fail the shared test module.
 ALIASED_TID_FUNCTION_MODULE = wp.Module("test_template_launch_bounds_aliased_tid_function")
 
@@ -58,6 +59,12 @@ def named_false_scalar_tid_kernel():
 
 
 @wp.kernel
+def named_false_tuple_tid_kernel():
+    if SCALAR_TID_DISABLED:
+        _i, _j = wp.tid()
+
+
+@wp.kernel
 def attributed_false_scalar_tid_kernel():
     if ScalarTidFlags.disabled:
         i = wp.tid()
@@ -78,6 +85,52 @@ def named_false_scalar_tid_if_exp_kernel():
 @wp.kernel
 def aliased_scalar_tid_kernel():
     i = TID_FUNCTION()
+
+
+@wp.kernel
+def aliased_tuple_tid_kernel(out: wp.array2d[int]):
+    i, j = TID_FUNCTION()
+    out[i, j] = i * 2 + j
+
+
+@wp.kernel
+def local_aliased_tuple_tid_kernel(out: wp.array2d[int]):
+    tid_function = TID_FUNCTION
+    i, j = tid_function()
+    out[i, j] = i * 2 + j
+
+
+@wp.kernel
+def qualified_aliased_tuple_tid_kernel(out: wp.array2d[int]):
+    i, j = TID_NAMESPACE.tid()
+    out[i, j] = i * 2 + j
+
+
+@wp.kernel
+def dead_rebound_aliased_tuple_tid_kernel(out: wp.array2d[int]):
+    tid_function = TID_FUNCTION
+    if SCALAR_TID_DISABLED:
+        tid_function = tid_name_collision_func
+    i, j = tid_function()
+    out[i, j] = i * 2 + j
+
+
+@wp.kernel
+def nested_aliased_tuple_tid_kernel(out: wp.array2d[int]):
+    if not SCALAR_TID_DISABLED:
+        tid_function = TID_FUNCTION
+    nested_tid_function = tid_function
+    i, j = nested_tid_function()
+    out[i, j] = i * 2 + j
+
+
+ALIASED_TUPLE_TID_KERNELS = (
+    aliased_tuple_tid_kernel,
+    local_aliased_tuple_tid_kernel,
+    qualified_aliased_tuple_tid_kernel,
+    dead_rebound_aliased_tuple_tid_kernel,
+    nested_aliased_tuple_tid_kernel,
+)
 
 
 @wp.func(module=ALIASED_TID_FUNCTION_MODULE)
@@ -332,11 +385,11 @@ def test_scalar_tid_rejects_oversized_extent(test, device):
     out = wp.zeros(1, dtype=int, device=device)
 
     with test.assertRaisesRegex(
-        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+        ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 0"
     ):
         wp.launch(
             regular_1d_kernel,
-            dim=SCALAR_TID_MAX_EXTENT + 1,
+            dim=TID_MAX_EXTENT + 1,
             inputs=[out],
             device=device,
             record_cmd=True,
@@ -348,11 +401,11 @@ def test_inline_scalar_tid_rejects_oversized_extent(test, device):
     out = wp.zeros(1, dtype=int, device=device)
 
     with test.assertRaisesRegex(
-        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+        ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 0"
     ):
         wp.launch(
             inline_tid_kernel,
-            dim=SCALAR_TID_MAX_EXTENT + 1,
+            dim=TID_MAX_EXTENT + 1,
             inputs=[out],
             device=device,
             record_cmd=True,
@@ -364,11 +417,11 @@ def test_mixed_tid_arities_reject_oversized_scalar_extent(test, device):
     out = wp.zeros(1, dtype=int, device=device)
 
     with test.assertRaisesRegex(
-        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+        ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 0"
     ):
         wp.launch(
             mixed_tid_arity_kernel,
-            dim=(SCALAR_TID_MAX_EXTENT + 1, 1),
+            dim=(TID_MAX_EXTENT + 1, 1),
             inputs=[out],
             device=device,
             record_cmd=True,
@@ -381,13 +434,63 @@ def test_scalar_tid_accepts_max_extent(test, device):
 
     launch = wp.launch(
         regular_1d_kernel,
-        dim=SCALAR_TID_MAX_EXTENT,
+        dim=TID_MAX_EXTENT,
         inputs=[out],
         device=device,
         record_cmd=True,
     )
 
-    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT)
+    test.assertEqual(launch.bounds.size, TID_MAX_EXTENT)
+
+
+def test_tuple_tid_validates_every_dimension(test, device):
+    """Apply the signed-coordinate boundary independently to every launch dimension."""
+    kernels = {
+        1: (regular_1d_kernel, ()),
+        2: (regular_2d_kernel, (1, 1)),
+        3: (regular_3d_kernel, (1, 1, 1)),
+        4: (regular_4d_kernel, (1, 1, 1)),
+    }
+
+    for rank, (kernel, extra_inputs) in kernels.items():
+        out = wp.zeros((1,) * rank, dtype=int, device=device)
+        inputs = [out, *extra_inputs]
+        for axis in range(rank):
+            with test.subTest(rank=rank, axis=axis):
+                dim = [1] * rank
+                dim[axis] = TID_MAX_EXTENT
+                launch = wp.launch(kernel, dim=dim, inputs=inputs, device=device, record_cmd=True)
+                test.assertEqual(tuple(launch.bounds.shape), tuple(dim))
+
+                dim[axis] += 1
+                with test.assertRaisesRegex(
+                    ValueError,
+                    rf"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension {axis}",
+                ):
+                    wp.launch(kernel, dim=dim, inputs=inputs, device=device, record_cmd=True)
+
+
+def test_tuple_tid_accepts_large_total_with_safe_extents(test, device):
+    """Allow total thread counts above signed 32-bit range when every coordinate is safe."""
+    dim = (2**16, 2**16)
+    out = wp.zeros((1, 1), dtype=int, device=device)
+
+    launch = wp.launch(regular_2d_kernel, dim=dim, inputs=[out, 1, 1], device=device, record_cmd=True)
+
+    test.assertEqual(tuple(launch.bounds.shape), dim)
+    test.assertEqual(launch.bounds.size, 2**32)
+
+
+def test_tuple_tid_accepts_oversized_extent_in_empty_launch(test, device):
+    """Allow an extent above the coordinate limit when no thread can observe it."""
+    dim = (0, TID_MAX_EXTENT + 1)
+    out = wp.zeros((1, 1), dtype=int, device=device)
+
+    launch = wp.launch(regular_2d_kernel, dim=(1, 1), inputs=[out, 1, 1], device=device, record_cmd=True)
+    launch.set_dim(dim)
+
+    test.assertEqual(tuple(launch.bounds.shape), dim)
+    test.assertEqual(launch.bounds.size, 0)
 
 
 def test_no_tid_accepts_oversized_extent(test, device):
@@ -396,25 +499,25 @@ def test_no_tid_accepts_oversized_extent(test, device):
 
     launch = wp.launch(
         no_tid_kernel,
-        dim=SCALAR_TID_MAX_EXTENT + 1,
+        dim=TID_MAX_EXTENT + 1,
         inputs=[out, 1.0],
         device=device,
         record_cmd=True,
     )
 
-    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 1)
+    test.assertEqual(launch.bounds.size, TID_MAX_EXTENT + 1)
 
 
 def test_static_false_scalar_tid_accepts_oversized_extent(test, device):
     """Ignore scalar ``wp.tid()`` calls removed by static control flow."""
     launch = wp.launch(
         static_false_scalar_tid_kernel,
-        dim=SCALAR_TID_MAX_EXTENT + 1,
+        dim=TID_MAX_EXTENT + 1,
         device=device,
         record_cmd=True,
     )
 
-    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 1)
+    test.assertEqual(launch.bounds.size, TID_MAX_EXTENT + 1)
 
 
 def test_codegen_false_scalar_tid_accepts_oversized_extent(test, device):
@@ -430,12 +533,24 @@ def test_codegen_false_scalar_tid_accepts_oversized_extent(test, device):
         with test.subTest(kernel=kernel.key):
             launch = wp.launch(
                 kernel,
-                dim=SCALAR_TID_MAX_EXTENT + 1,
+                dim=TID_MAX_EXTENT + 1,
                 device=device,
                 record_cmd=True,
             )
 
-            test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 1)
+            test.assertEqual(launch.bounds.size, TID_MAX_EXTENT + 1)
+
+
+def test_codegen_false_tuple_tid_accepts_oversized_extent(test, device):
+    """Ignore tuple-valued ``wp.tid()`` calls removed by code generation."""
+    launch = wp.launch(
+        named_false_tuple_tid_kernel,
+        dim=(1, TID_MAX_EXTENT + 1),
+        device=device,
+        record_cmd=True,
+    )
+
+    test.assertEqual(tuple(launch.bounds.shape), (1, TID_MAX_EXTENT + 1))
 
 
 def test_aliased_scalar_tid_rejects_oversized_extent(test, device):
@@ -443,13 +558,39 @@ def test_aliased_scalar_tid_rejects_oversized_extent(test, device):
     aliased_scalar_tid_kernel.module.get_module_hash(BLOCK_DIM)
 
     with test.assertRaisesRegex(
-        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+        ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 0"
     ):
         context._build_kernel_launch_bounds(
-            SCALAR_TID_MAX_EXTENT + 1,
+            TID_MAX_EXTENT + 1,
             aliased_scalar_tid_kernel,
             BLOCK_DIM,
         )
+
+
+def test_aliased_tuple_tid_coordinates_and_limits(test, device):
+    """Preserve coordinates and enforce extent limits for aliased tuple-valued ``wp.tid()`` calls."""
+    for kernel in ALIASED_TUPLE_TID_KERNELS:
+        with test.subTest(kernel=kernel.key, check="coordinates"):
+            out = wp.zeros((2, 2), dtype=int, device=device)
+
+            wp.launch(kernel, dim=(2, 2), inputs=[out], device=device)
+
+            np.testing.assert_array_equal(out.numpy(), np.arange(4).reshape((2, 2)))
+
+        with test.subTest(kernel=kernel.key, check="extent limit"):
+            out = wp.zeros((1, 1), dtype=int, device=device)
+
+            with test.assertRaisesRegex(
+                ValueError,
+                r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 1",
+            ):
+                wp.launch(
+                    kernel,
+                    dim=(1, TID_MAX_EXTENT + 1),
+                    inputs=[out],
+                    device=device,
+                    record_cmd=True,
+                )
 
 
 def test_aliased_tid_in_user_function_is_rejected(test, device):
@@ -461,7 +602,7 @@ def test_aliased_tid_in_user_function_is_rejected(test, device):
         r"tid\(\) may only be called from a Warp kernel",
     ):
         context._build_kernel_launch_bounds(
-            SCALAR_TID_MAX_EXTENT + 1,
+            TID_MAX_EXTENT + 1,
             aliased_tid_user_function_kernel,
             BLOCK_DIM,
         )
@@ -476,16 +617,26 @@ def test_scalar_tid_empty_dim_uses_padded_extent(test, device):
     test.assertEqual(bounds.size, 1)
 
 
-def test_small_launch_skips_exact_scalar_tid_resolution(test, device):
+def test_small_launch_skips_exact_tid_resolution(test, device):
     """Keep exact metadata codegen off the ordinary small-launch path."""
     regular_1d_kernel.module.get_module_hash(BLOCK_DIM)
 
     with mock.patch.object(
         regular_1d_kernel.module,
-        "_get_kernel_scalar_tid_extent_limit",
-        wraps=regular_1d_kernel.module._get_kernel_scalar_tid_extent_limit,
+        "_get_kernel_tid_extent_limit",
+        wraps=regular_1d_kernel.module._get_kernel_tid_extent_limit,
     ) as get_limit:
         bounds = context._build_kernel_launch_bounds(1, regular_1d_kernel, BLOCK_DIM)
+
+    test.assertEqual(bounds.size, 1)
+    get_limit.assert_not_called()
+
+    with mock.patch.object(
+        regular_2d_kernel.module,
+        "_get_kernel_tid_extent_limit",
+        wraps=regular_2d_kernel.module._get_kernel_tid_extent_limit,
+    ) as get_limit:
+        bounds = context._build_kernel_launch_bounds((1, 1), regular_2d_kernel, BLOCK_DIM)
 
     test.assertEqual(bounds.size, 1)
     get_limit.assert_not_called()
@@ -495,14 +646,14 @@ def test_launch_set_dim_accepts_compile_time_dead_scalar_tid(test, device):
     """Use exact scalar-``tid`` metadata when resizing a recorded launch."""
     launch = wp.launch(
         named_false_scalar_tid_kernel,
-        dim=SCALAR_TID_MAX_EXTENT + 1,
+        dim=TID_MAX_EXTENT + 1,
         device=device,
         record_cmd=True,
     )
 
-    launch.set_dim(SCALAR_TID_MAX_EXTENT + 2)
+    launch.set_dim(TID_MAX_EXTENT + 2)
 
-    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 2)
+    test.assertEqual(launch.bounds.size, TID_MAX_EXTENT + 2)
 
 
 def test_qualified_tid_name_collision_accepts_oversized_extent(test, device):
@@ -512,7 +663,7 @@ def test_qualified_tid_name_collision_accepts_oversized_extent(test, device):
     try:
         launch = wp.launch(
             qualified_tid_name_collision_kernel,
-            dim=SCALAR_TID_MAX_EXTENT + 1,
+            dim=TID_MAX_EXTENT + 1,
             inputs=[out],
             device=device,
             record_cmd=True,
@@ -520,33 +671,64 @@ def test_qualified_tid_name_collision_accepts_oversized_extent(test, device):
     except ValueError as error:
         test.fail(f"Qualified non-builtin function was mistaken for wp.tid(): {error}")
 
-    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT + 1)
+    test.assertEqual(launch.bounds.size, TID_MAX_EXTENT + 1)
 
 
-def test_scalar_tid_validates_retained_extent(test, device):
-    """Validate the retained scalar extent instead of the total launch size."""
+def test_scalar_tid_validates_first_dimension(test, device):
+    """Validate the first launch dimension instead of the total thread count."""
     out = wp.zeros(1, dtype=int, device=device)
 
     launch = wp.launch(
         regular_1d_kernel,
-        dim=(SCALAR_TID_MAX_EXTENT, 2),
+        dim=(TID_MAX_EXTENT, 2),
         inputs=[out],
         device=device,
         record_cmd=True,
     )
-    test.assertEqual(launch.bounds.size, SCALAR_TID_MAX_EXTENT * 2)
+    test.assertEqual(launch.bounds.size, TID_MAX_EXTENT * 2)
     test.assertEqual(launch.bounds.coord_mult, 2)
 
     with test.assertRaisesRegex(
-        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+        ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 0"
     ):
         wp.launch(
             regular_1d_kernel,
-            dim=(SCALAR_TID_MAX_EXTENT + 1, 2),
+            dim=(TID_MAX_EXTENT + 1, 2),
             inputs=[out],
             device=device,
             record_cmd=True,
         )
+
+
+def test_scalar_tid_accepts_oversized_folded_extent(test, device):
+    """Allow oversized dimensions folded into the scalar coordinate multiplier."""
+    out = wp.zeros(1, dtype=int, device=device)
+
+    launch = wp.launch(
+        regular_1d_kernel,
+        dim=(1, TID_MAX_EXTENT + 1),
+        inputs=[out],
+        device=device,
+        record_cmd=True,
+    )
+
+    test.assertEqual(launch.bounds.shape[0], 1)
+    test.assertEqual(launch.bounds.coord_mult, TID_MAX_EXTENT + 1)
+    test.assertEqual(launch.bounds.size, TID_MAX_EXTENT + 1)
+
+
+def test_direct_launch_accepts_oversized_extent_when_empty(test, device):
+    """Allow an extent above the coordinate limit when a direct launch has no threads."""
+    out = wp.zeros((1, 1), dtype=int, device=device)
+
+    result = wp.launch(
+        regular_2d_kernel,
+        dim=(0, TID_MAX_EXTENT + 1),
+        inputs=[out, 1, 1],
+        device=device,
+    )
+
+    test.assertIsNone(result)
 
 
 def test_launch_set_dim_validates_scalar_tid_extent(test, device):
@@ -554,13 +736,31 @@ def test_launch_set_dim_validates_scalar_tid_extent(test, device):
     out = wp.zeros(1, dtype=int, device=device)
     launch = wp.launch(regular_1d_kernel, dim=1, inputs=[out], device=device, record_cmd=True)
 
-    launch.set_dim(SCALAR_TID_MAX_EXTENT)
+    launch.set_dim(TID_MAX_EXTENT)
     last_valid_bounds = launch.bounds
 
     with test.assertRaisesRegex(
-        ValueError, r"Warp cannot launch a kernel using scalar wp\.tid\(\) with extent 2147483649"
+        ValueError, r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 0"
     ):
-        launch.set_dim(SCALAR_TID_MAX_EXTENT + 1)
+        launch.set_dim(TID_MAX_EXTENT + 1)
+
+    test.assertIs(launch.bounds, last_valid_bounds)
+    test.assertIs(launch.params[0], last_valid_bounds)
+
+
+def test_launch_set_dim_validates_nonleading_tid_extent(test, device):
+    """Keep the last valid recorded bounds after a non-leading extent rejection."""
+    out = wp.zeros((1, 1), dtype=int, device=device)
+    launch = wp.launch(regular_2d_kernel, dim=(1, 1), inputs=[out, 1, 1], device=device, record_cmd=True)
+
+    launch.set_dim((1, TID_MAX_EXTENT))
+    last_valid_bounds = launch.bounds
+
+    with test.assertRaisesRegex(
+        ValueError,
+        r"Warp cannot launch a kernel using wp\.tid\(\) with extent 2147483649 in dimension 1",
+    ):
+        launch.set_dim((1, TID_MAX_EXTENT + 1))
 
     test.assertIs(launch.bounds, last_valid_bounds)
     test.assertIs(launch.params[0], last_valid_bounds)
@@ -776,6 +976,24 @@ add_function_test(
 )
 add_function_test(
     TestTemplateLaunchBounds,
+    "test_tuple_tid_validates_every_dimension",
+    test_tuple_tid_validates_every_dimension,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_tuple_tid_accepts_large_total_with_safe_extents",
+    test_tuple_tid_accepts_large_total_with_safe_extents,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_tuple_tid_accepts_oversized_extent_in_empty_launch",
+    test_tuple_tid_accepts_oversized_extent_in_empty_launch,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
     "test_no_tid_accepts_oversized_extent",
     test_no_tid_accepts_oversized_extent,
     devices=devices,
@@ -794,9 +1012,21 @@ add_function_test(
 )
 add_function_test(
     TestTemplateLaunchBounds,
+    "test_codegen_false_tuple_tid_accepts_oversized_extent",
+    test_codegen_false_tuple_tid_accepts_oversized_extent,
+    devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
     "test_aliased_scalar_tid_rejects_oversized_extent",
     test_aliased_scalar_tid_rejects_oversized_extent,
     devices=["cpu"],
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_aliased_tuple_tid_coordinates_and_limits",
+    test_aliased_tuple_tid_coordinates_and_limits,
+    devices=devices,
 )
 add_function_test(
     TestTemplateLaunchBounds,
@@ -812,8 +1042,8 @@ add_function_test(
 )
 add_function_test(
     TestTemplateLaunchBounds,
-    "test_small_launch_skips_exact_scalar_tid_resolution",
-    test_small_launch_skips_exact_scalar_tid_resolution,
+    "test_small_launch_skips_exact_tid_resolution",
+    test_small_launch_skips_exact_tid_resolution,
     devices=["cpu"],
 )
 add_function_test(
@@ -830,14 +1060,32 @@ add_function_test(
 )
 add_function_test(
     TestTemplateLaunchBounds,
-    "test_scalar_tid_validates_retained_extent",
-    test_scalar_tid_validates_retained_extent,
+    "test_scalar_tid_validates_first_dimension",
+    test_scalar_tid_validates_first_dimension,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_scalar_tid_accepts_oversized_folded_extent",
+    test_scalar_tid_accepts_oversized_folded_extent,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_direct_launch_accepts_oversized_extent_when_empty",
+    test_direct_launch_accepts_oversized_extent_when_empty,
     devices=devices,
 )
 add_function_test(
     TestTemplateLaunchBounds,
     "test_launch_set_dim_validates_scalar_tid_extent",
     test_launch_set_dim_validates_scalar_tid_extent,
+    devices=devices,
+)
+add_function_test(
+    TestTemplateLaunchBounds,
+    "test_launch_set_dim_validates_nonleading_tid_extent",
+    test_launch_set_dim_validates_nonleading_tid_extent,
     devices=devices,
 )
 add_function_test(


### PR DESCRIPTION
## Description

The existing overflow check covered scalar calls to `wp.tid()`, but not calls that return multiple coordinates. A multidimensional launch could therefore store an extent such as `2**31` in a signed 32-bit launch bound, wrap it to a negative value, and reconstruct incorrect thread coordinates.

This PR checks every launch extent that corresponds to a coordinate returned by `wp.tid()`. For a launch with at least one thread, each such extent may be as large as `2**31`, whose largest coordinate is `2**31 - 1`. Larger extents raise a `ValueError`.

The check avoids extra work for ordinary launches. When the total thread count is at most `2**31`, validation returns immediately. Larger grids inspect at most four coordinate dimensions, and Warp builds exact kernel metadata only when one of those extents is above the limit. The check runs during launch setup, not once per thread.

Closes #1815.

## Changes

- Validate every launch extent corresponding to a `wp.tid()` coordinate for direct launches, recorded commands, `Launch.set_dim()`, JAX FFI calls, and legacy JAX custom calls.
- Preserve valid large grids when each returned coordinate fits. This includes grids with more than `2**31` total threads, additional launch dimensions that only multiply the thread count, empty launches, and kernels where code generation removes `wp.tid()`.
- Store launch-bound shapes as unsigned 32-bit values in Python and native code without changing the structure size or alignment.
- Write APIC `.wrp` files using format version 16 and continue reading versions 13 through 16. Version 16 stores launch extents as unsigned values. Files written in an older format are rejected if a launch extent does not fit the signed 32-bit representation used by that format.
- Extend the launch ASV benchmarks with 2D and 4D host-launch measurements and synchronized device-coordinate reconstruction measurements.
- Document the `wp.tid()` extent limit and APIC compatibility policy, with separate fixed and changed changelog fragments.

APIC format 16 is not readable by older Warp releases whose readers only accept formats through version 15.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

The original regression tests failed against the target branch: an extent of exactly `2**31` wrapped in tuple-valued launch bounds, while larger tuple extents were not rejected. Both cases pass with this change.

Targeted launch-bound, APIC, and JAX tests passed across CPU and CUDA. They cover every coordinate dimension from 1D through 4D, exact-boundary acceptance, oversized rejection, large valid thread counts, additional launch dimensions that do not add coordinates, empty launches, recorded-command resizing, JAX lowering, and APIC versions 13 through 16.

The native library rebuilt successfully. Pre-commit and the diff check also passed.

ASV measurements against an isolated target-branch checkout with the same benchmark definitions found no measurable regression:

| Benchmark | Target branch | This branch |
|---|---:|---:|
| Host launch, 1D | 6.23 ± 0.01 µs | 6.22 ± 0.01 µs |
| Host launch, 2D | 6.60 ± 0.02 µs | 6.49 ± 0.05 µs |
| Host launch, 4D | 6.68 ± 0.03 µs | 6.66 ± 0.03 µs |
| Host launch, no `wp.tid()` | 6.25 ± 0.03 µs | 6.22 ± 0.02 µs |
| Device coordinates, 2D | 15.7 ± 0.2 µs | 15.6 ± 0.2 µs |
| Device coordinates, 4D | 21.0 ± 0.1 µs | 21.0 ± 0.04 µs |

## Bug fix

The following recorded launch demonstrates the signed launch-bound overflow without dispatching the full grid. `record_cmd=True` exercises the same launch-bound construction as a direct launch while avoiding a dispatch of more than four billion threads.

```python
import warp as wp


@wp.kernel
def coordinates():
    i, j = wp.tid()


command = wp.launch(
    coordinates,
    dim=(2, 2**31),
    device="cuda",
    record_cmd=True,
)

print(tuple(command.bounds.shape))
```

Before this PR, the second extent is stored as `-2147483648`. With this PR, the result is `(2, 2147483648)`. Increasing either coordinate extent above `2**31` now raises a `ValueError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - APIC recordings now support unsigned 32-bit kernel launch dimensions.
  - Newly written APIC files use format version 16.
  - Added benchmarks for multidimensional launches and thread-coordinate reconstruction.

- **Bug Fixes**
  - `wp.tid()` validation now checks every coordinate, including through JAX integrations and aliases.
  - Oversized coordinates are rejected with clearer, dimension-specific errors.
  - Legacy APIC files with ambiguous oversized launch dimensions are rejected.
  - APIC errors and warnings now include consistent diagnostic prefixes.

- **Documentation**
  - Updated APIC compatibility and `wp.tid()` launch-limit documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
