### PR TITLE
Add Cloud Agent environment config for CPU-only Warp

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "Warp (CPU-only)",
+  "install": "bash ./.cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -16,8 +16,12 @@ fi
 # 2. Install the pinned CPython interpreter (uv reads .python-version).
 uv python install
 
-# 3. Sync the project environment with dev + examples dependencies.
-uv sync --extra dev
+# 3. Build the native libraries (CPU-only) BEFORE syncing the project.
+#    setup.py aborts if warp/bin is empty ("run build_lib.py first"), so the
+#    editable install in step 4 requires the binaries to already exist. Use
+#    --no-project so this step does not try to build the warp-lang package
+#    itself (which would hit the same empty-warp/bin failure).
+uv run --no-project --with numpy build_lib.py --no-cuda
 
-# 4. Build the native libraries (CPU-only). Rebuilds are cheap and idempotent.
-uv run build_lib.py --no-cuda
+# 4. Sync the project environment with dev + examples dependencies.
+uv sync --extra dev

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the Warp repository.
+#
+# The Cloud Agent VM is CPU-only (no NVIDIA GPU), so the native library is built
+# with --no-cuda. This produces the warp-clang CPU backend used to JIT-compile
+# kernels for the "cpu" device.
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+# 1. Ensure uv is available (pinned tooling comes from .python-version / uv.lock).
+if ! command -v uv >/dev/null 2>&1; then
+    python3 -m pip install --user --upgrade uv
+fi
+
+# 2. Install the pinned CPython interpreter (uv reads .python-version).
+uv python install
+
+# 3. Sync the project environment with dev + examples dependencies.
+uv sync --extra dev
+
+# 4. Build the native libraries (CPU-only). Rebuilds are cheap and idempotent.
+uv run build_lib.py --no-cuda


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a Cursor Cloud Agent development environment so the Warp repository is usable out of the box in Cloud Agents. The Cloud Agent VM is CPU-only (no NVIDIA GPU), so the native library is built with `--no-cuda`, producing the `warp-clang` CPU backend used to JIT-compile kernels for the `"cpu"` device.

## Changes

- Add `.cursor/environment.json` — a repository-managed environment named `Warp (CPU-only)` whose `install` phase runs `./.cursor/install.sh`.
- Add `.cursor/install.sh` — an idempotent bootstrap that:
  - installs `uv` (via `pip --user`) if missing,
  - installs the pinned CPython from `.python-version`,
  - builds the native libraries with `uv run --no-project --with numpy build_lib.py --no-cuda`,
  - runs `uv sync --extra dev`.

Ordering matters: `setup.py` aborts with `No libraries found in warp/bin. Please run build_lib.py first.` when `warp/bin` is empty, so the native binaries must be built **before** `uv sync` builds the editable `warp-lang` package. The build step uses `--no-project` so it does not itself try to build `warp-lang` on an empty `warp/bin`.

No `start`/`terminals` are configured because Warp is a library with no long-running services; the dev loop is build + test.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] I added a changelog fragment if this change affects users.

## Validation summary

Validated end to end on the Cloud Agent VM (Ubuntu 24.04, x86_64, CPU-only):

- Reproduced the empty-`warp/bin` failure on a clean checkout, then confirmed the reordered install script builds the native lib first and `uv sync` succeeds.
- Ran the install script to completion twice to confirm idempotence (~13s each, no `uv.lock` or working-tree changes).
- Native library: `Warp build succeeded` with `warp-clang` (LLVM 22.1.8), CUDA disabled; `warp/bin` contains `warp.so` and `warp-clang.so`.
- Hello-world SAXPY kernel JIT-compiles and runs on the `cpu` device, asserting against NumPy.
- Lint: `uvx pre-commit run -a` — all hooks passed (ruff, ruff format, uv-lock, typos, clang-format, generated-file checks).
- Tests: `uv run --extra dev -m warp.tests -s autodetect -k TestArray -k TestFunc` — 148 tests OK (7 CUDA-only skipped).
- Prebuilt environment build `bld-20260904-37915039-38e2-424e-8455-6aee4701b8bf` **SUCCEEDED** from a fresh checkout of this branch, and was verified in a fresh Cloud Agent booted from that build.

This is an environment-configuration change only; no library code is modified.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93065a45-f5c5-4c4b-ad8a-d32a2d3bde53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93065a45-f5c5-4c4b-ad8a-d32a2d3bde53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a ready-to-use CPU-only development environment for cloud-based development.
  - Automated setup for required tooling, the pinned Python interpreter, development dependencies, and example dependencies.
  - Added support for building native components without requiring CUDA or GPU hardware.
  - Setup can be safely re-run without duplicating or disrupting existing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->