### PR TITLE
Fix mixed-width texture sampling on sm_89

### DIFF
--- a/asv/benchmarks/texture.py
+++ b/asv/benchmarks/texture.py
@@ -12,12 +12,20 @@ from .benchmarks_utils import setup_once
 NUM_QUERIES = 1 << 20
 NUM_TEXTURES = 4
 
+# Cycle the one-million-query benchmark over 64K texels 16 times.
+TEXTURE_1D_WIDTH = 1 << 16
+
 TEXTURE_2D_WIDTH = 512
 TEXTURE_2D_HEIGHT = 512
 
 TEXTURE_3D_WIDTH = 128
 TEXTURE_3D_HEIGHT = 128
 TEXTURE_3D_DEPTH = 64
+
+
+@wp.func
+def query_1d(tid: int) -> float:
+    return (float(tid % TEXTURE_1D_WIDTH) + 0.5) / float(TEXTURE_1D_WIDTH)
 
 
 @wp.func
@@ -80,9 +88,39 @@ def texture_index(tid: int, lane_varying: bool) -> int:
 
 
 @wp.kernel
-def sample_texture2d_uv(tex: wp.Texture2D, output: wp.array[wp.vec4f]):
+def sample_texture2d_vec4(tex: wp.Texture2D, output: wp.array[wp.vec4f]):
     tid = wp.tid()
     output[tid] = wp.texture_sample(tex, query_2d(tid), dtype=wp.vec4f)
+
+
+@wp.kernel
+def sample_texture1d_vec2(tex: wp.Texture1D, output: wp.array[wp.vec2f]):
+    tid = wp.tid()
+    output[tid] = wp.texture_sample(tex, query_1d(tid), dtype=wp.vec2f)
+
+
+@wp.kernel
+def sample_texture1d_vec4(tex: wp.Texture1D, output: wp.array[wp.vec4f]):
+    tid = wp.tid()
+    output[tid] = wp.texture_sample(tex, query_1d(tid), dtype=wp.vec4f)
+
+
+@wp.kernel
+def sample_texture2d_vec2(tex: wp.Texture2D, output: wp.array[wp.vec2f]):
+    tid = wp.tid()
+    output[tid] = wp.texture_sample(tex, query_2d(tid), dtype=wp.vec2f)
+
+
+@wp.kernel
+def sample_texture3d_vec2(tex: wp.Texture3D, output: wp.array[wp.vec2f]):
+    tid = wp.tid()
+    output[tid] = wp.texture_sample(tex, query_3d(tid), dtype=wp.vec2f)
+
+
+@wp.kernel
+def sample_texture3d_vec4(tex: wp.Texture3D, output: wp.array[wp.vec4f]):
+    tid = wp.tid()
+    output[tid] = wp.texture_sample(tex, query_3d(tid), dtype=wp.vec4f)
 
 
 @wp.kernel
@@ -129,14 +167,31 @@ def sample_texture3d_array(
     output[tid] = finite_difference_gradient(tex, query_3d(tid))
 
 
-def _make_texture2d_data(seed: int) -> np.ndarray:
+def _make_texture1d_data(seed: int, num_channels: int) -> np.ndarray:
     rng = np.random.default_rng(seed)
-    return rng.random((TEXTURE_2D_HEIGHT, TEXTURE_2D_WIDTH, 4), dtype=np.float32)
+    return rng.random((TEXTURE_1D_WIDTH, num_channels), dtype=np.float32)
 
 
-def _make_texture3d_data(seed: int) -> np.ndarray:
+def _make_texture2d_data(seed: int, num_channels: int = 4) -> np.ndarray:
     rng = np.random.default_rng(seed)
-    return rng.random((TEXTURE_3D_DEPTH, TEXTURE_3D_HEIGHT, TEXTURE_3D_WIDTH), dtype=np.float32)
+    return rng.random((TEXTURE_2D_HEIGHT, TEXTURE_2D_WIDTH, num_channels), dtype=np.float32)
+
+
+def _make_texture3d_data(seed: int, num_channels: int = 1) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    shape = (TEXTURE_3D_DEPTH, TEXTURE_3D_HEIGHT, TEXTURE_3D_WIDTH)
+    if num_channels == 1:
+        return rng.random(shape, dtype=np.float32)
+    return rng.random((*shape, num_channels), dtype=np.float32)
+
+
+def _make_texture1d(data: np.ndarray, device: wp.Device) -> wp.Texture1D:
+    return wp.Texture1D(
+        data,
+        filter_mode=wp.TextureFilterMode.LINEAR,
+        address_mode=wp.TextureAddressMode.CLAMP,
+        device=device,
+    )
 
 
 def _make_texture2d(data: np.ndarray, device: wp.Device) -> wp.Texture2D:
@@ -158,6 +213,51 @@ def _make_texture3d(data: np.ndarray, device: wp.Device) -> wp.Texture3D:
     )
 
 
+class TextureBaseVector:
+    """Sample one base-level vector texture value per query."""
+
+    params = ["1d_vec2", "1d_vec4", "2d_vec2", "2d_vec4", "3d_vec2", "3d_vec4"]
+    param_names = ["sample"]
+    # On the L40 CI runner, these settings yield 0.8-1.3 ms timed calls and
+    # 51-83 ms samples.
+    number = 64
+    repeat = 10
+
+    @setup_once
+    def setup(self, sample):
+        wp.init()
+        self.device = wp.get_device("cuda:0")
+        dimension = sample[:2]
+        num_channels = int(sample[-1])
+        dtype = wp.vec2f if num_channels == 2 else wp.vec4f
+
+        if dimension == "1d":
+            self.texture = _make_texture1d(_make_texture1d_data(42, num_channels), self.device)
+            kernel = sample_texture1d_vec2 if num_channels == 2 else sample_texture1d_vec4
+        elif dimension == "2d":
+            self.texture = _make_texture2d(_make_texture2d_data(42, num_channels), self.device)
+            kernel = sample_texture2d_vec2 if num_channels == 2 else sample_texture2d_vec4
+        else:
+            self.texture = _make_texture3d(_make_texture3d_data(42, num_channels), self.device)
+            kernel = sample_texture3d_vec2 if num_channels == 2 else sample_texture3d_vec4
+
+        self.output = wp.empty(NUM_QUERIES, dtype=dtype, device=self.device)
+        self.cmd = wp.launch(
+            kernel,
+            dim=NUM_QUERIES,
+            inputs=[self.texture],
+            outputs=[self.output],
+            device=self.device,
+            record_cmd=True,
+        )
+        self.cmd.launch()
+        wp.synchronize_device(self.device)
+
+    def time_cuda(self, sample):
+        self.cmd.launch()
+        wp.synchronize_device(self.device)
+
+
 class Texture2DUv:
     """Sample one RGBA 2D texture value per query, as in UV-mapped rendering."""
 
@@ -171,7 +271,7 @@ class Texture2DUv:
         self.texture = _make_texture2d(_make_texture2d_data(42), self.device)
         self.output = wp.empty(NUM_QUERIES, dtype=wp.vec4f, device=self.device)
         self.cmd = wp.launch(
-            sample_texture2d_uv,
+            sample_texture2d_vec4,
             dim=NUM_QUERIES,
             inputs=[self.texture],
             outputs=[self.output],

--- a/changelog/1920.fixed.md
+++ b/changelog/1920.fixed.md
@@ -1,0 +1,1 @@
+Fix incorrect base-level vector texture samples in mixed-width functions on CUDA architectures through ``sm_89``.

--- a/warp/native/texture.h
+++ b/warp/native/texture.h
@@ -736,10 +736,31 @@ template <> struct texture_sample_helper<float> {
 };
 
 template <> struct texture_sample_helper<vec2f> {
+#if defined(WP_WORKAROUND_CUDA_TEXTURE_MIXED_WIDTH)
+    static CUDA_CALLABLE_DEVICE __noinline__ float2 sample_base_1d(const texture1d_t& tex, float u)
+    {
+        return tex1D<float2>(tex.tex, u);
+    }
+
+    static CUDA_CALLABLE_DEVICE __noinline__ float2 sample_base_2d(const texture2d_t& tex, float u, float v)
+    {
+        return tex2D<float2>(tex.tex, u, v);
+    }
+
+    static CUDA_CALLABLE_DEVICE __noinline__ float2 sample_base_3d(const texture3d_t& tex, float u, float v, float w)
+    {
+        return tex3D<float2>(tex.tex, u, v, w);
+    }
+#endif
+
     static CUDA_CALLABLE vec2f sample_1d(const texture1d_t& tex, float u, float lod)
     {
 #if defined(__CUDA_ARCH__)
+#if defined(WP_WORKAROUND_CUDA_TEXTURE_MIXED_WIDTH)
+        float2 val = (lod < 0.0f) ? sample_base_1d(tex, u) : tex1DLod<float2>(tex.tex, u, lod);
+#else
         float2 val = (lod < 0.0f) ? tex1D<float2>(tex.tex, u) : tex1DLod<float2>(tex.tex, u, lod);
+#endif
         return vec2f(val.x, val.y);
 #else
         if (tex.tex == 0)
@@ -756,7 +777,11 @@ template <> struct texture_sample_helper<vec2f> {
     static CUDA_CALLABLE vec2f sample_2d(const texture2d_t& tex, float u, float v, float lod)
     {
 #if defined(__CUDA_ARCH__)
+#if defined(WP_WORKAROUND_CUDA_TEXTURE_MIXED_WIDTH)
+        float2 val = (lod < 0.0f) ? sample_base_2d(tex, u, v) : tex2DLod<float2>(tex.tex, u, v, lod);
+#else
         float2 val = (lod < 0.0f) ? tex2D<float2>(tex.tex, u, v) : tex2DLod<float2>(tex.tex, u, v, lod);
+#endif
         return vec2f(val.x, val.y);
 #else
         if (tex.tex == 0)
@@ -773,7 +798,11 @@ template <> struct texture_sample_helper<vec2f> {
     static CUDA_CALLABLE vec2f sample_3d(const texture3d_t& tex, float u, float v, float w, float lod)
     {
 #if defined(__CUDA_ARCH__)
+#if defined(WP_WORKAROUND_CUDA_TEXTURE_MIXED_WIDTH)
+        float2 val = (lod < 0.0f) ? sample_base_3d(tex, u, v, w) : tex3DLod<float2>(tex.tex, u, v, w, lod);
+#else
         float2 val = (lod < 0.0f) ? tex3D<float2>(tex.tex, u, v, w) : tex3DLod<float2>(tex.tex, u, v, w, lod);
+#endif
         return vec2f(val.x, val.y);
 #else
         if (tex.tex == 0)
@@ -792,10 +821,31 @@ template <> struct texture_sample_helper<vec2f> {
 };
 
 template <> struct texture_sample_helper<vec4f> {
+#if defined(WP_WORKAROUND_CUDA_TEXTURE_MIXED_WIDTH)
+    static CUDA_CALLABLE_DEVICE __noinline__ float4 sample_base_1d(const texture1d_t& tex, float u)
+    {
+        return tex1D<float4>(tex.tex, u);
+    }
+
+    static CUDA_CALLABLE_DEVICE __noinline__ float4 sample_base_2d(const texture2d_t& tex, float u, float v)
+    {
+        return tex2D<float4>(tex.tex, u, v);
+    }
+
+    static CUDA_CALLABLE_DEVICE __noinline__ float4 sample_base_3d(const texture3d_t& tex, float u, float v, float w)
+    {
+        return tex3D<float4>(tex.tex, u, v, w);
+    }
+#endif
+
     static CUDA_CALLABLE vec4f sample_1d(const texture1d_t& tex, float u, float lod)
     {
 #if defined(__CUDA_ARCH__)
+#if defined(WP_WORKAROUND_CUDA_TEXTURE_MIXED_WIDTH)
+        float4 val = (lod < 0.0f) ? sample_base_1d(tex, u) : tex1DLod<float4>(tex.tex, u, lod);
+#else
         float4 val = (lod < 0.0f) ? tex1D<float4>(tex.tex, u) : tex1DLod<float4>(tex.tex, u, lod);
+#endif
         return vec4f(val.x, val.y, val.z, val.w);
 #else
         if (tex.tex == 0)
@@ -816,7 +866,11 @@ template <> struct texture_sample_helper<vec4f> {
     static CUDA_CALLABLE vec4f sample_2d(const texture2d_t& tex, float u, float v, float lod)
     {
 #if defined(__CUDA_ARCH__)
+#if defined(WP_WORKAROUND_CUDA_TEXTURE_MIXED_WIDTH)
+        float4 val = (lod < 0.0f) ? sample_base_2d(tex, u, v) : tex2DLod<float4>(tex.tex, u, v, lod);
+#else
         float4 val = (lod < 0.0f) ? tex2D<float4>(tex.tex, u, v) : tex2DLod<float4>(tex.tex, u, v, lod);
+#endif
         return vec4f(val.x, val.y, val.z, val.w);
 #else
         if (tex.tex == 0)
@@ -838,7 +892,11 @@ template <> struct texture_sample_helper<vec4f> {
     static CUDA_CALLABLE vec4f sample_3d(const texture3d_t& tex, float u, float v, float w, float lod)
     {
 #if defined(__CUDA_ARCH__)
+#if defined(WP_WORKAROUND_CUDA_TEXTURE_MIXED_WIDTH)
+        float4 val = (lod < 0.0f) ? sample_base_3d(tex, u, v, w) : tex3DLod<float4>(tex.tex, u, v, w, lod);
+#else
         float4 val = (lod < 0.0f) ? tex3D<float4>(tex.tex, u, v, w) : tex3DLod<float4>(tex.tex, u, v, w, lod);
+#endif
         return vec4f(val.x, val.y, val.z, val.w);
 #else
         if (tex.tex == 0)

--- a/warp/native/warp.cu
+++ b/warp/native/warp.cu
@@ -4692,6 +4692,13 @@ size_t wp_cuda_compile_program(
     opts.push_back(include_opt);
     opts.push_back("--std=c++17");
 
+    // CUDA can miscompile base-level vector texture sampling when functions mix
+    // texture return widths on sm_89 and older targets. Apply the workaround to
+    // every compiler version and mode because the affected combinations cannot
+    // be enumerated reliably.
+    if (arch < 90)
+        opts.push_back("--define-macro=WP_WORKAROUND_CUDA_TEXTURE_MIXED_WIDTH");
+
 #if CUDA_VERSION >= 12080 && CUDA_VERSION < 13000
     // CUDA 12 miscompiles optimized CUBIN texture sampling when texture handles
     // vary across lanes on sm_90 and newer targets. CUDA 12.8 is covered as a

--- a/warp/tests/cuda/test_texture_compiler.py
+++ b/warp/tests/cuda/test_texture_compiler.py
@@ -1,0 +1,437 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for CUDA mixed-width texture sampling.
+
+CUDA can miscompile a function that selects between scalar and vector texture
+fetches at runtime when targeting ``sm_89`` and older architectures. A selected
+fetch can return zero even though the other branches are never executed. Direct
+texture-sampling kernels do not reproduce the bug. The kernels below retain the
+smallest known source shapes that do.
+
+The 1D, 2D, and 3D kernels are deliberately explicit. Factoring their shared
+code into another function changes the generated CUDA call graph and can hide
+the compiler regression this module is meant to detect. The all-width case is
+smaller: it only requires a texture loaded from an array, a runtime selector,
+and two calls to the same sampling function.
+"""
+
+import unittest
+
+import numpy as np
+
+import warp as wp
+from warp.tests.unittest_utils import add_function_test, get_selected_cuda_test_devices
+
+
+@wp.struct
+class TextureSampleData1D:
+    texture: wp.Texture1D
+    kind: int
+    component: int
+
+
+@wp.struct
+class TextureSampleData2D:
+    texture: wp.Texture2D
+    kind: int
+    component: int
+
+
+@wp.struct
+class TextureSampleData3D:
+    texture: wp.Texture3D
+    kind: int
+    component: int
+
+
+@wp.func
+def sample_all_widths_1d(texture: wp.Texture1D, kind: int) -> float:
+    if kind == 1:
+        return wp.texture_sample(texture, 0.5, dtype=wp.vec2f)[kind]
+    if kind == 2:
+        return wp.texture_sample(texture, 0.5, dtype=wp.vec4f)[kind]
+    return wp.texture_sample(texture, 0.5, dtype=float)
+
+
+@wp.func
+def sample_scalar_or_vec2_1d(texture: wp.Texture1D, u: float, kind: int, component: int) -> float:
+    if kind == 1:
+        return wp.texture_sample(texture, u, dtype=wp.vec2f)[component]
+    return wp.texture_sample(texture, u, dtype=float)
+
+
+@wp.func
+def sample_scalar_or_vec2_2d(texture: wp.Texture2D, uv: wp.vec2f, kind: int, component: int) -> float:
+    if kind == 1:
+        return wp.texture_sample(texture, uv, dtype=wp.vec2f)[component]
+    return wp.texture_sample(texture, uv, dtype=float)
+
+
+@wp.func
+def sample_scalar_or_vec2_3d(texture: wp.Texture3D, uvw: wp.vec3f, kind: int, component: int) -> float:
+    if kind == 1:
+        return wp.texture_sample(texture, uvw, dtype=wp.vec2f)[component]
+    return wp.texture_sample(texture, uvw, dtype=float)
+
+
+@wp.func
+def sample_scalar_or_vec4_1d(texture: wp.Texture1D, u: float, kind: int, component: int) -> float:
+    if kind == 1:
+        return wp.texture_sample(texture, u, dtype=wp.vec4f)[component]
+    return wp.texture_sample(texture, u, dtype=float)
+
+
+@wp.func
+def sample_scalar_or_vec4_2d(texture: wp.Texture2D, uv: wp.vec2f, kind: int, component: int) -> float:
+    if kind == 1:
+        return wp.texture_sample(texture, uv, dtype=wp.vec4f)[component]
+    return wp.texture_sample(texture, uv, dtype=float)
+
+
+@wp.func
+def sample_scalar_or_vec4_3d(texture: wp.Texture3D, uvw: wp.vec3f, kind: int, component: int) -> float:
+    if kind == 1:
+        return wp.texture_sample(texture, uvw, dtype=wp.vec4f)[component]
+    return wp.texture_sample(texture, uvw, dtype=float)
+
+
+def sample_scalar_vec2_1d_kernel(
+    scale: wp.vec3f,
+    table: wp.array[TextureSampleData1D],
+    out_value: wp.array[float],
+):
+    """Sample a runtime-selected scalar or ``vec2`` value from a 1D texture."""
+    data = table[0]
+    local = wp.cw_div(wp.vec3f(1.0, 0.0, 0.0), scale)
+    clamped = wp.vec3f(
+        wp.clamp(local[0], -0.6, 0.6),
+        wp.clamp(local[1], -0.6, 0.6),
+        wp.clamp(local[2], -0.6, 0.6),
+    )
+    diff = local - clamped
+    f = (clamped[0] + 0.6) * 6.6666665
+    bx = wp.clamp(int(wp.floor(f)), 0, 7)
+    tx = f - float(bx)
+    v0 = sample_scalar_or_vec2_1d(data.texture, float(bx) + 0.5, data.kind, data.component)
+    v1 = sample_scalar_or_vec2_1d(data.texture, float(bx) + 1.5, data.kind, data.component)
+    value = v0 + (v1 - v0) * tx
+    out_value[0] = value + wp.length(diff)
+
+
+def sample_scalar_vec2_2d_kernel(
+    scale: wp.vec3f,
+    table: wp.array[TextureSampleData2D],
+    out_value: wp.array[float],
+):
+    """Sample a runtime-selected scalar or ``vec2`` value from a 2D texture."""
+    data = table[0]
+    local = wp.cw_div(wp.vec3f(1.0, 0.0, 0.0), scale)
+    clamped = wp.vec3f(
+        wp.clamp(local[0], -0.6, 0.6),
+        wp.clamp(local[1], -0.6, 0.6),
+        wp.clamp(local[2], -0.6, 0.6),
+    )
+    diff = local - clamped
+    f = (clamped[0] + 0.6) * 6.6666665
+    bx = wp.clamp(int(wp.floor(f)), 0, 7)
+    tx = f - float(bx)
+    v0 = sample_scalar_or_vec2_2d(
+        data.texture,
+        wp.vec2f(float(bx) + 0.5, 4.5),
+        data.kind,
+        data.component,
+    )
+    v1 = sample_scalar_or_vec2_2d(
+        data.texture,
+        wp.vec2f(float(bx) + 1.5, 4.5),
+        data.kind,
+        data.component,
+    )
+    value = v0 + (v1 - v0) * tx
+    out_value[0] = value + wp.length(diff)
+
+
+def sample_scalar_vec2_3d_kernel(
+    scale: wp.vec3f,
+    table: wp.array[TextureSampleData3D],
+    out_value: wp.array[float],
+):
+    """Sample a runtime-selected scalar or ``vec2`` value from a 3D texture."""
+    data = table[0]
+    local = wp.cw_div(wp.vec3f(1.0, 0.0, 0.0), scale)
+    clamped = wp.vec3f(
+        wp.clamp(local[0], -0.6, 0.6),
+        wp.clamp(local[1], -0.6, 0.6),
+        wp.clamp(local[2], -0.6, 0.6),
+    )
+    diff = local - clamped
+    f = (clamped[0] + 0.6) * 6.6666665
+    bx = wp.clamp(int(wp.floor(f)), 0, 7)
+    tx = f - float(bx)
+    v0 = sample_scalar_or_vec2_3d(
+        data.texture,
+        wp.vec3f(float(bx) + 0.5, 4.5, 4.5),
+        data.kind,
+        data.component,
+    )
+    v1 = sample_scalar_or_vec2_3d(
+        data.texture,
+        wp.vec3f(float(bx) + 1.5, 4.5, 4.5),
+        data.kind,
+        data.component,
+    )
+    value = v0 + (v1 - v0) * tx
+    out_value[0] = value + wp.length(diff)
+
+
+def sample_scalar_vec4_1d_kernel(
+    scale: wp.vec3f,
+    table: wp.array[TextureSampleData1D],
+    out_value: wp.array[float],
+):
+    """Sample a runtime-selected scalar or ``vec4`` value from a 1D texture."""
+    data = table[0]
+    local = wp.cw_div(wp.vec3f(1.0, 0.0, 0.0), scale)
+    clamped = wp.vec3f(
+        wp.clamp(local[0], -0.6, 0.6),
+        wp.clamp(local[1], -0.6, 0.6),
+        wp.clamp(local[2], -0.6, 0.6),
+    )
+    diff = local - clamped
+    f = (clamped[0] + 0.6) * 6.6666665
+    bx = wp.clamp(int(wp.floor(f)), 0, 7)
+    tx = f - float(bx)
+    v0 = sample_scalar_or_vec4_1d(data.texture, float(bx) + 0.5, data.kind, data.component)
+    v1 = sample_scalar_or_vec4_1d(data.texture, float(bx) + 1.5, data.kind, data.component)
+    value = v0 + (v1 - v0) * tx
+    out_value[0] = value + wp.length(diff)
+
+
+def sample_scalar_vec4_2d_kernel(
+    scale: wp.vec3f,
+    table: wp.array[TextureSampleData2D],
+    out_value: wp.array[float],
+):
+    """Sample a runtime-selected scalar or ``vec4`` value from a 2D texture."""
+    data = table[0]
+    local = wp.cw_div(wp.vec3f(1.0, 0.0, 0.0), scale)
+    clamped = wp.vec3f(
+        wp.clamp(local[0], -0.6, 0.6),
+        wp.clamp(local[1], -0.6, 0.6),
+        wp.clamp(local[2], -0.6, 0.6),
+    )
+    diff = local - clamped
+    f = (clamped[0] + 0.6) * 6.6666665
+    bx = wp.clamp(int(wp.floor(f)), 0, 7)
+    tx = f - float(bx)
+    v0 = sample_scalar_or_vec4_2d(
+        data.texture,
+        wp.vec2f(float(bx) + 0.5, 4.5),
+        data.kind,
+        data.component,
+    )
+    v1 = sample_scalar_or_vec4_2d(
+        data.texture,
+        wp.vec2f(float(bx) + 1.5, 4.5),
+        data.kind,
+        data.component,
+    )
+    value = v0 + (v1 - v0) * tx
+    out_value[0] = value + wp.length(diff)
+
+
+def sample_scalar_vec4_3d_kernel(
+    scale: wp.vec3f,
+    table: wp.array[TextureSampleData3D],
+    out_value: wp.array[float],
+):
+    """Sample a runtime-selected scalar or ``vec4`` value from a 3D texture."""
+    data = table[0]
+    local = wp.cw_div(wp.vec3f(1.0, 0.0, 0.0), scale)
+    clamped = wp.vec3f(
+        wp.clamp(local[0], -0.6, 0.6),
+        wp.clamp(local[1], -0.6, 0.6),
+        wp.clamp(local[2], -0.6, 0.6),
+    )
+    diff = local - clamped
+    f = (clamped[0] + 0.6) * 6.6666665
+    bx = wp.clamp(int(wp.floor(f)), 0, 7)
+    tx = f - float(bx)
+    v0 = sample_scalar_or_vec4_3d(
+        data.texture,
+        wp.vec3f(float(bx) + 0.5, 4.5, 4.5),
+        data.kind,
+        data.component,
+    )
+    v1 = sample_scalar_or_vec4_3d(
+        data.texture,
+        wp.vec3f(float(bx) + 1.5, 4.5, 4.5),
+        data.kind,
+        data.component,
+    )
+    value = v0 + (v1 - v0) * tx
+    out_value[0] = value + wp.length(diff)
+
+
+def sample_all_widths_1d_kernel(
+    textures: wp.array[wp.Texture1D],
+    out_value: wp.array[float],
+):
+    """Sample twice from a function containing scalar, ``vec2``, and ``vec4`` fetches."""
+    texture = textures[0]
+    # Keep the selector and vector component dynamic without another input.
+    kind = texture.width
+    out_value[0] = sample_all_widths_1d(texture, kind) + sample_all_widths_1d(texture, kind)
+
+
+KERNEL_FUNCTIONS = {
+    ("scalar_vec2", "1d"): sample_scalar_vec2_1d_kernel,
+    ("scalar_vec2", "2d"): sample_scalar_vec2_2d_kernel,
+    ("scalar_vec2", "3d"): sample_scalar_vec2_3d_kernel,
+    ("scalar_vec4", "1d"): sample_scalar_vec4_1d_kernel,
+    ("scalar_vec4", "2d"): sample_scalar_vec4_2d_kernel,
+    ("scalar_vec4", "3d"): sample_scalar_vec4_3d_kernel,
+    ("all_widths", "1d"): sample_all_widths_1d_kernel,
+}
+
+COMPILER_CONFIGS = (
+    ("cubin", 0),
+    ("cubin", 3),
+    ("ptx", 0),
+    ("ptx", 3),
+)
+
+# Register each combination as a named case while compiling only one shared
+# module for each compiler configuration.
+TEXTURE_COMPILER_KERNELS = {}
+for cuda_output, optimization_level in COMPILER_CONFIGS:
+    module = wp.Module(f"test_texture_compiler_{cuda_output}_{optimization_level}")
+    wp.set_module_options(
+        {"cuda_output": cuda_output, "optimization_level": optimization_level},
+        module=module,
+    )
+    for kernel_key, kernel_func in KERNEL_FUNCTIONS.items():
+        TEXTURE_COMPILER_KERNELS[(cuda_output, optimization_level, *kernel_key)] = wp.kernel(
+            kernel_func,
+            module=module,
+        )
+
+
+DIMENSION_CASES = (
+    ("1d", wp.Texture1D, TextureSampleData1D, (9,)),
+    ("2d", wp.Texture2D, TextureSampleData2D, (9, 9)),
+    ("3d", wp.Texture3D, TextureSampleData3D, (9, 9, 9)),
+)
+
+WIDTH_CASES = (
+    ("scalar_from_scalar_vec2", "scalar_vec2"),
+    ("scalar_from_scalar_vec4", "scalar_vec4"),
+)
+
+
+def make_constant_scalar_texture(texture_cls, shape, device):
+    return texture_cls(
+        np.full(shape, 0.1, dtype=np.float32),
+        filter_mode=wp.TextureFilterMode.CLOSEST,
+        address_mode=wp.TextureAddressMode.CLAMP,
+        normalized_coords=False,
+        device=device,
+    )
+
+
+def test_mixed_width_texture_sampling(
+    test,
+    device,
+    kernel,
+    texture_cls,
+    data_cls,
+    shape,
+):
+    texture = make_constant_scalar_texture(texture_cls, shape, device)
+    data = data_cls()
+    data.texture = texture
+    data.kind = 0
+    data.component = 0
+    table = wp.array([data], dtype=data_cls, device=device)
+    out_value = wp.empty(1, dtype=float, device=device)
+
+    wp.launch(
+        kernel,
+        dim=1,
+        inputs=[wp.vec3f(1.0), table],
+        outputs=[out_value],
+        device=device,
+    )
+
+    # The sampled first component is 0.1. Clamping local x from 1.0 to 0.6
+    # contributes the remaining distance of 0.4.
+    np.testing.assert_allclose(
+        out_value.numpy(),
+        np.array([0.5], dtype=np.float32),
+        rtol=0.0,
+        atol=1.0e-6,
+    )
+
+
+def test_all_widths_texture_sampling(test, device, kernel):
+    texture = wp.Texture1D(
+        np.full((2, 4), 0.1, dtype=np.float32),
+        filter_mode=wp.TextureFilterMode.CLOSEST,
+        address_mode=wp.TextureAddressMode.CLAMP,
+        normalized_coords=False,
+        device=device,
+    )
+    textures = wp.array([texture], dtype=wp.Texture1D, device=device)
+    out_value = wp.empty(1, dtype=float, device=device)
+
+    wp.launch(
+        kernel,
+        dim=1,
+        inputs=[textures],
+        outputs=[out_value],
+        device=device,
+    )
+
+    # A width of two selects component two of the vec4 branch. Each of the two
+    # samples contributes 0.1.
+    np.testing.assert_allclose(
+        out_value.numpy(),
+        np.array([0.2], dtype=np.float32),
+        rtol=0.0,
+        atol=1.0e-6,
+    )
+
+
+class TestTextureCompiler(unittest.TestCase):
+    pass
+
+
+devices = get_selected_cuda_test_devices()
+for cuda_output, optimization_level in COMPILER_CONFIGS:
+    for dimension, texture_cls, data_cls, shape in DIMENSION_CASES:
+        for selected_sample, width_pair in WIDTH_CASES:
+            kernel = TEXTURE_COMPILER_KERNELS[(cuda_output, optimization_level, width_pair, dimension)]
+            add_function_test(
+                TestTextureCompiler,
+                f"test_{selected_sample}_{dimension}_{cuda_output}_o{optimization_level}",
+                test_mixed_width_texture_sampling,
+                devices=devices,
+                kernel=kernel,
+                texture_cls=texture_cls,
+                data_cls=data_cls,
+                shape=shape,
+            )
+
+    kernel = TEXTURE_COMPILER_KERNELS[(cuda_output, optimization_level, "all_widths", "1d")]
+    add_function_test(
+        TestTextureCompiler,
+        f"test_vec4_from_all_widths_1d_{cuda_output}_o{optimization_level}",
+        test_all_widths_texture_sampling,
+        devices=devices,
+        kernel=kernel,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/warp/tests/unittest_suites.py
+++ b/warp/tests/unittest_suites.py
@@ -111,6 +111,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
     from warp.tests.cuda.test_pinned import TestPinned
     from warp.tests.cuda.test_streams import TestStreams
     from warp.tests.cuda.test_texture import TestTexture
+    from warp.tests.cuda.test_texture_compiler import TestTextureCompiler
     from warp.tests.cuda.test_unified_memory import TestUnifiedMemory
     from warp.tests.deterministic.test_deterministic_backward import TestDeterministicBackward
     from warp.tests.deterministic.test_deterministic_counter import TestDeterministicCounter
@@ -439,6 +440,7 @@ def default_suite(test_loader: unittest.TestLoader = unittest.defaultTestLoader)
         TestTape,
         TestTemplateLaunchBounds,
         TestTexture,
+        TestTextureCompiler,
         TestTile,
         TestTileAtomicBitwise,
         TestTileCholesky,


### PR DESCRIPTION
## Description

CUDA 12.8 and 12.9 can miscompile base-level texture samples on `sm_89` when the same function mixes scalar, `vec2f`, and `vec4f` return widths. The affected fetch may return zero, producing incorrect results for 1D, 2D, and 3D textures.

This change adds a narrow workaround for the affected CUDA versions and architecture. Base-level `vec2f` and `vec4f` fetches use a non-inlined call boundary, while scalar and explicit-LOD sampling remain unchanged.

Closes #1920.

## Changes

- Apply the workaround when compiling for `sm_89` with CUDA 12.8 or 12.9.
- Cover mixed-width sampling across texture dimensions, CUBIN and PTX output, and optimization levels 0 and 3.
- Add ASV benchmarks for vector texture sampling.
- Add a changelog fragment for the fix.

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

Validation was run on an NVIDIA L40 (`sm_89`) with CUDA 12.8.

- The mixed-width texture compiler regression test passed for CUBIN and PTX at optimization levels 0 and 3.
- The existing texture test suite passed.
- Pre-commit checks passed for all changed files.

## Bug fix

The complete standalone reproducer and affected configuration matrix are available in #1920. The compiler issue is triggered by a function that selects base-level texture samples with different return widths:

```python
@wp.func
def sample_mixed(
    texture: wp.Texture1D,
    u: float,
    kind: int,
    component: int,
) -> float:
    if kind == 1:
        return wp.texture_sample(texture, u, dtype=wp.vec2f)[component]
    if kind == 2:
        return wp.texture_sample(texture, u, dtype=wp.vec4f)[component]
    return wp.texture_sample(texture, u, dtype=float)
```

On an affected configuration, the reproducer returns approximately `0.4` instead of the expected `0.5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect 2- and 4-channel base-level texture sampling on CUDA architectures through sm_89.
  * Improved reliability of scalar and vector texture sampling across 1D, 2D, and 3D textures.

* **Tests**
  * Added regression coverage for mixed-width sampling across texture dimensions, channel formats, compiler outputs, and optimization levels.
  * Added benchmarks for vector texture sampling across multiple dimensions and data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->