### PR TITLE
Accept a one-element output list in wp.map() (GH-1913)

### DIFF
--- a/changelog/1913.fixed.md
+++ b/changelog/1913.fixed.md
@@ -1,0 +1,3 @@
+Fix `wp.map()` raising `UnboundLocalError` when `out` is a one-element list or tuple for a function with a single
+return value, or when `out` is not a Warp array. A one-element list is now accepted and other invalid values raise
+`TypeError`.

--- a/warp/_src/utils.py
+++ b/warp/_src/utils.py
@@ -997,7 +997,7 @@ def broadcast_shapes(shapes: list[tuple[int]]) -> tuple[int]:
 def map(
     func: Callable | wp.Function,
     *inputs: Array[DType] | Any,
-    out: Array[DType] | list[Array[DType]] | None = None,
+    out: Array[DType] | list[Array[DType]] | tuple[Array[DType], ...] | None = None,
     return_kernel: bool = False,
     block_dim: int = 256,
     device: DeviceLike = None,
@@ -1247,7 +1247,17 @@ def map(
         for dtype in out_dtypes:
             rg = requires_grad and Adjoint.is_differentiable_value_type(dtype)
             outputs.append(wp.empty(out_shape, dtype=dtype, requires_grad=rg, device=device))
-    elif len(out_dtypes) == 1 and is_array(out):
+    elif len(out_dtypes) == 1:
+        if isinstance(out, (tuple, list)):
+            if len(out) != 1:
+                raise TypeError(
+                    f"Number of provided output arrays ({len(out)}) does not match expected number of function outputs (1)"
+                )
+            out = out[0]
+        if not is_array(out):
+            raise TypeError(
+                f"Invalid output provided, expected a Warp array with shape {out_shape} and dtype {type_repr(out_dtypes[0])}"
+            )
         if not types_equal(out.dtype, out_dtypes[0]):
             raise TypeError(
                 f"Output array dtype {type_repr(out.dtype)} does not match expected dtype {type_repr(out_dtypes[0])}"
@@ -1255,7 +1265,7 @@ def map(
         if out.shape != out_shape:
             raise TypeError(f"Output array shape {out.shape} does not match expected shape {out_shape}")
         outputs = [out]
-    elif len(out_dtypes) > 1:
+    else:
         if isinstance(out, tuple) or isinstance(out, list):
             if len(out) != len(out_dtypes):
                 raise TypeError(

--- a/warp/tests/test_map.py
+++ b/warp/tests/test_map.py
@@ -447,6 +447,28 @@ def test_output_validity(test, device):
     ):
         wp.map(lambda x, y: (x, y), xs, ys, out=[out1, out2])
 
+    # a single output may also be passed as a one-element list or tuple
+    out = wp.empty(3, dtype=wp.float32)
+    wp.map(wp.sub, xs, ys, out=[out])
+    assert_np_equal(out.numpy(), np.full(3, -1.0, dtype=np.float32))
+    out.zero_()
+    wp.map(wp.sub, xs, ys, out=(out,))
+    assert_np_equal(out.numpy(), np.full(3, -1.0, dtype=np.float32))
+
+    out1 = wp.empty(3, dtype=wp.float32)
+    out2 = wp.empty(3, dtype=wp.float32)
+    with test.assertRaisesRegex(
+        TypeError,
+        r"Number of provided output arrays \(2\) does not match expected number of function outputs \(1\)$",
+    ):
+        wp.map(wp.sub, xs, ys, out=[out1, out2])
+
+    with test.assertRaisesRegex(
+        TypeError,
+        r"Invalid output provided, expected a Warp array with shape \(3,\) and dtype float32$",
+    ):
+        wp.map(wp.sub, xs, ys, out=5)
+
 
 def test_kernel_creation(test, device):
     a = wp.array(np.arange(10, dtype=np.float32), device=device)


### PR DESCRIPTION
## Description

`wp.map()` accepts `out: Array | list[Array] | None`, but with a single-output function only a bare `wp.array` reached an assignment of `outputs`. The list/tuple handling lives under `elif len(out_dtypes) > 1`, so `out=[o]`, `out=(o,)`, or an invalid value such as `out=5` fell through every branch and the launch below raised `UnboundLocalError: cannot access local variable 'outputs'`.

Closes #1913

## Changes

- `warp/_src/utils.py`: for a single-output function, unwrap a one-element list or tuple; raise `TypeError` for a wrong element count or a non-array value, using the same wording as the multi-output branch. The multi-output branch is otherwise unchanged (its `elif len(out_dtypes) > 1` became `else`).
- `warp/tests/test_map.py`: `test_output_validity` now covers `out=[o]` and `out=(o,)` producing the correct result, and the two new `TypeError` cases.
- `changelog/1913.fixed.md`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

CPU-only build of `main` at d4de134b on macOS arm64 (`build_lib.py --no-cuda`); no GPU available. The change is Python argument handling before the launch and does not depend on the device.

- `python -m unittest warp.tests.test_map -k test_output_validity` errors on `main` with `UnboundLocalError` at the `out=[out]` call and passes with the fix.
- `python -m unittest warp.tests.test_map`: 23 tests, OK (1 CUDA-only test skipped).
- `uvx pre-commit run --files ...` on the three changed files passes.

## Bug fix

```python
import warp as wp


@wp.func
def dbl(x: float) -> float:
    return x * 2.0


a = wp.array([1.0, 2.0, 3.0], dtype=wp.float32, device="cpu")
o = wp.empty(3, dtype=wp.float32, device="cpu")

wp.map(dbl, a, out=o)    # OK on main
wp.map(dbl, a, out=[o])  # main: UnboundLocalError: cannot access local variable 'outputs' ...
                         # this PR: o == [2. 4. 6.]
wp.map(dbl, a, out=5)    # main: same UnboundLocalError
                         # this PR: TypeError: Invalid output provided, expected a Warp array with shape (3,) and dtype float32
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `wp.map()` handling for single-output functions.
  - One-element lists and tuples are now accepted and unwrapped correctly.
  - Invalid output types and incorrectly sized containers now raise clear `TypeError` messages instead of unexpected errors.
  - Existing data type and shape validation remains enforced for mapped outputs.
- **Tests**
  - Added coverage for valid single-output containers and invalid map results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->