### PR TITLE
Add WIP HIP/ROCm shims

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,6 +293,7 @@ transformd = "transformd"
 
 [tool.typos.default.extend-identifiers]
 CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN = "CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN"
+hipDeviceAttributeSharedMemPerBlockOptin = "hipDeviceAttributeSharedMemPerBlockOptin"
 ba = "ba"
 
 [tool.pyright]

--- a/warp/native/cuda_util.h
+++ b/warp/native/cuda_util.h
@@ -9,15 +9,28 @@
 
 #include <vector>
 
+#include <stdio.h>
+
+#if defined(__HIP_PLATFORM_AMD__)
+#include "hip_util.h"
+#else
 #include <cudaTypedefs.h>
 #include <cuda_runtime_api.h>
-#include <stdio.h>
+#endif  // __HIP_PLATFORM_AMD__
+
+#ifndef WP_HAS_MEMCPY_BATCH
+#if defined(__HIP_PLATFORM_AMD__)
+#define WP_HAS_MEMCPY_BATCH (HIP_VERSION >= 70100000)
+#else
+#define WP_HAS_MEMCPY_BATCH (CUDA_VERSION >= 12080)
+#endif  // defined(__HIP_PLATFORM_AMD__)
+#endif  // WP_HAS_MEMCPY_BATCH
 
 #define check_cuda(code) (check_cuda_result(code, __FUNCTION__, __FILE__, __LINE__))
 #define check_cu(code) (check_cu_result(code, __FUNCTION__, __FILE__, __LINE__))
 
 
-#if defined(__CUDACC__)
+#if defined(__CUDACC__) || defined(__HIPCC__)
 #if _DEBUG
 // helper for launching kernels (synchronize + error checking after each kernel)
 #define wp_launch_device(context, kernel, dim, args) { \
@@ -42,7 +55,7 @@
         kernel<<<num_blocks, 256, 0, stream>>>args; \
         end_cuda_range(WP_TIMING_KERNEL_BUILTIN, stream); }}
 #endif  // _DEBUG
-#endif  // defined(__CUDACC__)
+#endif  // defined(__CUDACC__) || defined(__HIPCC__)
 
 
 CUresult cuDriverGetVersion_f(int* version);
@@ -58,7 +71,7 @@ CUresult cuDevicePrimaryCtxRetain_f(CUcontext* ctx, CUdevice dev);
 CUresult cuDevicePrimaryCtxRelease_f(CUdevice dev);
 CUresult cuDeviceCanAccessPeer_f(int* can_access, CUdevice dev, CUdevice peer_dev);
 CUresult cuMemGetInfo_f(size_t* free, size_t* total);
-#if CUDA_VERSION >= 12080
+#if WP_HAS_MEMCPY_BATCH
 // batched memcpy
 CUresult cuMemcpyBatchAsync_f(
     CUdeviceptr* dsts,
@@ -109,7 +122,7 @@ CUresult cuEventQuery_f(CUevent event);
 CUresult cuEventRecord_f(CUevent event, CUstream stream);
 CUresult cuEventRecordWithFlags_f(CUevent event, CUstream stream, unsigned int flags);
 CUresult cuEventSynchronize_f(CUevent event);
-#if CUDA_VERSION >= 12030
+#if defined(__HIP_PLATFORM_AMD__) || CUDA_VERSION >= 12030
 // function used to add conditional graph nodes, not available in older CUDA versions
 CUresult cuGraphAddNode_f(
     CUgraphNode* phGraphNode,

--- a/warp/native/hip_util.h
+++ b/warp/native/hip_util.h
@@ -1,0 +1,689 @@
+// SPDX-FileCopyrightText: 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+#error "hip_util.h should only be included for HIP builds."
+#endif
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
+#include <hip/hiprtc.h>
+
+#ifndef HIP_VERSION
+#if defined(HIP_VERSION_MAJOR) && defined(HIP_VERSION_MINOR) && defined(HIP_VERSION_PATCH)
+#define HIP_VERSION (HIP_VERSION_MAJOR * 10000000 + HIP_VERSION_MINOR * 100000 + HIP_VERSION_PATCH)
+#else
+#define HIP_VERSION 0
+#endif  // defined(HIP_VERSION_MAJOR) && defined(HIP_VERSION_MINOR) && defined(HIP_VERSION_PATCH)
+#endif  // HIP_VERSION
+#ifndef CUDA_VERSION
+#define CUDA_VERSION HIP_VERSION
+#endif  // CUDA_VERSION
+#ifndef NVRTC_SUCCESS
+#define NVRTC_SUCCESS HIPRTC_SUCCESS
+#endif  // NVRTC_SUCCESS
+#ifndef nvrtcGetErrorString
+#define nvrtcGetErrorString hiprtcGetErrorString
+#endif  // nvrtcGetErrorString
+#ifndef nvrtcCreateProgram
+#define nvrtcCreateProgram hiprtcCreateProgram
+#endif  // nvrtcCreateProgram
+#ifndef nvrtcCompileProgram
+#define nvrtcCompileProgram hiprtcCompileProgram
+#endif  // nvrtcCompileProgram
+#ifndef nvrtcDestroyProgram
+#define nvrtcDestroyProgram hiprtcDestroyProgram
+#endif  // nvrtcDestroyProgram
+#ifndef nvrtcGetProgramLogSize
+#define nvrtcGetProgramLogSize hiprtcGetProgramLogSize
+#endif  // nvrtcGetProgramLogSize
+#ifndef nvrtcGetProgramLog
+#define nvrtcGetProgramLog hiprtcGetProgramLog
+#endif  // nvrtcGetProgramLog
+#ifndef nvrtcGetPTXSize
+#define nvrtcGetPTXSize hiprtcGetCodeSize
+#endif  // nvrtcGetPTXSize
+#ifndef nvrtcGetPTX
+#define nvrtcGetPTX hiprtcGetCode
+#endif  // nvrtcGetPTX
+#ifndef nvrtcGetCUBINSize
+#define nvrtcGetCUBINSize hiprtcGetBitcodeSize
+#endif  // nvrtcGetCUBINSize
+#ifndef nvrtcGetCUBIN
+#define nvrtcGetCUBIN hiprtcGetBitcode
+#endif  // nvrtcGetCUBIN
+#if defined(nvrtcGetNumSupportedArchs)
+#undef nvrtcGetNumSupportedArchs
+#endif  // defined(nvrtcGetNumSupportedArchs)
+static inline hiprtcResult nvrtcGetNumSupportedArchs(int* count)
+{
+    if (count) {
+        *count = 0;
+    }
+    return HIPRTC_SUCCESS;
+}
+
+#if defined(nvrtcGetSupportedArchs)
+#undef nvrtcGetSupportedArchs
+#endif  // defined(nvrtcGetSupportedArchs)
+static inline hiprtcResult nvrtcGetSupportedArchs(int* archs)
+{
+    (void)archs;
+    return HIPRTC_SUCCESS;
+}
+#ifndef nvrtcVersion
+#define nvrtcVersion hiprtcVersion
+#endif  // nvrtcVersion
+#ifndef CUDAAPI
+#define CUDAAPI
+#endif  // CUDAAPI
+#if defined(CUDART_CB)
+#undef CUDART_CB
+#endif  // defined(CUDART_CB)
+#define CUDART_CB
+#ifndef CU_GET_PROC_ADDRESS_DEFAULT
+#define CU_GET_PROC_ADDRESS_DEFAULT 0
+#endif  // CU_GET_PROC_ADDRESS_DEFAULT
+#ifndef CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE
+#define CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE HIP_POINTER_ATTRIBUTE_MEMPOOL_HANDLE
+#endif  // CU_POINTER_ATTRIBUTE_MEMPOOL_HANDLE
+#ifndef CU_POINTER_ATTRIBUTE_IS_MANAGED
+#define CU_POINTER_ATTRIBUTE_IS_MANAGED HIP_POINTER_ATTRIBUTE_IS_MANAGED
+#endif  // CU_POINTER_ATTRIBUTE_IS_MANAGED
+#ifndef CU_POINTER_ATTRIBUTE_MEMORY_TYPE
+#define CU_POINTER_ATTRIBUTE_MEMORY_TYPE HIP_POINTER_ATTRIBUTE_MEMORY_TYPE
+#endif  // CU_POINTER_ATTRIBUTE_MEMORY_TYPE
+#ifndef CU_IPC_HANDLE_SIZE
+#define CU_IPC_HANDLE_SIZE sizeof(CUipcMemHandle)
+#endif  // CU_IPC_HANDLE_SIZE
+#ifndef CUDA_SUCCESS
+#define CUDA_SUCCESS hipSuccess
+#endif  // CUDA_SUCCESS
+#ifndef cudaErrorInvalidValue
+#define cudaErrorInvalidValue hipErrorInvalidValue
+#endif  // cudaErrorInvalidValue
+#ifndef cudaSuccess
+#define cudaSuccess hipSuccess
+#endif  // cudaSuccess
+#ifndef cudaGetErrorString
+#define cudaGetErrorString hipGetErrorString
+#endif  // cudaGetErrorString
+#ifndef cudaGetLastError
+#define cudaGetLastError hipGetLastError
+#endif  // cudaGetLastError
+#ifndef cudaDeviceSynchronize
+#define cudaDeviceSynchronize hipDeviceSynchronize
+#endif  // cudaDeviceSynchronize
+#ifndef cudaGetDevice
+#define cudaGetDevice hipGetDevice
+#endif  // cudaGetDevice
+#ifndef cudaGetDeviceCount
+#define cudaGetDeviceCount hipGetDeviceCount
+#endif  // cudaGetDeviceCount
+#ifndef cudaGetDeviceProperties
+#define cudaGetDeviceProperties hipGetDeviceProperties
+#endif  // cudaGetDeviceProperties
+#ifndef cudaDeviceCanAccessPeer
+#define cudaDeviceCanAccessPeer hipDeviceCanAccessPeer
+#endif  // cudaDeviceCanAccessPeer
+#ifndef cudaPointerGetAttributes
+#define cudaPointerGetAttributes hipPointerGetAttributes
+#endif  // cudaPointerGetAttributes
+#ifndef cudaMemcpy
+#define cudaMemcpy hipMemcpy
+#endif  // cudaMemcpy
+#ifndef cudaMemcpyAsync
+#define cudaMemcpyAsync hipMemcpyAsync
+#endif  // cudaMemcpyAsync
+#ifndef cudaMemcpyDeviceToDevice
+#define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
+#endif  // cudaMemcpyDeviceToDevice
+#ifndef cudaMemcpyDeviceToHost
+#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+#endif  // cudaMemcpyDeviceToHost
+#ifndef cudaMemcpyHostToDevice
+#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+#endif  // cudaMemcpyHostToDevice
+#ifndef cudaMemcpyHostToHost
+#define cudaMemcpyHostToHost hipMemcpyHostToHost
+#endif  // cudaMemcpyHostToHost
+#ifndef cudaMemcpyDefault
+#define cudaMemcpyDefault hipMemcpyDefault
+#endif  // cudaMemcpyDefault
+#ifndef cudaMemset
+#define cudaMemset hipMemset
+#endif  // cudaMemset
+#ifndef cudaMemsetAsync
+#define cudaMemsetAsync hipMemsetAsync
+#endif  // cudaMemsetAsync
+#ifndef cudaMalloc
+#define cudaMalloc hipMalloc
+#endif  // cudaMalloc
+#ifndef cudaMallocHost
+#define cudaMallocHost hipHostMalloc
+#endif  // cudaMallocHost
+#ifndef cudaFree
+#define cudaFree hipFree
+#endif  // cudaFree
+#ifndef cudaFreeHost
+#define cudaFreeHost hipHostFree
+#endif  // cudaFreeHost
+#ifndef cudaMallocManaged
+#define cudaMallocManaged hipMallocManaged
+#endif  // cudaMallocManaged
+#ifndef cudaMallocAsync
+#define cudaMallocAsync hipMallocAsync
+#endif  // cudaMallocAsync
+#ifndef cudaFreeAsync
+#define cudaFreeAsync hipFreeAsync
+#endif  // cudaFreeAsync
+#ifndef cudaDeviceGetDefaultMemPool
+#define cudaDeviceGetDefaultMemPool hipDeviceGetDefaultMemPool
+#endif  // cudaDeviceGetDefaultMemPool
+#ifndef cudaMemPoolSetAttribute
+#define cudaMemPoolSetAttribute hipMemPoolSetAttribute
+#endif  // cudaMemPoolSetAttribute
+#ifndef cudaMemPoolGetAttribute
+#define cudaMemPoolGetAttribute hipMemPoolGetAttribute
+#endif  // cudaMemPoolGetAttribute
+#ifndef cudaMemPoolGetAccess
+#define cudaMemPoolGetAccess hipMemPoolGetAccess
+#endif  // cudaMemPoolGetAccess
+#ifndef cudaMemPoolSetAccess
+#define cudaMemPoolSetAccess hipMemPoolSetAccess
+#endif  // cudaMemPoolSetAccess
+#ifndef cudaStreamSynchronize
+#define cudaStreamSynchronize hipStreamSynchronize
+#endif  // cudaStreamSynchronize
+#ifndef cudaStreamIsCapturing
+#define cudaStreamIsCapturing hipStreamIsCapturing
+#endif  // cudaStreamIsCapturing
+#ifndef cudaStreamBeginCapture
+#define cudaStreamBeginCapture hipStreamBeginCapture
+#endif  // cudaStreamBeginCapture
+#ifndef cudaStreamBeginCaptureToGraph
+#define cudaStreamBeginCaptureToGraph hipStreamBeginCaptureToGraph
+#endif  // cudaStreamBeginCaptureToGraph
+#ifndef cudaStreamEndCapture
+#define cudaStreamEndCapture hipStreamEndCapture
+#endif  // cudaStreamEndCapture
+#ifndef cudaStreamSetCaptureDependencies
+#define cudaStreamSetCaptureDependencies 0
+#endif  // cudaStreamSetCaptureDependencies
+#ifndef cudaEventCreate
+#define cudaEventCreate hipEventCreate
+#endif  // cudaEventCreate
+#ifndef cudaEventRecord
+#define cudaEventRecord hipEventRecord
+#endif  // cudaEventRecord
+#ifndef cudaEventSynchronize
+#define cudaEventSynchronize hipEventSynchronize
+#endif  // cudaEventSynchronize
+#ifndef cudaEventElapsedTime
+#define cudaEventElapsedTime hipEventElapsedTime
+#endif  // cudaEventElapsedTime
+#ifndef cudaEventDestroy
+#define cudaEventDestroy hipEventDestroy
+#endif  // cudaEventDestroy
+#ifndef cudaMemAdvise
+#define cudaMemAdvise hipMemAdvise
+#endif  // cudaMemAdvise
+#ifndef cudaMemPrefetchAsync
+#define cudaMemPrefetchAsync hipMemPrefetchAsync
+#endif  // cudaMemPrefetchAsync
+#ifndef cudaFuncSetAttribute
+#define cudaFuncSetAttribute hipFuncSetAttribute
+#endif  // cudaFuncSetAttribute
+#ifndef cudaFuncAttributeMaxDynamicSharedMemorySize
+#define cudaFuncAttributeMaxDynamicSharedMemorySize hipFuncAttributeMaxDynamicSharedMemorySize
+#endif  // cudaFuncAttributeMaxDynamicSharedMemorySize
+#ifndef CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
+#define CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
+#endif  // CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES
+#ifndef CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES
+#define CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES HIP_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES
+#endif  // CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES
+#ifndef CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK
+#define CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK HIP_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK
+#endif  // CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK
+#ifndef CU_FUNC_ATTRIBUTE_NUM_REGS
+#define CU_FUNC_ATTRIBUTE_NUM_REGS HIP_FUNC_ATTRIBUTE_NUM_REGS
+#endif  // CU_FUNC_ATTRIBUTE_NUM_REGS
+#ifndef CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES
+#define CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES HIP_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES
+#endif  // CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES
+#ifndef cudaCpuDeviceId
+#define cudaCpuDeviceId hipCpuDeviceId
+#endif  // cudaCpuDeviceId
+#ifndef cudaInvalidDeviceId
+#define cudaInvalidDeviceId hipInvalidDeviceId
+#endif  // cudaInvalidDeviceId
+#ifndef cudaGraphDestroy
+#define cudaGraphDestroy hipGraphDestroy
+#endif  // cudaGraphDestroy
+#ifndef cudaGraphExecDestroy
+#define cudaGraphExecDestroy hipGraphExecDestroy
+#endif  // cudaGraphExecDestroy
+#ifndef cudaGraphAddMemFreeNode
+#define cudaGraphAddMemFreeNode hipGraphAddMemFreeNode
+#endif  // cudaGraphAddMemFreeNode
+#ifndef cudaGraphAddMemcpyNode1D
+#define cudaGraphAddMemcpyNode1D hipGraphAddMemcpyNode1D
+#endif  // cudaGraphAddMemcpyNode1D
+
+#ifndef CU_STREAM_ADD_CAPTURE_DEPENDENCIES
+#define CU_STREAM_ADD_CAPTURE_DEPENDENCIES 0
+#endif  // CU_STREAM_ADD_CAPTURE_DEPENDENCIES
+#ifndef CU_STREAM_CAPTURE_STATUS_NONE
+#define CU_STREAM_CAPTURE_STATUS_NONE hipStreamCaptureStatusNone
+#endif  // CU_STREAM_CAPTURE_STATUS_NONE
+#ifndef CU_STREAM_CAPTURE_STATUS_ACTIVE
+#define CU_STREAM_CAPTURE_STATUS_ACTIVE hipStreamCaptureStatusActive
+#endif  // CU_STREAM_CAPTURE_STATUS_ACTIVE
+#ifndef cudaGraphExecMemcpyNodeSetParams1D
+#define cudaGraphExecMemcpyNodeSetParams1D hipGraphExecMemcpyNodeSetParams1D
+#endif  // cudaGraphExecMemcpyNodeSetParams1D
+#ifndef cudaGraphInstantiateWithFlags
+#define cudaGraphInstantiateWithFlags hipGraphInstantiateWithFlags
+#endif  // cudaGraphInstantiateWithFlags
+#ifndef cudaGraphUpload
+#define cudaGraphUpload hipGraphUpload
+#endif  // cudaGraphUpload
+#ifndef cudaGraphLaunch
+#define cudaGraphLaunch hipGraphLaunch
+#endif  // cudaGraphLaunch
+#ifndef cudaGraphGetNodes
+#define cudaGraphGetNodes hipGraphGetNodes
+#endif  // cudaGraphGetNodes
+#ifndef cudaGraphChildGraphNodeGetGraph
+#define cudaGraphChildGraphNodeGetGraph hipGraphChildGraphNodeGetGraph
+#endif  // cudaGraphChildGraphNodeGetGraph
+#ifndef cudaGraphAddChildGraphNode
+#define cudaGraphAddChildGraphNode hipGraphAddChildGraphNode
+#endif  // cudaGraphAddChildGraphNode
+#ifndef cudaGraphDebugDotPrint
+#define cudaGraphDebugDotPrint hipGraphDebugDotPrint
+#endif  // cudaGraphDebugDotPrint
+#ifndef cudaUserObjectCreate
+#define cudaUserObjectCreate hipUserObjectCreate
+#endif  // cudaUserObjectCreate
+#ifndef cudaGraphRetainUserObject
+#define cudaGraphRetainUserObject hipGraphRetainUserObject
+#endif  // cudaGraphRetainUserObject
+#ifndef cudaStreamSetCaptureDependencies
+#define cudaStreamSetCaptureDependencies hipStreamSetCaptureDependencies
+#endif  // cudaStreamSetCaptureDependencies
+
+#ifndef cudaGraphInstantiateFlagAutoFreeOnLaunch
+#define cudaGraphInstantiateFlagAutoFreeOnLaunch hipGraphInstantiateFlagAutoFreeOnLaunch
+#endif  // cudaGraphInstantiateFlagAutoFreeOnLaunch
+#ifndef cudaGraphUserObjectMove
+#define cudaGraphUserObjectMove hipGraphUserObjectMove
+#endif  // cudaGraphUserObjectMove
+#ifndef cudaUserObjectNoDestructorSync
+#define cudaUserObjectNoDestructorSync hipUserObjectNoDestructorSync
+#endif  // cudaUserObjectNoDestructorSync
+#ifndef cudaMemPoolAttrReleaseThreshold
+#define cudaMemPoolAttrReleaseThreshold hipMemPoolAttrReleaseThreshold
+#endif  // cudaMemPoolAttrReleaseThreshold
+#ifndef cudaMemPoolAttrUsedMemCurrent
+#define cudaMemPoolAttrUsedMemCurrent hipMemPoolAttrUsedMemCurrent
+#endif  // cudaMemPoolAttrUsedMemCurrent
+#ifndef cudaMemPoolAttrUsedMemHigh
+#define cudaMemPoolAttrUsedMemHigh hipMemPoolAttrUsedMemHigh
+#endif  // cudaMemPoolAttrUsedMemHigh
+#ifndef cudaMemAccessFlagsProtNone
+#define cudaMemAccessFlagsProtNone hipMemAccessFlagsProtNone
+#endif  // cudaMemAccessFlagsProtNone
+#ifndef cudaMemAccessFlagsProtReadWrite
+#define cudaMemAccessFlagsProtReadWrite hipMemAccessFlagsProtReadWrite
+#endif  // cudaMemAccessFlagsProtReadWrite
+#ifndef cudaMemLocationTypeDevice
+#define cudaMemLocationTypeDevice hipMemLocationTypeDevice
+#endif  // cudaMemLocationTypeDevice
+#ifndef cudaStreamCaptureStatusNone
+#define cudaStreamCaptureStatusNone hipStreamCaptureStatusNone
+#endif  // cudaStreamCaptureStatusNone
+#ifndef cudaStreamCaptureStatusActive
+#define cudaStreamCaptureStatusActive hipStreamCaptureStatusActive
+#endif  // cudaStreamCaptureStatusActive
+#ifndef cudaStreamCaptureModeThreadLocal
+#define cudaStreamCaptureModeThreadLocal hipStreamCaptureModeThreadLocal
+#endif  // cudaStreamCaptureModeThreadLocal
+#ifndef cudaStreamCaptureModeRelaxed
+#define cudaStreamCaptureModeRelaxed hipStreamCaptureModeRelaxed
+#endif  // cudaStreamCaptureModeRelaxed
+#ifndef cudaThreadExchangeStreamCaptureMode
+#define cudaThreadExchangeStreamCaptureMode hipThreadExchangeStreamCaptureMode
+#endif  // cudaThreadExchangeStreamCaptureMode
+#ifndef cudaStreamCaptureModeGlobal
+#define cudaStreamCaptureModeGlobal hipStreamCaptureModeGlobal
+#endif  // cudaStreamCaptureModeGlobal
+#ifndef cudaStreamGetFlags
+#define cudaStreamGetFlags hipStreamGetFlags
+#endif  // cudaStreamGetFlags
+#ifndef cudaStreamNonBlocking
+#define cudaStreamNonBlocking hipStreamNonBlocking
+#endif  // cudaStreamNonBlocking
+#ifndef CU_STREAM_SET_CAPTURE_DEPENDENCIES
+#define CU_STREAM_SET_CAPTURE_DEPENDENCIES hipStreamSetCaptureDependencies
+#endif  // CU_STREAM_SET_CAPTURE_DEPENDENCIES
+
+// Managed-memory attach flag and graph-memory attribute queries.
+#ifndef cudaMemAttachGlobal
+#define cudaMemAttachGlobal hipMemAttachGlobal
+#endif  // cudaMemAttachGlobal
+#ifndef cudaGraphAddEmptyNode
+#define cudaGraphAddEmptyNode hipGraphAddEmptyNode
+#endif  // cudaGraphAddEmptyNode
+#ifndef cudaGraphMemAttrUsedMemCurrent
+#define cudaGraphMemAttrUsedMemCurrent hipGraphMemAttrUsedMemCurrent
+#endif  // cudaGraphMemAttrUsedMemCurrent
+#ifndef cudaDeviceGetGraphMemAttribute
+#define cudaDeviceGetGraphMemAttribute hipDeviceGetGraphMemAttribute
+#endif  // cudaDeviceGetGraphMemAttribute
+#ifndef cudaDeviceGraphMemTrim
+#define cudaDeviceGraphMemTrim hipDeviceGraphMemTrim
+#endif  // cudaDeviceGraphMemTrim
+
+// Process-unique stream id query (used by get_stream_id).
+#ifndef cudaStreamGetId
+#define cudaStreamGetId hipStreamGetId
+#endif  // cudaStreamGetId
+
+// Graph memory alloc/free node introspection (used by graph_alloc_query).
+#ifndef CU_GRAPH_NODE_TYPE_MEM_ALLOC
+#define CU_GRAPH_NODE_TYPE_MEM_ALLOC hipGraphNodeTypeMemAlloc
+#endif  // CU_GRAPH_NODE_TYPE_MEM_ALLOC
+#ifndef CU_GRAPH_NODE_TYPE_MEM_FREE
+#define CU_GRAPH_NODE_TYPE_MEM_FREE hipGraphNodeTypeMemFree
+#endif  // CU_GRAPH_NODE_TYPE_MEM_FREE
+#ifndef cudaMemAllocNodeParams
+#define cudaMemAllocNodeParams hipMemAllocNodeParams
+#endif  // cudaMemAllocNodeParams
+#ifndef cudaGraphMemAllocNodeGetParams
+#define cudaGraphMemAllocNodeGetParams hipGraphMemAllocNodeGetParams
+#endif  // cudaGraphMemAllocNodeGetParams
+#ifndef cudaGraphMemFreeNodeGetParams
+#define cudaGraphMemFreeNodeGetParams hipGraphMemFreeNodeGetParams
+#endif  // cudaGraphMemFreeNodeGetParams
+
+// Cluster launch config type (used only in wrapper signatures; clusters are
+// unsupported on HIP, so the wrappers return an error without dereferencing it).
+#ifndef CUlaunchConfig
+#define CUlaunchConfig hipLaunchConfig_t
+#endif  // CUlaunchConfig
+
+#ifndef CUDA_ERROR_INVALID_VALUE
+#define CUDA_ERROR_INVALID_VALUE hipErrorInvalidValue
+#endif  // CUDA_ERROR_INVALID_VALUE
+#ifndef CUDA_ERROR_NOT_INITIALIZED
+#define CUDA_ERROR_NOT_INITIALIZED hipErrorNotInitialized
+#endif  // CUDA_ERROR_NOT_INITIALIZED
+#ifndef CUDA_ERROR_NOT_READY
+#define CUDA_ERROR_NOT_READY hipErrorNotReady
+#endif  // CUDA_ERROR_NOT_READY
+#ifndef CUDA_ERROR_NOT_SUPPORTED
+#define CUDA_ERROR_NOT_SUPPORTED hipErrorNotSupported
+#endif  // CUDA_ERROR_NOT_SUPPORTED
+#ifndef CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED
+#define CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED hipErrorPeerAccessAlreadyEnabled
+#endif  // CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED
+#ifndef CUDA_ERROR_PEER_ACCESS_NOT_ENABLED
+#define CUDA_ERROR_PEER_ACCESS_NOT_ENABLED hipErrorPeerAccessNotEnabled
+#endif  // CUDA_ERROR_PEER_ACCESS_NOT_ENABLED
+#ifndef cudaErrorCallRequiresNewerDriver
+#define cudaErrorCallRequiresNewerDriver hipErrorCallRequiresNewerDriver
+#endif  // cudaErrorCallRequiresNewerDriver
+#ifndef CU_STREAM_DEFAULT
+#define CU_STREAM_DEFAULT hipStreamDefault
+#endif  // CU_STREAM_DEFAULT
+#ifndef CU_EVENT_DEFAULT
+#define CU_EVENT_DEFAULT hipEventDefault
+#endif  // CU_EVENT_DEFAULT
+#ifndef CU_EVENT_DISABLE_TIMING
+#define CU_EVENT_DISABLE_TIMING hipEventDisableTiming
+#endif  // CU_EVENT_DISABLE_TIMING
+#ifndef CU_EVENT_RECORD_DEFAULT
+#define CU_EVENT_RECORD_DEFAULT 0
+#endif  // CU_EVENT_RECORD_DEFAULT
+#ifndef CU_EVENT_WAIT_DEFAULT
+#define CU_EVENT_WAIT_DEFAULT 0
+#endif  // CU_EVENT_WAIT_DEFAULT
+#ifndef CU_EVENT_RECORD_EXTERNAL
+#define CU_EVENT_RECORD_EXTERNAL 0
+#endif  // CU_EVENT_RECORD_EXTERNAL
+#ifndef CU_EVENT_WAIT_EXTERNAL
+#define CU_EVENT_WAIT_EXTERNAL 0
+#endif  // CU_EVENT_WAIT_EXTERNAL
+#ifndef CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS
+#define CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS 0
+#endif  // CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS
+#ifndef WP_HAS_MEMCPY_BATCH
+#define WP_HAS_MEMCPY_BATCH (HIP_VERSION >= 70100000)
+#endif  // WP_HAS_MEMCPY_BATCH
+
+#ifndef CU_MEMCPY_SRC_ACCESS_ORDER_STREAM
+#if WP_HAS_MEMCPY_BATCH
+#define CU_MEMCPY_SRC_ACCESS_ORDER_STREAM hipMemcpySrcAccessOrderStream
+#else
+#define CU_MEMCPY_SRC_ACCESS_ORDER_STREAM 0
+#endif  // WP_HAS_MEMCPY_BATCH
+#endif  // CU_MEMCPY_SRC_ACCESS_ORDER_STREAM
+
+using cudaError_t = hipError_t;
+using cudaStream_t = hipStream_t;
+using cudaEvent_t = hipEvent_t;
+using cudaDeviceProp = hipDeviceProp_t;
+using cudaPointerAttributes = hipPointerAttribute_t;
+using cudaMemcpyKind = hipMemcpyKind;
+using cudaMemoryAdvise = hipMemoryAdvise;
+using cudaStreamCaptureStatus = hipStreamCaptureStatus;
+using cudaStreamCaptureMode = hipStreamCaptureMode;
+using cudaGraph_t = hipGraph_t;
+using cudaGraphNode_t = hipGraphNode_t;
+using cudaGraphExec_t = hipGraphExec_t;
+using cudaMemPool_t = hipMemPool_t;
+using CUmemoryPool = hipMemPool_t;
+using cudaMemAccessFlags = hipMemAccessFlags;
+using cudaMemLocation = hipMemLocation;
+using cudaMemAccessDesc = hipMemAccessDesc;
+using cudaUserObject_t = hipUserObject_t;
+using cudaResourceDesc = hipResourceDesc;
+using cudaArray_t = hipArray_t;
+using cudaSurfaceObject_t = hipSurfaceObject_t;
+#ifndef cudaResourceTypeArray
+#define cudaResourceTypeArray hipResourceTypeArray
+#endif  // cudaResourceTypeArray
+#ifndef cudaCreateSurfaceObject
+#define cudaCreateSurfaceObject hipCreateSurfaceObject
+#endif  // cudaCreateSurfaceObject
+#ifndef cudaDestroySurfaceObject
+#define cudaDestroySurfaceObject hipDestroySurfaceObject
+#endif  // cudaDestroySurfaceObject
+using nvrtcProgram = hiprtcProgram;
+using nvrtcResult = hiprtcResult;
+using CUresult = hipError_t;
+using CUdevice = hipDevice_t;
+struct HipContext {
+    int device;
+};
+using CUcontext = HipContext*;
+using CUstream = hipStream_t;
+using CUevent = hipEvent_t;
+using CUmodule = hipModule_t;
+using CUfunction = hipFunction_t;
+using CUdeviceptr = hipDeviceptr_t;
+using CUuuid = hipUUID;
+using CUdevice_attribute = hipDeviceAttribute_t;
+using CUipcEventHandle = hipIpcEventHandle_t;
+using CUipcMemHandle = hipIpcMemHandle_t;
+using cuuint64_t = uint64_t;
+using CUgraphicsResource = hipGraphicsResource_t;
+using CUarray = hipArray_t;
+using CUmipmappedArray = hipMipmappedArray_t;
+using CUtexObject = hipTextureObject_t;
+using CUgraph = hipGraph_t;
+using CUgraphNode = hipGraphNode_t;
+using CUgraphNodeType = hipGraphNodeType;
+using CUgraphNodeParams = void;
+using CUgraphEdgeData = void;
+using CUstreamCaptureStatus = hipStreamCaptureStatus;
+using CUjit_option = int;
+using CUpointer_attribute = hipPointer_attribute;
+// Warp uses the driver-style function-attribute API (cuFuncGetAttribute /
+// cuFuncSetAttribute), which is keyed on the driver enum hipFunction_attribute
+// (HIP_FUNC_ATTRIBUTE_*), not the runtime enum hipFuncAttribute.
+using CUfunction_attribute = hipFunction_attribute;
+using CUgraphExec = hipGraphExec_t;
+// HIP has no equivalent of the CUDA `CUoccupancyB2DSize` callback (the only HIP
+// equivalents take a fixed `size_t` shared-memory size). Provide a stub typedef
+// so call sites that reference the type compile under HIP; HIP code paths must
+// ignore the callback (see cuOccupancyMaxPotentialBlockSize_f).
+typedef size_t(CUDAAPI* CUoccupancyB2DSize)(int blockSize);
+#if HIP_VERSION >= 70100000
+using CUmemcpyAttributes = hipMemcpyAttributes;
+#else
+struct CUmemcpyAttributes {
+    int dummy;
+};
+#endif  // HIP_VERSION >= 70100000
+using CUDA_ARRAY_DESCRIPTOR = HIP_ARRAY_DESCRIPTOR;
+using CUDA_ARRAY3D_DESCRIPTOR = HIP_ARRAY3D_DESCRIPTOR;
+#if HIP_VERSION >= 70000000
+using CUDA_MEMCPY2D = hip_Memcpy2D;
+using CUDA_MEMCPY3D = HIP_MEMCPY3D;
+using CUDA_RESOURCE_DESC = HIP_RESOURCE_DESC;
+using CUDA_TEXTURE_DESC = HIP_TEXTURE_DESC;
+using CUDA_RESOURCE_VIEW_DESC = HIP_RESOURCE_VIEW_DESC;
+
+using CUarray_format = hipArray_Format;
+using CUaddress_mode = HIPaddress_mode;
+
+#ifndef CU_AD_FORMAT_UNSIGNED_INT8
+#define CU_AD_FORMAT_UNSIGNED_INT8 HIP_AD_FORMAT_UNSIGNED_INT8
+#endif  // CU_AD_FORMAT_UNSIGNED_INT8
+#ifndef CU_AD_FORMAT_UNSIGNED_INT16
+#define CU_AD_FORMAT_UNSIGNED_INT16 HIP_AD_FORMAT_UNSIGNED_INT16
+#endif  // CU_AD_FORMAT_UNSIGNED_INT16
+#ifndef CU_AD_FORMAT_UNSIGNED_INT32
+#define CU_AD_FORMAT_UNSIGNED_INT32 HIP_AD_FORMAT_UNSIGNED_INT32
+#endif  // CU_AD_FORMAT_UNSIGNED_INT32
+#ifndef CU_AD_FORMAT_SIGNED_INT8
+#define CU_AD_FORMAT_SIGNED_INT8 HIP_AD_FORMAT_SIGNED_INT8
+#endif  // CU_AD_FORMAT_SIGNED_INT8
+#ifndef CU_AD_FORMAT_SIGNED_INT16
+#define CU_AD_FORMAT_SIGNED_INT16 HIP_AD_FORMAT_SIGNED_INT16
+#endif  // CU_AD_FORMAT_SIGNED_INT16
+#ifndef CU_AD_FORMAT_SIGNED_INT32
+#define CU_AD_FORMAT_SIGNED_INT32 HIP_AD_FORMAT_SIGNED_INT32
+#endif  // CU_AD_FORMAT_SIGNED_INT32
+#ifndef CU_AD_FORMAT_HALF
+#define CU_AD_FORMAT_HALF HIP_AD_FORMAT_HALF
+#endif  // CU_AD_FORMAT_HALF
+#ifndef CU_AD_FORMAT_FLOAT
+#define CU_AD_FORMAT_FLOAT HIP_AD_FORMAT_FLOAT
+#endif  // CU_AD_FORMAT_FLOAT
+
+#ifndef CU_TR_ADDRESS_MODE_WRAP
+#define CU_TR_ADDRESS_MODE_WRAP HIP_TR_ADDRESS_MODE_WRAP
+#endif  // CU_TR_ADDRESS_MODE_WRAP
+#ifndef CU_TR_ADDRESS_MODE_CLAMP
+#define CU_TR_ADDRESS_MODE_CLAMP HIP_TR_ADDRESS_MODE_CLAMP
+#endif  // CU_TR_ADDRESS_MODE_CLAMP
+#ifndef CU_TR_ADDRESS_MODE_MIRROR
+#define CU_TR_ADDRESS_MODE_MIRROR HIP_TR_ADDRESS_MODE_MIRROR
+#endif  // CU_TR_ADDRESS_MODE_MIRROR
+#ifndef CU_TR_ADDRESS_MODE_BORDER
+#define CU_TR_ADDRESS_MODE_BORDER HIP_TR_ADDRESS_MODE_BORDER
+#endif  // CU_TR_ADDRESS_MODE_BORDER
+
+#ifndef CU_TR_FILTER_MODE_POINT
+#define CU_TR_FILTER_MODE_POINT HIP_TR_FILTER_MODE_POINT
+#endif  // CU_TR_FILTER_MODE_POINT
+#ifndef CU_TR_FILTER_MODE_LINEAR
+#define CU_TR_FILTER_MODE_LINEAR HIP_TR_FILTER_MODE_LINEAR
+#endif  // CU_TR_FILTER_MODE_LINEAR
+
+#ifndef CU_TRSF_NORMALIZED_COORDINATES
+#define CU_TRSF_NORMALIZED_COORDINATES HIP_TRSF_NORMALIZED_COORDINATES
+#endif  // CU_TRSF_NORMALIZED_COORDINATES
+
+#ifndef CU_RESOURCE_TYPE_ARRAY
+#define CU_RESOURCE_TYPE_ARRAY HIP_RESOURCE_TYPE_ARRAY
+#endif  // CU_RESOURCE_TYPE_ARRAY
+#ifndef CU_RESOURCE_TYPE_MIPMAPPED_ARRAY
+#define CU_RESOURCE_TYPE_MIPMAPPED_ARRAY HIP_RESOURCE_TYPE_MIPMAPPED_ARRAY
+#endif  // CU_RESOURCE_TYPE_MIPMAPPED_ARRAY
+
+#ifndef CU_MEMORYTYPE_HOST
+#define CU_MEMORYTYPE_HOST hipMemoryTypeHost
+#endif  // CU_MEMORYTYPE_HOST
+#ifndef CU_MEMORYTYPE_DEVICE
+#define CU_MEMORYTYPE_DEVICE hipMemoryTypeDevice
+#endif  // CU_MEMORYTYPE_DEVICE
+#ifndef CU_MEMORYTYPE_ARRAY
+#define CU_MEMORYTYPE_ARRAY hipMemoryTypeArray
+#endif  // CU_MEMORYTYPE_ARRAY
+using CUmemorytype = hipMemoryType;
+#ifndef CUDA_ARRAY3D_SURFACE_LDST
+#define CUDA_ARRAY3D_SURFACE_LDST hipArraySurfaceLoadStore
+#endif  // CUDA_ARRAY3D_SURFACE_LDST
+#else
+using CUDA_MEMCPY2D = HIP_MEMCPY2D;
+using CUDA_MEMCPY3D = HIP_MEMCPY3D;
+using CUDA_RESOURCE_DESC = hipResourceDesc;
+using CUDA_TEXTURE_DESC = hipTextureDesc;
+using CUDA_RESOURCE_VIEW_DESC = hipResourceViewDesc;
+#endif  // HIP_VERSION >= 70000000
+
+#ifndef CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID
+#define CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID hipDeviceAttributePciDomainId
+#endif  // CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID
+#ifndef CU_DEVICE_ATTRIBUTE_PCI_BUS_ID
+#define CU_DEVICE_ATTRIBUTE_PCI_BUS_ID hipDeviceAttributePciBusId
+#endif  // CU_DEVICE_ATTRIBUTE_PCI_BUS_ID
+#ifndef CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID
+#define CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID hipDeviceAttributePciDeviceId
+#endif  // CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID
+#ifndef CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING
+#define CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING hipDeviceAttributeUnifiedAddressing
+#endif  // CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING
+#ifndef CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED
+#define CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED hipDeviceAttributeMemoryPoolsSupported
+#endif  // CU_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED
+#ifndef CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT
+#define CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT hipDeviceAttributeMultiprocessorCount
+#endif  // CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT
+#ifndef CU_DEVICE_ATTRIBUTE_INTEGRATED
+#define CU_DEVICE_ATTRIBUTE_INTEGRATED hipDeviceAttributeIntegrated
+#endif  // CU_DEVICE_ATTRIBUTE_INTEGRATED
+#ifndef CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN
+#define CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN hipDeviceAttributeSharedMemPerBlockOptin
+#endif  // CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN
+#ifndef CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR
+#define CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR hipDeviceAttributeComputeCapabilityMajor
+#endif  // CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR
+#ifndef CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR
+#define CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR hipDeviceAttributeComputeCapabilityMinor
+#endif  // CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR
+#ifndef CU_DEVICE_ATTRIBUTE_IPC_EVENT_SUPPORTED
+#define CU_DEVICE_ATTRIBUTE_IPC_EVENT_SUPPORTED ((CUdevice_attribute)-1)
+#endif  // CU_DEVICE_ATTRIBUTE_IPC_EVENT_SUPPORTED
+#ifndef CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS
+#define CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS hipDeviceAttributePageableMemoryAccess
+#endif  // CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS
+#ifndef CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST
+#define CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST hipDeviceAttributeDirectManagedMemAccessFromHost
+#endif  // CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST
+#ifndef CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED
+#define CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED hipDeviceAttributeHostNativeAtomicSupported
+#endif  // CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED
+#ifndef CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY
+#define CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY hipDeviceAttributeManagedMemory
+#endif  // CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY
+#ifndef CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS
+#define CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS hipDeviceAttributeConcurrentManagedAccess
+#endif  // CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS


### PR DESCRIPTION
## Description

This is a WIP change that lays the groundwork for AMD ROCm/HIP support in Warp's native runtime, without affecting the NVIDIA/CUDA build or its performance. It introduces `warp/native/hip_util.h`, a header-only CUDA→HIP compatibility shim and minimally wires it into `cuda_util.h` so that HIP builds pull in the shim in place of the CUDA driver/runtime headers. Every new codepath is gated behind `__HIP_PLATFORM_AMD__ / __HIPCC__` or `#ifndef` guards, so nvcc/CUDA compilation is byte-for-byte unchanged.

This PR provides the initial scaffolding, or plumbing, to pave the way for subsequent PRs that will enable complete HIP build support and functionality on ROCm hardware.

## Changes

- `warp/native/hip_util.h`: header-only CUDA-to-HIP compatibility shim providing type aliases, macro mappings (runtime/driver/nvrtc→hiprtc), device-attribute and stream-capture enum mappings, and version-gated helpers (`WP_HAS_MEMCPY_BATCH`, `CUoccupancyB2DSize` stub, etc.). Guarded with an `#error` so it can only be included in HIP builds.
- `warp/native/cuda_util.h` wiring (4 guarded spots, inert for CUDA)
- Include `hip_util.h` instead of `cudaTypedefs.h/cuda_runtime_api.h` under `__HIP_PLATFORM_AMD__`.
- Define `WP_HAS_MEMCPY_BATCH` per platform (HIP ≥ 7.1 vs CUDA ≥ 12.8) and gate `cuMemcpyBatchAsync_f` on it.
- Extend the `wp_launch_device` macro guard to `__CUDACC__ || __HIPCC__`.
- Allow the conditional-graph `cuGraphAddNode_f` declaration on HIP.
- `pyproject.toml`: add `hipDeviceAttributeSharedMemPerBlockOptin` to the typos identifier allowlist (mirrors the existing CUDA ..._OPTIN entry) so the HIP enum name passes the spell-check gate.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.

## Validation summary

Because this PR is compatibility scaffolding, validation focused on confirming the NVIDIA path is untouched and the new file meets repo conventions. 

All cuda unit tests pass

```

----------------------------------------------------------------------
Ran 12689 tests in 564.516s

OK (skipped=93)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and running CUDA-compatible functionality on HIP/AMD platforms.
  * Expanded support for HIP runtime features, including memory transfers, kernel launches, streams, events, graphs, textures, and surfaces.
  * Added compatibility handling across different HIP versions and supported GPU architectures.

* **Bug Fixes**
  * Improved feature detection for batched memory operations and graph functionality when using HIP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->