### PR TITLE
Reject invalid matrix component indices

### DIFF
--- a/changelog/+matrix-component-index-bounds.fixed.md
+++ b/changelog/+matrix-component-index-bounds.fixed.md
@@ -1,0 +1,1 @@
+Reading or writing a matrix component in Python with an out of range row or column now raises `IndexError` instead of silently addressing a neighbouring component.

--- a/warp/_src/types.py
+++ b/warp/_src/types.py
@@ -1347,6 +1347,17 @@ def matrix(shape, dtype):
                 v = converted
             super().__setitem__(slice(col_start, col_end, col_step), v)
 
+        def _component_index(self, row, col):
+            if row < -self._shape_[0] or row >= self._shape_[0]:
+                raise IndexError("Invalid row index")
+            if col < -self._shape_[1] or col >= self._shape_[1]:
+                raise IndexError("Invalid column index")
+            if row < 0:
+                row += self._shape_[0]
+            if col < 0:
+                col += self._shape_[1]
+            return row * self._shape_[1] + col
+
         def __getitem__(self, key):
             if isinstance(key, tuple):
                 # element indexing m[i,j]
@@ -1357,14 +1368,13 @@ def matrix(shape, dtype):
                 ndim = sum(1 for x in key if isinstance(x, slice))
 
                 if ndim == 0:
-                    row = key[0] + self._shape_[0] if key[0] < 0 else key[0]
-                    col = key[1] + self._shape_[1] if key[1] < 0 else key[1]
+                    idx = self._component_index(key[0], key[1])
 
                     if warp.config.legacy_scalar_return_types:
                         # Legacy path before addressing GH-905.
-                        return mat_t.scalar_export(super().__getitem__(row * self._shape_[1] + col))
+                        return mat_t.scalar_export(super().__getitem__(idx))
 
-                    value = mat_t.scalar_export(super().__getitem__(row * self._shape_[1] + col))
+                    value = mat_t.scalar_export(super().__getitem__(idx))
                     if dtype in native_scalar_types:
                         return value
                     return self._wp_scalar_type_(value)
@@ -1426,9 +1436,7 @@ def matrix(shape, dtype):
                             f"The provided value is expected to be a scalar but got an object of shape {v_shape} instead"
                         )
 
-                    row = key[0] + self._shape_[0] if key[0] < 0 else key[0]
-                    col = key[1] + self._shape_[1] if key[1] < 0 else key[1]
-                    idx = row * self._shape_[1] + col
+                    idx = self._component_index(key[0], key[1])
                     super().__setitem__(idx, mat_t.scalar_import(value))
                     return
 

--- a/warp/tests/matrix/test_mat_basics.py
+++ b/warp/tests/matrix/test_mat_basics.py
@@ -93,6 +93,18 @@ def test_components(test, device, dtype):
     test.assertEqual(m[1, 1], 17)
     test.assertEqual(m[1, 2], 18)
 
+    # negative component indices count from the end
+    test.assertEqual(m[-1, -1], 18)
+    test.assertEqual(m[-2, -3], 13)
+
+    # out of range component indices are rejected rather than folding into a
+    # neighbouring component, matching get_row(), get_col() and vector indexing
+    for row, col in ((0, 3), (0, -4), (2, 0), (-3, 0)):
+        with test.assertRaises(IndexError):
+            m[row, col]
+        with test.assertRaises(IndexError):
+            m[row, col] = 0
+
 
 def test_indexing(test, device, dtype, register_kernels=False):
     tol = {


### PR DESCRIPTION
`m[i, j]` normalizes negative indices but never range checks them, then hands the flat offset straight to ctypes. So on a 3x3, `m[0, 3]` returns `m[1, 0]` and `m[0, 3] = 99.0` silently overwrites it. Only indices big enough to push the offset past the whole array happen to trip an IndexError.

```python
m = wp.mat33f(1., 2., 3., 4., 5., 6., 7., 8., 9.)
m[0, 3]         # 4.0, expected IndexError
m[0, -4]        # 9.0
m[0, 3] = 99.0  # silently overwrites m[1, 0]
```

Everywhere else already rejects this. `get_row()` and `get_col()` raise on the same input, vector indexing raises because `vec_t` hands the key to ctypes unchanged, and inside a kernel `wp::extract` asserts on the same bounds in `mat.h`. Python scope element access was the one place without the check, so the guard here matches `get_row()`.

The new assertions go in `test_components` and fail without the change with `IndexError not raised`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Matrix component access now raises `IndexError` when row or column indices are out of range, instead of accessing an unintended neighboring component.
  * Negative row and column indices are supported consistently for both reading and writing matrix elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->