### PR TITLE
Floor integer division toward negative infinity [GH-1918]

### DIFF
--- a/changelog/1918.fixed.md
+++ b/changelog/1918.fixed.md
@@ -1,0 +1,2 @@
+Fix floor division for signed integers so `//` and `wp.floordiv()` round toward negative infinity,
+matching Python and NumPy.

--- a/warp/native/builtin.h
+++ b/warp/native/builtin.h
@@ -587,7 +587,6 @@ inline CUDA_CALLABLE T mod(T a, T b) { return a%b; } \
 inline CUDA_CALLABLE T min(T a, T b) { return a<b?a:b; } \
 inline CUDA_CALLABLE T max(T a, T b) { return a>b?a:b; } \
 inline CUDA_CALLABLE T clamp(T x, T a, T b) { return min(max(a, x), b); } \
-inline CUDA_CALLABLE T floordiv(T a, T b) { return a/b; } \
 inline CUDA_CALLABLE T nonzero(T x) { return x == T(0) ? T(0) : T(1); } \
 inline CUDA_CALLABLE T bit_and(T a, T b) { return a&b; } \
 inline CUDA_CALLABLE T bit_or(T a, T b) { return a|b; } \
@@ -633,6 +632,25 @@ DECLARE_INT_OPS(uint8)
 DECLARE_INT_OPS(uint16)
 DECLARE_INT_OPS(uint32)
 DECLARE_INT_OPS(uint64)
+
+/* C++ integer division truncates toward zero; adjust signed, non-exact
+   results with opposite signs to round toward negative infinity. */
+template <typename T> inline CUDA_CALLABLE T floordiv_signed(T a, T b)
+{
+    T q = a / b;
+    T r = a % b;
+    if (r != T(0) && ((r < T(0)) != (b < T(0))))
+        q -= T(1);
+    return q;
+}
+inline CUDA_CALLABLE int8 floordiv(int8 a, int8 b) { return floordiv_signed(a, b); }
+inline CUDA_CALLABLE int16 floordiv(int16 a, int16 b) { return floordiv_signed(a, b); }
+inline CUDA_CALLABLE int32 floordiv(int32 a, int32 b) { return floordiv_signed(a, b); }
+inline CUDA_CALLABLE int64 floordiv(int64 a, int64 b) { return floordiv_signed(a, b); }
+inline CUDA_CALLABLE uint8 floordiv(uint8 a, uint8 b) { return a / b; }
+inline CUDA_CALLABLE uint16 floordiv(uint16 a, uint16 b) { return a / b; }
+inline CUDA_CALLABLE uint32 floordiv(uint32 a, uint32 b) { return a / b; }
+inline CUDA_CALLABLE uint64 floordiv(uint64 a, uint64 b) { return a / b; }
 
 
 inline CUDA_CALLABLE int8 step(int8 x) { return x < 0 ? 1 : 0; }

--- a/warp/tests/test_arithmetic.py
+++ b/warp/tests/test_arithmetic.py
@@ -1094,6 +1094,37 @@ for dtype in np_float_types:
         TestArithmetic, f"test_float_to_int_{dtype.__name__}", test_float_to_int, devices=devices, dtype=dtype
     )
 
+
+def test_floordiv_negative(test, device, dtype, register_kernels=False):
+    # Warp's `//` maps to the floordiv builtin, which is documented as floor
+    # division and must round toward negative infinity for signed operands,
+    # matching Python/NumPy and the floating-point overloads.
+    wptype = wp.dtype_from_numpy(np.dtype(dtype))
+
+    def check_floordiv(
+        a: wp.array[wptype],
+        b: wp.array[wptype],
+        outputs: wp.array[wptype],
+    ):
+        for i in range(12):
+            outputs[i] = a[i] // b[i]
+
+    kernel = getkernel(check_floordiv, suffix=dtype.__name__, enable_backward=False)
+
+    if register_kernels:
+        return
+
+    a_np = np.array([-7, 7, -7, 7, -1, -8, 5, -5, 0, 6, 9, -9], dtype=dtype)
+    b_np = np.array([2, -2, -2, 2, 2, 4, 3, -3, -3, -3, -1, 1], dtype=dtype)
+
+    a = wp.array(a_np, dtype=wptype, device=device)
+    b = wp.array(b_np, dtype=wptype, device=device)
+    outputs = wp.zeros(len(a_np), dtype=wptype, device=device)
+
+    wp.launch(kernel, dim=1, inputs=[a, b], outputs=[outputs], device=device)
+    assert_np_equal(outputs.numpy(), np.floor_divide(a_np, b_np))
+
+
 for dtype in np_scalar_types:
     add_function_test_register_kernel(
         TestArithmetic, f"test_clamp_{dtype.__name__}", test_clamp, devices=devices, dtype=dtype
@@ -1104,6 +1135,16 @@ for dtype in np_scalar_types:
     add_function_test(TestArithmetic, f"test_arrays_{dtype.__name__}", test_arrays, devices=devices, dtype=dtype)
     add_function_test_register_kernel(
         TestArithmetic, f"test_binary_ops_{dtype.__name__}", test_binary_ops, devices=devices, dtype=dtype
+    )
+
+
+for dtype in np_signed_int_types:
+    add_function_test_register_kernel(
+        TestArithmetic,
+        f"test_floordiv_negative_{dtype.__name__}",
+        test_floordiv_negative,
+        devices=devices,
+        dtype=dtype,
     )
 
 


### PR DESCRIPTION
## Description

Closes #1918.

Integer floor division (`//`) truncates toward zero instead of rounding toward negative infinity, so kernels
silently compute the wrong value whenever exactly one operand is negative.

`ast.FloorDiv` maps to the `floordiv` builtin (`warp/_src/codegen.py`), which is documented as "Divide two scalars
using floor division" (`warp/_src/builtins.py`). The floating-point overloads honor that contract with
`floorf(a / b)` (`warp/native/builtin.h`), but the integer overload declared in `DECLARE_INT_OPS` is plain C
division, which truncates. There is no error or warning, so an expression such as `index // stride` with a
negative index quietly produces a wrong result.

Note that `mod` is intentionally different — it is documented as "Modulo operation using truncated division" — so
it is left unchanged.

This is a behavior change for code that depended on the previous truncating result, but that result contradicted
the documented semantics, Python's `//`, and Warp's own floating-point overloads.

## Changes

- `warp/native/builtin.h`: integer `floordiv()` moves out of `DECLARE_INT_OPS`. Signed types call a
  `floordiv_signed()` helper that lowers the truncated quotient when the remainder is non-zero and the operands have
  opposite signs; the unsigned overloads remain plain `a / b`, so no signed-only comparison is compiled for unsigned
  types.
- `warp/tests/test_arithmetic.py`: added `test_floordiv_negative`, registered for every signed integer type, which
  exercises the `//` operator over mixed-sign operands, including exact quotients with a negative divisor and a zero
  dividend, against `np.floor_divide`.
- Added changelog fragment `changelog/1918.fixed.md`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

Built with CUDA 12.9 (`python build_lib.py --cuda-path /usr/local/cuda`, Ubuntu 24.04, GCC 13.3) and CPU-only
(`--no-cuda`), and ran the arithmetic suite on `cpu` and `cuda:0` (NVIDIA L4).

- Verified `test_floordiv_negative` fails on `main` without this change, for `int8`, `int16`, `int32` and `int64`,
  on both devices. The int16 case reports:

  ```
  Mismatched elements: 3 / 12 (25%)
  ACTUAL:  array([-3, -3,  3,  3,  0, -2,  1,  1,  0, -2, -9, -9], dtype=int16)
  DESIRED: array([-4, -4,  3,  3, -1, -2,  1,  1,  0, -2, -9, -9], dtype=int16)
  ```

- Verified the new test passes with the fix applied, and that the rest of `test_arithmetic` (134 tests) still passes,
  including the existing `floordiv` coverage in `test_binary_ops` and the unsigned-integer cases.
- Warning check for the restructured dispatch:
  - nvcc build log: 0 occurrences of `warning #186-D` (the previous revision emitted 1352 on the same machine); the
    only remaining nvcc output is the pre-existing deprecated-architecture notice.
  - Runtime kernel compilation with `warp.config.log_level = warp.LOG_DEBUG`: the NVRTC program log is empty (the
    previous revision printed eight `#186-D` lines per CUDA module, with and without precompiled headers).
  - `g++ -std=c++17 -Wtype-limits -Werror -fsyntax-only` on a translation unit including `builtin.h`: clean (the
    previous revision failed with `comparison of unsigned expression in '< 0' is always false`).
- Confirmed the same kernel using `float32` returned the correct `-4.0` both before and after, which is what
  identified the integer/float inconsistency.
- `pre-commit run` (ruff, clang-format, typos, generated-files check) and `towncrier build --draft` pass locally.

## Bug fix

```python
import warp as wp
import numpy as np

@wp.kernel
def floor_div(a: wp.array(dtype=wp.int32), b: wp.array(dtype=wp.int32), out: wp.array(dtype=wp.int32)):
    i = wp.tid()
    out[i] = a[i] // b[i]

a = wp.array([-7, 7, -1], dtype=wp.int32)
b = wp.array([2, -2, 2], dtype=wp.int32)
out = wp.zeros(3, dtype=wp.int32)
wp.launch(floor_div, dim=3, inputs=[a, b], outputs=[out])

print(out.numpy())                                    # [-3 -3  0]  (truncated)
print(np.floor_divide(a.numpy(), b.numpy()))          # [-4 -4 -1]  (expected)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected signed-integer floor division to round toward negative infinity, matching Python and NumPy behavior.
  - Ensured `//` and `wp.floordiv()` handle negative operands consistently across supported integer types.

- **Tests**
  - Added coverage for negative signed-integer floor division across supported signed integer types.

- **Documentation**
  - Documented the corrected floor division behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
