### PR TITLE
Preserve the transform dtype when reading p and q

### DIFF
--- a/changelog/+transform-component-dtype.fixed.md
+++ b/changelog/+transform-component-dtype.fixed.md
@@ -1,0 +1,7 @@
+Fix reading the `p` and `q` components of a transformation from Python, which always returned `vec3f` and `quatf`
+regardless of the transform's own `dtype`. Reading a component of a `wp.transformd` rounded it to `float32`, so
+`t.p = t.p` silently discarded precision the transform still held. Components now carry the transform's scalar type,
+matching what `wp.transform_get_translation()` and `wp.transform_get_rotation()` already return in kernels.
+`wp.transformf` components are unchanged; for `wp.transformd` and `wp.transformh`, `isinstance(t.p, wp.vec3f)` is no
+longer true and `t.p[0]` is now a Warp scalar rather than a Python `float`, matching what `t[0]` already returned.
+Wrap it in `float()` where a Python `float` is required.

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -1666,6 +1666,26 @@ class quatd(quaternion(dtype=float64)):
 
 
 @functools.cache
+def _named_type(base_type):
+    """Return the named counterpart of a vector or quaternion base type, if there is one.
+
+    ``vector()`` and ``quaternion()`` build the base classes that named types such as ``vec3f``
+    and ``quatf`` derive from, so handing out a base class where a named one exists would break
+    ``isinstance(x, wp.vec3f)`` for callers. Combinations without a named counterpart, such as
+    ``bfloat16`` components, fall back to ``base_type``.
+
+    The lookup covers every entry of ``vector_types``, so it also resolves matrix, transform and
+    spatial base types. ``vector_types`` is declared further down this module, which is why the
+    lookup cannot run any earlier than the first call.
+    """
+    for cls in vector_types:
+        if base_type in cls.__bases__:
+            return cls
+
+    return base_type
+
+
+@functools.cache
 def transformation(dtype=Any):
     """Create a rigid-body transformation type with the given data type."""
 
@@ -1770,9 +1790,9 @@ def transformation(dtype=Any):
 
         def __getattr__(self, name):
             if name == "p":
-                return vec3(self[0:3])
+                return _named_type(vector(length=3, dtype=dtype))(self[0:3])
             elif name == "q":
-                return quat(self[3:7])
+                return _named_type(quaternion(dtype=dtype))(self[3:7])
             else:
                 return self.__getattribute__(name)
 

--- a/warp/tests/test_spatial.py
+++ b/warp/tests/test_spatial.py
@@ -2932,6 +2932,68 @@ class TestSpatial(unittest.TestCase):
             ):
                 transform_type(*components, pos=(8.0, 9.0, 10.0))
 
+    def test_transform_component_dtype(self):
+        """Reading `p`/`q` must carry the transform's own dtype instead of always narrowing to float32."""
+        component_types = {
+            wp.transformh: (wp.vec3h, wp.quath),
+            wp.transformf: (wp.vec3f, wp.quatf),
+            wp.transformd: (wp.vec3d, wp.quatd),
+        }
+
+        # Each row builds its own transform so that one dtype failing to construct
+        # is reported against its own subtest instead of ending the whole test.
+        for transform_type, (vec3_type, quat_type) in component_types.items():
+            type_name = transform_type.__name__
+
+            # The named types are handed back as they are, so `isinstance` checks
+            # against them keep working for callers.
+            with self.subTest(type=type_name, component="p"):
+                p = transform_type((1.0, 2.0, 3.0), (0.0, 0.0, 0.0, 1.0)).p
+                self.assertIs(type(p), vec3_type)
+                self.assertIsInstance(p, vec3_type)
+                self.assertEqual([float(x) for x in p], [1.0, 2.0, 3.0])
+
+            with self.subTest(type=type_name, component="q"):
+                q = transform_type((1.0, 2.0, 3.0), (0.0, 0.0, 0.0, 1.0)).q
+                self.assertIs(type(q), quat_type)
+                self.assertIsInstance(q, quat_type)
+                self.assertEqual([float(x) for x in q], [0.0, 0.0, 0.0, 1.0])
+
+        # Types built through `transformation(dtype=...)` resolve to the same
+        # named components as the named transform types do.
+        with self.subTest(type="generic"):
+            generic_type = wp.types.transformation(dtype=wp.float64)
+            t = generic_type((1.0, 2.0, 3.0), (0.0, 0.0, 0.0, 1.0))
+            self.assertIs(type(t.p), wp.vec3d)
+            self.assertIs(type(t.q), wp.quatd)
+
+        # A dtype with no named quaternion counterpart takes the fallback, so one
+        # transform covers both halves: `p` resolves to the named `vec3i` and `q`
+        # comes back as the base class `quaternion()` builds.
+        with self.subTest(type="generic", dtype="int32"):
+            generic_type = wp.types.transformation(dtype=wp.int32)
+            t = generic_type((1, 2, 3), (0, 0, 0, 1))
+            self.assertIs(type(t.p), wp.vec3i)
+            self.assertIs(type(t.q), wp.types.quaternion(dtype=wp.int32))
+            self.assertEqual([int(x) for x in t.p], [1, 2, 3])
+            self.assertEqual([int(x) for x in t.q], [0, 0, 0, 1])
+
+        # A value that survives float64 but not float32, so a component read that
+        # narrowed to float32 rounded it away, and writing the component back
+        # persisted that loss into the transform.
+        value = 1.0000000000009095
+
+        with self.subTest(type="transformd", form="read"):
+            t = wp.transformd((value, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0))
+            self.assertEqual(t.p[0], value)
+
+        with self.subTest(type="transformd", form="read/modify/write"):
+            t = wp.transformd((value, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0))
+            t.p = t.p
+            t.q = t.q
+            self.assertEqual(t[0], value)
+            self.assertEqual(t[6], 1.0)
+
     def test_transform_constructor_invalid_kernel_arity(self):
         """Verify that unsupported argument counts must be reported, not reach an internal error."""
 


### PR DESCRIPTION
## Description

Reading `p` or `q` on a `wp.transformd` silently destroys data. The getter narrows the component to `float32` while the setter honors the transform's `dtype`, so a read modify write round trip writes the narrowed value back. On a transform holding `1.0000000000009095`, `t[0]` gives `1.0000000000009095` but `t.p[0]` gives `1`, and after `t.p = t.p` the transform itself gives `1`. Nothing raises. Reproducer under Bug fix below.

`transformation()` in `warp/_src/types.py` builds both getters from the module level aliases `vec3` and `quat`, which are bound to `vec3f` and `quatf`, so the component type never depends on `dtype`. The `__setattr__` eight lines below uses `vector(length=3, dtype=dtype)` and `quaternion(dtype=dtype)` and is correct. That asymmetry is what turns a lossy read into a destructive write. `wp.transformh` components are typed wrong too, though float16 to float32 is lossless, so only the type is wrong there.

The kernel builtins already carry the dtype. `transform_get_translation` resolves `vector(length=3, dtype=float_infer_type(arg_types))` and `transform_get_rotation` resolves `quaternion(dtype=...)`, and the first one's docstring names `xform.p` and promises "a 3D vector of the same scalar type as `xform`". Python scope is the odd one out. The stubs point the same way, though less directly: they annotate the constructor as `transformd.__init__(self, p: vec3d, q: quatd)` and do not annotate the attributes at all.

Same family as GH-1839, different mechanism. #1882 fixes that one in `warp/_src/context.py` and leaves these getters alone, so the two do not overlap. I found no issue for this one.

## Changes

- `warp/_src/types.py`: resolve the component type from the transform's own `dtype` in `__getattr__`. A cached `_named_type()` helper returns the named class when one exists and the base class otherwise.
- `warp/tests/test_spatial.py`: add `test_transform_component_dtype`, covering component type and `isinstance` for `float16`, `float32` and `float64`, the generic `transformation(dtype=...)` type in both a named and an unnamed form, and a `float64` read modify write round trip.
- `changelog/+transform-component-dtype.fixed.md`: add a fragment.

Mirroring the setter with a bare `vector(length=3, dtype=dtype)` would regress the float32 majority: that call returns the base class `vec3f` derives from, not `vec3f` itself, so `isinstance(t.p, wp.vec3f)` flips to `False` on a default transform. I measured that before ruling it out. Resolving the named type keeps `wp.transformf` exactly as it is today, identity and `isinstance` included. The fallback is load bearing, since `transformation(dtype=bfloat16)` is constructible and no `vec3bf` exists. The lookup keys on the base class against the existing `vector_types` tuple, so later additions come for free and `vec4f` cannot collide with `quatf` the way a length plus scalar key would. Both `vector()` and `_named_type()` are cached; the added lookup measures 167 ns against 5684 ns for the whole of `t.p`, under 3%.

For `wp.transformd` and `wp.transformh`, two things change beyond the precision fix. `isinstance(t.p, wp.vec3f)` becomes `False`, and `t.p[0]` becomes a Warp scalar rather than a Python `float`, so it no longer takes a `float` format spec or `json.dumps`. Both were already true of `t[0]` and of `wp.vec3d(...)[0]`, so this aligns the component with the rest of the type rather than inventing a convention, and the fragment carries the migration note. A non float `dtype` shifts too: `transformation(dtype=wp.int32)` is not rejected at Python scope, and its `t.p` now reads back as `vec3i` instead of a silently cast `vec3f`. I filed the fragment as `fixed`, following `+builtin-dtype-type-hints.fixed.md` and `1839.fixed.md` for the same defect shape, and I am happy to move it to `changed`.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

I have no native build, so `warp/bin` is empty and `warp/tests/test_spatial.py` cannot be imported at all: it calls `get_test_devices()` at module scope. I extracted `test_transform_component_dtype` from the committed file by AST and ran that method, unmodified, under `unittest`.

- On `main` with only `warp/_src/types.py` reverted: 6 failures and 2 errors. The failures are `vec3f is not vec3d` and `quatf is not quatd` on `wp.transformd`, `vec3f is not vec3d` on the generic `float64` type, `vec3f is not vec3i` on the generic `int32` type, `1.0 != 1.0000000000009095` on the read, and `float64(1.0) != 1.0000000000009095` on the read modify write.
- With the fix applied: 0 failures, the same 2 errors.
- Those 2 errors are the `wp.transformh` rows, which cannot construct here at all, because `float_to_half_bits()` calls into the missing library. Stubbing that one conversion with `numpy` runs them: the baseline then reports 7 failures, adding `vec3f is not vec3h` and `quatf is not quath`, and the fix reports none. So the float16 assertions are exercised, just not against a real half implementation.
- The `wp.transformf` rows pass in every one of those runs. They are the no regression guard behind the float32 guarantee above, not an assertion I relaxed.

Each row builds its own transform inside its own `subTest`, so a dtype that fails to construct is reported on its own row instead of ending the test.

The `int32` row covers both halves of `_named_type()` in one transform: `p` resolves to the named `wp.vec3i`, and `q` takes the fallback, since no named integer quaternion exists. That is the branch the design decision above rests on, so it is worth pinning.

Not run here: any GPU path, the full suite, and `ruff`, which is not installed, though the longest line I add is 106 characters against the configured 120. The transform suites deserve a real run on a real build, and copy-pr-bot holds the NVIDIA runners until a maintainer vets the pull request.

## Bug fix

```python
import warp as wp

t = wp.transformd((1.0000000000009095, 0.0, 0.0), (0.0, 0.0, 0.0, 1.0))

print(type(t.p).__name__)  # vec3f              expected vec3d
print("%.17g" % t[0])      # 1.0000000000009095 the transform holds the value
print("%.17g" % t.p[0])    # 1                  reading the component rounds it

t.p = t.p                  # the setter honors dtype, storing the rounded value
print("%.17g" % t[0])      # 1                  the value is gone
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Transform position and rotation components now preserve their original scalar precision and type when accessed.
  - Double-precision transforms retain precision during component reads and updates.
  - Half-, single-, double-, and integer-based transform components now return correctly typed values.

- **Tests**
  - Added coverage for transform component types, values, precision, and read/modify/write behavior.
  - Expanded validation across supported transform scalar types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->