### PR TITLE
Document accepted output layouts for warp.fem.integrate() (GH-1912)

### DIFF
--- a/warp/_src/fem/integrate.py
+++ b/warp/_src/fem/integrate.py
@@ -1929,7 +1929,14 @@ def integrate(
         values: Additional variable values to be passed to the integrand, can be of any type accepted by warp kernel launches. Keys in the dictionary must match integrand parameter names.
         temporary_store: shared pool from which to allocate temporary arrays
         accumulate_dtype: Scalar type to be used for accumulating integration samples
-        output: Sparse matrix or warp array into which to store the result of the integration
+        output: Sparse matrix or warp array into which to store the result of the integration.
+          For linear forms the array must hold at least ``node_count`` rows, where ``node_count`` is the number of
+          nodes in the test field's space partition. If the test field has ``node_dof_count`` degrees of freedom per
+          node, the accepted layouts are: a 1-D array of vectors of length ``node_dof_count``; a 2-D scalar array of
+          shape ``(node_count, node_dof_count)``; or a contiguous 1-D scalar array with at least
+          ``node_count * node_dof_count`` entries, which is interpreted as the flattened 2-D layout. Any other
+          scalar layout (a mismatched last dimension, an undersized or non-contiguous flat array, or more than two
+          dimensions) raises ``RuntimeError`` before the integration is launched.
         output_dtype: Scalar type for returned results if `output` is not provided. If None, defaults to the geometry's scalar type (``wp.float32`` or ``wp.float64``)
         device: Device on which to perform the integration
         kernel_options: Overloaded options to be passed to the kernel builder (e.g, ``{"enable_backward": True}``)


### PR DESCRIPTION
## Description

Follow-up to #1912, where @shi-eric suggested documenting the accepted linear-form output layouts and shape constraints in the `warp.fem.integrate()` docstring after the validation fix landed in c9fb7f1.

The `output` argument description now lists, for a test field with `node_dof_count` degrees of freedom per node, the three accepted layouts: a 1-D array of vectors of length `node_dof_count`, a 2-D scalar array of shape `(node_count, node_dof_count)`, and a contiguous flat scalar array with at least `node_count * node_dof_count` entries (interpreted as the flattened 2-D layout). It also states that any other scalar layout raises `RuntimeError` before the integration is launched, which is what the validation in `integrate.py` now enforces.

Docstring-only change; no code, tests, or changelog fragment. `ruff check` and `ruff format --check` pass on the file.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] I added a changelog fragment if this change affects users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded `integrate()` documentation to clarify supported linear-form array layouts.
  - Documented when a `RuntimeError` is raised for invalid scalar-array shapes, sizes, dimensionality, or memory contiguity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->