### PR TITLE
Quote build paths that may contain spaces

### DIFF
--- a/build_llvm.py
+++ b/build_llvm.py
@@ -491,7 +491,7 @@ def build_warp_clang_for_arch(args, lib_name: str, arch: str) -> None:
             else:
                 libs.insert(0, "-Wl,--start-group")
                 libs.append("-Wl,--end-group")
-            libs.append(f"-L{libpath}")
+            libs.append(f"-L{quote(libpath)}")
             libs.append("-lpthread")
             libs.append("-ldl")
             if sys.platform != "darwin":

--- a/changelog/1925.fixed.md
+++ b/changelog/1925.fixed.md
@@ -1,0 +1,1 @@
+Fix building Warp from source paths containing spaces on Linux and macOS.

--- a/warp/_src/build_dll.py
+++ b/warp/_src/build_dll.py
@@ -899,9 +899,9 @@ def build_dll_for_arch(
 
                 if args.libmathdx_path:
                     if args.use_dynamic_cuda:
-                        ld_inputs.append(f"-lnvJitLink -L{args.libmathdx_path}/lib -lmathdx")
+                        ld_inputs.append(f"-lnvJitLink -L{quote(args.libmathdx_path + '/lib')} -lmathdx")
                     else:
-                        ld_inputs.append(f"-lnvJitLink_static -L{args.libmathdx_path}/lib -lmathdx_static")
+                        ld_inputs.append(f"-lnvJitLink_static -L{quote(args.libmathdx_path + '/lib')} -lmathdx_static")
 
             if args.jobs <= 1:
                 with ScopedTimer("build_cuda", active=args.verbose):
@@ -936,7 +936,9 @@ def build_dll_for_arch(
             # C++ hosts even on distros that flip the default to -z now via RELRO.
             opt_undefined = "-Wl,-z,lazy"
             opt_exclude_libs = "-Wl,--exclude-libs,ALL"
-            opt_static_runtime = f"-static-libstdc++ -static-libgcc -Wl,--version-script={native_dir}/warp.map"
+            opt_static_runtime = (
+                f"-static-libstdc++ -static-libgcc -Wl,--version-script={quote(native_dir + '/warp.map')}"
+            )
 
         sanitize_ld = f" -fsanitize={args.sanitize}" if args.sanitize else ""
 
@@ -979,11 +981,12 @@ def build_dll_for_arch(
             # Strip symbols to reduce the binary size
             if mode == "release":
                 if sys.platform == "darwin":
-                    run_cmd(f"strip -x {dll_path}")  # Strip all local symbols
+                    run_cmd(f"strip -x {quote(dll_path)}")  # Strip all local symbols
                 else:  # Linux
                     # Strip symbols not needed for dynamic linking, except those needed to support debugging JIT-compiled code
                     run_cmd(
-                        f"strip --strip-unneeded --keep-symbol=__jit_debug_register_code --keep-symbol=__jit_debug_descriptor {dll_path}"
+                        f"strip --strip-unneeded --keep-symbol=__jit_debug_register_code "
+                        f"--keep-symbol=__jit_debug_descriptor {quote(dll_path)}"
                     )
 
 


### PR DESCRIPTION
## Description

Building Warp from source fails to link when the repository path contains a space. Several paths are interpolated into build command strings without quoting, so the shell splits them on whitespace.

Cloning into a directory such as `/home/tushar/MY OPEN SOURCE CONTRIBUTION/warp` and running `uv run build_lib.py --quick` fails at link time, and once that is fixed, again at the strip step. Moving the same tree to a path without spaces makes the build succeed with no other changes.

This looks like an oversight rather than a deliberate choice, because in every case the surrounding code already quotes the same value:

| Location | Was | Compare against |
|---|---|---|
| `build_dll.py:902,904` | `-L{args.libmathdx_path}/lib` | line 675 quotes the *same variable*: `-I"{args.libmathdx_path}/include"` |
| `build_dll.py:939` | `-Wl,--version-script={native_dir}/warp.map` | line 933 quotes the macOS equivalent: `-Wl,-exported_symbols_list,"{...}"` |
| `build_dll.py:982,986` | `strip ... {dll_path}` | line 945 quotes the *same variable*: `-o '{dll_path}'` |
| `build_llvm.py:494` | `-L{libpath}` | line 485 quotes the Windows equivalent: `/LIBPATH:"{libpath}"` |

Everything else in these commands is already quoted (`-I"{native_dir}"`, `-c "{cpp_path}"`, `-o "{cu_out}"`, `"{host_linker}"`, `/out:"{dll_path}"`), and `find_nvcc_executable()` and `libmathdx_includes` quote correctly too, so these appear to be the only gaps.

Closes #1925.

## Changes

- Quote the interpolated paths at the five affected sites using the existing `quote()` helper, which is already used nearby for `ld_inputs.append(quote(cu_out))`, keeping the change consistent with the surrounding style.
- Add a changelog fragment.

No behavior changes for paths without spaces: the shell strips the quotes, so the resulting commands are identical.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

Per `AGENTS.md` ("Do not add meta-tests there for docs config, CI/release scripts, packaging, or test harness machinery; verify those workflows directly instead"), I did not add a unit test under `warp/tests` for this build-script change and verified the workflow directly instead. The validation narrative below covers that.

## Validation summary

Red/green on the actual build, on Linux (Ubuntu 26.04, GCC 15.2.0, Python 3.12.14, CPU-only build):

1. **Reproduced the failure.** With the tree at a path containing a space, `uv run build_lib.py --quick` failed to link:
   `ld.bfd: cannot open linker script file /home/tushar/MY: No such file or directory`.
2. **Confirmed the second failure.** After quoting only the linker flag, the build got further and failed in the strip step (`strip: 'SOURCE': No such file`), which is how the `strip` sites were found. Both are fixed here.
3. **Green with the fix.** From that same spaced path, the build now succeeds and produces `warp.so` and `warp-clang.so`; a Warp kernel compiles and runs from it.
4. **No regression without spaces.** Rebuilt from a path with no spaces; succeeds with no errors, as before.
5. **Confirmed the flags still take effect**, rather than merely no longer erroring:
   - `--version-script`: `nm -D --defined-only warp.so` reports 2296 exported symbols, **0** of which fail to match `wp_*`, matching `warp.map`.
   - `strip --keep-symbol`: `__jit_debug_descriptor` and `__jit_debug_register_code` are both still present after stripping.
6. **Test suite.** `uv run --extra dev -m warp.tests -s autodetect -k TestArray -k TestCodeGen -k TestFunc` → 300 tests pass (7 skipped, Torch not installed).
7. **Lint.** `uvx pre-commit run --files warp/_src/build_dll.py build_llvm.py changelog/1925.fixed.md` → all hooks pass.

Two limitations worth stating plainly:

- The macOS sites (`build_dll.py:982`, `build_llvm.py:494`) are from reading the code; I have no macOS machine, so they are **not** verified at runtime.
- This build is CPU-only, so the two `libmathdx` `-L` sites were not exercised by a real CUDA link. I verified those expressions produce the intended shell directly instead (each yields a single argument under `shlex.split` when the path contains a space, and is unchanged when it does not).

## Bug fix

Reproduce without this PR applied, on Linux:

```bash
git clone https://github.com/NVIDIA/warp.git "/tmp/dir with spaces/warp"
cd "/tmp/dir with spaces/warp"
uv run build_lib.py --quick
```

```
/usr/bin/x86_64-linux-gnu-ld.bfd: cannot open linker script file /tmp/dir: No such file or directory
collect2: error: ld returned 1 exit status
Warp build error: Command '/usr/bin/g++ ... -Wl,--version-script=/tmp/dir with spaces/warp/warp/native/warp.map ...' returned non-zero exit status 1.
```

With this PR the same build succeeds, and Warp runs from that path:

```python
import warp as wp
import numpy as np

@wp.kernel
def add_one(a: wp.array(dtype=float)):
    i = wp.tid()
    a[i] = a[i] + 1.0

wp.init()
x = wp.array(np.zeros(5, dtype=np.float32), dtype=float, device="cpu")
wp.launch(add_one, dim=5, inputs=[x], device="cpu")
print(x.numpy())  # [1. 1. 1. 1. 1.]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Linux and macOS builds when the source path contains spaces.
  * Improved handling of spaces in linker, strip, library, version script, and output file paths.
  * Builds from source now more reliably locate required libraries and generate output files in directories with spaces in their names.

* **Documentation**
  * Added a changelog entry describing the build fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->