### PR TITLE
[Experiment] Speed up BSR transpose and first-sample FEM construction

### DIFF
--- a/asv/benchmarks/sparse/transpose.py
+++ b/asv/benchmarks/sparse/transpose.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+
+import warp as wp
+import warp.sparse as wps
+
+
+class BsrSetTransposeCompact:
+    """Benchmark captured compact transposes across row lengths and storage occupancy."""
+
+    params = ["stencil8", "stencil32", "dense", "overallocated", "wide_hot_column", "shared_columns8"]
+    param_names = ["pattern"]
+    rounds = 1
+    repeat = 3
+    number = 10
+
+    def setup(self, pattern):
+        wp.init()
+        self.device = wp.get_device("cuda:0")
+        nrow = ncol = 65536
+        active_rows = nrow
+        degree = 8
+        if pattern == "stencil32":
+            nrow = ncol = active_rows = 16384
+            degree = 32
+        elif pattern == "dense":
+            nrow = ncol = active_rows = degree = 1024
+        elif pattern == "overallocated":
+            nrow, ncol, active_rows = 1310720, 524288, 3000
+        elif pattern == "wide_hot_column":
+            degree = 1
+
+        rows = np.repeat(np.arange(active_rows, dtype=np.int32), degree)
+        columns = (rows + np.tile(np.arange(degree, dtype=np.int32), active_rows)) % ncol
+        if pattern == "wide_hot_column":
+            columns.fill(0)
+        elif pattern == "shared_columns8":
+            columns = np.tile(np.arange(degree, dtype=np.int32), active_rows)
+        columns = np.sort(columns.reshape(active_rows, degree), axis=1).reshape(-1)
+        nnz = rows.size
+        capacity = 10485760 if pattern == "overallocated" else nnz
+        offsets = np.concatenate(([0], np.cumsum(np.bincount(rows, minlength=nrow)))).astype(np.int32)
+
+        with wp.ScopedDevice(self.device):
+            self.src = wps.bsr_zeros(nrow, ncol, float)
+            self.src.notify_nnz_changed(nnz=capacity)
+            self.src.columns.fill_(-1)
+            self.src.values.fill_(1.0)
+            wp.copy(self.src.offsets, wp.array(offsets, dtype=int))
+            wp.copy(self.src.columns, wp.array(columns, dtype=int), count=nnz)
+            self.dest = wps.bsr_zeros(ncol, nrow, float)
+            wps.bsr_set_transpose(self.dest, self.src)
+            with wp.ScopedCapture() as capture:
+                wps.bsr_set_transpose(self.dest, self.src)
+            self.graph = capture.graph
+        wp.synchronize_device(self.device)
+
+    def time_cuda(self, pattern):
+        wp.capture_launch(self.graph)
+        wp.synchronize_device(self.device)

--- a/changelog/+first-row-compression.changed.md
+++ b/changelog/+first-row-compression.changed.md
@@ -1,0 +1,1 @@
+Support row-compressed FEM interpolation with `reduction="first"`, preserving the owning element and interpolation arithmetic for changing space restrictions and CUDA Graph replay.

--- a/changelog/+row-transpose.changed.md
+++ b/changelog/+row-transpose.changed.md
@@ -1,0 +1,1 @@
+Added an active-entry counting and deterministic row-sorting path for compact CUDA BSR transposes of sparse stencils and overallocated matrices, while retaining the global sort for dense or narrow matrices, padded destinations, and shared topology.

--- a/warp/_src/fem/integrate.py
+++ b/warp/_src/fem/integrate.py
@@ -2458,7 +2458,9 @@ def get_interpolate_jacobian_at_nodes_kernel(
             )
 
             if wp.static(reduction == "first"):
-                block_offset = local_node_index * max_nodes_per_element + trial_node
+                # COO storage is restriction-ordered; direct BSR writes use partition rows.
+                row = local_node_index if triplet_rows else partition_node_index
+                block_offset = row * max_nodes_per_element + trial_node
             else:
                 if wp.static(reduction == "weighted_average"):
                     vol = domain.element_measure(domain_arg, sample)
@@ -2940,35 +2942,33 @@ def _launch_interpolate_kernel(
                 space_restriction.node_count() if reduction == "first" else space_restriction.total_node_element_count()
             )
 
-            if row_compress_bsr and reduction == "first":
-                if construction_policy == _BSR_CONSTRUCTION_AUTO:
-                    row_compress_bsr = False
-                else:
-                    raise RuntimeError(
-                        "fem.interpolate() with bsr_options['construction']='row_compress' does not support "
-                        "reduction='first' with a space restriction"
-                    )
-
             if row_compress_bsr:
                 _validate_interpolate_jacobian_dest(
                     point_index_count=space_restriction.space_partition.node_count(),
                     trial=trial,
                     dest=dest,
                 )
-                capacity_nnz = evaluation_point_count * max_nodes_per_element
-                bsr_set_zero(dest, topology="padded")
-                wp.launch(
-                    _fill_integrate_bsr_offsets_from_row_groups,
-                    dim=dest.nrow + 1,
-                    device=dest.device,
-                    inputs=[
-                        dest.nrow,
-                        space_restriction.partition_element_offsets(),
-                        max_nodes_per_element,
-                        dest.offsets,
-                        dest.row_counts,
-                    ],
-                )
+                if reduction == "first":
+                    capacity_nnz = dest.nrow * max_nodes_per_element
+                    if capacity_policy == _BSR_CAPACITY_REUSE:
+                        _require_bsr_capacity(dest, capacity_nnz, "fem.interpolate()")
+                    bsr_set_zero(dest, topology="padded", row_capacity=max_nodes_per_element)
+                    dest.row_counts.fill_(max_nodes_per_element)
+                else:
+                    capacity_nnz = evaluation_point_count * max_nodes_per_element
+                    bsr_set_zero(dest, topology="padded")
+                    wp.launch(
+                        _fill_integrate_bsr_offsets_from_row_groups,
+                        dim=dest.nrow + 1,
+                        device=dest.device,
+                        inputs=[
+                            dest.nrow,
+                            space_restriction.partition_element_offsets(),
+                            max_nodes_per_element,
+                            dest.offsets,
+                            dest.row_counts,
+                        ],
+                    )
                 triplet_rows, triplet_cols, triplet_values = _interpolate_jacobian_row_compress_storage(
                     dest=dest,
                     capacity_nnz=capacity_nnz,
@@ -3230,7 +3230,9 @@ def interpolate(
           ``construction="triplets"`` forces temporary COO triplet construction, while
           ``construction="row_compress"`` forces row-ordered candidate writes followed by
           :func:`warp.sparse.bsr_compress()`. Non-differentiable outputs use in-place compression for the
-          lowest memory overhead. Row compression for quadrature interpolation requires matching evaluation and
+          lowest memory overhead. At nodes, ``reduction="first"`` evaluates the same owning element as triplet
+          construction and reserves one trial-element stencil per destination partition node, including inactive rows.
+          Row compression for quadrature interpolation requires matching evaluation and
           indexed point counts.
     """
 

--- a/warp/native/sparse.cu
+++ b/warp/native/sparse.cu
@@ -19,6 +19,7 @@
 
 #define THRUST_IGNORE_CUB_VERSION_CHECK
 
+#include <cub/block/block_radix_sort.cuh>
 #include <cub/device/device_radix_sort.cuh>
 #include <cub/device/device_run_length_encode.cuh>
 #include <cub/device/device_scan.cuh>
@@ -446,6 +447,192 @@ void launch_bsr_fill_triplet_key_values(
         WP_CURRENT_CONTEXT, bsr_fill_triplet_key_values, nnz,
         (nnz, tpl_rows, tpl_columns, isNotZero, mask, block_indices, row_col)
     );
+}
+
+__device__ __forceinline__ int bsr_transpose_reserve(int* counters, int column)
+{
+#if __CUDA_ARCH__ >= 700
+    // Combine reservations for a shared column before issuing a global atomic.
+    const unsigned peers = __match_any_sync(__activemask(), column);
+    const int lane = threadIdx.x & 31;
+    const int leader = __ffs(peers) - 1;
+    int first = 0;
+    if (lane == leader)
+        first = atomicAdd(counters + column, __popc(peers));
+    first = __shfl_sync(peers, first, leader);
+    return first + __popc(peers & ((1u << lane) - 1));
+#else
+    return atomicAdd(counters + column, 1);
+#endif
+}
+
+__global__ void bsr_transpose_count_rows(
+    int row_count, int lane_shift, const int* offsets, const int* row_counts, const int* columns, int* counts
+)
+{
+    const size_t thread = size_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int lanes = 1 << lane_shift;
+    const int row = thread >> lane_shift;
+    const int lane = thread & (lanes - 1);
+    if (row >= row_count)
+        return;
+    for (int64_t block = int64_t(offsets[row]) + lane; block < bsr_active_row_end(offsets, row_counts, row);
+         block += lanes)
+        bsr_transpose_reserve(counts, columns[block] + 1);
+}
+
+__global__ void bsr_transpose_scatter_rows(
+    int row_count,
+    int lane_shift,
+    const int* offsets,
+    const int* row_counts,
+    const int* columns,
+    int* cursors,
+    int* transposed_columns,
+    int* src_blocks
+)
+{
+    const size_t thread = size_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int lanes = 1 << lane_shift;
+    const int row = thread >> lane_shift;
+    const int lane = thread & (lanes - 1);
+    if (row >= row_count)
+        return;
+    for (int64_t block = int64_t(offsets[row]) + lane; block < bsr_active_row_end(offsets, row_counts, row);
+         block += lanes) {
+        const int dest = bsr_transpose_reserve(cursors, columns[block]);
+        transposed_columns[dest] = row;
+        src_blocks[dest] = block;
+    }
+}
+
+__global__ void
+bsr_transpose_sort_short_rows(int row_count, const int* offsets, int* columns, int* indices, int* long_rows)
+{
+    const size_t thread = size_t(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int row = thread / 32;
+    const int lane = thread % 32;
+    if (row >= row_count)
+        return;
+    const int begin = offsets[row];
+    const int count = offsets[row + 1] - begin;
+    if (count <= 1)
+        return;
+    if (count > 32) {
+        if (lane == 0) {
+            const int tiles = 1 + (count - 1) / 256;
+            const int first = atomicAdd(long_rows, tiles);
+            atomicMax(long_rows + 1, count);
+            for (int tile = 0; tile < tiles; ++tile) {
+                long_rows[3 + 2 * (first + tile)] = row;
+                long_rows[4 + 2 * (first + tile)] = begin + 256 * tile;
+            }
+        }
+        return;
+    }
+    // Source block indices order source rows and resolve ties deterministically.
+    int key = lane < count ? indices[begin + lane] : INT_MAX;
+    int value = lane < count ? columns[begin + lane] : 0;
+    for (int size = 2; size <= 32; size *= 2) {
+        for (int stride = size / 2; stride > 0; stride /= 2) {
+            const int other_key = __shfl_xor_sync(0xffffffff, key, stride);
+            const int other_value = __shfl_xor_sync(0xffffffff, value, stride);
+            const bool ascending = ((lane & stride) == 0) == ((lane & size) == 0);
+            if (ascending ? other_key < key : other_key > key) {
+                key = other_key;
+                value = other_value;
+            }
+        }
+    }
+    if (lane < count) {
+        indices[begin + lane] = key;
+        columns[begin + lane] = value;
+    }
+}
+
+__global__ void bsr_transpose_sort_tiles(const int* offsets, int* columns, int* indices, int* work)
+{
+    // Distribute tiles across blocks even when all entries belong to one row.
+    using Sort = cub::BlockRadixSort<int, 256, 1, int>;
+    __shared__ Sort::TempStorage storage;
+    __shared__ int tile;
+    while (true) {
+        if (threadIdx.x == 0)
+            tile = atomicAdd(work + 2, 1);
+        __syncthreads();
+        if (tile >= work[0])
+            return;
+        const int row = work[3 + 2 * tile];
+        const int64_t i = int64_t(work[4 + 2 * tile]) + threadIdx.x;
+        const bool active = i < offsets[row + 1];
+        int keys[1] = { active ? indices[i] : INT_MAX };
+        int values[1] = { active ? columns[i] : 0 };
+        Sort(storage).Sort(keys, values);
+        if (active) {
+            indices[i] = keys[0];
+            columns[i] = values[0];
+        }
+        __syncthreads();
+    }
+}
+
+__global__ void bsr_transpose_merge_tiles(
+    int shift,
+    const int* offsets,
+    const int* in_columns,
+    const int* in_indices,
+    int* out_columns,
+    int* out_indices,
+    const int* work
+)
+{
+    const int64_t width = int64_t(1) << shift;
+    if (width >= work[1])
+        return;
+    for (int tile = blockIdx.x; tile < work[0]; tile += gridDim.x) {
+        const int row = work[3 + 2 * tile];
+        const int begin = offsets[row];
+        const int count = offsets[row + 1] - begin;
+        const int64_t i = int64_t(work[4 + 2 * tile]) + threadIdx.x - begin;
+        if (i >= count || width >= count)
+            continue;
+        const int64_t chunk = (i >> shift) << shift;
+        const int64_t pair = (i >> (shift + 1)) << (shift + 1);
+        const int other = int(chunk == pair ? min(chunk + width, int64_t(count)) : pair);
+        const int other_end = int(min(int64_t(other) + width, int64_t(count)));
+        const int key = in_indices[begin + i];
+        int lower = other;
+        int upper = other_end;
+        while (lower < upper) {
+            const int mid = lower + (upper - lower) / 2;
+            if (in_indices[begin + mid] < key)
+                lower = mid + 1;
+            else
+                upper = mid;
+        }
+        // The source index is unique, so its merge rank has exactly one writer.
+        const int dest = int(begin + pair + i - chunk + lower - other);
+        out_indices[dest] = key;
+        out_columns[dest] = in_columns[begin + i];
+    }
+}
+
+__global__ void bsr_transpose_finish_tiles(
+    const int* offsets, int* columns, int* indices, const int* temp_columns, const int* temp_indices, const int* work
+)
+{
+    for (int tile = blockIdx.x; tile < work[0]; tile += gridDim.x) {
+        const int row = work[3 + 2 * tile];
+        const int count = offsets[row + 1] - offsets[row];
+        int parity = 0;
+        for (int remaining = (count - 1) / 256; remaining; remaining >>= 1)
+            parity ^= 1;
+        const int64_t i = int64_t(work[4 + 2 * tile]) + threadIdx.x;
+        if (parity && i < offsets[row + 1]) {
+            indices[i] = temp_indices[i];
+            columns[i] = temp_columns[i];
+        }
+    }
 }
 
 __global__ void bsr_transpose_fill_row_col(
@@ -1472,6 +1659,76 @@ WP_API void wp_bsr_transpose_device(
 
     cudaStream_t stream = static_cast<cudaStream_t>(wp_cuda_stream_get_current());
     const bool padded = transposed_bsr_row_counts != nullptr;
+
+    const bool aliases_topology = bsr_offsets == transposed_bsr_offsets || bsr_columns == transposed_bsr_columns
+        || bsr_row_counts == transposed_bsr_offsets || bsr_row_counts == transposed_bsr_columns
+        || bsr_offsets == transposed_bsr_columns || bsr_columns == transposed_bsr_offsets;
+    // Prefer global sorting for dense or narrow matrices; the row path targets
+    // sparse stencils and large unused capacities without a host NNZ readback.
+    // Shared topology must be read before overwriting the destination offsets.
+    if (!padded && !aliases_topology && row_count > 32 && col_count > 32
+        && int64_t(nnz) <= 64 * int64_t(std::min(row_count, col_count))) {
+        const int lane_shift = nnz / row_count >= 32 ? 5 : (nnz / row_count >= 8 ? 3 : 0);
+        const int lanes = 1 << lane_shift;
+        ScopedTemporary<int> cursors(context, size_t(col_count + 1));
+        check_cuda(cudaMemsetAsync(transposed_bsr_offsets, 0, size_t(col_count + 1) * sizeof(int), stream));
+        wp_launch_device(
+            WP_CURRENT_CONTEXT, bsr_transpose_count_rows, size_t(row_count) * lanes,
+            (row_count, lane_shift, bsr_offsets, bsr_row_counts, bsr_columns, transposed_bsr_offsets)
+        );
+        size_t buff_size = 0;
+        check_cuda(
+            cub::DeviceScan::InclusiveSum(
+                nullptr, buff_size, transposed_bsr_offsets, transposed_bsr_offsets, col_count + 1, stream
+            )
+        );
+        ScopedTemporary<> temp(context, buff_size);
+        check_cuda(
+            cub::DeviceScan::InclusiveSum(
+                temp.buffer(), buff_size, transposed_bsr_offsets, transposed_bsr_offsets, col_count + 1, stream
+            )
+        );
+        check_cuda(cudaMemcpyAsync(
+            cursors.buffer(), transposed_bsr_offsets, size_t(col_count + 1) * sizeof(int), cudaMemcpyDeviceToDevice,
+            stream
+        ));
+        wp_launch_device(
+            WP_CURRENT_CONTEXT, bsr_transpose_scatter_rows, size_t(row_count) * lanes,
+            (row_count, lane_shift, bsr_offsets, bsr_row_counts, bsr_columns, cursors.buffer(), transposed_bsr_columns,
+             src_block_indices)
+        );
+        ScopedTemporary<int> sorted_columns(context, size_t(nnz));
+        ScopedTemporary<int> work(context, 3 + 2 * (size_t(col_count) + size_t(nnz) / 256));
+        check_cuda(cudaMemsetAsync(work.buffer(), 0, 3 * sizeof(int), stream));
+        wp_launch_device(
+            WP_CURRENT_CONTEXT, bsr_transpose_sort_short_rows, size_t(col_count) * 32,
+            (col_count, transposed_bsr_offsets, transposed_bsr_columns, src_block_indices, work.buffer())
+        );
+        wp_launch_device(
+            WP_CURRENT_CONTEXT, bsr_transpose_sort_tiles, 128 * 256,
+            (transposed_bsr_offsets, transposed_bsr_columns, src_block_indices, work.buffer())
+        );
+        int* in_columns = transposed_bsr_columns;
+        int* in_indices = src_block_indices;
+        int* out_columns = sorted_columns.buffer();
+        int* out_indices = src_block_indices + nnz;
+        // Fixed launches allow captured row lengths to change without host readback.
+        // Each pass skips rows that already fit in its sorted run length.
+        for (int shift = 8; (int64_t(1) << shift) < nnz; ++shift) {
+            wp_launch_device(
+                WP_CURRENT_CONTEXT, bsr_transpose_merge_tiles, 128 * 256,
+                (shift, transposed_bsr_offsets, in_columns, in_indices, out_columns, out_indices, work.buffer())
+            );
+            std::swap(in_columns, out_columns);
+            std::swap(in_indices, out_indices);
+        }
+        wp_launch_device(
+            WP_CURRENT_CONTEXT, bsr_transpose_finish_tiles, 128 * 256,
+            (transposed_bsr_offsets, transposed_bsr_columns, src_block_indices, sorted_columns.buffer(),
+             src_block_indices + nnz, work.buffer())
+        );
+        return;
+    }
 
     ScopedTemporary<BsrRowCol> combined_row_col(context, 2 * nnz);
     ScopedTemporary<int> active_count(context, 1);

--- a/warp/tests/fem/test_fem_integrate.py
+++ b/warp/tests/fem/test_fem_integrate.py
@@ -83,6 +83,11 @@ def vector_component_form(s: Sample, v: Field):
     return v(s)[0]
 
 
+@integrand
+def first_sample_form(s: Sample, u: Field):
+    return u(s) * float(s.element_index + 1)
+
+
 # -- Test functions --
 
 
@@ -520,6 +525,55 @@ def test_integrate_high_order(test, device):
         assert_np_equal(h0.values[:h0_nnz].numpy(), h1.values[:h1_nnz].numpy(), tol=1.0e-6)
 
 
+def test_interpolate_first_row_compression(test, device):
+    """Preserve first-sample Jacobians for changing, noncontiguous restrictions."""
+    with wp.ScopedDevice(device):
+        geo = fem.Grid3D(res=wp.vec3i(2))
+        indices = wp.array([1, 3, 5, 6], dtype=int)
+        domain = fem.Subdomain(fem.Cells(geo), element_indices=indices)
+        space = fem.make_polynomial_space(geo, degree=3, element_basis=fem.ElementBasis.SERENDIPITY)
+        trial_space = fem.make_polynomial_space(geo, degree=1, discontinuous=True)
+        trial = fem.make_trial(trial_space, domain=domain)
+        store = fem.TemporaryStore()
+        restriction = fem.make_space_restriction(space_topology=space.topology, domain=domain, temporary_store=store)
+        reference = bsr_zeros(space.node_count(), trial_space.node_count(), block_type=float)
+        candidate = bsr_zeros(space.node_count(), trial_space.node_count(), block_type=float)
+
+        def interpolate(matrix, construction, capacity="auto"):
+            fem.interpolate(
+                first_sample_form,
+                dest=matrix,
+                dest_space=space,
+                at=restriction,
+                fields={"u": trial},
+                reduction="first",
+                temporary_store=store,
+                bsr_options={"construction": construction, "capacity": capacity},
+                kernel_options={"enable_backward": False},
+            )
+
+        interpolate(candidate, "row_compress")
+        graph = None
+        if wp.get_device(device).is_cuda:
+            with wp.ScopedCapture() as capture:
+                restriction.rebuild(temporary_store=store)
+                interpolate(candidate, "row_compress", "reuse")
+            graph = capture.graph
+        for elements in ([1, 3, 5, 6], [0, 2, 4, 7], [-1, -1, -1, -1], [7, 6, 5, 4]):
+            indices.assign(np.array(elements, dtype=np.int32))
+            if graph is None:
+                restriction.rebuild(temporary_store=store)
+                interpolate(candidate, "row_compress", "reuse")
+            else:
+                wp.capture_launch(graph)
+            interpolate(reference, "triplets")
+            count = reference.nnz_sync()
+            test.assertEqual(candidate.nnz_sync(), count)
+            test.assertEqual(candidate.offsets.numpy().tobytes(), reference.offsets.numpy().tobytes())
+            test.assertEqual(candidate.columns.numpy()[:count].tobytes(), reference.columns.numpy()[:count].tobytes())
+            test.assertEqual(candidate.values.numpy()[:count].tobytes(), reference.values.numpy()[:count].tobytes())
+
+
 def test_padded_sparse_assembly(test, device):
     with wp.ScopedDevice(device):
         geo = fem.Grid3D(res=(4, 4, 4))
@@ -853,6 +907,9 @@ add_function_test(
 )
 add_function_test(TestFemIntegrate, "test_padded_sparse_assembly", test_padded_sparse_assembly, devices=cuda_devices)
 add_function_test(TestFemIntegrate, "test_interpolate_reduction", test_interpolate_reduction, devices=devices)
+add_function_test(
+    TestFemIntegrate, "test_interpolate_first_row_compression", test_interpolate_first_row_compression, devices=devices
+)
 add_function_test(TestFemIntegrate, "test_capturability", test_capturability, devices=cuda_devices_with_mempool)
 add_function_test(TestFemIntegrate, "test_restriction_rebuild", test_restriction_rebuild, devices=devices)
 

--- a/warp/tests/test_apic.py
+++ b/warp/tests/test_apic.py
@@ -2692,7 +2692,7 @@ def test_save_load_bsr_mm_reuse_topology_cuda(test, device):
 
 
 def test_capture_with_bsr_transpose(test, device):
-    """Recompute BSR transpose topology during CPU APIC replay.
+    """Recompute compact BSR transpose topology during APIC replay and reload.
 
     Regression: wp.sparse.bsr_transposed on CPU computes the transposed topology
     via a host function (wp_bsr_transpose_host) that was invisible to the APIC byte
@@ -2701,13 +2701,16 @@ def test_capture_with_bsr_transpose(test, device):
     topology."""
     from warp.sparse import bsr_set_from_triplets, bsr_set_transpose, bsr_zeros  # noqa: PLC0415
 
-    n = 6
+    n = 65
     rows = wp.zeros(n, dtype=wp.int32, device=device)
     columns = wp.zeros(n, dtype=wp.int32, device=device)
     values = wp.zeros(n, dtype=wp.float32, device=device)
     A = bsr_zeros(n, n, block_type=wp.float32, device=device)
     At = bsr_zeros(n, n, block_type=wp.float32, device=device)
 
+    if device.is_cuda:
+        bsr_set_from_triplets(A, rows, columns, values)
+        bsr_set_transpose(At, A)
     wp.load_module(device=device)
     with wp.ScopedCapture(device=device, apic=True, force_module_load=False) as capture:
         wp.launch(fill_diag_triplets_kernel, dim=n, inputs=[rows, columns, values], device=device)
@@ -2721,10 +2724,27 @@ def test_capture_with_bsr_transpose(test, device):
     wp.capture_launch(capture.graph)
     wp.synchronize_device(device)
 
-    # Diagonal matrix transposes to itself: nnz=6, columns=[0..5], values=[1..6].
+    # The diagonal matrix transposes to itself.
     test.assertEqual(int(At.offsets.numpy()[n]), n)
     np.testing.assert_array_equal(At.columns.numpy()[:n], np.arange(n, dtype=np.int32))
     np.testing.assert_allclose(At.values.numpy()[:n], np.arange(1, n + 1, dtype=np.float32))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "bsr_transpose")
+        wp.capture_save(
+            capture.graph, path, outputs={"offsets": At.offsets, "columns": At.columns, "values": At.values}
+        )
+        loaded = wp.capture_load(path, device=device)
+        wp.capture_launch(loaded)
+        offsets_out = wp.zeros_like(At.offsets)
+        columns_out = wp.zeros_like(At.columns)
+        values_out = wp.zeros_like(At.values)
+        loaded.get_param("offsets", offsets_out)
+        loaded.get_param("columns", columns_out)
+        loaded.get_param("values", values_out)
+        np.testing.assert_array_equal(offsets_out.numpy(), np.arange(n + 1, dtype=np.int32))
+        np.testing.assert_array_equal(columns_out.numpy()[:n], np.arange(n, dtype=np.int32))
+        np.testing.assert_array_equal(values_out.numpy()[:n], np.arange(1, n + 1, dtype=np.float32))
 
 
 def test_capture_with_padded_bsr_transpose(test, device):
@@ -3750,7 +3770,7 @@ add_function_test(
     TestApic,
     "test_capture_with_bsr_transpose",
     test_capture_with_bsr_transpose,
-    devices=[d for d in devices if d.is_cpu],
+    devices=devices,
 )
 add_function_test(
     TestApic,

--- a/warp/tests/test_sparse.py
+++ b/warp/tests/test_sparse.py
@@ -739,8 +739,8 @@ def make_test_bsr_transpose(block_shape, scalar_type):
     def test_bsr_transpose(test, device):
         rng = np.random.default_rng(123)
 
-        nrow = 4
-        ncol = 5
+        nrow = 65
+        ncol = 67
         nnz = 6
 
         rows = wp.array([0, 1, 2, 3, 2, 1], dtype=int, device=device)
@@ -753,10 +753,16 @@ def make_test_bsr_transpose(block_shape, scalar_type):
         bsr_set_from_triplets(bsr, rows, cols, vals)
         ref = 2.0 * np.transpose(_bsr_to_dense(bsr))
 
-        bsr_transposed = (2.0 * bsr).transpose().eval()
+        bsr.values.requires_grad = True
+        with wp.Tape() as tape:
+            bsr_transposed = (2.0 * bsr).transpose().eval()
 
         res = _bsr_to_dense(bsr_transposed)
         assert_np_equal(res, ref, 0.0001)
+
+        seed = wp.array(np.ones_like(bsr_transposed.values.numpy()), dtype=bsr_transposed.values.dtype, device=device)
+        tape.backward(grads={bsr_transposed.values: seed})
+        assert_np_equal(bsr.values.grad.numpy(), np.full_like(bsr.values.numpy(), 2.0))
 
         if block_shape[0] != block_shape[-1]:
             # test incompatible block shape
@@ -779,7 +785,77 @@ def make_test_bsr_transpose(block_shape, scalar_type):
         bsr_set_transpose(bsr_transposed, bsr, topology="masked")
         assert _bsr_pruned(bsr_transposed).nnz_sync() == 2
 
+        if block_shape == (1, 1):
+            diagonal = np.arange(1, nrow + 1, dtype=np.float32)
+            aliased = bsr_diag(wp.array(diagonal, dtype=scalar_type, device=device))
+            bsr_set_transpose(aliased, 2.0 * aliased)
+            test.assertEqual(aliased.nnz_sync(), nrow)
+            assert_np_equal(aliased.values.numpy(), 2.0 * diagonal)
+
     return test_bsr_transpose
+
+
+def make_test_bsr_transpose_rebuild(block_shape, scalar_type):
+    def test_bsr_transpose_rebuild(test, device):
+        rng = np.random.default_rng(17)
+        nrow, ncol = 1025, 257
+        block_type = wp.types.matrix(shape=block_shape, dtype=scalar_type)
+        transpose_type = wp.types.matrix(shape=block_shape[::-1], dtype=scalar_type)
+        numpy_type = wp.dtype_to_numpy(scalar_type)
+        capacity = nrow * 16
+
+        for padded in (False, True):
+            with test.subTest(padded=padded), wp.ScopedDevice(device):
+                src = bsr_zeros(nrow, ncol, block_type, row_capacity=16 if padded else None)
+                src.notify_nnz_changed(nnz=capacity)
+                dest = bsr_zeros(ncol, nrow, transpose_type)
+                bsr_set_transpose(dest, src)
+                graph = None
+                if wp.get_device(device).is_cuda:
+                    with wp.ScopedCapture() as capture:
+                        bsr_set_transpose(dest, src)
+                    graph = capture.graph
+
+                for count in (1, 600, 0, 31, 32, 33, 255, 256, 257, nrow, 120):
+                    # Include a long output row, changing topology, and poisoned padding.
+                    positions = (
+                        np.arange(count) * ncol
+                        if count in (31, 32, 33, 255, 256, 257, nrow)
+                        else np.sort(rng.choice(nrow * ncol, count, replace=False))
+                    )
+                    rows, columns = np.divmod(positions, ncol)
+                    counts = np.bincount(rows, minlength=nrow).astype(np.int32)
+                    offsets = np.concatenate(([0], np.cumsum(counts))).astype(np.int32)
+                    column_storage = np.full(capacity, -1, dtype=np.int32)
+                    values = rng.standard_normal((count, *block_shape)).astype(numpy_type)
+                    if count:
+                        values[0] = -0.0
+                    value_storage = np.full((capacity, *block_shape), np.nan, dtype=numpy_type)
+                    for row in range(nrow):
+                        begin, end = offsets[row : row + 2]
+                        start = row * 16 if padded else begin
+                        column_storage[start : start + end - begin] = columns[begin:end]
+                        value_storage[start : start + end - begin] = values[begin:end]
+                    if padded:
+                        wp.copy(src.row_counts, wp.array(counts, dtype=int))
+                    else:
+                        wp.copy(src.offsets, wp.array(offsets, dtype=int))
+                    wp.copy(src.columns, wp.array(column_storage, dtype=int))
+                    wp.copy(src.values, wp.array(value_storage, dtype=block_type))
+                    if graph is None:
+                        bsr_set_transpose(dest, src)
+                    else:
+                        wp.capture_launch(graph)
+
+                    order = np.lexsort((rows, columns))
+                    expected_offsets = np.concatenate(([0], np.cumsum(np.bincount(columns, minlength=ncol))))
+                    assert_np_equal(dest.offsets.numpy(), expected_offsets.astype(np.int32))
+                    assert_np_equal(dest.columns.numpy()[:count], rows[order].astype(np.int32))
+                    expected_values = values[order].transpose(0, 2, 1).copy()
+                    test.assertEqual(dest.values.numpy()[:count].tobytes(), expected_values.tobytes())
+                    test.assertEqual(dest.nnz_sync(), count)
+
+    return test_bsr_transpose_rebuild
 
 
 def make_test_bsr_axpy(block_shape, scalar_type):
@@ -1578,6 +1654,15 @@ add_function_test(TestSparse, "test_bsr_compress_gradient", test_bsr_compress_gr
 add_function_test(TestSparse, "test_csr_transpose", make_test_bsr_transpose((1, 1), wp.float32), devices=devices)
 add_function_test(TestSparse, "test_bsr_transpose_1_3", make_test_bsr_transpose((1, 3), wp.float32), devices=devices)
 add_function_test(TestSparse, "test_bsr_transpose_3_3", make_test_bsr_transpose((3, 3), wp.float64), devices=devices)
+add_function_test(
+    TestSparse, "test_bsr_transpose_rebuild_1_1", make_test_bsr_transpose_rebuild((1, 1), wp.float32), devices=devices
+)
+add_function_test(
+    TestSparse, "test_bsr_transpose_rebuild_2_3", make_test_bsr_transpose_rebuild((2, 3), wp.float32), devices=devices
+)
+add_function_test(
+    TestSparse, "test_bsr_transpose_rebuild_3_3", make_test_bsr_transpose_rebuild((3, 3), wp.float64), devices=devices
+)
 
 add_function_test(TestSparse, "test_csr_axpy", make_test_bsr_axpy((1, 1), wp.float32), devices=devices)
 add_function_test(TestSparse, "test_bsr_axpy_1_3", make_test_bsr_axpy((1, 3), wp.float32), devices=devices)


### PR DESCRIPTION
## Description

Speed up CUDA `bsr_set_transpose()` by sorting only the destination-row bits. Source blocks already follow source-row order, so CUB's stable radix sort preserves the full ordering. The bit range keeps padding after valid entries, including power-of-two row counts.

Also support FEM interpolation with `reduction="first"` and row compression, preserving sample ownership and coefficient arithmetic. No public API change or host readback is required during CUDA Graph replay.

Closes #1970 and #1971. Companion: [Newton #4214](https://github.com/newton-physics/newton/pull/4214).

## Changes

- Use the existing global radix sort with a reduced bit range; remove the experimental row sorter and its dispatch heuristic.
- Enable first-sample FEM row compression with space restrictions.
- Cover changing captured topology, padded column bounds, aliasing, block types, and exact value bytes.

## Validation summary

**107 Warp tests passed**: 98 sparse/FEM and 9 APIC transpose tests. Independent NumPy comparisons passed for 11 matrix patterns. Pre-commit checks passed. Follow-up `00d9967a` warms generated modules before capture, disables global module loading during capture, and keeps benchmark initialization in setup; all 16 affected CPU/CUDA tests and the standalone smoke run passed.

RTX 4090, CUDA 13.0, September 17: two reversed-order comparisons using a graph of 100 transposes. Geometric means of process medians; compilation and capture excluded.

| Pattern | Reference → candidate, ms | Speedup |
|---|---:|---:|
| Stencil, 8 entries/row | 0.108 → 0.059 | 1.84× |
| Stencil, 32 entries/row | 0.106 → 0.050 | 2.12× |
| Dense | 0.176 → 0.087 | 2.03× |
| Overallocated | 2.649 → 1.143 | 2.32× |
| One shared column | 0.060 → 0.030 | 1.98× |
| Eight shared columns | 0.100 → 0.055 | 1.83× |

The transpose still sorts reserved capacity; these measurements do not claim active-entry scaling. First-sample row compression also reserves every partition row and can be slower than triplets for sparse restrictions. The companion's captured [Isaac Lab teapot demo](https://github.com/maxkra15/IsaacLab/blob/6b8e133278ee4d68f20a1d1d2338133d7e10f545/scripts/demos/mpm/teapot_fill.py) measured **16.934 → 12.530 ms/step (+35.15%)**, with nine recorded state arrays bitwise identical at step 620. It requires Isaac Lab and demo assets. Captured multi-material trajectory equivalence remains unresolved and is excluded from speedup claims.

[Benchmark commands](https://github.com/maxkra15/warp/blob/e33c4f8f17c4059b764746a71d88e7f0988c0de4/asv/benchmarks/sparse/transpose.md) · [Raw results, harnesses, and pinned checkouts](https://gist.github.com/maxkra15/bf7f8eebfb3b9aa70d08b784205e686f)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added issue-linked changelog fragments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Row-compressed FEM interpolation now supports `reduction="first"` with changing restrictions and CUDA Graph replay.
  * CUDA BSR transpose operations now provide stable ordering, padded-topology preservation, and improved graph-capture support.

* **Bug Fixes**
  * Improved correctness for sparse transpose operations, including aliasing, gradients, padding, and changing sparsity patterns.

* **Documentation**
  * Added guidance for interpolation ownership, sparse transpose benchmarking, measurement, and result reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->