### PR TITLE
Fix fem.integrate() scalar output validation (GH-1912)

### DIFF
--- a/changelog/1912.fixed.md
+++ b/changelog/1912.fixed.md
@@ -1,0 +1,3 @@
+Fix `warp.fem.integrate()` raising `IndexError` for a flat scalar output array with a vector-valued test field, and
+reject a two-dimensional scalar output whose last dimension does not match the node degrees of freedom instead of
+writing past the end of each row.

--- a/warp/_src/fem/integrate.py
+++ b/warp/_src/fem/integrate.py
@@ -1521,10 +1521,20 @@ def _launch_integrate_kernel(
                     raise RuntimeError(
                         f"Incompatible output type {type_repr(output_dtype)}, must be scalar or vector of length {test.node_dof_count}"
                     )
-                if output.ndim != 2 and output.shape[1] != test.node_dof_count:
-                    raise RuntimeError(
-                        f"Incompatible output array shape, last dimension must be of size {test.node_dof_count}"
-                    )
+                if output.ndim == 2:
+                    if output.shape[1] != test.node_dof_count:
+                        raise RuntimeError(
+                            f"Incompatible output array shape, last dimension must be of size {test.node_dof_count}"
+                        )
+                elif output.ndim == 1:
+                    if output.shape[0] < test.space_partition.node_count() * test.node_dof_count:
+                        raise RuntimeError(
+                            f"Output array must have at least {test.space_partition.node_count() * test.node_dof_count} entries"
+                        )
+                    if not output.is_contiguous:
+                        raise RuntimeError("Flat scalar output arrays must be contiguous")
+                else:
+                    raise RuntimeError("Incompatible output array shape, expected a one- or two-dimensional array")
 
         # Launch the integration on the kernel on a 2d scalar view of the actual array
         if not add_to_output:

--- a/warp/tests/fem/test_fem_integrate.py
+++ b/warp/tests/fem/test_fem_integrate.py
@@ -78,6 +78,11 @@ def scaled_bilinear_form(s: Sample, u: Field, v: Field, scale: wp.array[float]):
     return u(s) * v(s) * scale[0]
 
 
+@integrand
+def vector_component_form(s: Sample, v: Field):
+    return v(s)[0]
+
+
 # -- Test functions --
 
 
@@ -756,6 +761,48 @@ cuda_devices = get_selected_cuda_test_devices()
 cuda_devices_with_mempool = get_selected_cuda_test_devices_with_mempool()
 
 
+def test_integrate_scalar_output_layouts(test, device):
+    with wp.ScopedDevice(device):
+        geo = fem.Grid2D(res=wp.vec2i(2, 2))
+        space = fem.make_polynomial_space(geo, degree=1, dtype=wp.vec2)
+        test_field = fem.make_test(space)
+        node_count = space.node_count()
+        dof_count = test_field.node_dof_count
+
+        ref = fem.integrate(vector_component_form, fields={"v": test_field}).numpy()
+        ref_flat = ref.reshape(node_count * dof_count)
+
+        # flat scalar output, reinterpreted as (node_count, dof_count)
+        out_flat = wp.zeros(node_count * dof_count, dtype=wp.float32)
+        fem.integrate(vector_component_form, fields={"v": test_field}, output=out_flat)
+        assert_np_equal(out_flat.numpy(), ref_flat, tol=1.0e-6)
+
+        # 2d scalar output with matching last dimension
+        out_2d = wp.zeros((node_count, dof_count), dtype=wp.float32)
+        fem.integrate(vector_component_form, fields={"v": test_field}, output=out_2d)
+        assert_np_equal(out_2d.numpy(), ref, tol=1.0e-6)
+
+        # 2d scalar output with the wrong last dimension must be rejected, not written out of bounds
+        out_narrow = wp.zeros((node_count, dof_count - 1), dtype=wp.float32)
+        with test.assertRaisesRegex(RuntimeError, "last dimension must be of size 2"):
+            fem.integrate(vector_component_form, fields={"v": test_field}, output=out_narrow)
+
+        # flat scalar output that is too small must be rejected
+        out_short = wp.zeros(node_count * dof_count - 1, dtype=wp.float32)
+        with test.assertRaisesRegex(RuntimeError, f"at least {node_count * dof_count} entries"):
+            fem.integrate(vector_component_form, fields={"v": test_field}, output=out_short)
+
+        # flat scalar output must be contiguous, since it is reinterpreted through its pointer
+        out_strided = wp.zeros(2 * node_count * dof_count, dtype=wp.float32)[::2]
+        with test.assertRaisesRegex(RuntimeError, "must be contiguous"):
+            fem.integrate(vector_component_form, fields={"v": test_field}, output=out_strided)
+
+        # higher-dimensional scalar outputs are not reinterpreted
+        out_3d = wp.zeros((node_count, dof_count, 1), dtype=wp.float32)
+        with test.assertRaisesRegex(RuntimeError, "one- or two-dimensional"):
+            fem.integrate(vector_component_form, fields={"v": test_field}, output=out_3d)
+
+
 class TestFemIntegrate(unittest.TestCase):
     def test_make_space_partition_requires_space_topology(self):
         with self.assertRaisesRegex(TypeError, "missing 1 required positional argument: 'space_topology'"):
@@ -801,6 +848,9 @@ add_function_test(TestFemIntegrate, "test_vector_divergence_theorem", test_vecto
 add_function_test(TestFemIntegrate, "test_tensor_divergence_theorem", test_tensor_divergence_theorem, devices=devices)
 add_function_test(TestFemIntegrate, "test_grad_decomposition", test_grad_decomposition, devices=devices)
 add_function_test(TestFemIntegrate, "test_integrate_high_order", test_integrate_high_order, devices=cuda_devices)
+add_function_test(
+    TestFemIntegrate, "test_integrate_scalar_output_layouts", test_integrate_scalar_output_layouts, devices=devices
+)
 add_function_test(TestFemIntegrate, "test_padded_sparse_assembly", test_padded_sparse_assembly, devices=cuda_devices)
 add_function_test(TestFemIntegrate, "test_interpolate_reduction", test_interpolate_reduction, devices=devices)
 add_function_test(TestFemIntegrate, "test_capturability", test_capturability, devices=cuda_devices_with_mempool)


### PR DESCRIPTION
## Description

`fem.integrate()` validates a caller-provided scalar `output` array for a vector-valued test field with

```python
if output.ndim != 2 and output.shape[1] != test.node_dof_count:
```

For a flat 1-D output the first operand is true, so `output.shape[1]` is evaluated on a length-1 tuple and raises `IndexError` before the `_as_2d_array` reinterpretation a few lines below (which exists precisely to support that layout). For a 2-D output with the wrong last dimension the check short-circuits to `False`, the array is accepted, and the launch over `(node_count, node_dof_count)` writes past the end of each row.

Closes #1912

## Changes

- `warp/_src/fem/integrate.py`: check the last dimension only when `output.ndim == 2`; for a flat 1-D output require at least `node_count * node_dof_count` entries and a contiguous layout, since `_as_2d_array` reinterprets the array through its pointer; reject other ranks instead of silently flattening them. Messages follow the existing `RuntimeError` style.
- `warp/tests/fem/test_fem_integrate.py`: `test_integrate_scalar_output_layouts` integrates a `vec2` test field into a flat scalar array and a `(node_count, 2)` array and compares both to the allocated-output result, then checks that `(node_count, 1)`, a too-short flat array, a strided flat view, and a 3-D array are rejected.
- `changelog/1912.fixed.md`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

CPU-only build of `main` at d4de134b on macOS arm64 (`build_lib.py --no-cuda`); no GPU available. The change is Python-side shape validation and does not depend on the device.

- `python -m unittest warp.tests.fem.test_fem_integrate -k test_integrate_scalar_output_layouts` errors on `main` with `IndexError: tuple index out of range` at the flat-output call and passes with the fix.
- `python -m unittest warp.tests.fem.test_fem_integrate`: 14 tests, OK (3 CUDA-only tests skipped).
- `uvx pre-commit run --files ...` on the three changed files passes.

## Bug fix

```python
import warp as wp
import warp.fem as fem


@fem.integrand
def lf(s: fem.Sample, v: fem.Field):
    return v(s)[0]


geo = fem.Grid2D(res=wp.vec2i(2, 2))
space = fem.make_polynomial_space(geo, degree=1, dtype=wp.vec2)  # node_dof_count == 2
test = fem.make_test(space)
n = space.node_count()  # 9

out_flat = wp.zeros(n * 2, dtype=wp.float32, device="cpu")
fem.integrate(lf, fields={"v": test}, output=out_flat)
# main: IndexError: tuple index out of range

out_narrow = wp.zeros((n, 1), dtype=wp.float32, device="cpu")
fem.integrate(lf, fields={"v": test}, output=out_narrow)
# main: accepted, writes output[node, 1] outside each row
# this PR: RuntimeError: Incompatible output array shape, last dimension must be of size 2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
