### PR TITLE
Fix APIC handling of PyTorch tensor views

### DIFF
--- a/changelog/1908.fixed.md
+++ b/changelog/1908.fixed.md
@@ -1,0 +1,1 @@
+Preserve PyTorch storage bounds and aliasing when serializing APIC graphs that use tensor views.

--- a/warp/_src/apic/capture.py
+++ b/warp/_src/apic/capture.py
@@ -38,11 +38,11 @@ class APICapture:
         # C++ APICState*
         self.apic_state: ctypes.c_void_p = runtime.core.wp_apic_create_state()
 
-        # Region tracking: id(base_array) -> (region_id, base_ptr, capacity, base_array).
+        # Region tracking: region key -> (region_id, base_ptr, capacity, base_array).
         # The base array is retained so Python cannot recycle its id() (which would
         # otherwise alias unrelated allocations to the same region_id) and so that
         # capture_save still has a valid base_ptr to read from.
-        self._regions: dict[int, tuple[int, int, int, object]] = {}
+        self._regions: dict[object, tuple[int, int, int, object]] = {}
 
         # Region ids whose backing was allocated *during* this capture (graph-scoped
         # on a memory-pool device). Their memory is gone once the capture ends, so
@@ -81,17 +81,28 @@ class APICapture:
         """Walk the _ref chain to find the base allocation.
 
         Returns:
-            (base_array, byte_offset) where base_array is the root allocation
-            and byte_offset is the offset of arr.ptr from base_array.ptr.
+            (base_array, base_ptr, base_capacity, byte_offset) where base_array
+            is the root array, and byte_offset is the offset of arr.ptr within
+            the backing allocation.
         """
         base = arr
         while hasattr(base, "_ref") and base._ref is not None and hasattr(base._ref, "ptr"):
             base = base._ref
+
+        base_ptr = base._storage_base_ptr if base._storage_base_ptr is not None else base.ptr
+        base_capacity = base._storage_nbytes if base._storage_nbytes is not None else base.capacity
+
         # Empty arrays (shape=(0,)) have arr.ptr == None; treat as zero offset.
-        if arr.ptr is None or base.ptr is None:
-            return base, 0
-        byte_offset = arr.ptr - base.ptr
-        return base, byte_offset
+        if arr.ptr is None or base_ptr is None:
+            return base, base_ptr, base_capacity, 0
+        byte_offset = arr.ptr - base_ptr
+        return base, base_ptr, base_capacity, byte_offset
+
+    @staticmethod
+    def _region_key(base, base_ptr):
+        if base._storage_base_ptr is not None:
+            return "external", base_ptr
+        return id(base)
 
     def _find_handle_offsets(self, dtype, base_offset: int = 0) -> list[int]:
         """Recursively find byte offsets of ``wp.handle`` fields in a type.
@@ -129,27 +140,32 @@ class APICapture:
         if self.device is not None and arr.device != self.device:
             return -1, 0
 
-        base, byte_offset = self._find_base(arr)
-        base_id = id(base)
+        base, base_ptr, base_capacity, byte_offset = self._find_base(arr)
+        region_key = self._region_key(base, base_ptr)
 
-        if base_id in self._regions:
-            region_id, _, _, _ = self._regions[base_id]
+        if region_key in self._regions:
+            region_id, _, registered_capacity, _ = self._regions[region_key]
+            if base._storage_base_ptr is not None and registered_capacity != base_capacity:
+                raise RuntimeError(
+                    f"APIC external allocation at 0x{base_ptr:x} has conflicting capacities "
+                    f"({registered_capacity} and {base_capacity})"
+                )
             return region_id, byte_offset
 
         # Register new region in C++
         region_id = self.runtime.core.wp_apic_register_memory_region_by_ptr(
             self.apic_state,
-            ctypes.c_uint64(base.ptr),
-            ctypes.c_uint64(base.capacity),
+            ctypes.c_uint64(base_ptr),
+            ctypes.c_uint64(base_capacity),
             ctypes.c_uint32(warp._src.types.type_size_in_bytes(base.dtype)),
         )
         if region_id == 0:
             raise RuntimeError(
                 f"APIC region registration failed "
-                f"(apic_state={self.apic_state}, base_id={base_id}, "
-                f"ptr=0x{base.ptr:x}, capacity={base.capacity})"
+                f"(apic_state={self.apic_state}, region_key={region_key}, "
+                f"ptr=0x{base_ptr:x}, capacity={base_capacity})"
             )
-        self._regions[base_id] = (region_id, base.ptr, base.capacity, base)
+        self._regions[region_key] = (region_id, base_ptr, base_capacity, base)
 
         # Mark the region transient only if its base was allocated by *this* APIC
         # capture (matching apic_state). Such memory is graph-scoped: capture_save
@@ -180,10 +196,10 @@ class APICapture:
         """Get the region_id for an array (must have been tracked already)."""
         if arr is None or not arr.ptr:
             return -1
-        base, _ = self._find_base(arr)
-        base_id = id(base)
-        if base_id in self._regions:
-            return self._regions[base_id][0]
+        base, base_ptr, _, _ = self._find_base(arr)
+        region_key = self._region_key(base, base_ptr)
+        if region_key in self._regions:
+            return self._regions[region_key][0]
         # Fall back to tracking
         region_id, _ = self.track_array(arr)
         return region_id

--- a/warp/_src/context.py
+++ b/warp/_src/context.py
@@ -13783,7 +13783,7 @@ def capture_save(graph: Graph, path: str, inputs: dict | None = None, outputs: d
             runtime.core.wp_apic_register_binding(state, name.encode("utf-8"), region_id)
 
     # Snapshot memory: copy device data to host and register with C++
-    for _base_id, (region_id, base_ptr, capacity, _base) in apic_capture._regions.items():
+    for _region_key, (region_id, base_ptr, capacity, _base) in apic_capture._regions.items():
         if graph.device.is_cuda:
             if region_id in apic_capture._transient_regions:
                 # Allocated during capture (graph-scoped): its backing is gone now

--- a/warp/_src/torch.py
+++ b/warp/_src/torch.py
@@ -305,11 +305,20 @@ def from_torch(
         return array_ctype
 
     else:
+        ptr = t.data_ptr()
+        capacity = 0
+        if ptr:
+            storage = t.untyped_storage()
+            storage_base_ptr = storage.data_ptr()
+            storage_nbytes = storage.nbytes()
+            capacity = storage_nbytes - (ptr - storage_base_ptr)
+
         a = warp.array(
-            ptr=t.data_ptr(),
+            ptr=ptr,
             dtype=dtype,
             shape=shape,
             strides=strides,
+            capacity=capacity,
             device=device_from_torch(t.device),
             copy=False,
             grad=grad,
@@ -319,6 +328,10 @@ def from_torch(
 
         # save a reference to the source tensor, otherwise it may get deallocated
         a._tensor = t
+        if ptr:
+            # Preserve the full storage bounds so APIC can recognize separately converted views as aliases.
+            a._storage_base_ptr = storage_base_ptr
+            a._storage_nbytes = storage_nbytes
 
         return a
 

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -3281,10 +3281,10 @@ class array(Array[DType, NDim]):
         dtype (DType): The data type of the array.
         ndim (int): The number of array dimensions.
         size (int): The number of items in the array.
-        capacity (int): The amount of memory in bytes allocated for this array.
+        capacity (int): Maximum number of bytes addressable from ``ptr`` for this array.
         shape (tuple[int]): Dimensions of the array.
         strides (tuple[int]): Number of bytes in each dimension between successive elements of the array.
-        ptr (int): Pointer to underlying memory allocation backing the array.
+        ptr (int): Pointer to the array's first element. For a view, this may point inside a larger backing allocation.
         device (Device): The device where the array's memory allocation resides.
         pinned (bool): Indicates whether the array was allocated in pinned host memory.
         is_contiguous (bool): Indicates whether this array has a contiguous memory layout.
@@ -3353,8 +3353,9 @@ class array(Array[DType, NDim]):
             dtype: One of the available `data types <#data-types>`_, such as :class:`warp.float32`, :class:`warp.mat33`, or a custom `struct <#structs>`_. If dtype is ``Any`` and data is an ndarray, then it will be inferred from the array data type
             shape: Dimensions of the array
             strides: Number of bytes in each dimension between successive elements of the array
-            ptr: Address of an external memory address to alias (``data`` should be ``None``)
-            capacity: Maximum size in bytes of the ``ptr`` allocation (``data`` should be ``None``)
+            ptr: Address of the first element to alias (``data`` should be ``None``). This may point inside a larger
+                external allocation.
+            capacity: Maximum number of bytes addressable from ``ptr`` (``data`` should be ``None``).
             device: Device the array lives on
             copy: Whether the incoming ``data`` will be copied or aliased. Aliasing requires that
                 the incoming ``data`` already lives on the ``device`` specified and the data types match.
@@ -3381,6 +3382,12 @@ class array(Array[DType, NDim]):
 
         # reference to other array
         self._ref = None
+
+        self._storage_base_ptr: int | None = None
+        """Start of the complete backing storage; unlike ``ptr``, this may precede the array's first element."""
+
+        self._storage_nbytes: int | None = None
+        """Total backing-storage size; unlike ``capacity``, this includes bytes preceding ``ptr``."""
 
         # canonicalize dtype
         if dtype is int:

--- a/warp/tests/interop/test_torch.py
+++ b/warp/tests/interop/test_torch.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import tempfile
 import unittest
 from functools import cache
 
@@ -79,6 +81,12 @@ def copy2d_vec3_kernel(dst: wp.array2d[wp.vec3], src: wp.array2d[wp.vec3]):
 def copy2d_mat22_kernel(dst: wp.array2d[wp.mat22], src: wp.array2d[wp.mat22]):
     i, j = wp.tid()
     dst[i, j] = src[i, j]
+
+
+@wp.kernel
+def write_then_read_alias_kernel(a: wp.array[float], b: wp.array[float], out: wp.array[float]):
+    a[2] = 99.0
+    out[0] = b[0]
 
 
 def _import_torch():
@@ -574,6 +582,71 @@ def test_from_torch_slices(test, device):
     a_contiguous = wp.empty_like(a)
     wp.launch(copy2d_mat22_kernel, dim=a.shape, inputs=[a_contiguous, a], device=device)
     assert_np_equal(a_contiguous.numpy(), t.cpu().numpy())
+
+
+def test_from_torch_view_capacity(test, device):
+    """Verify that Warp arrays created from PyTorch tensor views report the remaining storage capacity."""
+    torch = _import_torch()
+
+    torch_device = wp.device_to_torch(device)
+    base = torch.arange(24, dtype=torch.float32, device=torch_device).reshape((4, 6))
+    issue_base = torch.arange(6, dtype=torch.float32, device=torch_device).reshape((1, 6))
+
+    cases = (
+        ("issue tail view", issue_base[:, 3:], 12),
+        ("interior view", base[1:3, 2:5], 64),
+        ("strided view", base[2:, 1::2], 44),
+    )
+
+    for name, tensor, expected_capacity in cases:
+        with test.subTest(name=name):
+            array = wp.from_torch(tensor)
+            test.assertEqual(array.capacity, expected_capacity)
+
+
+def test_from_torch_apic_storage_alias(test, device):
+    """Verify that APIC round-trips preserve aliasing between PyTorch tensor views converted to Warp arrays."""
+    torch = _import_torch()
+
+    torch_device = wp.device_to_torch(device)
+    base = torch.arange(6, dtype=torch.float32, device=torch_device)
+    first_view = wp.from_torch(base[:4])
+    overlapping_view = wp.from_torch(base[2:])
+    out = wp.zeros(1, dtype=wp.float32, device=device)
+
+    wp.load_module(device=device)
+    if base.is_cuda:
+        torch.cuda.synchronize(base.device)
+    with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
+        wp.launch(
+            write_then_read_alias_kernel,
+            dim=1,
+            inputs=[first_view, overlapping_view, out],
+            device=device,
+        )
+
+    # CPU capture executes eagerly. Restore the values that should be serialized
+    # so a stale copy of the overlapping view cannot hide broken aliasing.
+    base.copy_(torch.arange(6, dtype=torch.float32, device=torch_device))
+    if base.is_cuda:
+        torch.cuda.synchronize(base.device)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "torch_storage_alias")
+        wp.capture_save(
+            capture.graph,
+            path,
+            inputs={"first_view": first_view, "overlapping_view": overlapping_view},
+            outputs={"out": out},
+        )
+        loaded = wp.capture_load(path, device=device)
+        wp.capture_launch(loaded)
+        # CUDA replay is asynchronous; synchronize before get_param() copies the output on a separate stream.
+        wp.synchronize_device(device)
+
+        result = wp.zeros(1, dtype=wp.float32, device=device)
+        loaded.get_param("out", result)
+        np.testing.assert_allclose(result.numpy(), np.array([99.0], dtype=np.float32))
 
 
 def test_from_torch_zero_strides(test, device):
@@ -1293,6 +1366,7 @@ except Exception as error:
 else:
     torch_candidate_devices = get_test_devices()
     torch_cuda_candidate_devices = [device for device in torch_candidate_devices if device.is_cuda]
+    torch_apic_candidate_devices = get_test_devices_with_cuda_graph_module_load()
 
     @cache
     def _torch_device_error(device_alias):
@@ -1336,6 +1410,13 @@ else:
             TestTorch,
             "test_from_torch_slices",
             test_from_torch_slices,
+            devices=torch_candidate_devices,
+            device_check=_check_torch_device,
+        )
+        add_function_test(
+            TestTorch,
+            "test_from_torch_view_capacity",
+            test_from_torch_view_capacity,
             devices=torch_candidate_devices,
             device_check=_check_torch_device,
         )
@@ -1479,6 +1560,15 @@ else:
             "test_cuda_array_interface",
             test_cuda_array_interface,
             devices=torch_cuda_candidate_devices,
+            device_check=_check_torch_device,
+        )
+
+    if torch_apic_candidate_devices:
+        add_function_test(
+            TestTorch,
+            "test_from_torch_apic_storage_alias",
+            test_from_torch_apic_storage_alias,
+            devices=torch_apic_candidate_devices,
             device_check=_check_torch_device,
         )
 


### PR DESCRIPTION
## Description

`wp.from_torch()` previously treated a tensor view's data pointer as the start of its allocation. For offset or strided views, this could cause APIC to snapshot past the underlying PyTorch storage. Separately converted views of the same storage were also treated as unrelated regions, which broke their aliasing after saving and loading a graph.

This change records the PyTorch storage base and size on the Warp array. APIC uses that metadata to calculate view offsets and recognize arrays backed by the same storage. The array's `capacity` now reflects the bytes available from its `ptr` to the end of the storage.

Closes #1908.

## Changes

- Derive a PyTorch-backed array's capacity from the tensor's underlying storage.
- Use the storage base pointer to identify shared external regions in APIC.
- Preserve aliasing between separately converted PyTorch views after an APIC save and load.
- Clarify the distinction between `ptr` and `capacity` and the corresponding full-storage metadata.
- Add CPU and CUDA coverage for view capacity and APIC storage aliasing.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

The first version of `test_from_torch_view_capacity` passed unchanged on `main`, so it did not establish a red test. I extended it to cover the reported offset view as well as interior and strided views. The final test fails for all three cases on `main`, on both CPU and CUDA, and passes on this branch.

The APIC aliasing test also fails on `main` on CPU and CUDA, returning `2.0` instead of the expected `99.0`. It passes on this branch.

I reproduced #1908 with `PYTORCH_NO_CUDA_MEMORY_CACHING=1`. On `main`, `wp.capture_save()` fails with the reported invalid device-to-host copy. On this branch, the offset view reports a capacity of 12 bytes and the graph saves successfully.

A fresh run of the `TestTorch` and `TestApic` selections completed 224 tests across CPU and CUDA without failures. Targeted pre-commit checks also passed.

## Bug fix

Run this example with `PYTORCH_NO_CUDA_MEMORY_CACHING=1` to reproduce the out-of-bounds snapshot on `main`:

```python
import torch
import warp as wp


@wp.kernel
def write_value(view: wp.array2d[float]):
    view[0, 0] = 1.0


wp.init()

base = torch.zeros((1, 6), dtype=torch.float32, device="cuda:0")
view = wp.from_torch(base[:, 3:])

with wp.ScopedCapture(device="cuda:0", apic=True) as capture:
    wp.launch(write_value, dim=1, inputs=[view], device="cuda:0")

wp.capture_save(capture.graph, "offset_view", inputs={"view": view})
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PyTorch interoperability by preserving storage bounds and aliasing for tensor views.
  - APIC capture and replay now correctly maintain shared storage relationships between converted tensor views.
  - Added validation for inconsistent external storage capacities.

- **Documentation**
  - Clarified array capacity, pointer views, external allocation aliasing, and backing-storage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->