### PR TITLE
Fix scaled BSR expression on the left of + and - (GH-1910)

### DIFF
--- a/changelog/1910.fixed.md
+++ b/changelog/1910.fixed.md
@@ -1,0 +1,2 @@
+Fix `(scale * A) + B` and `(scale * A) - B` on BSR matrices applying the scale to `B` instead of `A`. Only the
+form with the scaled expression on the left was affected; `B + (scale * A)` and `A += scale * B` were already correct.

--- a/warp/_src/sparse.py
+++ b/warp/_src/sparse.py
@@ -1749,13 +1749,13 @@ class _BsrScalingExpression(_BsrExpression):
 
     # Overloaded math operators
     def __add__(self, y):
-        return bsr_axpy(y, bsr_copy(self.mat), alpha=self.scale)
+        return bsr_axpy(y, bsr_copy(self.mat), beta=self.scale)
 
     def __radd__(self, x):
         return bsr_axpy(x, bsr_copy(self.mat), beta=self.scale)
 
     def __sub__(self, y):
-        return bsr_axpy(y, bsr_copy(self.mat), alpha=-self.scale)
+        return bsr_axpy(y, bsr_copy(self.mat), alpha=-1.0, beta=self.scale)
 
     def __rsub__(self, x):
         return bsr_axpy(x, bsr_copy(self.mat), beta=-self.scale)

--- a/warp/tests/test_sparse.py
+++ b/warp/tests/test_sparse.py
@@ -1492,6 +1492,39 @@ def test_bsr_alloc(test, device):
     assert bsr.values.shape[0] >= 6
 
 
+def test_bsr_scaled_expression_add_sub(test, device):
+    # Scaled expressions must give the same result on either side of + and -
+    rng = np.random.default_rng(123)
+
+    nrow = 3
+    ncol = 4
+    nnz = 6
+
+    x_rows = wp.array(rng.integers(0, high=nrow, size=nnz, dtype=int), dtype=int, device=device)
+    x_cols = wp.array(rng.integers(0, high=ncol, size=nnz, dtype=int), dtype=int, device=device)
+    x_vals = wp.array(rng.random(size=nnz), dtype=float, device=device)
+    x = bsr_from_triplets(nrow, ncol, x_rows, x_cols, x_vals)
+
+    y_rows = wp.array(rng.integers(0, high=nrow, size=nnz, dtype=int), dtype=int, device=device)
+    y_cols = wp.array(rng.integers(0, high=ncol, size=nnz, dtype=int), dtype=int, device=device)
+    y_vals = wp.array(rng.random(size=nnz), dtype=float, device=device)
+    y = bsr_from_triplets(nrow, ncol, y_rows, y_cols, y_vals)
+
+    x_dense = _bsr_to_dense(x)
+    y_dense = _bsr_to_dense(y)
+
+    assert_np_equal(_bsr_to_dense((2.0 * x) + y), 2.0 * x_dense + y_dense, 0.0001)
+    assert_np_equal(_bsr_to_dense(y + (2.0 * x)), 2.0 * x_dense + y_dense, 0.0001)
+    assert_np_equal(_bsr_to_dense((2.0 * x) - y), 2.0 * x_dense - y_dense, 0.0001)
+    assert_np_equal(_bsr_to_dense(y - (2.0 * x)), y_dense - 2.0 * x_dense, 0.0001)
+    assert_np_equal(_bsr_to_dense((2.0 * x) + (3.0 * y)), 2.0 * x_dense + 3.0 * y_dense, 0.0001)
+    assert_np_equal(_bsr_to_dense((2.0 * x) - (3.0 * y)), 2.0 * x_dense - 3.0 * y_dense, 0.0001)
+
+    # operands must be left untouched
+    assert_np_equal(_bsr_to_dense(x), x_dense, 0.0001)
+    assert_np_equal(_bsr_to_dense(y), y_dense, 0.0001)
+
+
 devices = get_test_devices()
 cuda_test_devices = get_selected_cuda_test_devices()
 cuda_test_devices_with_mempool = get_selected_cuda_test_devices_with_mempool()
@@ -1618,6 +1651,7 @@ add_function_test(
 add_function_test(TestSparse, "test_bsr_mm_max_new_nnz", test_bsr_mm_max_new_nnz, devices=devices, check_output=False)
 
 add_function_test(TestSparse, "test_bsr_alloc", test_bsr_alloc, devices=devices)
+add_function_test(TestSparse, "test_bsr_scaled_expression_add_sub", test_bsr_scaled_expression_add_sub, devices=devices)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Description

`(s * A) + B` and `(s * A) - B` on BSR matrices put the scale on `B` instead of `A`. `_BsrScalingExpression.__add__` / `__sub__` call `bsr_axpy(other, bsr_copy(self.mat), alpha=self.scale)`, and `bsr_axpy(x, y, alpha, beta)` computes `y := alpha * x + beta * y`, so `alpha` scales the other operand while the copy of the scaled matrix goes in unscaled. The reflected forms (`B + (s * A)`, `B - (s * A)`) already use `beta` and are correct, so the same expression gives a different matrix depending on operand order. `A += s * B` was also unaffected because `BsrMatrix.__iadd__` goes through `_extract_matrix_and_scale`.

Closes #1910

## Changes

- `warp/_src/sparse.py`: `__add__` passes the scale as `beta`; `__sub__` passes `alpha=-1.0, beta=self.scale`. Mirrors `__radd__` / `__rsub__`.
- `warp/tests/test_sparse.py`: new `test_bsr_scaled_expression_add_sub` checks `(2x) + y`, `y + (2x)`, `(2x) - y`, `y - (2x)`, `(2x) + (3y)`, `(2x) - (3y)` against a dense reference and verifies the operands are untouched.
- `changelog/1910.fixed.md`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

CPU-only build of `main` at d4de134b on macOS arm64 (`build_lib.py --no-cuda`); no GPU available. The operators are pure Python and dispatch to the same `bsr_axpy` on every device.

- `python -m unittest warp.tests.test_sparse -k test_bsr_scaled_expression_add_sub` fails on `main` without the fix at the first assertion (`(2x) + y` returns `2y + x`) and passes with it.
- `python -m unittest warp.tests.test_sparse`: 38 tests, OK (9 CUDA tests skipped).
- `uvx pre-commit run --files ...` on the three changed files passes.

## Bug fix

```python
import warp as wp
from warp.sparse import bsr_from_triplets

dev = "cpu"
rows = wp.array([0, 1], dtype=int, device=dev)
cols = wp.array([0, 1], dtype=int, device=dev)
A = bsr_from_triplets(2, 2, rows, cols, wp.array([1.0, 1.0], dtype=float, device=dev))
B = bsr_from_triplets(2, 2, rows, cols, wp.array([10.0, 10.0], dtype=float, device=dev))

C = (2.0 * A) + B
print(C.values.numpy()[: C.nnz_sync()])  # main: [21. 21.]  (= 2B + A); expected [12. 12.]
D = (2.0 * A) - B
print(D.values.numpy()[: D.nnz_sync()])  # main: [-19. -19.]; expected [-8. -8.]
E = B + (2.0 * A)
print(E.values.numpy()[: E.nnz_sync()])  # [12. 12.] on both
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected scaling behavior for sparse BSR matrix addition and subtraction expressions.
  - Ensured the scale is applied to the intended matrix operand for both addition and subtraction.

- **Tests**
  - Added coverage for multiple scaling factors, operand orderings, device configurations, and preservation of input matrices.

- **Documentation**
  - Added a changelog entry describing the corrected BSR matrix scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->