### PR TITLE
Add differentiable array component assignments

### DIFF
--- a/changelog/+array-composite-slot-gradients.fixed.md
+++ b/changelog/+array-composite-slot-gradients.fixed.md
@@ -1,1 +1,0 @@
-Fix adjoints for overwritten array-rooted composite slot writes.

--- a/changelog/+array-composite-slot-gradients.fixed.md
+++ b/changelog/+array-composite-slot-gradients.fixed.md
@@ -1,0 +1,1 @@
+Fix adjoints for overwritten array-rooted composite slot writes.

--- a/changelog/1451.added.md
+++ b/changelog/1451.added.md
@@ -1,1 +1,1 @@
-Support array-rooted writes into composite slots, including supported slot augmented assignments.
+Add differentiable assignments and supported augmented assignments to composite components stored in arrays, such as ``out[i].x = src[i]``, ``out[i][j] += value``, and ``matrices[i][r, c] = value``.

--- a/changelog/1451.added.md
+++ b/changelog/1451.added.md
@@ -1,0 +1,1 @@
+Support array-rooted writes into composite slots, including supported slot augmented assignments.

--- a/docs/user_guide/differentiability.rst
+++ b/docs/user_guide/differentiability.rst
@@ -148,6 +148,13 @@ detect array overwrites. :ref:`Read more here<array_overwrite_tracking>`.
     Though in-place operations such as ``x[tid] += 1.0`` and :func:`wp.atomic_add() <warp._src.lang.atomic_add>` are technically overwrite operations,
     the Warp graph specifically accommodates adjoint accumulation in these cases. :ref:`Read more here<in_place_math>`.
 
+Warp can differentiate builtin atomic ``+=`` and ``-=`` updates to array components.
+It rejects other augmented assignments to differentiable components when generating
+backward code, including those handled by user-defined operators. For example,
+``values[i].x += rhs`` is unsupported if a user-defined ``add`` function handles it.
+Write the result to a separate array, or set
+``enable_backward=False`` on the kernel if you only need forward execution.
+
 Copying is Differentiable
 #########################
 

--- a/docs/user_guide/execution_and_performance/deterministic_execution.rst
+++ b/docs/user_guide/execution_and_performance/deterministic_execution.rst
@@ -274,6 +274,14 @@ written in Warp code using supported atomic patterns:
         wp.adjoint[values][index] += adj_ret
 
 
+For kernels with composite component updates, deterministic mode rejects
+parallel CUDA backward passes that both mutate an array and accumulate into
+its gradient, including through aliases. Component overwrites consume the
+gradient at that point, so reductions cannot be deferred until after the kernel.
+The check treats the whole array as one target; independent indices or
+components may still trigger it. Split mutation and gradient reduction into
+separate kernels. CPU and single-thread CUDA backward launches remain supported.
+
 The deterministic launcher distinguishes forward-only, backward-only, and
 shared deterministic targets.  Backward-only gradient targets are part of the
 compiled hidden ABI, but forward launches pass inert helper buffers for those
@@ -285,7 +293,7 @@ corresponding backward target as inactive and leaves the generated helper as a
 no-op.  Other gradients from the same backward kernel are still reduced
 deterministically.
 
-The unsupported autodiff case is Pattern 2 slot allocation with a consumed
+Another unsupported autodiff case is Pattern 2 slot allocation with a consumed
 counter return.  A generated backward pass normally replays the original
 forward code before running reverse statements.  Replaying
 ``slot = wp.atomic_add(counter, index, value)`` would allocate new slots from

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -14741,6 +14741,7 @@ def matrix_index_row_value_func(arg_types: Mapping[str, type], arg_values: Mappi
 
 
 def matrix_index_row_dispatch_func(input_types: Mapping[str, type], return_type: Any, args: Mapping[str, Var]):
+    """Return native arguments for matrix row-reference indexing."""
     func_args = (Reference(args["a"]), args["i"])
     template_args = ()
     return (func_args, template_args)
@@ -15224,8 +15225,6 @@ add_builtin(
     export=False,
     group="Utility",
 )
-
-
 # implements bool_matrix[i] = bool_row (bool is not part of Scalar)
 add_builtin(
     "assign_inplace",
@@ -15238,7 +15237,6 @@ add_builtin(
     group="Utility",
 )
 
-
 # implements matrix[i,j] = value
 add_builtin(
     "assign_inplace",
@@ -15249,8 +15247,6 @@ add_builtin(
     export=False,
     group="Utility",
 )
-
-
 # implements bool_matrix[i,j] = bool (bool is not part of Scalar)
 add_builtin(
     "assign_inplace",
@@ -15278,8 +15274,6 @@ add_builtin(
     export=False,
     group="Utility",
 )
-
-
 # implements bool_matrix[i] = bool_row (bool is not part of Scalar)
 add_builtin(
     "assign_copy",
@@ -15291,7 +15285,6 @@ add_builtin(
     group="Utility",
 )
 
-
 # implements matrix[i,j] = value
 add_builtin(
     "assign_copy",
@@ -15302,8 +15295,6 @@ add_builtin(
     export=False,
     group="Utility",
 )
-
-
 # implements bool_matrix[i,j] = bool (bool is not part of Scalar)
 add_builtin(
     "assign_copy",
@@ -15314,7 +15305,6 @@ add_builtin(
     export=False,
     group="Utility",
 )
-
 
 # implements matrix[i] += value
 add_builtin(

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -14740,6 +14740,34 @@ def matrix_index_row_value_func(arg_types: Mapping[str, type], arg_values: Mappi
     return Reference(row_type)
 
 
+def matrix_index_row_dispatch_func(input_types: Mapping[str, type], return_type: Any, args: Mapping[str, Var]):
+    func_args = (Reference(args["a"]), args["i"])
+    template_args = ()
+    return (func_args, template_args)
+
+
+# implements &(*matrix)[i] = row
+add_builtin(
+    "indexref",
+    input_types={"a": matrix(shape=(Any, Any), dtype=Scalar), "i": Int},
+    value_func=matrix_index_row_value_func,
+    dispatch_func=matrix_index_row_dispatch_func,
+    hidden=True,
+    group="Utility",
+    skip_replay=True,
+    is_differentiable=False,
+)
+# implements &(*bool_matrix)[i] = bool_row (bool is not part of Scalar)
+add_builtin(
+    "indexref",
+    input_types={"a": matrix(shape=(Any, Any), dtype=bool), "i": Int},
+    value_func=matrix_index_row_value_func,
+    dispatch_func=matrix_index_row_dispatch_func,
+    hidden=True,
+    group="Utility",
+    skip_replay=True,
+    is_differentiable=False,
+)
 # implements &(*matrix)[i, j]
 add_builtin(
     "indexref",
@@ -15047,6 +15075,16 @@ add_builtin(
     skip_replay=True,
     is_differentiable=False,
 )
+# implements &bool_matrix[i] = bool_row (bool is not part of Scalar)
+add_builtin(
+    "index",
+    input_types={"a": matrix(shape=(Any, Any), dtype=bool), "i": int},
+    value_func=matrix_index_row_value_func,
+    hidden=True,
+    group="Utility",
+    skip_replay=True,
+    is_differentiable=False,
+)
 
 
 def matrix_index_value_func(arg_types: Mapping[str, type], arg_values: Mapping[str, Any]):
@@ -15060,6 +15098,16 @@ def matrix_index_value_func(arg_types: Mapping[str, type], arg_values: Mapping[s
 add_builtin(
     "index",
     input_types={"a": matrix(shape=(Any, Any), dtype=Scalar), "i": int, "j": int},
+    value_func=matrix_index_value_func,
+    hidden=True,
+    group="Utility",
+    skip_replay=True,
+    is_differentiable=False,
+)
+# implements &bool_matrix[i,j] = bool (bool is not part of Scalar)
+add_builtin(
+    "index",
+    input_types={"a": matrix(shape=(Any, Any), dtype=bool), "i": int, "j": int},
     value_func=matrix_index_value_func,
     hidden=True,
     group="Utility",
@@ -15178,10 +15226,35 @@ add_builtin(
 )
 
 
+# implements bool_matrix[i] = bool_row (bool is not part of Scalar)
+add_builtin(
+    "assign_inplace",
+    input_types={"a": matrix(shape=(Any, Any), dtype=bool), "i": Any, "value": Any},
+    constraint=matrix_vector_sametype,
+    value_type=None,
+    dispatch_func=matrix_assign_dispatch_func,
+    hidden=True,
+    export=False,
+    group="Utility",
+)
+
+
 # implements matrix[i,j] = value
 add_builtin(
     "assign_inplace",
     input_types={"a": matrix(shape=(Any, Any), dtype=Scalar), "i": Any, "j": Any, "value": Any},
+    value_type=None,
+    dispatch_func=matrix_assign_dispatch_func,
+    hidden=True,
+    export=False,
+    group="Utility",
+)
+
+
+# implements bool_matrix[i,j] = bool (bool is not part of Scalar)
+add_builtin(
+    "assign_inplace",
+    input_types={"a": matrix(shape=(Any, Any), dtype=bool), "i": Any, "j": Any, "value": Any},
     value_type=None,
     dispatch_func=matrix_assign_dispatch_func,
     hidden=True,
@@ -15207,10 +15280,34 @@ add_builtin(
 )
 
 
+# implements bool_matrix[i] = bool_row (bool is not part of Scalar)
+add_builtin(
+    "assign_copy",
+    input_types={"a": matrix(shape=(Any, Any), dtype=bool), "i": Any, "value": Any},
+    value_func=matrix_assign_copy_value_func,
+    dispatch_func=matrix_assign_dispatch_func,
+    hidden=True,
+    export=False,
+    group="Utility",
+)
+
+
 # implements matrix[i,j] = value
 add_builtin(
     "assign_copy",
     input_types={"a": matrix(shape=(Any, Any), dtype=Scalar), "i": Any, "j": Any, "value": Any},
+    value_func=matrix_assign_copy_value_func,
+    dispatch_func=matrix_assign_dispatch_func,
+    hidden=True,
+    export=False,
+    group="Utility",
+)
+
+
+# implements bool_matrix[i,j] = bool (bool is not part of Scalar)
+add_builtin(
+    "assign_copy",
+    input_types={"a": matrix(shape=(Any, Any), dtype=bool), "i": Any, "j": Any, "value": Any},
     value_func=matrix_assign_copy_value_func,
     dispatch_func=matrix_assign_dispatch_func,
     hidden=True,

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -984,6 +984,29 @@ class _LValueOrigin:
 
         return expr
 
+    def emit_lvalue_materialized_views(
+        self,
+        adjoint: bool = False,
+        adj=None,
+        prelude: list[str] | None = None,
+    ) -> str:
+        if prelude is None or not any(step.kind == "view" for step in self.steps):
+            return self.emit_lvalue(adjoint)
+
+        if self.root_is_ref_parameter:
+            root_expr = self.root.emit("adj") if adjoint else self.root.emit()
+            expr = f"*({root_expr})"
+        else:
+            expr = self.root.emit("adj" if adjoint else "var")
+
+        for step in self.steps:
+            if step.kind == "view":
+                expr = self._emit_materialized_view(adj, prelude, expr, step)
+            else:
+                expr = self._emit_step_lvalue(expr, step)
+
+        return expr
+
     @classmethod
     def _emit_materialized_view(cls, adj, prelude: list[str], base_expr: str, step: _LValueStep) -> str:
         name = f"_wp_ref_view_{adj.label_count}"
@@ -1748,7 +1771,8 @@ class SlotAccessPlan(NamedTuple):
     root_var: Var
     array_indices_ast: list  # list[ast.expr]: outer array subscripts, left-to-right
     access_parts: list  # list[str | ast.expr]: str text segments + index AST nodes
-    slot_type: object  # informational leaf type; already validated against rhs_type
+    slot_type: object  # informational leaf type; optionally validated against rhs_type
+    root_is_adjoint: bool = False
 
 
 class _SharedFunctionSource:
@@ -3648,7 +3672,17 @@ class Adjoint:
                 attr_name = aggregate.label + "." + node.attr
                 attr_type = _aggregate_vars(aggregate.type)[node.attr].type
 
-                return Var(attr_name, attr_type)
+                attr = Var(attr_name, attr_type)
+                if isinstance(aggregate, Var):
+                    attr_var = aggregate.type.vars[node.attr]
+                    field_origin = adj.array_field_ref_origin(aggregate, (attr_var.label,))
+                    if field_origin is not None:
+                        attr.ref_origin = field_origin
+                    elif origin := adj.reference_origin_for_var(aggregate):
+                        attr.ref_origin = origin.extend_field(node.attr)
+                    adj.deterministic.propagate_attribute_reference(attr, aggregate, attr_var, attr_type)
+                    adj.apply_struct_array_field_metadata(attr, aggregate, (attr_var.label,))
+                return attr
 
             aggregate_type = strip_reference(aggregate.type)
 
@@ -3673,6 +3707,11 @@ class Adjoint:
                 if origin := adj.reference_origin_for_var(aggregate):
                     out.ref_origin = origin.extend_field(component)
 
+                if hasattr(aggregate, "array_root"):
+                    out.array_root = aggregate.array_root
+                    out.array_indices = aggregate.array_indices
+                    out.array_access_prefix = f"{getattr(aggregate, 'array_access_prefix', '')}.{component}"
+
                 return out
 
             else:
@@ -3692,14 +3731,20 @@ class Adjoint:
                 # Array descriptor fields, such as ``shape``, must be taken from
                 # the descriptor Var itself; replaying an origin may reconstruct
                 # an rvalue view like ``wp::view(...).shape``.
-                origin = None if is_array(aggregate_type) else adj.reference_origin_for_var(aggregate)
+                field_origin = adj.array_field_ref_origin(aggregate, (attr_var.label,))
+                origin = field_origin
+                if origin is None and not is_array(aggregate_type):
+                    origin = adj.reference_origin_for_var(aggregate)
 
                 if origin is not None:
-                    attr.ref_origin = origin.extend_field(
-                        attr_var.label,
-                        pointer_cast=cast,
-                        adjoint_pointer_cast=adj_cast,
-                    )
+                    if field_origin is None:
+                        attr.ref_origin = origin.extend_field(
+                            attr_var.label,
+                            pointer_cast=cast,
+                            adjoint_pointer_cast=adj_cast,
+                        )
+                    else:
+                        attr.ref_origin = origin
                     adj.add_forward(f"{attr.emit()} = {attr.ref_origin.emit_pointer()};")
                 elif is_reference(aggregate.type):
                     adj.add_forward(f"{attr.emit()} = {cast}&({aggregate.emit()}->{attr_var.label});")
@@ -3707,11 +3752,17 @@ class Adjoint:
                     adj.add_forward(f"{attr.emit()} = {cast}&({aggregate.emit()}.{attr_var.label});")
 
                 adj.deterministic.propagate_attribute_reference(attr, aggregate, attr_var, attr_type)
+                adj.apply_struct_array_field_metadata(attr, aggregate, (attr_var.label,))
 
                 if adj.is_differentiable_value_type(strip_reference(attr_type)):
                     adj.add_reverse(f"{aggregate.emit_adj()}.{attr_var.label} += {adj_cast}{attr.emit_adj()};")
                 else:
                     adj.add_reverse(f"{aggregate.emit_adj()}.{attr_var.label} = {adj_cast}{attr.emit_adj()};")
+
+                if hasattr(aggregate, "array_root"):
+                    attr.array_root = aggregate.array_root
+                    attr.array_indices = aggregate.array_indices
+                    attr.array_access_prefix = f"{getattr(aggregate, 'array_access_prefix', '')}.{attr_var.label}"
 
                 return attr
 
@@ -4597,10 +4648,18 @@ class Adjoint:
             if len(indices) == target_type.ndim and all(
                 warp._src.types.type_is_int(strip_reference(x.type)) for x in indices
             ):
+                indices = tuple(adj.load(x) for x in indices)
                 # handles array loads (where each dimension has an index specified)
                 out = adj.add_builtin_call("address", [target, *indices])
                 if origin := adj.reference_origin_for_var(target):
                     out.ref_origin = origin.extend_array(indices)
+
+                if warp._src.types.matches_array_class(target_type, warp._src.types.array) and (
+                    type_is_composite(target_type.dtype) or isinstance(target_type.dtype, Struct)
+                ):
+                    out.array_root = target
+                    out.array_indices = tuple(indices)
+                    out.array_access_prefix = ""
 
                 if adj.builder_options.get("verify_autograd_array_access", False):
                     target.mark_read()
@@ -4661,6 +4720,14 @@ class Adjoint:
                     and index_types_are_int
                 ):
                     out.ref_origin = origin.extend_index(indices[0])
+
+            if hasattr(target, "array_root"):
+                slot_access = adj._composite_subscript_slot_access(target_type, indices)
+                if slot_access is not None:
+                    access_cpp, _ = slot_access
+                    out.array_root = target.array_root
+                    out.array_indices = target.array_indices
+                    out.array_access_prefix = f"{getattr(target, 'array_access_prefix', '')}{access_cpp}"
 
         return out
 
@@ -5059,11 +5126,7 @@ class Adjoint:
         if hasattr(node.value, "attr") and node.value.attr == "adjoint":
             # handle adjoint of a variable, i.e. wp.adjoint[var]
             node.slice.is_adjoint = True
-            var = adj.eval(node.slice)
-            var_name = var.label
-            var = Var(f"adj_{var_name}", type=var.type, constant=None, prefix=False)
-            adj.deterministic.mark_adjoint_target(var, var_name)
-            return var
+            return adj.make_adjoint_target_var(adj.eval(node.slice))
 
         target, indices = adj.eval_subscript(node)
 
@@ -5093,6 +5156,182 @@ class Adjoint:
             )
 
         adj.add_forward(f"*{ref_var.emit()} = {value.emit()};")
+
+    def clear_array_slot_metadata(adj, value):
+        """Detach array-slot provenance when binding a value to a local."""
+        if not isinstance(value, Var) or is_array(strip_reference(value.type)):
+            return value
+
+        for name in ("array_root", "array_indices", "array_access_prefix"):
+            if hasattr(value, name):
+                delattr(value, name)
+        return value
+
+    def _struct_array_field_paths(adj, struct_type, prefix=()):
+        """Yield array-typed field paths inside ``struct_type``."""
+        if not isinstance(struct_type, Struct):
+            return
+
+        for field_name, field_var in struct_type.vars.items():
+            field_path = (*prefix, field_name)
+            field_type = strip_reference(field_var.type)
+            if is_array(field_type):
+                yield field_path, field_type
+            elif isinstance(field_type, Struct):
+                yield from adj._struct_array_field_paths(field_type, field_path)
+
+    @staticmethod
+    def _origin_with_field_path(origin, field_path):
+        for field_name in field_path:
+            origin = origin.extend_field(field_name)
+        return origin
+
+    def _base_struct_alias_origin(adj, src):
+        if getattr(src, "ref_origin", None) is not None:
+            return src.ref_origin
+        if any(src is arg for arg in adj.args):
+            return _LValueOrigin.from_local(src)
+        return None
+
+    def propagate_struct_array_alias_metadata(adj, out, src):
+        """Carry array-field storage provenance through struct aliases."""
+        if not isinstance(out, Var) or not isinstance(src, Var):
+            return out
+
+        out_type = strip_reference(out.type)
+        src_type = strip_reference(src.type)
+        if not isinstance(out_type, Struct) or not isinstance(src_type, Struct):
+            return out
+
+        inherited_origins = getattr(src, "array_field_ref_origins", {})
+        inherited_det_targets = getattr(src, "array_field_deterministic_targets", {})
+        base_origin = adj._base_struct_alias_origin(src)
+        base_root_label = getattr(src, "deterministic_ref_root_label", None)
+        base_attr_path = tuple(getattr(src, "deterministic_ref_attr_path", ()))
+        if base_root_label is None and any(src is arg for arg in adj.args):
+            base_root_label = src.label
+
+        origins = {}
+        det_targets = {}
+        for field_path, array_type in adj._struct_array_field_paths(out_type):
+            if field_path in inherited_origins:
+                origins[field_path] = inherited_origins[field_path]
+            elif base_origin is not None:
+                origins[field_path] = adj._origin_with_field_path(base_origin, field_path)
+
+            if field_path in inherited_det_targets:
+                det_targets[field_path] = inherited_det_targets[field_path]
+            elif base_root_label is not None:
+                det_targets[field_path] = (base_root_label, (*base_attr_path, *field_path), array_type)
+
+        if origins:
+            out.array_field_ref_origins = origins
+        if det_targets:
+            out.array_field_deterministic_targets = det_targets
+
+        return out
+
+    @staticmethod
+    def array_field_ref_origin(aggregate, field_path):
+        return getattr(aggregate, "array_field_ref_origins", {}).get(tuple(field_path))
+
+    def apply_struct_array_field_metadata(adj, attr, aggregate, field_path):
+        """Apply field-specific array provenance after a struct attribute read."""
+        field_path = tuple(field_path)
+        origin = adj.array_field_ref_origin(aggregate, field_path)
+        if origin is not None:
+            attr.ref_origin = origin
+
+        det_targets = getattr(aggregate, "array_field_deterministic_targets", {})
+        if field_path in det_targets:
+            root_label, attr_path, array_type = det_targets[field_path]
+            attr.deterministic_ref_root_label = root_label
+            attr.deterministic_ref_attr_path = tuple(attr_path)
+            attr.deterministic_ref_array_type = array_type
+
+        nested_origins = {}
+        for path, nested_origin in getattr(aggregate, "array_field_ref_origins", {}).items():
+            if len(path) > len(field_path) and path[: len(field_path)] == field_path:
+                nested_origins[path[len(field_path) :]] = nested_origin
+        if nested_origins:
+            attr.array_field_ref_origins = nested_origins
+
+        nested_det_targets = {}
+        for path, target in det_targets.items():
+            if len(path) > len(field_path) and path[: len(field_path)] == field_path:
+                nested_det_targets[path[len(field_path) :]] = target
+        if nested_det_targets:
+            attr.array_field_deterministic_targets = nested_det_targets
+
+        return attr
+
+    def propagate_array_alias_metadata(adj, out, src):
+        """Carry array storage provenance through descriptor aliases."""
+        if not isinstance(out, Var) or not isinstance(src, Var):
+            return out
+        if not is_array(strip_reference(out.type)):
+            return out
+
+        out.ref_origin = getattr(src, "ref_origin", None)
+        for name in (
+            "deterministic_ref_root_label",
+            "deterministic_ref_attr_path",
+            "deterministic_ref_array_type",
+            "deterministic_view_parent",
+            "deterministic_view_indices",
+            "deterministic_adjoint_target",
+            "deterministic_adjoint_root_label",
+        ):
+            if hasattr(src, name):
+                setattr(out, name, getattr(src, name))
+
+        if (
+            not hasattr(out, "deterministic_ref_root_label")
+            and not hasattr(out, "deterministic_view_parent")
+            and not getattr(out, "deterministic_adjoint_target", False)
+            and any(src is arg for arg in adj.args)
+        ):
+            out.deterministic_ref_root_label = src.label
+            out.deterministic_ref_attr_path = ()
+            out.deterministic_ref_array_type = strip_reference(src.type)
+
+        return out
+
+    def make_adjoint_target_var(adj, src_var):
+        """Return the storage expression represented by ``wp.adjoint[src_var]``."""
+        if not isinstance(src_var, Var):
+            return None
+
+        src_type = strip_reference(src_var.type)
+        if not is_array(src_type):
+            return Var(f"adj_{src_var.label}", type=src_var.type, constant=None, prefix=False)
+
+        view_parent = getattr(src_var, "deterministic_view_parent", None)
+        if view_parent is not None:
+            adj_parent = adj.make_adjoint_target_var(view_parent)
+            if adj_parent is None:
+                return None
+            view_indices = tuple(adj.load(idx) for idx in getattr(src_var, "deterministic_view_indices", ()))
+            out = adj.add_builtin_call("view", (adj_parent, *view_indices))
+            adj.deterministic.track_view(out, adj_parent, view_indices)
+            return out
+
+        origin = getattr(src_var, "ref_origin", None)
+        if origin is not None:
+            out = Var(origin.emit_lvalue(adjoint=True), type=src_type, constant=None, prefix=False)
+        else:
+            out = Var(f"adj_{src_var.label}", type=src_type, constant=None, prefix=False)
+
+        root_label = getattr(src_var, "deterministic_ref_root_label", None)
+        if root_label is not None:
+            out.deterministic_adjoint_target = True
+            out.deterministic_adjoint_root_label = root_label
+            out.deterministic_ref_attr_path = tuple(getattr(src_var, "deterministic_ref_attr_path", ()))
+            out.deterministic_ref_array_type = src_type
+        elif origin is None or not any(step.kind == "view" for step in origin.steps):
+            adj.deterministic.mark_adjoint_target(out, src_var.label)
+
+        return out
 
     def emit_Assign(adj, node):
         if len(node.targets) != 1:
@@ -5152,10 +5391,21 @@ class Adjoint:
                 # storing any ref target so tuple assignment keeps its
                 # simultaneous semantics, e.g. `old, x = x, 2.0`.
                 out = tuple(
-                    adj.load(value) if isinstance(value, Var) and is_reference(value.type) else value for value in rhs
+                    adj.add_builtin_call("copy", [value])
+                    if isinstance(value, Var) and is_reference(value.type)
+                    else value
+                    for value in rhs
                 )
             else:
-                out = rhs
+                out = tuple(
+                    adj.add_builtin_call("copy", [value])
+                    if isinstance(value, Var) and is_reference(value.type)
+                    else value
+                    for value in rhs
+                )
+            out = tuple(
+                adj.propagate_array_alias_metadata(value, rhs_value) for value, rhs_value in zip(out, rhs, strict=True)
+            )
 
             for name, rhs in zip(names, out, strict=True):
                 # A tuple-unpack target that is a wp.ref[T] parameter mutates
@@ -5166,6 +5416,7 @@ class Adjoint:
                     adj.store_ref_param_value(name, rhs)
                     continue
 
+                local_rhs = adj.clear_array_slot_metadata(rhs)
                 if name in adj.symbols:
                     if isinstance(adj.symbols[name], warp._src.context.GradWrapper):
                         raise WarpCodegenError(
@@ -5176,14 +5427,14 @@ class Adjoint:
 
                     # Sibling query-kind types may rebind over one another: a later
                     # branch merge decays the symbol to their shared erased parent.
-                    if not types_equal(rhs.type, adj.symbols[name].type) and not type_erasure_join(
-                        rhs.type, adj.symbols[name].type
+                    if not types_equal(local_rhs.type, adj.symbols[name].type) and not type_erasure_join(
+                        local_rhs.type, adj.symbols[name].type
                     ):
                         raise WarpCodegenTypeError(
-                            f"Error, assigning to existing symbol {name} ({adj.symbols[name].type}) with different type ({rhs.type})"
+                            f"Error, assigning to existing symbol {name} ({adj.symbols[name].type}) with different type ({local_rhs.type})"
                         )
 
-                adj.symbols[name] = rhs
+                adj.symbols[name] = local_rhs
 
         # handles the case where we are assigning to an array index (e.g.: arr[i] = 2.0)
         elif isinstance(lhs, ast.Subscript):
@@ -5191,7 +5442,9 @@ class Adjoint:
                 # handle adjoint of a variable, i.e. wp.adjoint[var]
                 lhs.slice.is_adjoint = True
                 src_var = adj.eval(lhs.slice)
-                var = Var(f"adj_{src_var.label}", type=src_var.type, constant=None, prefix=False)
+                var = adj.make_adjoint_target_var(src_var)
+                if var is None:
+                    return
                 adj.add_forward(f"{var.emit()} = {rhs.emit()};")
                 return
 
@@ -5201,9 +5454,24 @@ class Adjoint:
             if adj._try_lower_array_slot_write(lhs, rhs):
                 return
 
+            # Materialize an rhs reference (e.g. ``src[j]`` -> ``address(src, j)``)
+            # before evaluating the (possibly side-effecting) target index
+            # expression. Python evaluates the rhs of a plain assignment before
+            # the assignment target, so ``dst[mutate(src)] = src[0]`` must store
+            # the original ``src[0]``. ``_store_subscript`` would otherwise route
+            # the rhs reference through a builtin call that loads it only after
+            # the target index has been emitted. Use ``copy`` (not ``load``):
+            # ``load``'s adjoint is a nop, which would drop the read-side
+            # gradient for ``dst[i] = src[j]``; ``copy`` keeps the adjoint chain
+            # back to the source array intact (matching the slot fast path).
+            if is_reference(rhs.type):
+                rhs = adj.add_builtin_call("copy", [rhs])
+
             target, indices = adj.eval_subscript(lhs)
             target_type = strip_reference(target.type)
             indices = adj.eval_indices(target_type, indices)
+            if adj._try_lower_evaluated_array_slot_write(target, indices, rhs):
+                return
             adj._store_subscript(lhs, target, indices, rhs)
 
         elif isinstance(lhs, ast.Name):
@@ -5276,7 +5544,11 @@ class Adjoint:
                 out = rhs
 
             if isinstance(out, Var) and is_array(out.type):
-                out.ref_origin = getattr(rhs, "ref_origin", None)
+                adj.propagate_array_alias_metadata(out, rhs)
+            elif isinstance(out, Var) and isinstance(strip_reference(out.type), Struct):
+                adj.propagate_struct_array_alias_metadata(out, rhs)
+            else:
+                out = adj.clear_array_slot_metadata(out)
 
             # update symbol map (assumes lhs is a Name node)
             adj.symbols[name] = out
@@ -5286,7 +5558,12 @@ class Adjoint:
             # wp.adjoint[var].field reaches here but declines because root name "wp" is not a symbol.
             if adj._try_lower_array_slot_write(lhs, rhs):
                 return
-            adj._store_attribute(lhs, adj.resolve_attribute_store_aggregate(lhs.value), rhs)
+            if isinstance(rhs, Var) and is_reference(rhs.type):
+                rhs = adj.add_builtin_call("copy", [rhs])
+            aggregate = adj.resolve_attribute_store_aggregate(lhs.value)
+            if adj._try_lower_evaluated_array_slot_attribute_write(lhs, aggregate, rhs):
+                return
+            adj._store_attribute(lhs, aggregate, rhs)
 
         else:
             raise WarpCodegenError("Error, unsupported assignment statement.")
@@ -5319,6 +5596,8 @@ class Adjoint:
           - ``arr[i].x`` — vec/quat component via attribute (leaf SCALAR).
           - ``arr[i][k]`` — vec/quat scalar subscript (leaf SCALAR).
           - ``arr[i][r, c]`` — mat element subscript (leaf SCALAR).
+          - ``arr[i][r][c]`` - mat row then scalar subscript (leaf SCALAR).
+          - ``arr[i][r]`` - mat row subscript (leaf COMPOSITE: vec).
           - ``arr[i].p`` / ``arr[i].q`` — transform translation / rotation
             (leaf is COMPOSITE: vec3 or quat).
           - ``arr[i].field`` — struct field (leaf SCALAR or COMPOSITE).
@@ -5333,7 +5612,7 @@ class Adjoint:
           - Arrays other than plain ``wp.array`` (indexed, fabric, fixed):
             those have no ``adj_array_store_slot`` overload (the slot call
             would fail to compile for them).
-          - Vec/quat/mat slices (writing a sub-vec, a row, or a sub-mat):
+          - Vec/quat/mat non-row slices (writing a sub-vec or sub-mat):
             the slot is a composite that isn't trivially addressable as
             a single reference via the lambda pattern.
           - Chains that traverse an array field of a struct
@@ -5346,48 +5625,425 @@ class Adjoint:
         plan = adj._classify_slot_access(lhs, rhs.type)
         if plan is None:
             return False
+        root_var = adj._slot_plan_root_var(plan)
+        if root_var is None:
+            return False
 
+        # Materialize an rhs reference (e.g. ``src[i]`` -> ``address(src, i)``)
+        # BEFORE evaluating the slot-index expressions. Python evaluates the
+        # rhs of a plain assignment before the assignment target, so a
+        # side-effecting index expression must not be able to alter the value
+        # the rhs reads (e.g. ``dst[mutate(src)].x = src[0]`` must read the
+        # original ``src[0]``). Deferring the copy into _emit_array_slot_write
+        # would read the slot after _eval_array_slot_access has run the index
+        # expressions. Using ``copy`` (not ``load``) keeps the read-side
+        # adjoint chain intact.
+        if is_reference(rhs.type):
+            rhs = adj.add_builtin_call("copy", [rhs])
+
+        array_index_vars, access_cpp = adj._eval_array_slot_access(plan.array_indices_ast, plan.access_parts)
+
+        return adj._emit_array_slot_write(root_var, array_index_vars, access_cpp, rhs, plan.slot_type)
+
+    def _try_lower_array_slot_atomic_augassign(adj, lhs, eval_rhs, op):
+        """Lower array-rooted composite slot augmented assignments atomically.
+
+        ``eval_rhs`` is a thunk that evaluates the right-hand side on demand.
+        It is invoked only after the slot indices have been evaluated, so a
+        side-effecting target index expression is emitted before the rhs,
+        matching Python's augmented-assignment evaluation order.
+        """
+        plan = adj._classify_slot_access(lhs, None)
+        if plan is None:
+            return False
+        root_var = adj._slot_plan_root_var(plan)
+        if root_var is None:
+            return False
+
+        op_name = adj._atomic_slot_augassign_op_name(op)
+        if op_name is None:
+            # Keep unsupported ops like ``/=`` on the existing load-op-store
+            # path, matching whole-array augmented assignment behavior.
+            return False
+
+        if not adj._is_supported_atomic_slot_type(plan.slot_type, op):
+            # Keep non-atomic slot types on the existing load-op-store path,
+            # matching whole-array augmented assignment behavior.
+            return False
+
+        array_index_vars, access_cpp = adj._eval_array_slot_access(plan.array_indices_ast, plan.access_parts)
+        return adj._try_emit_array_slot_atomic_augassign(
+            root_var, array_index_vars, access_cpp, eval_rhs, plan.slot_type, op_name
+        )
+
+    def _eval_array_slot_access(adj, array_indices_ast, access_parts):
+        # Evaluate indices AFTER committing to the fast path, in Python
+        # left-to-right order: array subscripts outermost first, then the
+        # composite-component chain inner subscripts in order. Reference-typed
+        # indices (e.g. ``arr[idx[0]].x``, where ``idx[0]`` is an array read)
+        # must be loaded to a value before being emitted into ``wp::index(...)``
+        # and the access lambda: unlike the generic store path, these indices
+        # are emitted as raw C++ rather than passed through a builtin call that
+        # would load them, so a bare reference would be a pointer where an
+        # integer is expected and fail to compile.
+        array_index_vars = []
+        for n in array_indices_ast:
+            idx_var = adj.load(adj.eval(n))
+            if not adj._is_integer_index_var(idx_var):
+                idx_type = getattr(idx_var, "type", type(idx_var))
+                raise WarpCodegenTypeError(
+                    f"Array slot write indices must be integers, got {type_repr(strip_reference(idx_type))}"
+                )
+            array_index_vars.append(idx_var)
+
+        access_cpp_parts = []
+        for part in access_parts:
+            if isinstance(part, str):
+                access_cpp_parts.append(part)
+            else:
+                idx_var = adj.load(adj.eval(part))
+                if not adj._is_integer_index_var(idx_var):
+                    raise WarpCodegenTypeError(
+                        f"Composite slot write indices must be integers, got {type_repr(strip_reference(idx_var.type))}"
+                    )
+                access_cpp_parts.append(idx_var.emit())
+
+        return array_index_vars, "".join(access_cpp_parts)
+
+    def _is_integer_index_var(adj, index):
+        return hasattr(index, "type") and warp._src.types.type_is_int(strip_reference(index.type))
+
+    def _slot_plan_root_var(adj, plan):
+        if not plan.root_is_adjoint:
+            return plan.root_var
+        return adj.make_adjoint_target_var(plan.root_var)
+
+    def _atomic_slot_augassign_op_name(adj, op):
+        if isinstance(op, ast.Add):
+            return "add"
+        if isinstance(op, ast.Sub):
+            return "sub"
+        if isinstance(op, ast.BitAnd):
+            return "and"
+        if isinstance(op, ast.BitOr):
+            return "or"
+        if isinstance(op, ast.BitXor):
+            return "xor"
+        return None
+
+    def _is_supported_atomic_slot_type(adj, slot_type, op):
+        scalar_type = getattr(slot_type, "_wp_scalar_type_", slot_type)
+        if isinstance(op, str):
+            op_name = op
+        else:
+            op_name = adj._atomic_slot_augassign_op_name(op)
+
+        if op_name in ("add", "sub"):
+            supported_atomic_types = (int32, uint32, int64, uint64, float16, bfloat16, float32, float64)
+        elif op_name in ("and", "or", "xor"):
+            supported_atomic_types = (int32, uint32, int64, uint64)
+        else:
+            return False
+        return any(types_equal_generic(scalar_type, t) for t in supported_atomic_types)
+
+    def _composite_subscript_slot_access(adj, target_type, indices):
+        if type_is_matrix(target_type):
+            if len(indices) == 1:
+                indices = tuple(adj.load(idx) for idx in indices)
+                if not adj._is_integer_index_var(indices[0]):
+                    return None
+                return f".row_ref({indices[0].emit()})", getattr(target_type, "_wp_row_type_", None)
+            if len(indices) == 2:
+                indices = tuple(adj.load(idx) for idx in indices)
+                if not all(adj._is_integer_index_var(idx) for idx in indices):
+                    return None
+                return (
+                    f".element_ref({indices[0].emit()}, {indices[1].emit()})",
+                    getattr(target_type, "_wp_scalar_type_", None),
+                )
+        elif type_is_vector(target_type) or type_is_quaternion(target_type) or type_is_transformation(target_type):
+            if len(indices) != 1:
+                return None
+            indices = tuple(adj.load(idx) for idx in indices)
+            if not adj._is_integer_index_var(indices[0]):
+                return None
+            # Route through component_ref() so negative indices are normalized;
+            # raw operator[] would index before storage.
+            return f".component_ref({indices[0].emit()})", getattr(target_type, "_wp_scalar_type_", None)
+
+        return None
+
+    def _composite_attribute_slot_access(adj, attr, aggregate_type):
+        if type_is_vector(aggregate_type) or type_is_quaternion(aggregate_type):
+            index = adj.vector_component_index(attr, aggregate_type)
+            return f".component_ref({index.emit()})", getattr(aggregate_type, "_wp_scalar_type_", None)
+        if type_is_transformation(aggregate_type):
+            component = adj.transform_component(attr)
+            scalar_t = getattr(aggregate_type, "_wp_scalar_type_", None)
+            if scalar_t is None:
+                return None
+            slot_type = vector(length=3, dtype=scalar_t) if component == "p" else quaternion(dtype=scalar_t)
+            return f".{component}", slot_type
+        if isinstance(aggregate_type, Struct):
+            if attr not in aggregate_type.vars:
+                return None
+            attr_var = aggregate_type.vars[attr]
+            if is_array(attr_var.type):
+                return None
+            return f".{attr_var.label}", attr_var.type
+
+        return None
+
+    def _evaluated_array_slot_context(adj, carrier):
+        if not isinstance(carrier, Var):
+            return None
+
+        root_var = getattr(carrier, "array_root", None)
+        if not isinstance(root_var, Var):
+            return None
+
+        root_type = strip_reference(root_var.type)
+        if not warp._src.types.matches_array_class(root_type, warp._src.types.array):
+            return None
+        if root_type.dtype in warp._src.types.non_atomic_types:
+            return None
+
+        array_index_vars = getattr(carrier, "array_indices", None)
+        if array_index_vars is None:
+            return None
+        array_index_vars = tuple(adj.load(idx) for idx in array_index_vars)
+        if not all(adj._is_integer_index_var(idx) for idx in array_index_vars):
+            return None
+
+        return root_var, array_index_vars, getattr(carrier, "array_access_prefix", "")
+
+    def _try_lower_evaluated_array_slot_write(adj, target, indices, rhs, *, emit_reverse=True):
+        """Lower an array-rooted composite slot write using evaluated indices.
+
+        ``emit_AugAssign`` has already evaluated the LHS through
+        ``eval_subscript()`` before it reaches this path. Re-walking the
+        original AST would re-run index expressions, so this helper uses
+        the array-root metadata attached to the evaluated reference.
+        """
+        context = adj._evaluated_array_slot_context(target)
+        if context is None:
+            return False
+        root_var, array_index_vars, access_cpp = context
+
+        target_type = strip_reference(target.type)
+        slot_access = adj._composite_subscript_slot_access(target_type, indices)
+        if slot_access is None:
+            return False
+        suffix_cpp, slot_type = slot_access
+        access_cpp += suffix_cpp
+
+        if slot_type is None:
+            return False
+
+        if not types_equal(strip_reference(rhs.type), slot_type):
+            return False
+
+        return adj._emit_array_slot_write(
+            root_var, array_index_vars, access_cpp, rhs, slot_type, emit_reverse=emit_reverse
+        )
+
+    def _try_lower_evaluated_array_slot_atomic_augassign(adj, target, indices, eval_rhs, op):
+        """Lower evaluated array-rooted composite subscript augmented assignment."""
+        context = adj._evaluated_array_slot_context(target)
+        if context is None:
+            return False
+        root_var, array_index_vars, access_cpp = context
+
+        target_type = strip_reference(target.type)
+        slot_access = adj._composite_subscript_slot_access(target_type, indices)
+        if slot_access is None:
+            return False
+        suffix_cpp, slot_type = slot_access
+        if slot_type is None:
+            return False
+
+        op_name = adj._atomic_slot_augassign_op_name(op)
+        if op_name is None:
+            return False
+
+        return adj._try_emit_array_slot_atomic_augassign(
+            root_var, array_index_vars, access_cpp + suffix_cpp, eval_rhs, slot_type, op_name
+        )
+
+    def _try_lower_evaluated_array_slot_attribute_write(adj, lhs, aggregate, rhs, *, emit_reverse=True):
+        """Lower an array-rooted composite attribute write using an evaluated aggregate."""
+        context = adj._evaluated_array_slot_context(aggregate)
+        if context is None:
+            return False
+        root_var, array_index_vars, access_cpp = context
+
+        aggregate_type = strip_reference(aggregate.type)
+        slot_access = adj._composite_attribute_slot_access(lhs.attr, aggregate_type)
+        if slot_access is None:
+            return False
+        suffix_cpp, slot_type = slot_access
+        access_cpp += suffix_cpp
+
+        if slot_type is None:
+            return False
+
+        if not types_equal(strip_reference(rhs.type), slot_type):
+            return False
+
+        return adj._emit_array_slot_write(
+            root_var, array_index_vars, access_cpp, rhs, slot_type, emit_reverse=emit_reverse
+        )
+
+    def _try_lower_evaluated_array_slot_attribute_atomic_augassign(adj, lhs, aggregate, eval_rhs, op):
+        """Lower evaluated array-rooted composite attribute augmented assignment."""
+        context = adj._evaluated_array_slot_context(aggregate)
+        if context is None:
+            return False
+        root_var, array_index_vars, access_cpp = context
+
+        aggregate_type = strip_reference(aggregate.type)
+        slot_access = adj._composite_attribute_slot_access(lhs.attr, aggregate_type)
+        if slot_access is None:
+            return False
+        suffix_cpp, slot_type = slot_access
+        access_cpp += suffix_cpp
+
+        if slot_type is None:
+            return False
+
+        op_name = adj._atomic_slot_augassign_op_name(op)
+        if op_name is None:
+            return False
+
+        return adj._try_emit_array_slot_atomic_augassign(
+            root_var, array_index_vars, access_cpp, eval_rhs, slot_type, op_name
+        )
+
+    def _try_emit_array_slot_atomic_augassign(
+        adj, root_var, array_index_vars, access_cpp, eval_rhs, slot_type, op_name
+    ):
+        """Validate and emit a composite slot atomic augmented assignment."""
+        root_type = strip_reference(root_var.type)
+        if not warp._src.types.matches_array_class(root_type, warp._src.types.array):
+            return False
+        if root_type.dtype in warp._src.types.non_atomic_types:
+            return False
+
+        if not adj._is_supported_atomic_slot_type(slot_type, op_name):
+            return False
+
+        rhs = eval_rhs()
+        return adj._emit_array_slot_atomic_augassign(root_var, array_index_vars, access_cpp, rhs, slot_type, op_name)
+
+    def _array_slot_root_expr(adj, root_var):
+        """Return a C++ array descriptor expression for a slot root."""
+        if is_reference(root_var.type):
+            return f"*({root_var.emit()})"
+        return root_var.emit()
+
+    def _array_slot_root_adj_expr(adj, root_var):
+        """Return the C++ adjoint array descriptor expression for a slot root."""
+        if origin := adj.reference_origin_for_var(root_var):
+            prelude = []
+            expr = origin.emit_lvalue_materialized_views(adjoint=True, adj=adj, prelude=prelude)
+            return expr, prelude
+        return root_var.emit_adj(), []
+
+    def _emit_array_slot_write(adj, root_var, array_index_vars, access_cpp, rhs, slot_type, *, emit_reverse=True):
         # ``src[i]`` arrives as ``address(src, i)``; route it through ``copy``
         # so the rhs has a working adjoint chain back to the source array
         # (``load`` would route through a nop adjoint and drop the read-side
         # gradient).
         if is_reference(rhs.type):
             rhs = adj.add_builtin_call("copy", [rhs])
+        rhs_value_type = strip_reference(rhs.type)
+        if not types_equal(rhs_value_type, slot_type):
+            raise WarpCodegenTypeError(
+                f"Composite slot assignment expects value of type {type_repr(slot_type)}, "
+                f"got {type_repr(rhs_value_type)}"
+            )
 
-        # Committed: evaluate indices in Python left-to-right order
-        # (outer array subscripts first, then composite-chain subscripts).
-        array_indices_cpp = ", ".join(adj.eval(n).emit() for n in plan.array_indices_ast)
-        access_cpp = "".join(p if isinstance(p, str) else adj.eval(p).emit() for p in plan.access_parts)
-
-        arr_cpp = plan.root_var.emit()
-        adj_arr_cpp = plan.root_var.emit_adj()
+        arr_cpp = adj._array_slot_root_expr(root_var)
+        adj_arr_cpp, adj_arr_prelude = adj._array_slot_root_adj_expr(root_var)
         rhs_cpp = rhs.emit()
         adj_rhs_cpp = rhs.emit_adj()
+        array_indices_cpp = ", ".join(v.emit() for v in array_index_vars)
 
-        # Forward: one slot store (wrapped for deterministic atomic mode).
+        # Forward: one slot store. Like array_store(), this mutates memory and
+        # must not replay during backward.
         slot_lvalue = f"wp::index({arr_cpp}, {array_indices_cpp}){access_cpp}"
-        adj.add_forward(adj.deterministic.wrap_slot_store(slot_lvalue, rhs_cpp))
+        fwd_store = adj.deterministic.wrap_slot_store(slot_lvalue, rhs_cpp)
+        adj.deterministic.mark_store_target(root_var)
+        adj.add_forward(fwd_store, replay=f"// {fwd_store}")
 
-        # Reverse: single call to the slot-level adj_array_store variant,
-        # with the composite-component access encoded as a short lambda.
-        # The grad-routing (adj_buf vs buf.grad) and RETAIN_GRAD handling
-        # live in the native helper, matching adj_array_store's existing
-        # logic scoped to the single slot.
-        adj.add_reverse(
-            f"wp::adj_array_store_slot({arr_cpp}, {adj_arr_cpp}, {adj_rhs_cpp}, "
-            f"[&](auto& _e) -> auto& {{ return _e{access_cpp}; }}, {array_indices_cpp});"
-        )
+        if emit_reverse:
+            # The native helper handles grad-routing and RETAIN_GRAD for this
+            # one overwritten slot, matching adj_array_store's existing logic.
+            adj.add_reverse(
+                f"wp::adj_array_store_slot({arr_cpp}, {adj_arr_cpp}, {adj_rhs_cpp}, "
+                f"[&](auto& _e) -> auto& {{ return _e{access_cpp}; }}, {array_indices_cpp});"
+            )
+            for stmt in reversed(adj_arr_prelude):
+                adj.add_reverse(stmt)
 
-        adj._mark_array_write(plan.root_var)
+        adj._mark_array_write(root_var)
         return True
 
-    def _classify_slot_access(adj, lhs, rhs_type):
+    def _emit_array_slot_atomic_augassign(adj, root_var, array_index_vars, access_cpp, rhs, slot_type, op_name):
+        if is_reference(rhs.type):
+            rhs = adj.add_builtin_call("copy", [rhs])
+        rhs_value_type = strip_reference(rhs.type)
+        if not types_equal(rhs_value_type, slot_type):
+            raise WarpCodegenTypeError(
+                f"Composite slot augmented assignment expects value of type {type_repr(slot_type)}, "
+                f"got {type_repr(rhs_value_type)}"
+            )
+
+        arr_cpp = adj._array_slot_root_expr(root_var)
+        adj_arr_cpp, adj_arr_prelude = adj._array_slot_root_adj_expr(root_var)
+        rhs_cpp = rhs.emit()
+        adj_rhs_cpp = rhs.emit_adj()
+        array_indices_cpp = ", ".join(v.emit() for v in array_index_vars)
+        access_lambda = f"[&](auto& _e) -> auto& {{ return _e{access_cpp}; }}"
+        suffix = f", {array_indices_cpp}" if array_indices_cpp else ""
+
+        stmt = f"wp::array_atomic_{op_name}_slot({arr_cpp}, {rhs_cpp}, {access_lambda}{suffix});"
+        scalar_type = getattr(slot_type, "_wp_scalar_type_", slot_type)
+        if adj.deterministic.enabled:
+            if adj.deterministic.emit_adjoint_slot_scatter(
+                root_var, array_index_vars, access_cpp, rhs, slot_type, op_name, stmt
+            ):
+                return True
+            if op_name in ("add", "sub") and type_is_float(scalar_type):
+                raise WarpCodegenError(
+                    "Deterministic mode does not yet support floating-point composite slot augmented assignment "
+                    "atomics."
+                )
+            stmt = adj.deterministic.wrap_side_effect_call(stmt)
+
+        adj.add_forward(stmt, replay=f"// {stmt}")
+        adj.add_reverse(
+            f"wp::adj_array_atomic_{op_name}_slot({arr_cpp}, {adj_arr_cpp}, {adj_rhs_cpp}, {access_lambda}{suffix});"
+        )
+        for stmt in reversed(adj_arr_prelude):
+            adj.add_reverse(stmt)
+
+        if adj.builder_options.get("verify_autograd_array_access", False):
+            kernel_name = adj.fun_name
+            filename = adj.filename
+            lineno = adj.lineno + adj.fun_lineno
+            root_var.mark_write(kernel_name=kernel_name, filename=filename, lineno=lineno)
+
+        return True
+
+    def _classify_slot_access(adj, lhs, rhs_type=None):
         """Pure analysis of an array slot-write LHS — emits no IR.
 
         Returns a ``SlotAccessPlan`` if ``lhs`` is an array-rooted composite-
         component write the fast path can lower, else ``None``. Performs only
-        AST-shape and type checks; the caller evaluates indices and emits IR
-        after acceptance, so a decline never pollutes the IR.
+        AST-shape checks and, when ``rhs_type`` is provided, type checks; the
+        caller evaluates indices and emits IR after acceptance, so a decline
+        never pollutes the IR.
         """
         # Walk LHS leaf-to-root, then validate root.
         chain = []
@@ -5397,13 +6053,28 @@ class Adjoint:
             node = node.value
         if not isinstance(node, ast.Name):
             return None
-        # ``wp``-rooted chains (e.g. ``wp.adjoint[var].field``) decline here:
-        # the module alias ``wp`` is never a key in ``adj.symbols``. Plain and
-        # augmented ``wp.adjoint[var]`` writes are also intercepted upstream in
-        # emit_Assign before this fast path is reached.
-        if node.id not in adj.symbols:
+        chain.reverse()
+        root_is_adjoint = False
+        if node.id in adj.symbols:
+            root_var = adj.symbols[node.id]
+        elif (
+            len(chain) >= 2
+            and isinstance(chain[0], ast.Attribute)
+            and chain[0].attr == "adjoint"
+            and isinstance(chain[1], ast.Subscript)
+            and chain[1].value is chain[0]
+        ):
+            if not isinstance(chain[1].slice, ast.Name):
+                return None
+            src_var = adj.symbols.get(chain[1].slice.id)
+            if not isinstance(src_var, Var):
+                return None
+            root_var = src_var
+            root_is_adjoint = True
+            chain = chain[2:]
+        else:
             return None
-        root_var = adj.symbols[node.id]
+
         # ``adj.symbols`` may also hold ``GradWrapper`` and other non-Var values.
         if not isinstance(root_var, Var):
             return None
@@ -5414,7 +6085,6 @@ class Adjoint:
             return None
 
         # Consume ``ndim`` outermost subscripts as the array indices.
-        chain.reverse()
         needed = root_type.ndim
         array_indices_ast = []
         consumed = 0
@@ -5442,7 +6112,9 @@ class Adjoint:
         # Member-access fragments below encode native layout: vec_t uses .c[i],
         # mat_t uses .data[r][c], quat_t uses named .x/.y/.z/.w, transform_t .p/.q.
         # The same access string drives both the forward store and the reverse lambda.
-        for step in remaining:
+        step_index = 0
+        while step_index < len(remaining):
+            step = remaining[step_index]
             if isinstance(step, ast.Attribute):
                 if type_is_vector(current_type):
                     dim = current_type._shape_[0]
@@ -5472,20 +6144,53 @@ class Adjoint:
                 elif isinstance(current_type, Struct):
                     if step.attr not in current_type.vars:
                         return None
-                    access_parts.append(f".{step.attr}")
-                    current_type = current_type.vars[step.attr].type
+                    attr_var = current_type.vars[step.attr]
+                    access_parts.append(f".{attr_var.label}")
+                    current_type = attr_var.type
                     # Array-field chains (``state.v[i] = rhs``) are plain
                     # array writes; let the legacy path handle them.
                     if is_array(current_type):
                         return None
                 else:
                     return None
+                step_index += 1
             else:  # ast.Subscript
                 if type_is_matrix(current_type):
-                    if not isinstance(step.slice, ast.Tuple) or len(step.slice.elts) != 2:
-                        return None
-                    access_parts.extend([".data[", step.slice.elts[0], "][", step.slice.elts[1], "]"])
-                    current_type = getattr(current_type, "_wp_scalar_type_", None)
+                    if isinstance(step.slice, ast.Tuple):
+                        slice_elts = step.slice.elts
+                        if len(slice_elts) != 2:
+                            return None
+                        if any(isinstance(elt, ast.Slice) for elt in slice_elts):
+                            return None
+                        access_parts.extend([".element_ref(", slice_elts[0], ", ", slice_elts[1], ")"])
+                        current_type = getattr(current_type, "_wp_scalar_type_", None)
+                        step_index += 1
+                    else:
+                        if isinstance(step.slice, ast.Slice):
+                            return None
+
+                        # Chained matrix row+column syntax, ``mat[r][c]``,
+                        # must normalize both indices. Lower it through the
+                        # matrix element helper instead of ``row_ref(r)[c]``;
+                        # vector subscript does not normalize negative indices.
+                        if step_index + 1 < len(remaining):
+                            next_step = remaining[step_index + 1]
+                            if isinstance(next_step, ast.Subscript):
+                                if isinstance(next_step.slice, ast.Tuple) or isinstance(next_step.slice, ast.Slice):
+                                    return None
+                                access_parts.extend([".element_ref(", step.slice, ", ", next_step.slice, ")"])
+                                current_type = getattr(current_type, "_wp_scalar_type_", None)
+                                step_index += 2
+                                if current_type is None:
+                                    return None
+                                continue
+
+                        # Single-index subscript: mat[r] to row write via row_ref().
+                        # row_ref() returns vec_t<Cols, Type>& which adj_array_store_slot
+                        # can accumulate into directly.
+                        access_parts.extend([".row_ref(", step.slice, ")"])
+                        current_type = getattr(current_type, "_wp_row_type_", None)
+                        step_index += 1
                 elif (
                     type_is_vector(current_type)
                     or type_is_quaternion(current_type)
@@ -5493,18 +6198,23 @@ class Adjoint:
                 ):
                     if isinstance(step.slice, ast.Tuple):
                         return None
-                    access_parts.extend(["[", step.slice, "]"])
+                    if isinstance(step.slice, ast.Slice):
+                        return None
+                    # Route through component_ref() so negative indices are
+                    # normalized; raw operator[] would index before storage.
+                    access_parts.extend([".component_ref(", step.slice, ")"])
                     current_type = getattr(current_type, "_wp_scalar_type_", None)
+                    step_index += 1
                 else:
                     return None
             if current_type is None:
                 return None
 
         slot_type = current_type
-        if not types_equal(strip_reference(rhs_type), slot_type):
+        if rhs_type is not None and not types_equal(strip_reference(rhs_type), slot_type):
             return None
 
-        return SlotAccessPlan(root_var, array_indices_ast, access_parts, slot_type)
+        return SlotAccessPlan(root_var, array_indices_ast, access_parts, slot_type, root_is_adjoint)
 
     def _mark_array_write(adj, target):
         """Record an array write for the autograd access verifier.
@@ -5862,11 +6572,27 @@ class Adjoint:
                 adj.symbols[lhs.id] = result
             return
 
-        # Evaluate RHS once for non-Name targets.
-        rhs = adj.eval(node.value)
+        # Evaluate the RHS lazily (once, on first use) for non-Name targets.
+        # Python evaluates an augmented assignment's target -- including any
+        # side-effecting index subexpressions -- before the RHS, so the RHS
+        # must not be emitted until the target and its indices have been
+        # evaluated. Each path below evaluates its indices first, then calls
+        # ``eval_rhs()``.
+        _rhs_cache = []
+
+        def eval_rhs():
+            if not _rhs_cache:
+                _rhs_cache.append(adj.eval(node.value))
+            return _rhs_cache[0]
+
+        if isinstance(lhs, (ast.Attribute, ast.Subscript)) and adj._try_lower_array_slot_atomic_augassign(
+            lhs, eval_rhs, node.op
+        ):
+            return
 
         def apply_op(current):
             """Compute ``current <op> rhs`` using user-defined overloads or builtins."""
+            rhs = eval_rhs()
             op_name = builtin_operators[type(node.op)]
             try:
                 user_func = adj.resolve_external_reference(op_name)
@@ -5876,14 +6602,35 @@ class Adjoint:
                 pass
             return adj.add_builtin_call(op_name, [current, rhs])
 
+        def unsupported_differentiable_slot_augassign(result, target):
+            """Return whether an array-rooted fallback would silently drop adjoints."""
+            if isinstance(node.op, (ast.Add, ast.Sub, ast.BitAnd, ast.BitOr, ast.BitXor)):
+                return False
+            if not (adj.custom_reverse_mode or adj.force_adjoint_codegen or adj.used_by_backward_kernel):
+                return False
+            if not isinstance(target, Var) or not hasattr(target, "array_root"):
+                return False
+            return adj.is_differentiable_value_type(strip_reference(result.type))
+
+        def reject_differentiable_slot_augassign(result, target):
+            if unsupported_differentiable_slot_augassign(result, target):
+                raise WarpCodegenError(
+                    "Differentiable composite slot augmented assignments with this operator are not supported "
+                    "with backward code generation enabled. Use an explicit out-of-place expression or mark the "
+                    "kernel with enable_backward=False for forward-only code."
+                )
+
         def augassign_subscript(target, indices):
             """Load current value via pre-evaluated target/indices, apply op, store back."""
+            indices = tuple(adj.load(idx) for idx in indices)
+            if adj._try_lower_evaluated_array_slot_atomic_augassign(target, indices, eval_rhs, node.op):
+                return
+
             target_type = strip_reference(target.type)
 
             with adj.suppress_read_tracking():
                 if is_reference(target.type):
-                    current_ref = adj.add_builtin_call("indexref", [target, *indices])
-                    current = adj.load(current_ref)
+                    current = adj.add_builtin_call("extract", [target, *indices])
                 elif is_array(target_type):
                     current = adj.add_builtin_call("address", [target, *indices])
                 elif is_tile(target_type):
@@ -5892,17 +6639,23 @@ class Adjoint:
                     current = adj.add_builtin_call("extract", [target, *indices])
 
             result = apply_op(current)
-            adj._store_subscript(lhs, target, indices, result)
+            reject_differentiable_slot_augassign(result, target)
+            if not adj._try_lower_evaluated_array_slot_write(target, indices, result):
+                adj._store_subscript(lhs, target, indices, result)
 
         def augassign_attribute():
             """Load current value of attribute target, apply op, store back."""
             aggregate = adj.resolve_attribute_store_aggregate(lhs.value)
+            if adj._try_lower_evaluated_array_slot_attribute_atomic_augassign(lhs, aggregate, eval_rhs, node.op):
+                return
 
             with adj.suppress_read_tracking():
                 current = adj.emit_Attribute(lhs, aggregate=aggregate)
 
             result = apply_op(current)
-            adj._store_attribute(lhs, aggregate, result)
+            reject_differentiable_slot_augassign(result, aggregate)
+            if not adj._try_lower_evaluated_array_slot_attribute_write(lhs, aggregate, result):
+                adj._store_attribute(lhs, aggregate, result)
 
         if isinstance(lhs, ast.Subscript):
             # wp.adjoint[var] appears in custom grad functions; handle the
@@ -5914,7 +6667,9 @@ class Adjoint:
                 result = apply_op(current)
                 lhs.slice.is_adjoint = True
                 src_var = adj.eval(lhs.slice)
-                var = Var(f"adj_{src_var.label}", type=src_var.type, constant=None, prefix=False)
+                var = adj.make_adjoint_target_var(src_var)
+                if var is None:
+                    return
                 adj.add_forward(f"{var.emit()} = {result.emit()};")
                 return
 
@@ -5946,19 +6701,19 @@ class Adjoint:
                 # The Python expression has no visible return value, so the
                 # generated atomic return is intentionally discarded.
                 if isinstance(node.op, ast.Add):
-                    adj.add_builtin_call("atomic_add", [target, *indices, rhs], return_value_used=False)
+                    adj.add_builtin_call("atomic_add", [target, *indices, eval_rhs()], return_value_used=False)
                     adj._mark_array_write(target)
                 elif isinstance(node.op, ast.Sub):
-                    adj.add_builtin_call("atomic_sub", [target, *indices, rhs], return_value_used=False)
+                    adj.add_builtin_call("atomic_sub", [target, *indices, eval_rhs()], return_value_used=False)
                     adj._mark_array_write(target)
                 elif isinstance(node.op, ast.BitAnd):
-                    adj.add_builtin_call("atomic_and", [target, *indices, rhs], return_value_used=False)
+                    adj.add_builtin_call("atomic_and", [target, *indices, eval_rhs()], return_value_used=False)
                     adj._mark_array_write(target)
                 elif isinstance(node.op, ast.BitOr):
-                    adj.add_builtin_call("atomic_or", [target, *indices, rhs], return_value_used=False)
+                    adj.add_builtin_call("atomic_or", [target, *indices, eval_rhs()], return_value_used=False)
                     adj._mark_array_write(target)
                 elif isinstance(node.op, ast.BitXor):
-                    adj.add_builtin_call("atomic_xor", [target, *indices, rhs], return_value_used=False)
+                    adj.add_builtin_call("atomic_xor", [target, *indices, eval_rhs()], return_value_used=False)
                     adj._mark_array_write(target)
                 else:
                     log_debug(f"Warning: in-place op {node.op} is not differentiable")
@@ -5971,20 +6726,24 @@ class Adjoint:
                 or type_is_matrix(target_type)
                 or type_is_transformation(target_type)
             ):
+                # When the target is a reference (i.e. an array element accessed via
+                # arr[i]), the ``*_inplace`` builtins operate on a loaded copy and
+                # silently discard the result. Fall back to the load-op-store path
+                # so that _store_subscript (and its _try_lower_array_slot_write fast
+                # path) can write the result back to the actual array element.
                 if is_reference(target.type):
                     augassign_subscript(target, indices)
                     return
-
                 if isinstance(node.op, ast.Add):
-                    adj.add_builtin_call("add_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("add_inplace", [target, *indices, eval_rhs()])
                 elif isinstance(node.op, ast.Sub):
-                    adj.add_builtin_call("sub_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("sub_inplace", [target, *indices, eval_rhs()])
                 elif isinstance(node.op, ast.BitAnd):
-                    adj.add_builtin_call("bit_and_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("bit_and_inplace", [target, *indices, eval_rhs()])
                 elif isinstance(node.op, ast.BitOr):
-                    adj.add_builtin_call("bit_or_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("bit_or_inplace", [target, *indices, eval_rhs()])
                 elif isinstance(node.op, ast.BitXor):
-                    adj.add_builtin_call("bit_xor_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("bit_xor_inplace", [target, *indices, eval_rhs()])
                 else:
                     log_debug(f"Warning: in-place op {node.op} is not differentiable")
                     augassign_subscript(target, indices)
@@ -6003,15 +6762,15 @@ class Adjoint:
                         "supported. Read the view, update it, and assign it back explicitly."
                     )
                 if isinstance(node.op, ast.Add):
-                    adj.add_builtin_call("tile_add_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("tile_add_inplace", [target, *indices, eval_rhs()])
                 elif isinstance(node.op, ast.Sub):
-                    adj.add_builtin_call("tile_sub_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("tile_sub_inplace", [target, *indices, eval_rhs()])
                 elif isinstance(node.op, ast.BitAnd):
-                    adj.add_builtin_call("tile_bit_and_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("tile_bit_and_inplace", [target, *indices, eval_rhs()])
                 elif isinstance(node.op, ast.BitOr):
-                    adj.add_builtin_call("tile_bit_or_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("tile_bit_or_inplace", [target, *indices, eval_rhs()])
                 elif isinstance(node.op, ast.BitXor):
-                    adj.add_builtin_call("tile_bit_xor_inplace", [target, *indices, rhs])
+                    adj.add_builtin_call("tile_bit_xor_inplace", [target, *indices, eval_rhs()])
                 else:
                     log_debug(f"Warning: in-place op {node.op} is not differentiable")
                     augassign_subscript(target, indices)

--- a/warp/_src/codegen.py
+++ b/warp/_src/codegen.py
@@ -20,7 +20,7 @@ import threading
 import types
 import weakref
 from collections import deque
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from copy import copy as shallowcopy
 from dataclasses import dataclass
 from typing import Any, ClassVar, Literal, NamedTuple, get_args, get_origin
@@ -984,29 +984,6 @@ class _LValueOrigin:
 
         return expr
 
-    def emit_lvalue_materialized_views(
-        self,
-        adjoint: bool = False,
-        adj=None,
-        prelude: list[str] | None = None,
-    ) -> str:
-        if prelude is None or not any(step.kind == "view" for step in self.steps):
-            return self.emit_lvalue(adjoint)
-
-        if self.root_is_ref_parameter:
-            root_expr = self.root.emit("adj") if adjoint else self.root.emit()
-            expr = f"*({root_expr})"
-        else:
-            expr = self.root.emit("adj" if adjoint else "var")
-
-        for step in self.steps:
-            if step.kind == "view":
-                expr = self._emit_materialized_view(adj, prelude, expr, step)
-            else:
-                expr = self._emit_step_lvalue(expr, step)
-
-        return expr
-
     @classmethod
     def _emit_materialized_view(cls, adj, prelude: list[str], base_expr: str, step: _LValueStep) -> str:
         name = f"_wp_ref_view_{adj.label_count}"
@@ -1077,6 +1054,7 @@ class Var:
         # For Reference(T) vars, records the lvalue provenance used to derive
         # the adjoint storage pointer on demand.
         self.ref_origin: _LValueOrigin | None = None
+        self.array_slot: _ArraySlot | None = None
 
         # Used to associate the variable with the Python statement that resulted in it being created.
         self.relative_lineno = relative_lineno
@@ -1759,20 +1737,18 @@ def synchronized(rlock: threading.RLock | None = None):
     return decorator
 
 
-class SlotAccessPlan(NamedTuple):
-    """Result of classifying an array-rooted composite-component write LHS.
+class _ArraySlot(NamedTuple):
+    """An evaluated array location, shared by stores and atomic updates.
 
-    Built by ``Adjoint._classify_slot_access`` without emitting any IR. The
-    AST nodes in ``array_indices_ast`` and the AST nodes interleaved in
-    ``access_parts`` are evaluated by the caller only after the access is
-    accepted, so a declined write never pollutes the IR.
+    Indices are values, never AST nodes: resolving a target evaluates each
+    index once. ``access`` selects a component of the indexed array element.
+    Only target expressions carry a slot; copying a value detaches it.
     """
 
-    root_var: Var
-    array_indices_ast: list  # list[ast.expr]: outer array subscripts, left-to-right
-    access_parts: list  # list[str | ast.expr]: str text segments + index AST nodes
-    slot_type: object  # informational leaf type; optionally validated against rhs_type
-    root_is_adjoint: bool = False
+    root: Var
+    indices: tuple[Var, ...]
+    access: str
+    type: object
 
 
 class _SharedFunctionSource:
@@ -2192,6 +2168,10 @@ class Adjoint:
         # wp.ref[T] callees lacking a manual adjoint; rejected post-build, once used_by_backward_kernel is final
         adj.unvalidated_ref_calls = []
 
+        # Slot overwrites that cannot generate an adjoint. Backward use may
+        # only become known after a shared helper has already been built.
+        adj.slot_augassign_error: str | None = None
+
         # Function-specialized functions replace selected argument Vars with
         # Function objects so calls like `op(x)` resolve statically.
         for a in adj.args:
@@ -2475,6 +2455,44 @@ class Adjoint:
 
         if line_directive := adj.get_line_directive(statement, adj.lineno):
             adj.blocks[-1].body_reverse.append(line_directive)
+
+    def array_slot_adjoint(adj, root: Var) -> str:
+        """Resolve gradient storage for a component update without rebinding descriptors.
+
+        A missing enclosing gradient falls back to the primal array's ``grad``
+        pointer in the native slot adjoint, matching whole-array stores.
+        """
+        origin = adj.reference_origin_for_var(root)
+        if origin is None:
+            return root.emit_adj()
+        array_type = strip_reference(root.type)
+        adjoint_expression = origin.root.emit_adj()
+        if origin.root_is_ref_parameter:
+            adjoint_expression = f"*({adjoint_expression})"
+        if not origin.steps:
+            return adjoint_expression
+
+        current_type = strip_reference(origin.root.type)
+        statements = [f"auto slot_adj_0 = {adjoint_expression};"]
+        for index, step in enumerate(origin.steps):
+            source = f"slot_adj_{index}"
+            if step.kind in ("array", "view"):
+                # Fabric views return plain arrays, but their source descriptors
+                # do not carry gradient storage. Use the native slot fallback.
+                if not warp._src.types.matches_array_class(current_type, warp._src.types.array):
+                    return root.emit_adj()
+                statements.append(f"if (!{source}.data) return {{}};")
+                if step.kind == "array":
+                    current_type = current_type.dtype
+            elif step.kind == "field":
+                current_type = strip_reference(_aggregate_vars(current_type)[step.payload].type)
+            else:
+                return root.emit_adj()
+            # Integer-indexed views require an lvalue descriptor. Materialize
+            # each step locally so chained views remain valid C++ expressions.
+            statements.append(f"auto slot_adj_{index + 1} = {origin._emit_step_lvalue(source, step)};")
+        statements.append(f"return slot_adj_{len(origin.steps)};")
+        return f"([&]() -> {Var.type_to_ctype(array_type)} {{ {' '.join(statements)} }}())"
 
     def add_constant(adj, n):
         output = adj.add_var(type=get_arg_type(n), constant=n)
@@ -3637,7 +3655,7 @@ class Adjoint:
             return Adjoint.type_contains_native_value(var_type.dtype)
         return False
 
-    def emit_Attribute(adj, node, aggregate=None):
+    def emit_Attribute(adj, node, aggregate=None, *, as_target=False):
         if hasattr(node, "is_adjoint"):
             node.value.is_adjoint = True
 
@@ -3675,16 +3693,22 @@ class Adjoint:
                 attr = Var(attr_name, attr_type)
                 if isinstance(aggregate, Var):
                     attr_var = aggregate.type.vars[node.attr]
-                    field_origin = adj.array_field_ref_origin(aggregate, (attr_var.label,))
-                    if field_origin is not None:
-                        attr.ref_origin = field_origin
-                    elif origin := adj.reference_origin_for_var(aggregate):
+                    if origin := adj.reference_origin_for_var(aggregate):
                         attr.ref_origin = origin.extend_field(node.attr)
                     adj.deterministic.propagate_attribute_reference(attr, aggregate, attr_var, attr_type)
                     adj.apply_struct_array_field_metadata(attr, aggregate, (attr_var.label,))
                 return attr
 
             aggregate_type = strip_reference(aggregate.type)
+
+            if as_target and (slot := adj.select_array_slot(aggregate, attr=node.attr)) is not None:
+                origin = adj.reference_origin_for_var(aggregate)
+                if origin is not None:
+                    if type_is_vector(aggregate_type) or type_is_quaternion(aggregate_type):
+                        origin = origin.extend_index(adj.vector_component_index(node.attr, aggregate_type))
+                    else:
+                        origin = origin.extend_field(node.attr)
+                return adj.array_slot_reference(slot, origin)
 
             # reading a vector or quaternion component
             if type_is_vector(aggregate_type) or type_is_quaternion(aggregate_type):
@@ -3707,11 +3731,6 @@ class Adjoint:
                 if origin := adj.reference_origin_for_var(aggregate):
                     out.ref_origin = origin.extend_field(component)
 
-                if hasattr(aggregate, "array_root"):
-                    out.array_root = aggregate.array_root
-                    out.array_indices = aggregate.array_indices
-                    out.array_access_prefix = f"{getattr(aggregate, 'array_access_prefix', '')}.{component}"
-
                 return out
 
             else:
@@ -3731,20 +3750,14 @@ class Adjoint:
                 # Array descriptor fields, such as ``shape``, must be taken from
                 # the descriptor Var itself; replaying an origin may reconstruct
                 # an rvalue view like ``wp::view(...).shape``.
-                field_origin = adj.array_field_ref_origin(aggregate, (attr_var.label,))
-                origin = field_origin
-                if origin is None and not is_array(aggregate_type):
-                    origin = adj.reference_origin_for_var(aggregate)
+                origin = None if is_array(aggregate_type) else adj.reference_origin_for_var(aggregate)
 
                 if origin is not None:
-                    if field_origin is None:
-                        attr.ref_origin = origin.extend_field(
-                            attr_var.label,
-                            pointer_cast=cast,
-                            adjoint_pointer_cast=adj_cast,
-                        )
-                    else:
-                        attr.ref_origin = origin
+                    attr.ref_origin = origin.extend_field(
+                        attr_var.label,
+                        pointer_cast=cast,
+                        adjoint_pointer_cast=adj_cast,
+                    )
                     adj.add_forward(f"{attr.emit()} = {attr.ref_origin.emit_pointer()};")
                 elif is_reference(aggregate.type):
                     adj.add_forward(f"{attr.emit()} = {cast}&({aggregate.emit()}->{attr_var.label});")
@@ -3758,11 +3771,6 @@ class Adjoint:
                     adj.add_reverse(f"{aggregate.emit_adj()}.{attr_var.label} += {adj_cast}{attr.emit_adj()};")
                 else:
                     adj.add_reverse(f"{aggregate.emit_adj()}.{attr_var.label} = {adj_cast}{attr.emit_adj()};")
-
-                if hasattr(aggregate, "array_root"):
-                    attr.array_root = aggregate.array_root
-                    attr.array_indices = aggregate.array_indices
-                    attr.array_access_prefix = f"{getattr(aggregate, 'array_access_prefix', '')}.{attr_var.label}"
 
                 return attr
 
@@ -4640,35 +4648,43 @@ class Adjoint:
         else:
             return tuple(adj.eval(x) for x in nodes)
 
-    def emit_indexing(adj, target, indices):
+    def emit_indexing(adj, target, indices, *, as_target=False):
         target_type = strip_reference(target.type)
         indices = adj.eval_indices(target_type, indices)
 
         if is_array(target_type):
+            # Intermediate subscripts may form views on the way to a slot.
+            if as_target and not all(
+                adj._is_integer_index_var(index) or is_slice(strip_reference(index.type)) for index in indices
+            ):
+                raise WarpCodegenTypeError("Array slot write indices must be integers or slices")
             if len(indices) == target_type.ndim and all(
                 warp._src.types.type_is_int(strip_reference(x.type)) for x in indices
             ):
                 indices = tuple(adj.load(x) for x in indices)
+                if (
+                    as_target
+                    and warp._src.types.matches_array_class(target_type, warp._src.types.array)
+                    and (type_is_composite(target_type.dtype) or isinstance(target_type.dtype, Struct))
+                ):
+                    origin = adj.reference_origin_for_var(target)
+                    return adj.array_slot_reference(
+                        _ArraySlot(target, indices, "", target_type.dtype),
+                        origin.extend_array(indices) if origin is not None else None,
+                    )
                 # handles array loads (where each dimension has an index specified)
                 out = adj.add_builtin_call("address", [target, *indices])
                 if origin := adj.reference_origin_for_var(target):
                     out.ref_origin = origin.extend_array(indices)
 
-                if warp._src.types.matches_array_class(target_type, warp._src.types.array) and (
-                    type_is_composite(target_type.dtype) or isinstance(target_type.dtype, Struct)
-                ):
-                    out.array_root = target
-                    out.array_indices = tuple(indices)
-                    out.array_access_prefix = ""
-
                 if adj.builder_options.get("verify_autograd_array_access", False):
                     target.mark_read()
 
             else:
-                view_indices = tuple(indices)
+                indices = tuple(adj.load(index) for index in indices)
                 # handles array views (fewer indices than dimensions)
                 out = adj.add_builtin_call("view", [target, *indices])
-                adj.deterministic.track_view(out, target, view_indices)
+                adj.deterministic.track_view(out, target, indices)
                 if origin := adj.reference_origin_for_var(target):
                     out.ref_origin = origin.extend_view(indices)
 
@@ -4704,6 +4720,11 @@ class Adjoint:
                 )
 
         else:
+            if as_target and (slot := adj.select_array_slot(target, indices=indices)) is not None:
+                origin = adj.reference_origin_for_var(target)
+                if origin is not None:
+                    origin = origin.extend_index(indices if type_is_matrix(target_type) else indices[0])
+                return adj.array_slot_reference(slot, origin)
             # handles non-array type indexing, e.g: vec3, mat33, etc
             out = adj.add_builtin_call("extract", [target, *indices])
             if origin := adj.reference_origin_for_var(target):
@@ -4720,14 +4741,6 @@ class Adjoint:
                     and index_types_are_int
                 ):
                     out.ref_origin = origin.extend_index(indices[0])
-
-            if hasattr(target, "array_root"):
-                slot_access = adj._composite_subscript_slot_access(target_type, indices)
-                if slot_access is not None:
-                    access_cpp, _ = slot_access
-                    out.array_root = target.array_root
-                    out.array_indices = target.array_indices
-                    out.array_access_prefix = f"{getattr(target, 'array_access_prefix', '')}{access_cpp}"
 
         return out
 
@@ -4748,7 +4761,7 @@ class Adjoint:
 
         return indices
 
-    def recurse_subscript(adj, node, indices):
+    def recurse_subscript(adj, node, indices, *, as_target=False):
         if isinstance(node, ast.Name):
             target = adj.eval(node)
             return target, indices
@@ -4764,18 +4777,18 @@ class Adjoint:
 
             indices = [ij, *indices]  # prepend
 
-            target, indices = adj.recurse_subscript(node.value, indices)
+            target, indices = adj.recurse_subscript(node.value, indices, as_target=as_target)
 
             target_type = strip_reference(target.type)
             if is_array(target_type):
                 flat_indices = [i for ij in indices for i in ij]
                 if len(flat_indices) > target_type.ndim:
-                    target = adj.emit_indexing(target, flat_indices[: target_type.ndim])
+                    target = adj.emit_indexing(target, flat_indices[: target_type.ndim], as_target=as_target)
                     indices = adj.strip_indices(indices, target_type.ndim)
 
             return target, indices
 
-        target = adj.eval(node)
+        target = adj.eval_store_target(node) if as_target else adj.eval(node)
         return target, indices
 
     def _tile_type_probe_copy_type(adj, arg_type):
@@ -5094,8 +5107,8 @@ class Adjoint:
         return any(adj._tile_group_produces_view(group) for group in groups)
 
     # returns the object being indexed, and the list of indices
-    def eval_subscript(adj, node):
-        target, indices = adj.recurse_subscript(node, [])
+    def eval_subscript(adj, node, *, as_target=False):
+        target, indices = adj.recurse_subscript(node, [], as_target=as_target)
 
         # Chained tile subscripts (a[X][Y]...) apply each bracket group to the
         # result of the previous one, innermost group first, for arbitrary depth.
@@ -5132,6 +5145,21 @@ class Adjoint:
 
         return adj.emit_indexing(target, indices)
 
+    def eval_store_target(adj, node: ast.expr) -> Any:
+        """Resolve a location without generating read adjoints for its address.
+
+        Only the attribute/subscript spine is a target. Calls and index
+        expressions are evaluated normally, including their side effects and
+        gradients. The same traversal handles named arrays, views, struct
+        descriptors, and call results; there is no speculative AST fast path.
+        """
+        if isinstance(node, ast.Attribute):
+            return adj.emit_Attribute(node, aggregate=adj.eval_store_target(node.value), as_target=True)
+        if isinstance(node, ast.Subscript) and not (hasattr(node.value, "attr") and node.value.attr == "adjoint"):
+            target, indices = adj.eval_subscript(node, as_target=True)
+            return adj.emit_indexing(target, indices, as_target=True)
+        return adj.eval(node)
+
     def emit_Slice(adj, node):
         start = SLICE_BEGIN if node.lower is None else adj.eval(node.lower)
         stop = SLICE_END if node.upper is None else adj.eval(node.upper)
@@ -5157,17 +5185,11 @@ class Adjoint:
 
         adj.add_forward(f"*{ref_var.emit()} = {value.emit()};")
 
-    def clear_array_slot_metadata(adj, value):
-        """Detach array-slot provenance when binding a value to a local."""
-        if not isinstance(value, Var) or is_array(strip_reference(value.type)):
-            return value
-
-        for name in ("array_root", "array_indices", "array_access_prefix"):
-            if hasattr(value, name):
-                delattr(value, name)
-        return value
-
-    def _struct_array_field_paths(adj, struct_type, prefix=()):
+    def _struct_array_field_paths(
+        adj,
+        struct_type: Any,
+        prefix: tuple[str, ...] = (),
+    ) -> Iterator[tuple[tuple[str, ...], Any]]:
         """Yield array-typed field paths inside ``struct_type``."""
         if not isinstance(struct_type, Struct):
             return
@@ -5180,158 +5202,126 @@ class Adjoint:
             elif isinstance(field_type, Struct):
                 yield from adj._struct_array_field_paths(field_type, field_path)
 
-    @staticmethod
-    def _origin_with_field_path(origin, field_path):
-        for field_name in field_path:
-            origin = origin.extend_field(field_name)
-        return origin
-
-    def _base_struct_alias_origin(adj, src):
-        if getattr(src, "ref_origin", None) is not None:
-            return src.ref_origin
-        if any(src is arg for arg in adj.args):
-            return _LValueOrigin.from_local(src)
-        return None
-
-    def propagate_struct_array_alias_metadata(adj, out, src):
+    def propagate_struct_array_alias_metadata(adj, destination_var: Any, source_var: Any) -> Any:
         """Carry array-field storage provenance through struct aliases."""
-        if not isinstance(out, Var) or not isinstance(src, Var):
-            return out
+        if not isinstance(destination_var, Var) or not isinstance(source_var, Var):
+            return destination_var
 
-        out_type = strip_reference(out.type)
-        src_type = strip_reference(src.type)
-        if not isinstance(out_type, Struct) or not isinstance(src_type, Struct):
-            return out
+        destination_type = strip_reference(destination_var.type)
+        source_type = strip_reference(source_var.type)
+        if not isinstance(destination_type, Struct) or not isinstance(source_type, Struct):
+            return destination_var
 
-        inherited_origins = getattr(src, "array_field_ref_origins", {})
-        inherited_det_targets = getattr(src, "array_field_deterministic_targets", {})
-        base_origin = adj._base_struct_alias_origin(src)
-        base_root_label = getattr(src, "deterministic_ref_root_label", None)
-        base_attr_path = tuple(getattr(src, "deterministic_ref_attr_path", ()))
-        if base_root_label is None and any(src is arg for arg in adj.args):
-            base_root_label = src.label
+        inherited_targets = getattr(source_var, "array_field_deterministic_targets", {})
+        base_root_label = getattr(source_var, "deterministic_ref_root_label", None)
+        base_attr_path = tuple(getattr(source_var, "deterministic_ref_attr_path", ()))
+        if base_root_label is None and any(source_var is arg for arg in adj.args):
+            base_root_label = source_var.label
 
-        origins = {}
-        det_targets = {}
-        for field_path, array_type in adj._struct_array_field_paths(out_type):
-            if field_path in inherited_origins:
-                origins[field_path] = inherited_origins[field_path]
-            elif base_origin is not None:
-                origins[field_path] = adj._origin_with_field_path(base_origin, field_path)
-
-            if field_path in inherited_det_targets:
-                det_targets[field_path] = inherited_det_targets[field_path]
+        deterministic_targets = {}
+        for field_path, array_type in adj._struct_array_field_paths(destination_type):
+            if field_path in inherited_targets:
+                deterministic_targets[field_path] = inherited_targets[field_path]
             elif base_root_label is not None:
-                det_targets[field_path] = (base_root_label, (*base_attr_path, *field_path), array_type)
+                deterministic_targets[field_path] = (base_root_label, (*base_attr_path, *field_path), array_type)
 
-        if origins:
-            out.array_field_ref_origins = origins
-        if det_targets:
-            out.array_field_deterministic_targets = det_targets
+        if deterministic_targets:
+            destination_var.array_field_deterministic_targets = deterministic_targets
 
-        return out
+        return destination_var
 
     @staticmethod
-    def array_field_ref_origin(aggregate, field_path):
-        return getattr(aggregate, "array_field_ref_origins", {}).get(tuple(field_path))
-
-    def apply_struct_array_field_metadata(adj, attr, aggregate, field_path):
+    def apply_struct_array_field_metadata(
+        field_reference: Var,
+        aggregate_var: Var,
+        field_path: Sequence[str],
+    ) -> Var:
         """Apply field-specific array provenance after a struct attribute read."""
         field_path = tuple(field_path)
-        origin = adj.array_field_ref_origin(aggregate, field_path)
-        if origin is not None:
-            attr.ref_origin = origin
+        deterministic_targets = getattr(aggregate_var, "array_field_deterministic_targets", {})
+        if field_path in deterministic_targets:
+            root_label, attr_path, array_type = deterministic_targets[field_path]
+            field_reference.deterministic_ref_root_label = root_label
+            field_reference.deterministic_ref_attr_path = tuple(attr_path)
+            field_reference.deterministic_ref_array_type = array_type
 
-        det_targets = getattr(aggregate, "array_field_deterministic_targets", {})
-        if field_path in det_targets:
-            root_label, attr_path, array_type = det_targets[field_path]
-            attr.deterministic_ref_root_label = root_label
-            attr.deterministic_ref_attr_path = tuple(attr_path)
-            attr.deterministic_ref_array_type = array_type
-
-        nested_origins = {}
-        for path, nested_origin in getattr(aggregate, "array_field_ref_origins", {}).items():
+        nested_targets = {}
+        for path, target in deterministic_targets.items():
             if len(path) > len(field_path) and path[: len(field_path)] == field_path:
-                nested_origins[path[len(field_path) :]] = nested_origin
-        if nested_origins:
-            attr.array_field_ref_origins = nested_origins
+                nested_targets[path[len(field_path) :]] = target
+        if nested_targets:
+            field_reference.array_field_deterministic_targets = nested_targets
 
-        nested_det_targets = {}
-        for path, target in det_targets.items():
-            if len(path) > len(field_path) and path[: len(field_path)] == field_path:
-                nested_det_targets[path[len(field_path) :]] = target
-        if nested_det_targets:
-            attr.array_field_deterministic_targets = nested_det_targets
+        return field_reference
 
-        return attr
-
-    def propagate_array_alias_metadata(adj, out, src):
+    def propagate_array_alias_metadata(adj, destination_var: Any, source_var: Any) -> Any:
         """Carry array storage provenance through descriptor aliases."""
-        if not isinstance(out, Var) or not isinstance(src, Var):
-            return out
-        if not is_array(strip_reference(out.type)):
-            return out
+        if not isinstance(destination_var, Var) or not isinstance(source_var, Var):
+            return destination_var
+        if not is_array(strip_reference(destination_var.type)):
+            return destination_var
 
-        out.ref_origin = getattr(src, "ref_origin", None)
-        for name in (
+        destination_var.ref_origin = getattr(source_var, "ref_origin", None)
+        for metadata_name in (
             "deterministic_ref_root_label",
             "deterministic_ref_attr_path",
             "deterministic_ref_array_type",
-            "deterministic_view_parent",
+            "deterministic_view_alias_source",
+            "deterministic_view_reduction_parent",
             "deterministic_view_indices",
             "deterministic_adjoint_target",
             "deterministic_adjoint_root_label",
         ):
-            if hasattr(src, name):
-                setattr(out, name, getattr(src, name))
+            if hasattr(source_var, metadata_name):
+                setattr(destination_var, metadata_name, getattr(source_var, metadata_name))
 
         if (
-            not hasattr(out, "deterministic_ref_root_label")
-            and not hasattr(out, "deterministic_view_parent")
-            and not getattr(out, "deterministic_adjoint_target", False)
-            and any(src is arg for arg in adj.args)
+            not hasattr(destination_var, "deterministic_ref_root_label")
+            and not hasattr(destination_var, "deterministic_view_reduction_parent")
+            and not getattr(destination_var, "deterministic_adjoint_target", False)
+            and any(source_var is arg for arg in adj.args)
         ):
-            out.deterministic_ref_root_label = src.label
-            out.deterministic_ref_attr_path = ()
-            out.deterministic_ref_array_type = strip_reference(src.type)
+            destination_var.deterministic_ref_root_label = source_var.label
+            destination_var.deterministic_ref_attr_path = ()
+            destination_var.deterministic_ref_array_type = strip_reference(source_var.type)
 
-        return out
+        return destination_var
 
-    def make_adjoint_target_var(adj, src_var):
-        """Return the storage expression represented by ``wp.adjoint[src_var]``."""
-        if not isinstance(src_var, Var):
+    def make_adjoint_target_var(adj, source_var: Any) -> Var | None:
+        """Return the storage expression represented by ``wp.adjoint[source_var]``."""
+        if not isinstance(source_var, Var):
             return None
 
-        src_type = strip_reference(src_var.type)
-        if not is_array(src_type):
-            return Var(f"adj_{src_var.label}", type=src_var.type, constant=None, prefix=False)
+        source_type = strip_reference(source_var.type)
+        if not is_array(source_type):
+            return Var(f"adj_{source_var.label}", type=source_var.type, constant=None, prefix=False)
 
-        view_parent = getattr(src_var, "deterministic_view_parent", None)
-        if view_parent is not None:
-            adj_parent = adj.make_adjoint_target_var(view_parent)
-            if adj_parent is None:
+        alias_source = getattr(source_var, "deterministic_view_alias_source", None)
+        if alias_source is not None:
+            adjoint_source = adj.make_adjoint_target_var(alias_source)
+            if adjoint_source is None:
                 return None
-            view_indices = tuple(adj.load(idx) for idx in getattr(src_var, "deterministic_view_indices", ()))
-            out = adj.add_builtin_call("view", (adj_parent, *view_indices))
-            adj.deterministic.track_view(out, adj_parent, view_indices)
-            return out
+            view_indices = tuple(adj.load(idx) for idx in getattr(source_var, "deterministic_view_indices", ()))
+            adjoint_target = adj.add_builtin_call("view", (adjoint_source, *view_indices))
+            adj.deterministic.track_view(adjoint_target, adjoint_source, view_indices)
+            return adjoint_target
 
-        origin = getattr(src_var, "ref_origin", None)
+        origin = getattr(source_var, "ref_origin", None)
         if origin is not None:
-            out = Var(origin.emit_lvalue(adjoint=True), type=src_type, constant=None, prefix=False)
+            adjoint_target = Var(origin.emit_lvalue(adjoint=True), type=source_type, constant=None, prefix=False)
         else:
-            out = Var(f"adj_{src_var.label}", type=src_type, constant=None, prefix=False)
+            adjoint_target = Var(f"adj_{source_var.label}", type=source_type, constant=None, prefix=False)
 
-        root_label = getattr(src_var, "deterministic_ref_root_label", None)
+        root_label = getattr(source_var, "deterministic_ref_root_label", None)
         if root_label is not None:
-            out.deterministic_adjoint_target = True
-            out.deterministic_adjoint_root_label = root_label
-            out.deterministic_ref_attr_path = tuple(getattr(src_var, "deterministic_ref_attr_path", ()))
-            out.deterministic_ref_array_type = src_type
+            adjoint_target.deterministic_adjoint_target = True
+            adjoint_target.deterministic_adjoint_root_label = root_label
+            adjoint_target.deterministic_ref_attr_path = tuple(getattr(source_var, "deterministic_ref_attr_path", ()))
+            adjoint_target.deterministic_ref_array_type = source_type
         elif origin is None or not any(step.kind == "view" for step in origin.steps):
-            adj.deterministic.mark_adjoint_target(out, src_var.label)
+            adj.deterministic.mark_adjoint_target(adjoint_target, source_var.label)
 
-        return out
+        return adjoint_target
 
     def emit_Assign(adj, node):
         if len(node.targets) != 1:
@@ -5391,21 +5381,10 @@ class Adjoint:
                 # storing any ref target so tuple assignment keeps its
                 # simultaneous semantics, e.g. `old, x = x, 2.0`.
                 out = tuple(
-                    adj.add_builtin_call("copy", [value])
-                    if isinstance(value, Var) and is_reference(value.type)
-                    else value
-                    for value in rhs
+                    adj.load(value) if isinstance(value, Var) and is_reference(value.type) else value for value in rhs
                 )
             else:
-                out = tuple(
-                    adj.add_builtin_call("copy", [value])
-                    if isinstance(value, Var) and is_reference(value.type)
-                    else value
-                    for value in rhs
-                )
-            out = tuple(
-                adj.propagate_array_alias_metadata(value, rhs_value) for value, rhs_value in zip(out, rhs, strict=True)
-            )
+                out = rhs
 
             for name, rhs in zip(names, out, strict=True):
                 # A tuple-unpack target that is a wp.ref[T] parameter mutates
@@ -5416,7 +5395,6 @@ class Adjoint:
                     adj.store_ref_param_value(name, rhs)
                     continue
 
-                local_rhs = adj.clear_array_slot_metadata(rhs)
                 if name in adj.symbols:
                     if isinstance(adj.symbols[name], warp._src.context.GradWrapper):
                         raise WarpCodegenError(
@@ -5427,14 +5405,14 @@ class Adjoint:
 
                     # Sibling query-kind types may rebind over one another: a later
                     # branch merge decays the symbol to their shared erased parent.
-                    if not types_equal(local_rhs.type, adj.symbols[name].type) and not type_erasure_join(
-                        local_rhs.type, adj.symbols[name].type
+                    if not types_equal(rhs.type, adj.symbols[name].type) and not type_erasure_join(
+                        rhs.type, adj.symbols[name].type
                     ):
                         raise WarpCodegenTypeError(
-                            f"Error, assigning to existing symbol {name} ({adj.symbols[name].type}) with different type ({local_rhs.type})"
+                            f"Error, assigning to existing symbol {name} ({adj.symbols[name].type}) with different type ({rhs.type})"
                         )
 
-                adj.symbols[name] = local_rhs
+                adj.symbols[name] = rhs
 
         # handles the case where we are assigning to an array index (e.g.: arr[i] = 2.0)
         elif isinstance(lhs, ast.Subscript):
@@ -5442,16 +5420,10 @@ class Adjoint:
                 # handle adjoint of a variable, i.e. wp.adjoint[var]
                 lhs.slice.is_adjoint = True
                 src_var = adj.eval(lhs.slice)
-                var = adj.make_adjoint_target_var(src_var)
-                if var is None:
+                adjoint_target = adj.make_adjoint_target_var(src_var)
+                if adjoint_target is None:
                     return
-                adj.add_forward(f"{var.emit()} = {rhs.emit()};")
-                return
-
-            # Fast path: array-rooted composite-component write -> single-slot
-            # store with a correct adjoint (the legacy path's adjoint is a no-op).
-            # wp.adjoint[var] is handled by the intercept above and never reaches here.
-            if adj._try_lower_array_slot_write(lhs, rhs):
+                adj.add_forward(f"{adjoint_target.emit()} = {rhs.emit()};")
                 return
 
             # Materialize an rhs reference (e.g. ``src[j]`` -> ``address(src, j)``)
@@ -5463,14 +5435,14 @@ class Adjoint:
             # the target index has been emitted. Use ``copy`` (not ``load``):
             # ``load``'s adjoint is a nop, which would drop the read-side
             # gradient for ``dst[i] = src[j]``; ``copy`` keeps the adjoint chain
-            # back to the source array intact (matching the slot fast path).
+            # back to the source array intact.
             if is_reference(rhs.type):
                 rhs = adj.add_builtin_call("copy", [rhs])
 
-            target, indices = adj.eval_subscript(lhs)
+            target, indices = adj.eval_subscript(lhs, as_target=True)
             target_type = strip_reference(target.type)
             indices = adj.eval_indices(target_type, indices)
-            if adj._try_lower_evaluated_array_slot_write(target, indices, rhs):
+            if adj.store_array_slot(adj.select_array_slot(target, indices=indices), rhs):
                 return
             adj._store_subscript(lhs, target, indices, rhs)
 
@@ -5547,178 +5519,29 @@ class Adjoint:
                 adj.propagate_array_alias_metadata(out, rhs)
             elif isinstance(out, Var) and isinstance(strip_reference(out.type), Struct):
                 adj.propagate_struct_array_alias_metadata(out, rhs)
-            else:
-                out = adj.clear_array_slot_metadata(out)
 
             # update symbol map (assumes lhs is a Name node)
             adj.symbols[name] = out
 
         elif isinstance(lhs, ast.Attribute):
-            # Fast path: array-rooted composite-component write (see _try_lower_array_slot_write).
-            # wp.adjoint[var].field reaches here but declines because root name "wp" is not a symbol.
-            if adj._try_lower_array_slot_write(lhs, rhs):
-                return
             if isinstance(rhs, Var) and is_reference(rhs.type):
                 rhs = adj.add_builtin_call("copy", [rhs])
             aggregate = adj.resolve_attribute_store_aggregate(lhs.value)
-            if adj._try_lower_evaluated_array_slot_attribute_write(lhs, aggregate, rhs):
+            if adj.store_array_slot(adj.select_array_slot(aggregate, attr=lhs.attr), rhs):
                 return
             adj._store_attribute(lhs, aggregate, rhs)
 
         else:
             raise WarpCodegenError("Error, unsupported assignment statement.")
 
-    def _try_lower_array_slot_write(adj, lhs, rhs):
-        """Intercept array-rooted composite-component writes and emit
-        direct slot access. Returns True if the write was handled.
-
-        For ``arr[i].y = rhs`` on a ``wp.array(dtype=wp.vec3)``, emits:
-
-        - Forward: ``wp::index(arr, i).c[1] = rhs;`` (one scalar-sized store).
-        - Reverse: ``wp::adj_array_store_slot(arr, adj_arr, adj_rhs,
-          [&](auto& _e) -> auto& { return _e.c[1]; }, i);`` — the native
-          helper reads the slot's accumulated adjoint into ``adj_rhs`` and
-          zeros it (overwrite semantic), or uses ``buf.grad`` as a fallback
-          source when no adjoint array is passed by the tape.
-
-        Motivation: the generic path lowers a composite-component write as a
-        whole-element load / ``assign_copy`` / ``array_store`` chain whose
-        reverse pass has a **no-op adjoint** — gradients are silently dropped,
-        not merely slow. This slot-level lowering stores only the touched
-        scalar/sub-composite, giving correct gradients at single-slot cost
-        (the generic chain also costs up to ~10x more for large composite
-        dtypes such as ``mat44``).
-
-        Shapes accepted on this fast path (where ``SCALAR`` means the
-        element's scalar dtype, e.g. ``float32``; ``COMPOSITE`` means a
-        ``vec``/``quat``/``mat``/``transform``):
-
-          - ``arr[i].x`` — vec/quat component via attribute (leaf SCALAR).
-          - ``arr[i][k]`` — vec/quat scalar subscript (leaf SCALAR).
-          - ``arr[i][r, c]`` — mat element subscript (leaf SCALAR).
-          - ``arr[i][r][c]`` - mat row then scalar subscript (leaf SCALAR).
-          - ``arr[i][r]`` - mat row subscript (leaf COMPOSITE: vec).
-          - ``arr[i].p`` / ``arr[i].q`` — transform translation / rotation
-            (leaf is COMPOSITE: vec3 or quat).
-          - ``arr[i].field`` — struct field (leaf SCALAR or COMPOSITE).
-          - ``arr[i].outer.inner.a`` — nested struct chains terminating in
-            any of the above.
-          - ``arr[i].inner.m[r, c]``, ``arr[i].v.y``, etc. — struct chains
-            descending into a composite field.
-          - Any of the above on 2D/3D/4D arrays.
-
-        Declines (returns False) for:
-
-          - Arrays other than plain ``wp.array`` (indexed, fabric, fixed):
-            those have no ``adj_array_store_slot`` overload (the slot call
-            would fail to compile for them).
-          - Vec/quat/mat non-row slices (writing a sub-vec or sub-mat):
-            the slot is a composite that isn't trivially addressable as
-            a single reference via the lambda pattern.
-          - Chains that traverse an array field of a struct
-            (``state.v[i] = rhs`` where ``v`` is ``wp.array``): that's
-            a plain array write, already handled by ``array_store``.
-          - Non-Name roots (e.g. ``func_call().field``).
-          - Dtypes that don't support atomic accumulation at the array
-            level.
-        """
-        plan = adj._classify_slot_access(lhs, rhs.type)
-        if plan is None:
-            return False
-        root_var = adj._slot_plan_root_var(plan)
-        if root_var is None:
-            return False
-
-        # Materialize an rhs reference (e.g. ``src[i]`` -> ``address(src, i)``)
-        # BEFORE evaluating the slot-index expressions. Python evaluates the
-        # rhs of a plain assignment before the assignment target, so a
-        # side-effecting index expression must not be able to alter the value
-        # the rhs reads (e.g. ``dst[mutate(src)].x = src[0]`` must read the
-        # original ``src[0]``). Deferring the copy into _emit_array_slot_write
-        # would read the slot after _eval_array_slot_access has run the index
-        # expressions. Using ``copy`` (not ``load``) keeps the read-side
-        # adjoint chain intact.
-        if is_reference(rhs.type):
-            rhs = adj.add_builtin_call("copy", [rhs])
-
-        array_index_vars, access_cpp = adj._eval_array_slot_access(plan.array_indices_ast, plan.access_parts)
-
-        return adj._emit_array_slot_write(root_var, array_index_vars, access_cpp, rhs, plan.slot_type)
-
-    def _try_lower_array_slot_atomic_augassign(adj, lhs, eval_rhs, op):
-        """Lower array-rooted composite slot augmented assignments atomically.
-
-        ``eval_rhs`` is a thunk that evaluates the right-hand side on demand.
-        It is invoked only after the slot indices have been evaluated, so a
-        side-effecting target index expression is emitted before the rhs,
-        matching Python's augmented-assignment evaluation order.
-        """
-        plan = adj._classify_slot_access(lhs, None)
-        if plan is None:
-            return False
-        root_var = adj._slot_plan_root_var(plan)
-        if root_var is None:
-            return False
-
-        op_name = adj._atomic_slot_augassign_op_name(op)
-        if op_name is None:
-            # Keep unsupported ops like ``/=`` on the existing load-op-store
-            # path, matching whole-array augmented assignment behavior.
-            return False
-
-        if not adj._is_supported_atomic_slot_type(plan.slot_type, op):
-            # Keep non-atomic slot types on the existing load-op-store path,
-            # matching whole-array augmented assignment behavior.
-            return False
-
-        array_index_vars, access_cpp = adj._eval_array_slot_access(plan.array_indices_ast, plan.access_parts)
-        return adj._try_emit_array_slot_atomic_augassign(
-            root_var, array_index_vars, access_cpp, eval_rhs, plan.slot_type, op_name
-        )
-
-    def _eval_array_slot_access(adj, array_indices_ast, access_parts):
-        # Evaluate indices AFTER committing to the fast path, in Python
-        # left-to-right order: array subscripts outermost first, then the
-        # composite-component chain inner subscripts in order. Reference-typed
-        # indices (e.g. ``arr[idx[0]].x``, where ``idx[0]`` is an array read)
-        # must be loaded to a value before being emitted into ``wp::index(...)``
-        # and the access lambda: unlike the generic store path, these indices
-        # are emitted as raw C++ rather than passed through a builtin call that
-        # would load them, so a bare reference would be a pointer where an
-        # integer is expected and fail to compile.
-        array_index_vars = []
-        for n in array_indices_ast:
-            idx_var = adj.load(adj.eval(n))
-            if not adj._is_integer_index_var(idx_var):
-                idx_type = getattr(idx_var, "type", type(idx_var))
-                raise WarpCodegenTypeError(
-                    f"Array slot write indices must be integers, got {type_repr(strip_reference(idx_type))}"
-                )
-            array_index_vars.append(idx_var)
-
-        access_cpp_parts = []
-        for part in access_parts:
-            if isinstance(part, str):
-                access_cpp_parts.append(part)
-            else:
-                idx_var = adj.load(adj.eval(part))
-                if not adj._is_integer_index_var(idx_var):
-                    raise WarpCodegenTypeError(
-                        f"Composite slot write indices must be integers, got {type_repr(strip_reference(idx_var.type))}"
-                    )
-                access_cpp_parts.append(idx_var.emit())
-
-        return array_index_vars, "".join(access_cpp_parts)
-
-    def _is_integer_index_var(adj, index):
+    @staticmethod
+    def _is_integer_index_var(index: Any) -> bool:
+        """Return whether ``index`` is an integer-typed code-generation variable."""
         return hasattr(index, "type") and warp._src.types.type_is_int(strip_reference(index.type))
 
-    def _slot_plan_root_var(adj, plan):
-        if not plan.root_is_adjoint:
-            return plan.root_var
-        return adj.make_adjoint_target_var(plan.root_var)
-
-    def _atomic_slot_augassign_op_name(adj, op):
+    @staticmethod
+    def _atomic_slot_augassign_op_name(op: ast.operator) -> str | None:
+        """Return the builtin atomic name for ``op``, if supported."""
         if isinstance(op, ast.Add):
             return "add"
         if isinstance(op, ast.Sub):
@@ -5731,7 +5554,8 @@ class Adjoint:
             return "xor"
         return None
 
-    def _is_supported_atomic_slot_type(adj, slot_type, op):
+    def _is_supported_atomic_slot_type(adj, slot_type: Any, op: ast.operator | str) -> bool:
+        """Return whether ``slot_type`` supports the requested atomic update."""
         scalar_type = getattr(slot_type, "_wp_scalar_type_", slot_type)
         if isinstance(op, str):
             op_name = op
@@ -5746,7 +5570,12 @@ class Adjoint:
             return False
         return any(types_equal_generic(scalar_type, t) for t in supported_atomic_types)
 
-    def _composite_subscript_slot_access(adj, target_type, indices):
+    def _composite_subscript_slot_access(
+        adj,
+        target_type: Any,
+        indices: Sequence[Var],
+    ) -> tuple[str, Any] | None:
+        """Return the native accessor and type for a composite subscript slot."""
         if type_is_matrix(target_type):
             if len(indices) == 1:
                 indices = tuple(adj.load(idx) for idx in indices)
@@ -5773,7 +5602,8 @@ class Adjoint:
 
         return None
 
-    def _composite_attribute_slot_access(adj, attr, aggregate_type):
+    def _composite_attribute_slot_access(adj, attr: str, aggregate_type: Any) -> tuple[str, Any] | None:
+        """Return the native accessor and type for a composite attribute slot."""
         if type_is_vector(aggregate_type) or type_is_quaternion(aggregate_type):
             index = adj.vector_component_index(attr, aggregate_type)
             return f".component_ref({index.emit()})", getattr(aggregate_type, "_wp_scalar_type_", None)
@@ -5794,427 +5624,129 @@ class Adjoint:
 
         return None
 
-    def _evaluated_array_slot_context(adj, carrier):
-        if not isinstance(carrier, Var):
-            return None
-
-        root_var = getattr(carrier, "array_root", None)
-        if not isinstance(root_var, Var):
-            return None
-
-        root_type = strip_reference(root_var.type)
-        if not warp._src.types.matches_array_class(root_type, warp._src.types.array):
-            return None
-        if root_type.dtype in warp._src.types.non_atomic_types:
-            return None
-
-        array_index_vars = getattr(carrier, "array_indices", None)
-        if array_index_vars is None:
-            return None
-        array_index_vars = tuple(adj.load(idx) for idx in array_index_vars)
-        if not all(adj._is_integer_index_var(idx) for idx in array_index_vars):
-            return None
-
-        return root_var, array_index_vars, getattr(carrier, "array_access_prefix", "")
-
-    def _try_lower_evaluated_array_slot_write(adj, target, indices, rhs, *, emit_reverse=True):
-        """Lower an array-rooted composite slot write using evaluated indices.
-
-        ``emit_AugAssign`` has already evaluated the LHS through
-        ``eval_subscript()`` before it reaches this path. Re-walking the
-        original AST would re-run index expressions, so this helper uses
-        the array-root metadata attached to the evaluated reference.
-        """
-        context = adj._evaluated_array_slot_context(target)
-        if context is None:
-            return False
-        root_var, array_index_vars, access_cpp = context
-
-        target_type = strip_reference(target.type)
-        slot_access = adj._composite_subscript_slot_access(target_type, indices)
-        if slot_access is None:
-            return False
-        suffix_cpp, slot_type = slot_access
-        access_cpp += suffix_cpp
-
-        if slot_type is None:
-            return False
-
-        if not types_equal(strip_reference(rhs.type), slot_type):
-            return False
-
-        return adj._emit_array_slot_write(
-            root_var, array_index_vars, access_cpp, rhs, slot_type, emit_reverse=emit_reverse
+    def array_slot_reference(adj, slot: _ArraySlot, origin: _LValueOrigin | None) -> Var:
+        """Materialize an address, not a read, while resolving a store target."""
+        slot_reference = adj.add_var(Reference(slot.type))
+        slot_reference.array_slot = slot
+        slot_reference.ref_origin = origin
+        array_expression = adj._array_slot_root_expr(slot.root)
+        index_expressions = ", ".join(index.emit() for index in slot.indices)
+        adj.add_forward(
+            f"{slot_reference.emit()} = &(wp::index({array_expression}, {index_expressions}){slot.access});"
         )
+        return slot_reference
 
-    def _try_lower_evaluated_array_slot_atomic_augassign(adj, target, indices, eval_rhs, op):
-        """Lower evaluated array-rooted composite subscript augmented assignment."""
-        context = adj._evaluated_array_slot_context(target)
-        if context is None:
+    def select_array_slot(
+        adj,
+        evaluated_target: Any,
+        *,
+        indices: Sequence[Var] | None = None,
+        attr: str | None = None,
+    ) -> _ArraySlot | None:
+        """Project an evaluated array location onto one field or component."""
+        if not isinstance(evaluated_target, Var) or evaluated_target.array_slot is None:
+            return None
+        source_slot = evaluated_target.array_slot
+        if strip_reference(source_slot.root.type).dtype in warp._src.types.non_atomic_types:
+            return None
+        if attr is None:
+            selected_access = adj._composite_subscript_slot_access(source_slot.type, indices)
+        else:
+            selected_access = adj._composite_attribute_slot_access(attr, source_slot.type)
+        if selected_access is None:
+            return None
+        access_suffix, slot_type = selected_access
+        return _ArraySlot(source_slot.root, source_slot.indices, source_slot.access + access_suffix, slot_type)
+
+    def store_array_slot(adj, slot: _ArraySlot | None, rhs: Var) -> bool:
+        """Store ``rhs`` in ``slot`` and report whether the slot was resolved."""
+        if slot is None:
             return False
-        root_var, array_index_vars, access_cpp = context
+        return adj.emit_array_slot(slot, rhs)
 
-        target_type = strip_reference(target.type)
-        slot_access = adj._composite_subscript_slot_access(target_type, indices)
-        if slot_access is None:
+    def atomic_array_slot(
+        adj,
+        slot: _ArraySlot | None,
+        eval_rhs: Callable[[], Var],
+        op: ast.operator,
+    ) -> bool:
+        """Lower a supported atomic slot update and report whether it was emitted."""
+        if slot is None or not adj._is_supported_atomic_slot_type(slot.type, op):
             return False
-        suffix_cpp, slot_type = slot_access
-        if slot_type is None:
-            return False
+        return adj.emit_array_slot(slot, eval_rhs(), adj._atomic_slot_augassign_op_name(op))
 
-        op_name = adj._atomic_slot_augassign_op_name(op)
-        if op_name is None:
-            return False
-
-        return adj._try_emit_array_slot_atomic_augassign(
-            root_var, array_index_vars, access_cpp + suffix_cpp, eval_rhs, slot_type, op_name
-        )
-
-    def _try_lower_evaluated_array_slot_attribute_write(adj, lhs, aggregate, rhs, *, emit_reverse=True):
-        """Lower an array-rooted composite attribute write using an evaluated aggregate."""
-        context = adj._evaluated_array_slot_context(aggregate)
-        if context is None:
-            return False
-        root_var, array_index_vars, access_cpp = context
-
-        aggregate_type = strip_reference(aggregate.type)
-        slot_access = adj._composite_attribute_slot_access(lhs.attr, aggregate_type)
-        if slot_access is None:
-            return False
-        suffix_cpp, slot_type = slot_access
-        access_cpp += suffix_cpp
-
-        if slot_type is None:
-            return False
-
-        if not types_equal(strip_reference(rhs.type), slot_type):
-            return False
-
-        return adj._emit_array_slot_write(
-            root_var, array_index_vars, access_cpp, rhs, slot_type, emit_reverse=emit_reverse
-        )
-
-    def _try_lower_evaluated_array_slot_attribute_atomic_augassign(adj, lhs, aggregate, eval_rhs, op):
-        """Lower evaluated array-rooted composite attribute augmented assignment."""
-        context = adj._evaluated_array_slot_context(aggregate)
-        if context is None:
-            return False
-        root_var, array_index_vars, access_cpp = context
-
-        aggregate_type = strip_reference(aggregate.type)
-        slot_access = adj._composite_attribute_slot_access(lhs.attr, aggregate_type)
-        if slot_access is None:
-            return False
-        suffix_cpp, slot_type = slot_access
-        access_cpp += suffix_cpp
-
-        if slot_type is None:
-            return False
-
-        op_name = adj._atomic_slot_augassign_op_name(op)
-        if op_name is None:
-            return False
-
-        return adj._try_emit_array_slot_atomic_augassign(
-            root_var, array_index_vars, access_cpp, eval_rhs, slot_type, op_name
-        )
-
-    def _try_emit_array_slot_atomic_augassign(
-        adj, root_var, array_index_vars, access_cpp, eval_rhs, slot_type, op_name
-    ):
-        """Validate and emit a composite slot atomic augmented assignment."""
-        root_type = strip_reference(root_var.type)
-        if not warp._src.types.matches_array_class(root_type, warp._src.types.array):
-            return False
-        if root_type.dtype in warp._src.types.non_atomic_types:
-            return False
-
-        if not adj._is_supported_atomic_slot_type(slot_type, op_name):
-            return False
-
-        rhs = eval_rhs()
-        return adj._emit_array_slot_atomic_augassign(root_var, array_index_vars, access_cpp, rhs, slot_type, op_name)
-
-    def _array_slot_root_expr(adj, root_var):
+    @staticmethod
+    def _array_slot_root_expr(root_var: Var) -> str:
         """Return a C++ array descriptor expression for a slot root."""
         if is_reference(root_var.type):
             return f"*({root_var.emit()})"
         return root_var.emit()
 
-    def _array_slot_root_adj_expr(adj, root_var):
-        """Return the C++ adjoint array descriptor expression for a slot root."""
-        if origin := adj.reference_origin_for_var(root_var):
-            prelude = []
-            expr = origin.emit_lvalue_materialized_views(adjoint=True, adj=adj, prelude=prelude)
-            return expr, prelude
-        return root_var.emit_adj(), []
+    def emit_array_slot(
+        adj,
+        slot: _ArraySlot,
+        rhs: Var,
+        operation: str | None = None,
+    ) -> bool:
+        """Emit one store or atomic update from the resolved location.
 
-    def _emit_array_slot_write(adj, root_var, array_index_vars, access_cpp, rhs, slot_type, *, emit_reverse=True):
-        # ``src[i]`` arrives as ``address(src, i)``; route it through ``copy``
-        # so the rhs has a working adjoint chain back to the source array
-        # (``load`` would route through a nop adjoint and drop the read-side
-        # gradient).
-        if is_reference(rhs.type):
-            rhs = adj.add_builtin_call("copy", [rhs])
-        rhs_value_type = strip_reference(rhs.type)
-        if not types_equal(rhs_value_type, slot_type):
-            raise WarpCodegenTypeError(
-                f"Composite slot assignment expects value of type {type_repr(slot_type)}, "
-                f"got {type_repr(rhs_value_type)}"
-            )
+        Both operations mutate only the selected slot and never replay.
+        An overwrite consumes and clears that slot's gradient; an atomic
+        update accumulates without clearing it.
 
-        arr_cpp = adj._array_slot_root_expr(root_var)
-        adj_arr_cpp, adj_arr_prelude = adj._array_slot_root_adj_expr(root_var)
-        rhs_cpp = rhs.emit()
-        adj_rhs_cpp = rhs.emit_adj()
-        array_indices_cpp = ", ".join(v.emit() for v in array_index_vars)
+        Args:
+            slot: Evaluated array element and composite-slot selection.
+            rhs: Value assigned to or accumulated into the slot.
+            operation: Native atomic operation, or ``None`` for assignment.
 
-        # Forward: one slot store. Like array_store(), this mutates memory and
-        # must not replay during backward.
-        slot_lvalue = f"wp::index({arr_cpp}, {array_indices_cpp}){access_cpp}"
-        fwd_store = adj.deterministic.wrap_slot_store(slot_lvalue, rhs_cpp)
-        adj.deterministic.mark_store_target(root_var)
-        adj.add_forward(fwd_store, replay=f"// {fwd_store}")
-
-        if emit_reverse:
-            # The native helper handles grad-routing and RETAIN_GRAD for this
-            # one overwritten slot, matching adj_array_store's existing logic.
-            adj.add_reverse(
-                f"wp::adj_array_store_slot({arr_cpp}, {adj_arr_cpp}, {adj_rhs_cpp}, "
-                f"[&](auto& _e) -> auto& {{ return _e{access_cpp}; }}, {array_indices_cpp});"
-            )
-            for stmt in reversed(adj_arr_prelude):
-                adj.add_reverse(stmt)
-
-        adj._mark_array_write(root_var)
-        return True
-
-    def _emit_array_slot_atomic_augassign(adj, root_var, array_index_vars, access_cpp, rhs, slot_type, op_name):
-        if is_reference(rhs.type):
-            rhs = adj.add_builtin_call("copy", [rhs])
-        rhs_value_type = strip_reference(rhs.type)
-        if not types_equal(rhs_value_type, slot_type):
-            raise WarpCodegenTypeError(
-                f"Composite slot augmented assignment expects value of type {type_repr(slot_type)}, "
-                f"got {type_repr(rhs_value_type)}"
-            )
-
-        arr_cpp = adj._array_slot_root_expr(root_var)
-        adj_arr_cpp, adj_arr_prelude = adj._array_slot_root_adj_expr(root_var)
-        rhs_cpp = rhs.emit()
-        adj_rhs_cpp = rhs.emit_adj()
-        array_indices_cpp = ", ".join(v.emit() for v in array_index_vars)
-        access_lambda = f"[&](auto& _e) -> auto& {{ return _e{access_cpp}; }}"
-        suffix = f", {array_indices_cpp}" if array_indices_cpp else ""
-
-        stmt = f"wp::array_atomic_{op_name}_slot({arr_cpp}, {rhs_cpp}, {access_lambda}{suffix});"
-        scalar_type = getattr(slot_type, "_wp_scalar_type_", slot_type)
-        if adj.deterministic.enabled:
-            if adj.deterministic.emit_adjoint_slot_scatter(
-                root_var, array_index_vars, access_cpp, rhs, slot_type, op_name, stmt
-            ):
-                return True
-            if op_name in ("add", "sub") and type_is_float(scalar_type):
-                raise WarpCodegenError(
-                    "Deterministic mode does not yet support floating-point composite slot augmented assignment "
-                    "atomics."
-                )
-            stmt = adj.deterministic.wrap_side_effect_call(stmt)
-
-        adj.add_forward(stmt, replay=f"// {stmt}")
-        adj.add_reverse(
-            f"wp::adj_array_atomic_{op_name}_slot({arr_cpp}, {adj_arr_cpp}, {adj_rhs_cpp}, {access_lambda}{suffix});"
-        )
-        for stmt in reversed(adj_arr_prelude):
-            adj.add_reverse(stmt)
-
-        if adj.builder_options.get("verify_autograd_array_access", False):
-            kernel_name = adj.fun_name
-            filename = adj.filename
-            lineno = adj.lineno + adj.fun_lineno
-            root_var.mark_write(kernel_name=kernel_name, filename=filename, lineno=lineno)
-
-        return True
-
-    def _classify_slot_access(adj, lhs, rhs_type=None):
-        """Pure analysis of an array slot-write LHS — emits no IR.
-
-        Returns a ``SlotAccessPlan`` if ``lhs`` is an array-rooted composite-
-        component write the fast path can lower, else ``None``. Performs only
-        AST-shape checks and, when ``rhs_type`` is provided, type checks; the
-        caller evaluates indices and emits IR after acceptance, so a decline
-        never pollutes the IR.
+        Returns:
+            ``True`` after emitting the slot update.
         """
-        # Walk LHS leaf-to-root, then validate root.
-        chain = []
-        node = lhs
-        while isinstance(node, ast.Attribute | ast.Subscript):
-            chain.append(node)
-            node = node.value
-        if not isinstance(node, ast.Name):
-            return None
-        chain.reverse()
-        root_is_adjoint = False
-        if node.id in adj.symbols:
-            root_var = adj.symbols[node.id]
-        elif (
-            len(chain) >= 2
-            and isinstance(chain[0], ast.Attribute)
-            and chain[0].attr == "adjoint"
-            and isinstance(chain[1], ast.Subscript)
-            and chain[1].value is chain[0]
-        ):
-            if not isinstance(chain[1].slice, ast.Name):
-                return None
-            src_var = adj.symbols.get(chain[1].slice.id)
-            if not isinstance(src_var, Var):
-                return None
-            root_var = src_var
-            root_is_adjoint = True
-            chain = chain[2:]
+        if is_reference(rhs.type):
+            rhs = adj.add_builtin_call("copy", [rhs])
+        if not types_equal(strip_reference(rhs.type), slot.type):
+            raise WarpCodegenTypeError(
+                f"Composite slot assignment expects value of type {type_repr(slot.type)}, "
+                f"got {type_repr(strip_reference(rhs.type))}"
+            )
+
+        array_root = slot.root
+        if adj.deterministic.enabled:
+            adj.det_meta.has_component_updates = True
+        array_expression = adj._array_slot_root_expr(array_root)
+        index_expressions = ", ".join(index.emit() for index in slot.indices)
+        slot_accessor = f"[&](auto& _e) -> auto& {{ return _e{slot.access}; }}"
+        if operation is None:
+            slot_lvalue = f"wp::index({array_expression}, {index_expressions}){slot.access}"
+            forward_statement = adj.deterministic.wrap_slot_store(slot_lvalue, rhs.emit())
+            adj.deterministic.mark_store_target(array_root)
+            reverse_operation = "store"
         else:
-            return None
-
-        # ``adj.symbols`` may also hold ``GradWrapper`` and other non-Var values.
-        if not isinstance(root_var, Var):
-            return None
-        root_type = strip_reference(root_var.type)
-        if not warp._src.types.matches_array_class(root_type, warp._src.types.array):
-            return None
-        if root_type.dtype in warp._src.types.non_atomic_types:
-            return None
-
-        # Consume ``ndim`` outermost subscripts as the array indices.
-        needed = root_type.ndim
-        array_indices_ast = []
-        consumed = 0
-        for step in chain:
-            if not isinstance(step, ast.Subscript) or needed == 0:
-                break
-            elts = list(step.slice.elts) if isinstance(step.slice, ast.Tuple) else [step.slice]
-            if len(elts) > needed:
-                return None
-            array_indices_ast.extend(elts)
-            needed -= len(elts)
-            consumed += 1
-        if needed != 0:
-            return None
-        remaining = chain[consumed:]
-        if not remaining:
-            # Whole-element write — not a composite-component write.
-            return None
-
-        # Walk the composite-component chain. ``access_parts`` interleaves
-        # text segments (``str``) and AST nodes for subscript indices
-        # (evaluated after acceptance, so a reject doesn't pollute IR).
-        access_parts: list = []  # list[str | ast.expr]
-        current_type = root_type.dtype
-        # Member-access fragments below encode native layout: vec_t uses .c[i],
-        # mat_t uses .data[r][c], quat_t uses named .x/.y/.z/.w, transform_t .p/.q.
-        # The same access string drives both the forward store and the reverse lambda.
-        step_index = 0
-        while step_index < len(remaining):
-            step = remaining[step_index]
-            if isinstance(step, ast.Attribute):
-                if type_is_vector(current_type):
-                    dim = current_type._shape_[0]
-                    swizzles = "xyzw"[:dim]
-                    if len(step.attr) != 1 or step.attr not in swizzles:
-                        return None
-                    access_parts.append(f".c[{swizzles.index(step.attr)}]")
-                    current_type = getattr(current_type, "_wp_scalar_type_", None)
-                elif type_is_quaternion(current_type):
-                    if step.attr not in ("x", "y", "z", "w"):
-                        return None
-                    # quat_t exposes named scalar fields .x/.y/.z/.w; vec_t uses .c[N].
-                    access_parts.append(f".{step.attr}")
-                    current_type = getattr(current_type, "_wp_scalar_type_", None)
-                elif type_is_transformation(current_type):
-                    scalar_t = getattr(current_type, "_wp_scalar_type_", None)
-                    if scalar_t is None:
-                        return None
-                    if step.attr == "p":
-                        access_parts.append(".p")
-                        current_type = vector(length=3, dtype=scalar_t)
-                    elif step.attr == "q":
-                        access_parts.append(".q")
-                        current_type = quaternion(dtype=scalar_t)
-                    else:
-                        return None
-                elif isinstance(current_type, Struct):
-                    if step.attr not in current_type.vars:
-                        return None
-                    attr_var = current_type.vars[step.attr]
-                    access_parts.append(f".{attr_var.label}")
-                    current_type = attr_var.type
-                    # Array-field chains (``state.v[i] = rhs``) are plain
-                    # array writes; let the legacy path handle them.
-                    if is_array(current_type):
-                        return None
-                else:
-                    return None
-                step_index += 1
-            else:  # ast.Subscript
-                if type_is_matrix(current_type):
-                    if isinstance(step.slice, ast.Tuple):
-                        slice_elts = step.slice.elts
-                        if len(slice_elts) != 2:
-                            return None
-                        if any(isinstance(elt, ast.Slice) for elt in slice_elts):
-                            return None
-                        access_parts.extend([".element_ref(", slice_elts[0], ", ", slice_elts[1], ")"])
-                        current_type = getattr(current_type, "_wp_scalar_type_", None)
-                        step_index += 1
-                    else:
-                        if isinstance(step.slice, ast.Slice):
-                            return None
-
-                        # Chained matrix row+column syntax, ``mat[r][c]``,
-                        # must normalize both indices. Lower it through the
-                        # matrix element helper instead of ``row_ref(r)[c]``;
-                        # vector subscript does not normalize negative indices.
-                        if step_index + 1 < len(remaining):
-                            next_step = remaining[step_index + 1]
-                            if isinstance(next_step, ast.Subscript):
-                                if isinstance(next_step.slice, ast.Tuple) or isinstance(next_step.slice, ast.Slice):
-                                    return None
-                                access_parts.extend([".element_ref(", step.slice, ", ", next_step.slice, ")"])
-                                current_type = getattr(current_type, "_wp_scalar_type_", None)
-                                step_index += 2
-                                if current_type is None:
-                                    return None
-                                continue
-
-                        # Single-index subscript: mat[r] to row write via row_ref().
-                        # row_ref() returns vec_t<Cols, Type>& which adj_array_store_slot
-                        # can accumulate into directly.
-                        access_parts.extend([".row_ref(", step.slice, ")"])
-                        current_type = getattr(current_type, "_wp_row_type_", None)
-                        step_index += 1
-                elif (
-                    type_is_vector(current_type)
-                    or type_is_quaternion(current_type)
-                    or type_is_transformation(current_type)
+            forward_statement = (
+                f"wp::array_atomic_{operation}_slot("
+                f"{array_expression}, {rhs.emit()}, {slot_accessor}, {index_expressions});"
+            )
+            if adj.deterministic.enabled:
+                if adj.deterministic.emit_adjoint_slot_scatter(
+                    array_root, slot.indices, slot.access, rhs, operation, forward_statement
                 ):
-                    if isinstance(step.slice, ast.Tuple):
-                        return None
-                    if isinstance(step.slice, ast.Slice):
-                        return None
-                    # Route through component_ref() so negative indices are
-                    # normalized; raw operator[] would index before storage.
-                    access_parts.extend([".component_ref(", step.slice, ")"])
-                    current_type = getattr(current_type, "_wp_scalar_type_", None)
-                    step_index += 1
-                else:
-                    return None
-            if current_type is None:
-                return None
+                    return True
+                scalar_type = getattr(slot.type, "_wp_scalar_type_", slot.type)
+                if operation in ("add", "sub") and type_is_float(scalar_type):
+                    raise WarpCodegenError(
+                        "Deterministic mode does not yet support floating-point composite slot augmented assignment "
+                        "atomics."
+                    )
+                forward_statement = adj.deterministic.wrap_side_effect_call(forward_statement)
+            reverse_operation = f"atomic_{operation}"
 
-        slot_type = current_type
-        if rhs_type is not None and not types_equal(strip_reference(rhs_type), slot_type):
-            return None
-
-        return SlotAccessPlan(root_var, array_indices_ast, access_parts, slot_type, root_is_adjoint)
+        adj.add_forward(forward_statement, replay=f"// {forward_statement}")
+        adj.add_reverse(
+            f"wp::adj_array_{reverse_operation}_slot({array_expression}, {adj.array_slot_adjoint(array_root)}, "
+            f"{rhs.emit_adj()}, {slot_accessor}, {index_expressions});"
+        )
+        adj._mark_array_write(array_root)
+        return True
 
     def _mark_array_write(adj, target):
         """Record an array write for the autograd access verifier.
@@ -6245,6 +5777,7 @@ class Adjoint:
                 adj.deterministic.add_array_store(target, indices, rhs)
             else:
                 adj.add_builtin_call("array_store", [target, *indices, rhs])
+                adj.deterministic.mark_store_target(target)
 
             adj._mark_array_write(target)
 
@@ -6322,9 +5855,9 @@ class Adjoint:
                     out = adj.add_builtin_call("assign_copy", [target, *indices, rhs])
 
                     # re-point target symbol to out var
-                    for id in adj.symbols:
-                        if adj.symbols[id] == target:
-                            adj.symbols[id] = out
+                    for symbol_name in adj.symbols:
+                        if adj.symbols[symbol_name] == target:
+                            adj.symbols[symbol_name] = out
                             break
                 else:
                     adj.add_builtin_call("assign_inplace", [target, *indices, rhs])
@@ -6353,7 +5886,7 @@ class Adjoint:
         member = adj._resolve_struct_member_lvalue(node)
         if member is not None and isinstance(member.type, Struct):
             return member
-        return adj.eval(node)
+        return adj.eval_store_target(node)
 
     def _resolve_struct_member_lvalue(adj, node):
         """Resolve a struct attribute chain rooted at a local variable to a flat dotted
@@ -6504,7 +6037,18 @@ class Adjoint:
                 for i, arg in enumerate(adj.args):
                     arg.is_read = is_read_states[i]
 
-    def emit_AugAssign(adj, node):
+    def emit_AugAssign(adj, node: ast.AugAssign) -> None:
+        """Emit code for an augmented assignment.
+
+        Name targets rebind a local or reference parameter directly. Attribute
+        and subscript targets first evaluate their complete location, then
+        evaluate the right-hand side once. Those compound targets honor user
+        operator overloads before selecting an atomic array-slot update or the
+        general load-operator-store path.
+
+        Args:
+            node: Augmented-assignment syntax tree node to lower.
+        """
         lhs = node.target
 
         # For simple name targets (x += expr), evaluate the RHS once and
@@ -6539,23 +6083,23 @@ class Adjoint:
 
             # Non-inplace: produces a new value, rebind the symbol.
             # Check for user-defined operator overloads first (same as emit_BinOp).
-            op_name = builtin_operators[type(node.op)]
+            operator_name = builtin_operators[type(node.op)]
 
             try:
-                user_func = adj.resolve_external_reference(op_name)
-                if isinstance(user_func, warp._src.context.Function):
-                    result = adj.add_call(user_func, (target, rhs), {}, {})
+                user_operator = adj.resolve_external_reference(operator_name)
+                if isinstance(user_operator, warp._src.context.Function):
+                    result = adj.add_call(user_operator, (target, rhs), {}, {})
             except WarpCodegenError:
                 pass
             else:
-                if isinstance(user_func, warp._src.context.Function):
+                if isinstance(user_operator, warp._src.context.Function):
                     if lhs.id in adj.ref_params:
                         adj.store_ref_param_value(lhs.id, result, augmented=True)
                     else:
                         adj.symbols[lhs.id] = result
                     return
 
-            result = adj.add_builtin_call(op_name, [target, rhs])
+            result = adj.add_builtin_call(operator_name, [target, rhs])
 
             if lhs.id in adj.ref_params:
                 # Write the computed result back into the referenced storage.
@@ -6578,52 +6122,68 @@ class Adjoint:
         # must not be emitted until the target and its indices have been
         # evaluated. Each path below evaluates its indices first, then calls
         # ``eval_rhs()``.
-        _rhs_cache = []
+        rhs_cache: list[Var] = []
 
-        def eval_rhs():
-            if not _rhs_cache:
-                _rhs_cache.append(adj.eval(node.value))
-            return _rhs_cache[0]
+        def eval_rhs() -> Var:
+            """Evaluate and cache the augmented-assignment right-hand side."""
+            if not rhs_cache:
+                rhs_cache.append(adj.eval(node.value))
+            return rhs_cache[0]
 
-        if isinstance(lhs, (ast.Attribute, ast.Subscript)) and adj._try_lower_array_slot_atomic_augassign(
-            lhs, eval_rhs, node.op
-        ):
-            return
+        operator_name = builtin_operators[type(node.op)]
+        user_operator_cache: list[warp._src.context.Function | None] = []
 
-        def apply_op(current):
+        def find_user_operator() -> warp._src.context.Function | None:
+            """Find the operator's user-defined overload set without evaluating the RHS."""
+            if not user_operator_cache:
+                user_operator = None
+                try:
+                    candidate = adj.resolve_external_reference(operator_name)
+                    if isinstance(candidate, warp._src.context.Function):
+                        user_operator = candidate
+                except WarpCodegenError:
+                    pass
+                user_operator_cache.append(user_operator)
+            return user_operator_cache[0]
+
+        def resolve_user_operator(current: Var) -> warp._src.context.Function | None:
+            """Select a user overload matching the evaluated operand types."""
+            candidate = find_user_operator()
+            if candidate is None:
+                return None
+            return candidate.get_overload((get_arg_type(current), get_arg_type(eval_rhs())), {})
+
+        def apply_operator(current: Var) -> Var:
             """Compute ``current <op> rhs`` using user-defined overloads or builtins."""
             rhs = eval_rhs()
-            op_name = builtin_operators[type(node.op)]
-            try:
-                user_func = adj.resolve_external_reference(op_name)
-                if isinstance(user_func, warp._src.context.Function):
-                    return adj.add_call(user_func, (current, rhs), {}, {})
-            except WarpCodegenError:
-                pass
-            return adj.add_builtin_call(op_name, [current, rhs])
+            user_operator = resolve_user_operator(current)
+            if user_operator is not None:
+                return adj.add_call(user_operator, (current, rhs), {}, {})
+            return adj.add_builtin_call(operator_name, [current, rhs])
 
-        def unsupported_differentiable_slot_augassign(result, target):
-            """Return whether an array-rooted fallback would silently drop adjoints."""
-            if isinstance(node.op, (ast.Add, ast.Sub, ast.BitAnd, ast.BitOr, ast.BitXor)):
-                return False
-            if not (adj.custom_reverse_mode or adj.force_adjoint_codegen or adj.used_by_backward_kernel):
-                return False
-            if not isinstance(target, Var) or not hasattr(target, "array_root"):
-                return False
-            return adj.is_differentiable_value_type(strip_reference(result.type))
-
-        def reject_differentiable_slot_augassign(result, target):
-            if unsupported_differentiable_slot_augassign(result, target):
-                raise WarpCodegenError(
+        def record_unsupported_slot_adjoint(result: Var, target: Any) -> None:
+            """Record an unsupported slot overwrite for backward code generation."""
+            # Supported atomics return before reaching this fallback. Even +=
+            # and -= can be arbitrary computations when user-overloaded.
+            if not isinstance(target, Var) or target.array_slot is None:
+                return
+            if not adj.is_differentiable_value_type(strip_reference(result.type)):
+                return
+            if adj.slot_augassign_error is None:
+                adj.slot_augassign_error = (
+                    f"In function '{adj.fun_name}' at {adj.filename}:{adj.lineno + adj.fun_lineno}: "
                     "Differentiable composite slot augmented assignments with this operator are not supported "
-                    "with backward code generation enabled. Use an explicit out-of-place expression or mark the "
-                    "kernel with enable_backward=False for forward-only code."
+                    "with backward code generation enabled. Write the result to a separate array, or use "
+                    "enable_backward=False for forward-only code."
                 )
+            if adj.custom_reverse_mode:
+                raise WarpCodegenError(adj.slot_augassign_error)
 
-        def augassign_subscript(target, indices):
+        def lower_subscript_augassign(target: Var, indices: Sequence[Var]) -> None:
             """Load current value via pre-evaluated target/indices, apply op, store back."""
             indices = tuple(adj.load(idx) for idx in indices)
-            if adj._try_lower_evaluated_array_slot_atomic_augassign(target, indices, eval_rhs, node.op):
+            slot = adj.select_array_slot(target, indices=indices)
+            if find_user_operator() is None and adj.atomic_array_slot(slot, eval_rhs, node.op):
                 return
 
             target_type = strip_reference(target.type)
@@ -6638,42 +6198,49 @@ class Adjoint:
                 else:
                     current = adj.add_builtin_call("extract", [target, *indices])
 
-            result = apply_op(current)
-            reject_differentiable_slot_augassign(result, target)
-            if not adj._try_lower_evaluated_array_slot_write(target, indices, result):
+            # Snapshot the current value before evaluating a user operator's RHS.
+            # An unrelated overload must still take the builtin atomic path.
+            if resolve_user_operator(current) is None and adj.atomic_array_slot(slot, eval_rhs, node.op):
+                return
+            result = apply_operator(current)
+            record_unsupported_slot_adjoint(result, target)
+            if not adj.store_array_slot(slot, result):
                 adj._store_subscript(lhs, target, indices, result)
 
-        def augassign_attribute():
+        def lower_attribute_augassign() -> None:
             """Load current value of attribute target, apply op, store back."""
             aggregate = adj.resolve_attribute_store_aggregate(lhs.value)
-            if adj._try_lower_evaluated_array_slot_attribute_atomic_augassign(lhs, aggregate, eval_rhs, node.op):
+            slot = adj.select_array_slot(aggregate, attr=lhs.attr)
+            if find_user_operator() is None and adj.atomic_array_slot(slot, eval_rhs, node.op):
                 return
 
             with adj.suppress_read_tracking():
                 current = adj.emit_Attribute(lhs, aggregate=aggregate)
 
-            result = apply_op(current)
-            reject_differentiable_slot_augassign(result, aggregate)
-            if not adj._try_lower_evaluated_array_slot_attribute_write(lhs, aggregate, result):
+            if resolve_user_operator(current) is None and adj.atomic_array_slot(slot, eval_rhs, node.op):
+                return
+            result = apply_operator(current)
+            record_unsupported_slot_adjoint(result, aggregate)
+            if not adj.store_array_slot(slot, result):
                 adj._store_attribute(lhs, aggregate, result)
 
         if isinstance(lhs, ast.Subscript):
             # wp.adjoint[var] appears in custom grad functions; handle the
-            # adjoint store inline rather than through augassign_subscript.
+            # adjoint store inline rather than through lower_subscript_augassign.
             if hasattr(lhs.value, "attr") and lhs.value.attr == "adjoint":
                 with adj.suppress_read_tracking():
                     current = adj.eval(lhs)
 
-                result = apply_op(current)
+                result = apply_operator(current)
                 lhs.slice.is_adjoint = True
                 src_var = adj.eval(lhs.slice)
-                var = adj.make_adjoint_target_var(src_var)
-                if var is None:
+                adjoint_target = adj.make_adjoint_target_var(src_var)
+                if adjoint_target is None:
                     return
-                adj.add_forward(f"{var.emit()} = {result.emit()};")
+                adj.add_forward(f"{adjoint_target.emit()} = {result.emit()};")
                 return
 
-            target, indices = adj.eval_subscript(lhs)
+            target, indices = adj.eval_subscript(lhs, as_target=True)
 
             target_type = strip_reference(target.type)
             indices = adj.eval_indices(target_type, indices)
@@ -6681,7 +6248,7 @@ class Adjoint:
             if is_array(target_type):
                 # target_types int8, uint8, int16, uint16 are not suitable for atomic array accumulation
                 if target_type.dtype in warp._src.types.non_atomic_types:
-                    augassign_subscript(target, indices)
+                    lower_subscript_augassign(target, indices)
                     return
 
                 # the same holds true for vecs/mats/quats that are composed of these types
@@ -6691,9 +6258,9 @@ class Adjoint:
                     or type_is_matrix(target_type.dtype)
                     or type_is_transformation(target_type.dtype)
                 ):
-                    dtype = getattr(target_type.dtype, "_wp_scalar_type_", None)
-                    if dtype in warp._src.types.non_atomic_types:
-                        augassign_subscript(target, indices)
+                    scalar_dtype = getattr(target_type.dtype, "_wp_scalar_type_", None)
+                    if scalar_dtype in warp._src.types.non_atomic_types:
+                        lower_subscript_augassign(target, indices)
                         return
 
                 # Array augmented assignment lowers to a Warp atomic, e.g.
@@ -6717,7 +6284,7 @@ class Adjoint:
                     adj._mark_array_write(target)
                 else:
                     log_debug(f"Warning: in-place op {node.op} is not differentiable")
-                    augassign_subscript(target, indices)
+                    lower_subscript_augassign(target, indices)
                     return
 
             elif (
@@ -6729,10 +6296,9 @@ class Adjoint:
                 # When the target is a reference (i.e. an array element accessed via
                 # arr[i]), the ``*_inplace`` builtins operate on a loaded copy and
                 # silently discard the result. Fall back to the load-op-store path
-                # so that _store_subscript (and its _try_lower_array_slot_write fast
-                # path) can write the result back to the actual array element.
+                # so the resolved slot can write back to the array element.
                 if is_reference(target.type):
-                    augassign_subscript(target, indices)
+                    lower_subscript_augassign(target, indices)
                     return
                 if isinstance(node.op, ast.Add):
                     adj.add_builtin_call("add_inplace", [target, *indices, eval_rhs()])
@@ -6746,7 +6312,7 @@ class Adjoint:
                     adj.add_builtin_call("bit_xor_inplace", [target, *indices, eval_rhs()])
                 else:
                     log_debug(f"Warning: in-place op {node.op} is not differentiable")
-                    augassign_subscript(target, indices)
+                    lower_subscript_augassign(target, indices)
                     return
 
             elif is_tile(target.type):
@@ -6773,14 +6339,14 @@ class Adjoint:
                     adj.add_builtin_call("tile_bit_xor_inplace", [target, *indices, eval_rhs()])
                 else:
                     log_debug(f"Warning: in-place op {node.op} is not differentiable")
-                    augassign_subscript(target, indices)
+                    lower_subscript_augassign(target, indices)
                     return
 
             else:
                 raise WarpCodegenError("Can only subscript in-place assign array, vector, quaternion, and matrix types")
 
         elif isinstance(lhs, ast.Attribute):
-            augassign_attribute()
+            lower_attribute_augassign()
             return
 
         else:
@@ -8150,6 +7716,9 @@ def codegen_func_forward(adj, func_type="kernel", device="cpu", grid_stride=Fals
 
 
 def codegen_func_reverse(adj, func_type="kernel", device="cpu", grid_stride=False):
+    if adj.slot_augassign_error is not None:
+        raise WarpCodegenError(adj.slot_augassign_error)
+
     if device == "cpu":
         indent = 4
     elif device == "cuda":

--- a/warp/_src/deterministic.py
+++ b/warp/_src/deterministic.py
@@ -37,6 +37,7 @@ from warp._src.types import array_t, float_types, int32, is_array, type_is_int, 
 from warp.config import DeterministicMode
 
 if TYPE_CHECKING:
+    from warp._src.codegen import Var
     from warp._src.context import Device, KernelHooks, Stream
     from warp._src.types import launch_bounds_t
 
@@ -131,6 +132,17 @@ def _det_dest_size_elements(arr) -> int:
     return int(max_offset_bytes // element_size) + 1
 
 
+def _det_array_byte_bounds(arr) -> tuple[int, int] | None:
+    """Return a conservative storage interval for a possibly strided array."""
+    if arr is None or not getattr(arr, "ptr", None) or not getattr(arr, "size", 0):
+        return None
+    offsets = [(size - 1) * stride for size, stride in zip(arr.shape, arr.strides, strict=True)]
+    return (
+        arr.ptr + sum(min(offset, 0) for offset in offsets),
+        arr.ptr + sum(max(offset, 0) for offset in offsets) + type_size_in_bytes(arr.dtype),
+    )
+
+
 # Reduction operation constants (must match C++ ReduceOp enum in deterministic.cu).
 REDUCE_OP_ADD = 0
 REDUCE_OP_MIN = 1
@@ -193,11 +205,6 @@ def target_label(array_var_label: str, attr_path=()) -> str:
 def scatter_cpp_type(target: ScatterTarget) -> str:
     """Return the C++ helper type for a scatter target."""
     return f"wp::det_scatter_buf_t<{target.value_ctype}>"
-
-
-def _null_scatter_arg(target: ScatterTarget) -> str:
-    """Return a typed null scatter helper expression for generated calls."""
-    return f"{scatter_cpp_type(target)}{{nullptr, nullptr, nullptr, 0}}"
 
 
 def counter_cpp_type(_target: CounterTarget) -> str:
@@ -307,13 +314,13 @@ class DeterministicMeta:
     counter_records_per_thread: dict[CounterTarget, int] = field(default_factory=dict)
     counter_replay_targets: set[CounterTarget] = field(default_factory=set)
     store_targets_seen: set[ArrayStoreTarget] = field(default_factory=set)
-    adjoint_store_targets_in_body: set[ArrayStoreTarget] = field(default_factory=set)
     side_effect_atomic_targets: set[SideEffectAtomicTarget] = field(default_factory=set)
     needs_context: bool = False
     # Set by Adjoint.build() once the body has been pre-scanned.
     has_consumed_atomic: bool = False
     has_side_effect_store: bool = False
     has_unsupported_consumed_counter_backward: bool = False
+    has_component_updates: bool = False
 
     def add_scatter_target(self, target: ScatterTarget, records_per_thread: int = 1):
         """Record a scatter target requirement for this function or kernel."""
@@ -334,12 +341,12 @@ class DeterministicMeta:
     def include(self, other: DeterministicMeta):
         """Merge the transitive deterministic requirements of another adjoint."""
         self.needs_context |= other.needs_context
+        self.has_component_updates |= other.has_component_updates
         for target, count in other.scatter_records_per_thread.items():
             self.add_scatter_target(target, records_per_thread=count)
         for target, count in other.counter_records_per_thread.items():
             self.add_counter_target(target, records_per_thread=count)
         self.store_targets_seen |= other.store_targets_seen
-        self.adjoint_store_targets_in_body |= other.adjoint_store_targets_in_body
         self.side_effect_atomic_targets |= other.side_effect_atomic_targets
 
     @property
@@ -353,6 +360,28 @@ class DeterministicMeta:
     @property
     def needs_deterministic(self):
         return self.needs_context or self.has_scatter or self.has_counter
+
+    @property
+    def ordered_backward_targets(self) -> list[ScatterTarget]:
+        """Return backward reductions that cannot be deferred past an array mutation.
+
+        Compute this from completed lowering metadata, including called functions.
+        A primal store can clear its destination adjoint; custom adjoints can also
+        overwrite gradients directly. Both require updates in program order.
+        Target identity is conservative: indices and composite slots are ignored.
+        """
+        return [
+            target
+            for target in self.scatter_targets
+            if target.use_backward
+            and (
+                ArrayStoreTarget(target.array_var_label, target.attr_path, target.adjoint) in self.store_targets_seen
+                or (
+                    target.adjoint
+                    and ArrayStoreTarget(target.array_var_label, target.attr_path, False) in self.store_targets_seen
+                )
+            )
+        ]
 
 
 @dataclass
@@ -394,7 +423,6 @@ class DeterministicCodegen:
                 determinism_mode=deterministic_mode,
                 max_records=builder_options.get("deterministic_max_records", 0),
                 has_consumed_atomic=_deterministic_has_consumed_atomic_impl(self.adj.tree, self.adj, seen=None),
-                adjoint_store_targets_in_body=_deterministic_adjoint_store_targets(self.adj.tree),
                 has_side_effect_store=self.adj.is_user_function
                 and _deterministic_has_propagating_side_effect(self.adj.tree),
             )
@@ -453,25 +481,19 @@ class DeterministicCodegen:
     def call_args(self, func, bound_args):
         if func.is_builtin():
             return []
-        return self.helper_args_for_meta(getattr(func.adj, "det_meta", None), bound_args, for_backward=False)
+        return self.helper_args_for_meta(getattr(func.adj, "det_meta", None), bound_args)
 
     def replay_call_args(self, func, bound_args, default_args):
         if func.custom_replay_func is None:
             return default_args
-        return self.helper_args_for_meta(
-            getattr(func.custom_replay_func.adj, "det_meta", None), bound_args, for_backward=False
-        )
+        return self.helper_args_for_meta(getattr(func.custom_replay_func.adj, "det_meta", None), bound_args)
 
     def reverse_call_args(self, func, bound_args, default_args):
-        if func.is_builtin():
-            return default_args
         if func.custom_grad_func is None:
-            return self.helper_args_for_meta(getattr(func.adj, "det_meta", None), bound_args, for_backward=True)
-        return self.helper_args_for_meta(
-            getattr(func.custom_grad_func.adj, "det_meta", None), bound_args, for_backward=True
-        )
+            return default_args
+        return self.helper_args_for_meta(getattr(func.custom_grad_func.adj, "det_meta", None), bound_args)
 
-    def helper_args_for_meta(self, meta, bound_args, *, for_backward: bool):
+    def helper_args_for_meta(self, meta, bound_args):
         """Return helper arguments to pass into a deterministic ``@wp.func``."""
         if self.adj.det_meta is None or meta is None or not meta.needs_deterministic:
             return []
@@ -503,10 +525,6 @@ class DeterministicCodegen:
 
         for target in meta.scatter_targets:
             mapped_label, mapped_attr_path = _deterministic_map_target(target, bound_args)
-            if for_backward and self._scatter_target_needs_call_fallback(target, mapped_label, mapped_attr_path):
-                det_args.append(_null_scatter_arg(target))
-                continue
-
             mapped_target = _deterministic_find_target(
                 self.adj.det_meta.scatter_targets,
                 mapped_label,
@@ -533,20 +551,6 @@ class DeterministicCodegen:
             det_args.append(mapped_target.helper_name if mapped_target is not None else target.helper_name)
 
         return det_args
-
-    def _scatter_target_needs_call_fallback(self, target, mapped_label, mapped_attr_path) -> bool:
-        """Return whether a callee scatter must run inline to preserve caller order."""
-        if self.adj.det_meta is None or not getattr(target, "use_backward", False):
-            return False
-
-        attr_path = tuple(mapped_attr_path)
-        primal_store = ArrayStoreTarget(mapped_label, attr_path, False)
-        adjoint_store = ArrayStoreTarget(mapped_label, attr_path, True)
-        return (
-            primal_store in self.adj.det_meta.store_targets_seen
-            or adjoint_store in self.adj.det_meta.store_targets_seen
-            or adjoint_store in self.adj.det_meta.adjoint_store_targets_in_body
-        )
 
     def wrap_unintercepted_side_effect_atomic(
         self,
@@ -587,14 +591,16 @@ class DeterministicCodegen:
         """
         from warp._src.codegen import Var, WarpCodegenError  # noqa: PLC0415
 
-        if not fwd_args or not output_list:
+        # A custom adjoint executes its forward statements during backward;
+        # its own reverse statements are never called or reduced.
+        if self.adj.custom_reverse_mode or not fwd_args or not output_list:
             return fallback_call
 
         arr_var = fwd_args[0]
         view_prefix_vars = []
-        while getattr(arr_var, "deterministic_view_parent", None) is not None:
+        while getattr(arr_var, "deterministic_view_reduction_parent", None) is not None:
             view_prefix_vars = list(arr_var.deterministic_view_indices) + view_prefix_vars
-            arr_var = arr_var.deterministic_view_parent
+            arr_var = arr_var.deterministic_view_reduction_parent
 
         try:
             target_info = _deterministic_target_info(arr_var)
@@ -615,9 +621,10 @@ class DeterministicCodegen:
             if not any(arg.label == target_root_label for arg in self.adj.args):
                 return fallback_call
 
-            store_target = ArrayStoreTarget(target_root_label, tuple(target_attr_path), bool(target_is_adjoint))
-            if store_target in self.adj.det_meta.store_targets_seen:
-                return fallback_call
+            if not self.adj.det_meta.has_component_updates:
+                store_target = ArrayStoreTarget(target_root_label, tuple(target_attr_path), bool(target_is_adjoint))
+                if store_target in self.adj.det_meta.store_targets_seen:
+                    return fallback_call
 
             value_ctype = Var.dtype_to_ctype(value_dtype)
             target = get_or_create_scatter_target(
@@ -655,31 +662,60 @@ class DeterministicCodegen:
             f"{flat_idx_expr}, {adj_output}, {fallback_call});"
         )
 
-    def emit_adjoint_slot_scatter(self, root_var, array_index_vars, access_cpp, rhs, slot_type, op_name, fallback_stmt):
-        """Emit deterministic scatter for composite slots in ``wp.adjoint[array]``."""
-        del slot_type
+    def emit_adjoint_slot_scatter(
+        self,
+        slot_root: Var,
+        slot_indices: Sequence[Var],
+        slot_access: str,
+        update_value: Var,
+        operation: str,
+        fallback_statement: str,
+    ) -> bool:
+        """Emit a deterministic scatter for a composite adjoint-array slot.
 
-        if not self.enabled or op_name not in ("add", "sub"):
+        Resolve views back to a kernel argument, register that argument as a
+        reduction target, and encode the selected component or row as a sparse
+        value for the existing scatter-sort-reduce path. Unsupported targets
+        are left to the caller's normal atomic lowering.
+
+        Args:
+            slot_root: Array variable containing the selected composite slot.
+            slot_indices: Indices selecting an element of ``slot_root``.
+            slot_access: C++ suffix selecting a component, row, or field.
+            update_value: Value added to or subtracted from the slot.
+            operation: Augmented-assignment operation name.
+            fallback_statement: Native atomic statement used when deterministic
+                scattering is inactive at runtime.
+
+        Returns:
+            ``True`` when deterministic scatter code was emitted, or ``False``
+            when the caller should use its normal atomic lowering.
+        """
+        if not self.enabled or operation not in ("add", "sub"):
             return False
 
         from warp._src.codegen import Var, WarpCodegenError  # noqa: PLC0415
 
-        view_prefix_vars = []
-        target_var = root_var
-        while getattr(target_var, "deterministic_view_parent", None) is not None:
-            view_prefix_vars = list(target_var.deterministic_view_indices) + view_prefix_vars
-            target_var = target_var.deterministic_view_parent
+        # Follow integer-index views and prepend their reduction indices.
+        # Sliced views do not provide this reduction mapping.
+        view_indices: list[Var] = []
+        target_root = slot_root
+        while getattr(target_root, "deterministic_view_reduction_parent", None) is not None:
+            view_indices = list(target_root.deterministic_view_indices) + view_indices
+            target_root = target_root.deterministic_view_reduction_parent
 
+        # Accept only floating-point adjoint arrays whose destination can be
+        # represented by a launch-time scatter target.
         try:
-            target_info = _deterministic_target_info(target_var)
-            if target_info is None:
+            target_metadata = _deterministic_target_info(target_root)
+            if target_metadata is None:
                 return False
 
-            target_root_label, target_attr_path, arr_type, target_is_adjoint = target_info
-            if not target_is_adjoint or not is_array(arr_type):
+            target_root_label, target_attr_path, array_type, is_adjoint_target = target_metadata
+            if not is_adjoint_target or not is_array(array_type):
                 return False
 
-            value_dtype = arr_type.dtype
+            value_dtype = array_type.dtype
             scalar_dtype = getattr(value_dtype, "_wp_scalar_type_", value_dtype)
             if scalar_dtype not in float_types:
                 return False
@@ -690,17 +726,8 @@ class DeterministicCodegen:
                     "for composite slot augmented assignment to a kernel argument."
                 )
 
-            store_target = ArrayStoreTarget(target_root_label, tuple(target_attr_path), True)
-            if (
-                store_target in self.adj.det_meta.store_targets_seen
-                or store_target in self.adj.det_meta.adjoint_store_targets_in_body
-            ):
-                stmt = self.wrap_side_effect_call(fallback_stmt)
-                self.adj.add_forward(stmt, replay=f"// {fallback_stmt}")
-                return True
-
             value_ctype = Var.dtype_to_ctype(value_dtype)
-            target = get_or_create_scatter_target(
+            scatter_target = get_or_create_scatter_target(
                 self.adj.det_registry,
                 self.adj.det_meta,
                 target_root_label,
@@ -721,26 +748,29 @@ class DeterministicCodegen:
                 f"Deterministic mode could not lower composite slot augmented assignment: {e}"
             ) from e
 
-        target_expr = _deterministic_array_expr(self.adj, target_root_label, target_attr_path, adjoint=True)
-        if target_expr is None:
+        # Convert the complete view-plus-element index into the flat destination
+        # used by deterministic reduction buffers.
+        target_array_expr = _deterministic_array_expr(self.adj, target_root_label, target_attr_path, adjoint=True)
+        if target_array_expr is None:
             return False
 
-        idx_loaded_list = [self.adj.load(var) for var in view_prefix_vars] + [
-            self.adj.load(var) for var in array_index_vars
-        ]
-        flat_idx_expr = _deterministic_flat_index_expr(
-            self.adj, target_expr, idx_loaded_list, f"array_atomic_{op_name}_slot", value_ctype
+        loaded_indices = [self.adj.load(index) for index in view_indices]
+        loaded_indices.extend(self.adj.load(index) for index in slot_indices)
+        flat_index_expr = _deterministic_flat_index_expr(
+            self.adj, target_array_expr, loaded_indices, f"array_atomic_{operation}_slot", value_ctype
         )
 
-        delta = self.adj.add_var(value_dtype)
-        rhs_expr = rhs.emit()
-        if op_name == "sub":
-            rhs_expr = f"-({rhs_expr})"
-        self.adj.add_forward(f"{delta.emit()} = {value_ctype}{{}};")
-        self.adj.add_forward(f"{delta.emit()}{access_cpp} = {rhs_expr};")
+        # Pack the slot update into a zero-initialized aggregate so the normal
+        # whole-value reducer changes only the selected component or row.
+        scatter_value = self.adj.add_var(value_dtype)
+        update_expression = update_value.emit()
+        if operation == "sub":
+            update_expression = f"-({update_expression})"
+        self.adj.add_forward(f"{scatter_value.emit()} = {value_ctype}{{}};")
+        self.adj.add_forward(f"{scatter_value.emit()}{slot_access} = {update_expression};")
         self.adj.add_forward(
-            f"WP_DET_SCATTER_OR_FALLBACK(det_ctx, {target.helper_name}, {flat_idx_expr}, "
-            f"{delta.emit()}, {fallback_stmt});",
+            f"WP_DET_SCATTER_OR_FALLBACK(det_ctx, {scatter_target.helper_name}, {flat_index_expr}, "
+            f"{scatter_value.emit()}, {fallback_statement});",
             replay="// deterministic scatter replay (skipped)",
         )
         return True
@@ -836,9 +866,11 @@ class DeterministicCodegen:
         if self.adj.det_meta is None:
             return
 
+        # Mutation checks must follow all view aliases, including slices whose
+        # offsets cannot be represented by the reduction mapping.
         store_target_var = target
-        while getattr(store_target_var, "deterministic_view_parent", None) is not None:
-            store_target_var = store_target_var.deterministic_view_parent
+        while getattr(store_target_var, "deterministic_view_alias_source", None) is not None:
+            store_target_var = store_target_var.deterministic_view_alias_source
 
         store_target_info = _deterministic_target_info(store_target_var)
         if store_target_info is None:
@@ -869,15 +901,29 @@ class DeterministicCodegen:
         if is_array(strip_reference(attr_type)):
             attr.deterministic_ref_array_type = strip_reference(attr_type)
 
-    def track_view(self, out, target, indices) -> None:
-        """Track integer-only array views so atomics through views can be remapped."""
+    def track_view(self, out: Var, target: Var, indices: Sequence[Var]) -> None:
+        """Record view aliases separately from supported reduction offsets.
+
+        ``deterministic_view_alias_source`` links every view, including slices,
+        to its source for mutation checks and adjoint descriptor reconstruction.
+
+        ``deterministic_view_reduction_parent`` links only integer-index views,
+        such as a row view ``a[i]``. Reductions prepend these views' indices to
+        recover the destination in the parent array; this cannot represent the
+        offset and stride changes of a slice such as ``a[::2]``.
+
+        ``deterministic_view_indices`` stores the original selectors for either
+        kind of view. Treat them as a reduction prefix only when the reduction
+        parent exists.
+        """
         from warp._src.codegen import strip_reference  # noqa: PLC0415
 
+        out.deterministic_view_alias_source = target
+        out.deterministic_view_indices = tuple(indices)
         if not all(type_is_int(strip_reference(index.type)) for index in indices):
             return
 
-        out.deterministic_view_parent = target
-        out.deterministic_view_indices = tuple(indices)
+        out.deterministic_view_reduction_parent = target
         if getattr(target, "deterministic_adjoint_target", False):
             out.deterministic_adjoint_target = True
             out.deterministic_adjoint_root_label = getattr(target, "deterministic_adjoint_root_label", None)
@@ -1107,147 +1153,6 @@ def _deterministic_has_propagating_side_effect(tree):
     return False
 
 
-def _deterministic_is_wp_adjoint(node):
-    """Return whether ``node`` is the ``wp.adjoint`` attribute expression."""
-    return (
-        isinstance(node, ast.Attribute)
-        and node.attr == "adjoint"
-        and isinstance(node.value, ast.Name)
-        and node.value.id == "wp"
-    )
-
-
-def _deterministic_expr_target_path(node, aliases):
-    """Return ``(root_label, attr_path, adjoint)`` for a target expression."""
-    if isinstance(node, ast.Name):
-        return aliases.get(node.id, (node.id, (), False))
-    if isinstance(node, ast.Attribute):
-        base = _deterministic_expr_target_path(node.value, aliases)
-        if base is None:
-            return None
-        root_label, attr_path, adjoint = base
-        return root_label, (*attr_path, node.attr), adjoint
-    if isinstance(node, ast.Subscript):
-        if _deterministic_is_wp_adjoint(node.value):
-            base = _deterministic_expr_target_path(node.slice, aliases)
-            if base is None:
-                return None
-            root_label, attr_path, _ = base
-            return root_label, attr_path, True
-        return _deterministic_expr_target_path(node.value, aliases)
-    return None
-
-
-def _deterministic_adjoint_store_target(node, aliases):
-    """Return the adjoint array target overwritten by ``node``, if any."""
-    while isinstance(node, ast.Attribute | ast.Subscript):
-        if isinstance(node, ast.Subscript) and _deterministic_is_wp_adjoint(node.value):
-            target_path = _deterministic_expr_target_path(node.slice, aliases)
-            if target_path is None:
-                return None
-            root_label, attr_path, _ = target_path
-            return ArrayStoreTarget(root_label, tuple(attr_path), True)
-
-        target_path = _deterministic_expr_target_path(node.value, aliases)
-        if target_path is not None:
-            root_label, attr_path, adjoint = target_path
-            if adjoint:
-                return ArrayStoreTarget(root_label, tuple(attr_path), True)
-
-        node = node.value
-
-    target_path = _deterministic_expr_target_path(node, aliases)
-    if target_path is not None:
-        root_label, attr_path, adjoint = target_path
-        if adjoint:
-            return ArrayStoreTarget(root_label, tuple(attr_path), True)
-    return None
-
-
-def _deterministic_collect_alias_targets(target, names):
-    """Collect direct local names bound by an assignment target."""
-    if isinstance(target, ast.Name):
-        names.add(target.id)
-    elif isinstance(target, (ast.Tuple, ast.List)):
-        for element in target.elts:
-            _deterministic_collect_alias_targets(element, names)
-
-
-def _deterministic_update_aliases_from_assign(target, value, aliases):
-    """Update local array aliases after a supported assignment."""
-    target_names = set()
-    _deterministic_collect_alias_targets(target, target_names)
-    for name in target_names:
-        aliases.pop(name, None)
-
-    if isinstance(target, ast.Name):
-        value_path = _deterministic_expr_target_path(value, aliases)
-        if value_path is not None:
-            aliases[target.id] = value_path
-    elif isinstance(target, (ast.Tuple, ast.List)) and isinstance(value, (ast.Tuple, ast.List)):
-        for target_elt, value_elt in zip(target.elts, value.elts, strict=False):
-            _deterministic_update_aliases_from_assign(target_elt, value_elt, aliases)
-
-
-def _deterministic_bind_alias_target(target, value_path, aliases):
-    """Bind a direct assignment target to a precomputed target path."""
-    if isinstance(target, ast.Name):
-        aliases[target.id] = value_path
-
-
-def _deterministic_statement_children(node):
-    """Yield nested statement blocks that need independent alias scans."""
-    for field_name in ("body", "orelse", "finalbody"):
-        child = getattr(node, field_name, None)
-        if child:
-            yield child
-    handlers = getattr(node, "handlers", ())
-    for handler in handlers:
-        yield handler.body
-
-
-def _deterministic_scan_adjoint_store_targets(statements, aliases):
-    """Return adjoint array targets overwritten in ``statements``."""
-    targets = set()
-    for statement in statements:
-        if isinstance(statement, ast.Assign):
-            for target in statement.targets:
-                store_target = _deterministic_adjoint_store_target(target, aliases)
-                if store_target is not None:
-                    targets.add(store_target)
-            if len(statement.targets) == 1:
-                _deterministic_update_aliases_from_assign(statement.targets[0], statement.value, aliases)
-            else:
-                target_names = set()
-                for target in statement.targets:
-                    _deterministic_collect_alias_targets(target, target_names)
-                for name in target_names:
-                    aliases.pop(name, None)
-                value_path = _deterministic_expr_target_path(statement.value, aliases)
-                if value_path is not None:
-                    for target in statement.targets:
-                        _deterministic_bind_alias_target(target, value_path, aliases)
-        elif isinstance(statement, ast.AnnAssign):
-            store_target = _deterministic_adjoint_store_target(statement.target, aliases)
-            if store_target is not None:
-                targets.add(store_target)
-            if statement.value is not None:
-                _deterministic_update_aliases_from_assign(statement.target, statement.value, aliases)
-        elif isinstance(statement, ast.AugAssign):
-            _deterministic_update_aliases_from_assign(statement.target, ast.Constant(None), aliases)
-
-        for child_statements in _deterministic_statement_children(statement):
-            targets |= _deterministic_scan_adjoint_store_targets(child_statements, aliases.copy())
-
-    return targets
-
-
-def _deterministic_adjoint_store_targets(tree):
-    """Return adjoint arrays directly overwritten in the function body."""
-    body = getattr(tree, "body", ())
-    return _deterministic_scan_adjoint_store_targets(body, {})
-
-
 def _deterministic_has_consumed_atomic(tree):
     """Return whether codegen will treat any atomic return value as consumed."""
     return _deterministic_has_consumed_atomic_impl(tree, adj=None, seen=None)
@@ -1423,9 +1328,9 @@ def emit_deterministic_atomic(adj, func, bound_args, return_type, output, output
     arr_var = args_list[0]  # the target array, possibly a view such as arr[i]
     view_prefix_vars = []
 
-    while getattr(arr_var, "deterministic_view_parent", None) is not None:
+    while getattr(arr_var, "deterministic_view_reduction_parent", None) is not None:
         view_prefix_vars = list(arr_var.deterministic_view_indices) + view_prefix_vars
-        arr_var = arr_var.deterministic_view_parent
+        arr_var = arr_var.deterministic_view_reduction_parent
 
     try:
         target_info = _deterministic_target_info(arr_var)
@@ -1820,6 +1725,7 @@ def _include_deterministic_call_meta(adj, meta, bound_args, *, include_replay_ta
         return
 
     adj.det_meta.needs_context |= meta.needs_context
+    adj.det_meta.has_component_updates |= meta.has_component_updates
 
     for target in meta.store_targets_seen:
         mapped_label, mapped_attr_path = _deterministic_map_target(target, bound_args)
@@ -2204,7 +2110,11 @@ def _deterministic_launch_class():
                 return False
 
             arg_label = self.kernel.adj.args[index].label
-            targets = (*self.det_meta.scatter_targets, *self.det_meta.counter_targets)
+            targets = (
+                *self.det_meta.scatter_targets,
+                *self.det_meta.counter_targets,
+                *self.det_meta.store_targets_seen,
+            )
             return any(target.array_var_label == arg_label for target in targets)
 
         def set_param_at_index(self, index: int, value: Any, adjoint: bool = False):
@@ -2383,8 +2293,44 @@ def launch_deterministic(
             )
         return getattr(array, "ptr", None) is not None and getattr(array, "size", 0) > 0
 
+    # Distinct argument labels can alias the same storage at launch time. A
+    # primal store may execute in replay or clear its adjoint, while an explicit
+    # adjoint store writes the gradient directly. Include both possible storage
+    # intervals without reading device memory or assuming contiguous layouts.
+    check_component_order = adjoint and det_meta.has_component_updates
+    ordered_backward_targets = det_meta.ordered_backward_targets if check_component_order else []
+    if check_component_order:
+        store_bounds = []
+        for store in det_meta.store_targets_seen:
+            for is_adjoint in (True,) if store.adjoint else (False, True):
+                storage = ArrayStoreTarget(store.array_var_label, store.attr_path, is_adjoint)
+                interval = _det_array_byte_bounds(resolve_det_target_array(storage))
+                if interval is not None:
+                    store_bounds.append(interval)
+        for target in det_meta.scatter_targets:
+            if not target.use_backward or target in ordered_backward_targets:
+                continue
+            interval = _det_array_byte_bounds(resolve_det_target_array(target))
+            if interval is not None and any(interval[0] < end and start < interval[1] for start, end in store_bounds):
+                ordered_backward_targets.append(target)
+
+    # Mutation-dependent reductions cannot be postponed to a post-kernel pass.
+    # A single CUDA thread can use native updates in program order; parallel
+    # launches must fail before execution rather than silently using atomics.
+    serial_backward = bool(ordered_backward_targets)
+    if serial_backward and bounds.size > 1:
+        target_names = ", ".join(target.target_label for target in ordered_backward_targets)
+        raise RuntimeError(
+            f"Deterministic mode does not support parallel backward launches in kernel '{kernel.key}' with "
+            f"array mutation and gradient reduction on target(s): {target_names}. "
+            "Use separate mutation and reduction kernels, use a single-thread launch, "
+            "or disable deterministic mode for this kernel."
+        )
+
     active_scatter_targets = []
     for target in det_meta.scatter_targets:
+        if serial_backward:
+            continue
         if not (target.use_backward if adjoint else target.use_forward):
             continue
         if adjoint and not target_has_resolvable_destination(target):

--- a/warp/_src/deterministic.py
+++ b/warp/_src/deterministic.py
@@ -195,6 +195,11 @@ def scatter_cpp_type(target: ScatterTarget) -> str:
     return f"wp::det_scatter_buf_t<{target.value_ctype}>"
 
 
+def _null_scatter_arg(target: ScatterTarget) -> str:
+    """Return a typed null scatter helper expression for generated calls."""
+    return f"{scatter_cpp_type(target)}{{nullptr, nullptr, nullptr, 0}}"
+
+
 def counter_cpp_type(_target: CounterTarget) -> str:
     """Return the C++ helper type for a counter target."""
     return "wp::det_counter_buf_t"
@@ -302,6 +307,7 @@ class DeterministicMeta:
     counter_records_per_thread: dict[CounterTarget, int] = field(default_factory=dict)
     counter_replay_targets: set[CounterTarget] = field(default_factory=set)
     store_targets_seen: set[ArrayStoreTarget] = field(default_factory=set)
+    adjoint_store_targets_in_body: set[ArrayStoreTarget] = field(default_factory=set)
     side_effect_atomic_targets: set[SideEffectAtomicTarget] = field(default_factory=set)
     needs_context: bool = False
     # Set by Adjoint.build() once the body has been pre-scanned.
@@ -333,6 +339,7 @@ class DeterministicMeta:
         for target, count in other.counter_records_per_thread.items():
             self.add_counter_target(target, records_per_thread=count)
         self.store_targets_seen |= other.store_targets_seen
+        self.adjoint_store_targets_in_body |= other.adjoint_store_targets_in_body
         self.side_effect_atomic_targets |= other.side_effect_atomic_targets
 
     @property
@@ -387,6 +394,7 @@ class DeterministicCodegen:
                 determinism_mode=deterministic_mode,
                 max_records=builder_options.get("deterministic_max_records", 0),
                 has_consumed_atomic=_deterministic_has_consumed_atomic_impl(self.adj.tree, self.adj, seen=None),
+                adjoint_store_targets_in_body=_deterministic_adjoint_store_targets(self.adj.tree),
                 has_side_effect_store=self.adj.is_user_function
                 and _deterministic_has_propagating_side_effect(self.adj.tree),
             )
@@ -445,19 +453,25 @@ class DeterministicCodegen:
     def call_args(self, func, bound_args):
         if func.is_builtin():
             return []
-        return self.helper_args_for_meta(getattr(func.adj, "det_meta", None), bound_args)
+        return self.helper_args_for_meta(getattr(func.adj, "det_meta", None), bound_args, for_backward=False)
 
     def replay_call_args(self, func, bound_args, default_args):
         if func.custom_replay_func is None:
             return default_args
-        return self.helper_args_for_meta(getattr(func.custom_replay_func.adj, "det_meta", None), bound_args)
+        return self.helper_args_for_meta(
+            getattr(func.custom_replay_func.adj, "det_meta", None), bound_args, for_backward=False
+        )
 
     def reverse_call_args(self, func, bound_args, default_args):
-        if func.custom_grad_func is None:
+        if func.is_builtin():
             return default_args
-        return self.helper_args_for_meta(getattr(func.custom_grad_func.adj, "det_meta", None), bound_args)
+        if func.custom_grad_func is None:
+            return self.helper_args_for_meta(getattr(func.adj, "det_meta", None), bound_args, for_backward=True)
+        return self.helper_args_for_meta(
+            getattr(func.custom_grad_func.adj, "det_meta", None), bound_args, for_backward=True
+        )
 
-    def helper_args_for_meta(self, meta, bound_args):
+    def helper_args_for_meta(self, meta, bound_args, *, for_backward: bool):
         """Return helper arguments to pass into a deterministic ``@wp.func``."""
         if self.adj.det_meta is None or meta is None or not meta.needs_deterministic:
             return []
@@ -489,6 +503,10 @@ class DeterministicCodegen:
 
         for target in meta.scatter_targets:
             mapped_label, mapped_attr_path = _deterministic_map_target(target, bound_args)
+            if for_backward and self._scatter_target_needs_call_fallback(target, mapped_label, mapped_attr_path):
+                det_args.append(_null_scatter_arg(target))
+                continue
+
             mapped_target = _deterministic_find_target(
                 self.adj.det_meta.scatter_targets,
                 mapped_label,
@@ -515,6 +533,20 @@ class DeterministicCodegen:
             det_args.append(mapped_target.helper_name if mapped_target is not None else target.helper_name)
 
         return det_args
+
+    def _scatter_target_needs_call_fallback(self, target, mapped_label, mapped_attr_path) -> bool:
+        """Return whether a callee scatter must run inline to preserve caller order."""
+        if self.adj.det_meta is None or not getattr(target, "use_backward", False):
+            return False
+
+        attr_path = tuple(mapped_attr_path)
+        primal_store = ArrayStoreTarget(mapped_label, attr_path, False)
+        adjoint_store = ArrayStoreTarget(mapped_label, attr_path, True)
+        return (
+            primal_store in self.adj.det_meta.store_targets_seen
+            or adjoint_store in self.adj.det_meta.store_targets_seen
+            or adjoint_store in self.adj.det_meta.adjoint_store_targets_in_body
+        )
 
     def wrap_unintercepted_side_effect_atomic(
         self,
@@ -623,6 +655,96 @@ class DeterministicCodegen:
             f"{flat_idx_expr}, {adj_output}, {fallback_call});"
         )
 
+    def emit_adjoint_slot_scatter(self, root_var, array_index_vars, access_cpp, rhs, slot_type, op_name, fallback_stmt):
+        """Emit deterministic scatter for composite slots in ``wp.adjoint[array]``."""
+        del slot_type
+
+        if not self.enabled or op_name not in ("add", "sub"):
+            return False
+
+        from warp._src.codegen import Var, WarpCodegenError  # noqa: PLC0415
+
+        view_prefix_vars = []
+        target_var = root_var
+        while getattr(target_var, "deterministic_view_parent", None) is not None:
+            view_prefix_vars = list(target_var.deterministic_view_indices) + view_prefix_vars
+            target_var = target_var.deterministic_view_parent
+
+        try:
+            target_info = _deterministic_target_info(target_var)
+            if target_info is None:
+                return False
+
+            target_root_label, target_attr_path, arr_type, target_is_adjoint = target_info
+            if not target_is_adjoint or not is_array(arr_type):
+                return False
+
+            value_dtype = arr_type.dtype
+            scalar_dtype = getattr(value_dtype, "_wp_scalar_type_", value_dtype)
+            if scalar_dtype not in float_types:
+                return False
+
+            if not any(arg.label == target_root_label for arg in self.adj.args):
+                raise WarpCodegenError(
+                    f"Deterministic mode could not map atomic target '{target_root_label}' "
+                    "for composite slot augmented assignment to a kernel argument."
+                )
+
+            store_target = ArrayStoreTarget(target_root_label, tuple(target_attr_path), True)
+            if (
+                store_target in self.adj.det_meta.store_targets_seen
+                or store_target in self.adj.det_meta.adjoint_store_targets_in_body
+            ):
+                stmt = self.wrap_side_effect_call(fallback_stmt)
+                self.adj.add_forward(stmt, replay=f"// {fallback_stmt}")
+                return True
+
+            value_ctype = Var.dtype_to_ctype(value_dtype)
+            target = get_or_create_scatter_target(
+                self.adj.det_registry,
+                self.adj.det_meta,
+                target_root_label,
+                value_dtype,
+                value_ctype,
+                scalar_dtype,
+                REDUCE_OP_ADD,
+                attr_path=target_attr_path,
+                adjoint=True,
+                use_forward=False,
+                use_backward=True,
+            )
+            warp_scalar_type_to_id(scalar_dtype)
+        except WarpCodegenError:
+            raise
+        except (AttributeError, KeyError, TypeError, ValueError) as e:
+            raise WarpCodegenError(
+                f"Deterministic mode could not lower composite slot augmented assignment: {e}"
+            ) from e
+
+        target_expr = _deterministic_array_expr(self.adj, target_root_label, target_attr_path, adjoint=True)
+        if target_expr is None:
+            return False
+
+        idx_loaded_list = [self.adj.load(var) for var in view_prefix_vars] + [
+            self.adj.load(var) for var in array_index_vars
+        ]
+        flat_idx_expr = _deterministic_flat_index_expr(
+            self.adj, target_expr, idx_loaded_list, f"array_atomic_{op_name}_slot", value_ctype
+        )
+
+        delta = self.adj.add_var(value_dtype)
+        rhs_expr = rhs.emit()
+        if op_name == "sub":
+            rhs_expr = f"-({rhs_expr})"
+        self.adj.add_forward(f"{delta.emit()} = {value_ctype}{{}};")
+        self.adj.add_forward(f"{delta.emit()}{access_cpp} = {rhs_expr};")
+        self.adj.add_forward(
+            f"WP_DET_SCATTER_OR_FALLBACK(det_ctx, {target.helper_name}, {flat_idx_expr}, "
+            f"{delta.emit()}, {fallback_stmt});",
+            replay="// deterministic scatter replay (skipped)",
+        )
+        return True
+
     def function_args(self):
         """Return hidden deterministic parameters for generated ``@wp.func`` calls."""
         if self.adj.det_meta is None or not self.adj.det_meta.needs_deterministic:
@@ -703,12 +825,33 @@ class DeterministicCodegen:
         )
 
     def wrap_slot_store(self, slot_lvalue: str, value_expr: str) -> str:
+        """Return a deterministic-context guarded slot-store statement."""
         if self.needs_store_guard():
             self.adj.det_meta.needs_context = True
             return f"WP_DET_SLOT_STORE_IF_ACTIVE(det_ctx, {slot_lvalue}, {value_expr});"
-        return f"{slot_lvalue} = {value_expr};"
+        return f"wp::store(&({slot_lvalue}), {value_expr});"
+
+    def mark_store_target(self, target) -> None:
+        """Record an array target whose backward adjoints must not be deferred."""
+        if self.adj.det_meta is None:
+            return
+
+        store_target_var = target
+        while getattr(store_target_var, "deterministic_view_parent", None) is not None:
+            store_target_var = store_target_var.deterministic_view_parent
+
+        store_target_info = _deterministic_target_info(store_target_var)
+        if store_target_info is None:
+            return
+
+        target_root_label, target_attr_path, target_type, target_is_adjoint = store_target_info
+        if is_array(target_type):
+            self.adj.det_meta.store_targets_seen.add(
+                ArrayStoreTarget(target_root_label, tuple(target_attr_path), bool(target_is_adjoint))
+            )
 
     def add_array_store(self, target, indices, rhs) -> None:
+        """Emit a deterministic guarded whole-array store."""
         self.adj.det_meta.needs_context = True
         _add_deterministic_array_store(self.adj, target, indices, rhs)
 
@@ -740,6 +883,7 @@ class DeterministicCodegen:
             out.deterministic_adjoint_root_label = getattr(target, "deterministic_adjoint_root_label", None)
 
     def mark_adjoint_target(self, var, root_label: str) -> None:
+        """Mark ``var`` as an adjoint view of the array named by ``root_label``."""
         var.deterministic_adjoint_target = True
         var.deterministic_adjoint_root_label = root_label
 
@@ -940,6 +1084,8 @@ def _deterministic_contains_atomic_call(node):
 def _deterministic_contains_subscript_target(node):
     if isinstance(node, ast.Subscript):
         return True
+    if isinstance(node, ast.Attribute):
+        return _deterministic_contains_subscript_target(node.value)
     if isinstance(node, (ast.Tuple, ast.List)):
         return any(_deterministic_contains_subscript_target(element) for element in node.elts)
     return False
@@ -961,12 +1107,154 @@ def _deterministic_has_propagating_side_effect(tree):
     return False
 
 
+def _deterministic_is_wp_adjoint(node):
+    """Return whether ``node`` is the ``wp.adjoint`` attribute expression."""
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "adjoint"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "wp"
+    )
+
+
+def _deterministic_expr_target_path(node, aliases):
+    """Return ``(root_label, attr_path, adjoint)`` for a target expression."""
+    if isinstance(node, ast.Name):
+        return aliases.get(node.id, (node.id, (), False))
+    if isinstance(node, ast.Attribute):
+        base = _deterministic_expr_target_path(node.value, aliases)
+        if base is None:
+            return None
+        root_label, attr_path, adjoint = base
+        return root_label, (*attr_path, node.attr), adjoint
+    if isinstance(node, ast.Subscript):
+        if _deterministic_is_wp_adjoint(node.value):
+            base = _deterministic_expr_target_path(node.slice, aliases)
+            if base is None:
+                return None
+            root_label, attr_path, _ = base
+            return root_label, attr_path, True
+        return _deterministic_expr_target_path(node.value, aliases)
+    return None
+
+
+def _deterministic_adjoint_store_target(node, aliases):
+    """Return the adjoint array target overwritten by ``node``, if any."""
+    while isinstance(node, ast.Attribute | ast.Subscript):
+        if isinstance(node, ast.Subscript) and _deterministic_is_wp_adjoint(node.value):
+            target_path = _deterministic_expr_target_path(node.slice, aliases)
+            if target_path is None:
+                return None
+            root_label, attr_path, _ = target_path
+            return ArrayStoreTarget(root_label, tuple(attr_path), True)
+
+        target_path = _deterministic_expr_target_path(node.value, aliases)
+        if target_path is not None:
+            root_label, attr_path, adjoint = target_path
+            if adjoint:
+                return ArrayStoreTarget(root_label, tuple(attr_path), True)
+
+        node = node.value
+
+    target_path = _deterministic_expr_target_path(node, aliases)
+    if target_path is not None:
+        root_label, attr_path, adjoint = target_path
+        if adjoint:
+            return ArrayStoreTarget(root_label, tuple(attr_path), True)
+    return None
+
+
+def _deterministic_collect_alias_targets(target, names):
+    """Collect direct local names bound by an assignment target."""
+    if isinstance(target, ast.Name):
+        names.add(target.id)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for element in target.elts:
+            _deterministic_collect_alias_targets(element, names)
+
+
+def _deterministic_update_aliases_from_assign(target, value, aliases):
+    """Update local array aliases after a supported assignment."""
+    target_names = set()
+    _deterministic_collect_alias_targets(target, target_names)
+    for name in target_names:
+        aliases.pop(name, None)
+
+    if isinstance(target, ast.Name):
+        value_path = _deterministic_expr_target_path(value, aliases)
+        if value_path is not None:
+            aliases[target.id] = value_path
+    elif isinstance(target, (ast.Tuple, ast.List)) and isinstance(value, (ast.Tuple, ast.List)):
+        for target_elt, value_elt in zip(target.elts, value.elts, strict=False):
+            _deterministic_update_aliases_from_assign(target_elt, value_elt, aliases)
+
+
+def _deterministic_bind_alias_target(target, value_path, aliases):
+    """Bind a direct assignment target to a precomputed target path."""
+    if isinstance(target, ast.Name):
+        aliases[target.id] = value_path
+
+
+def _deterministic_statement_children(node):
+    """Yield nested statement blocks that need independent alias scans."""
+    for field_name in ("body", "orelse", "finalbody"):
+        child = getattr(node, field_name, None)
+        if child:
+            yield child
+    handlers = getattr(node, "handlers", ())
+    for handler in handlers:
+        yield handler.body
+
+
+def _deterministic_scan_adjoint_store_targets(statements, aliases):
+    """Return adjoint array targets overwritten in ``statements``."""
+    targets = set()
+    for statement in statements:
+        if isinstance(statement, ast.Assign):
+            for target in statement.targets:
+                store_target = _deterministic_adjoint_store_target(target, aliases)
+                if store_target is not None:
+                    targets.add(store_target)
+            if len(statement.targets) == 1:
+                _deterministic_update_aliases_from_assign(statement.targets[0], statement.value, aliases)
+            else:
+                target_names = set()
+                for target in statement.targets:
+                    _deterministic_collect_alias_targets(target, target_names)
+                for name in target_names:
+                    aliases.pop(name, None)
+                value_path = _deterministic_expr_target_path(statement.value, aliases)
+                if value_path is not None:
+                    for target in statement.targets:
+                        _deterministic_bind_alias_target(target, value_path, aliases)
+        elif isinstance(statement, ast.AnnAssign):
+            store_target = _deterministic_adjoint_store_target(statement.target, aliases)
+            if store_target is not None:
+                targets.add(store_target)
+            if statement.value is not None:
+                _deterministic_update_aliases_from_assign(statement.target, statement.value, aliases)
+        elif isinstance(statement, ast.AugAssign):
+            _deterministic_update_aliases_from_assign(statement.target, ast.Constant(None), aliases)
+
+        for child_statements in _deterministic_statement_children(statement):
+            targets |= _deterministic_scan_adjoint_store_targets(child_statements, aliases.copy())
+
+    return targets
+
+
+def _deterministic_adjoint_store_targets(tree):
+    """Return adjoint arrays directly overwritten in the function body."""
+    body = getattr(tree, "body", ())
+    return _deterministic_scan_adjoint_store_targets(body, {})
+
+
 def _deterministic_has_consumed_atomic(tree):
     """Return whether codegen will treat any atomic return value as consumed."""
     return _deterministic_has_consumed_atomic_impl(tree, adj=None, seen=None)
 
 
 def _deterministic_collect_target_names(target, names):
+    """Collect local names introduced by assignment-like targets."""
     if isinstance(target, ast.Name):
         names.add(target.id)
     elif isinstance(target, (ast.Tuple, ast.List)):
@@ -975,6 +1263,7 @@ def _deterministic_collect_target_names(target, names):
 
 
 def _deterministic_local_names(tree):
+    """Return local names that should shadow external function lookup."""
     names = set()
 
     for node in ast.walk(tree):
@@ -1006,6 +1295,7 @@ def _deterministic_local_names(tree):
 
 
 def _deterministic_call_path(node):
+    """Return the dotted call path represented by ``node``."""
     path = []
 
     while isinstance(node, ast.Attribute):
@@ -1021,6 +1311,7 @@ def _deterministic_call_path(node):
 
 
 def _deterministic_resolve_static_call(adj, node, local_names, local_aliases=None):
+    """Resolve statically-known Python call targets used by deterministic scans."""
     if adj is None:
         return None
 
@@ -1061,6 +1352,7 @@ def _deterministic_resolve_static_call(adj, node, local_names, local_aliases=Non
 
 
 def _deterministic_function_aliases(adj, tree, local_names):
+    """Return local aliases that bind directly to Warp functions."""
     aliases = {}
     if adj is None:
         return aliases
@@ -1433,16 +1725,7 @@ def _add_deterministic_array_store(adj, target, indices, rhs):
             loaded_arg = adj.load(func_arg)
         fwd_args.append(strip_reference(loaded_arg))
 
-    store_target_var = target
-    while getattr(store_target_var, "deterministic_view_parent", None) is not None:
-        store_target_var = store_target_var.deterministic_view_parent
-    store_target_info = _deterministic_target_info(store_target_var)
-    if store_target_info is not None:
-        target_root_label, target_attr_path, target_type, target_is_adjoint = store_target_info
-        if is_array(target_type):
-            adj.det_meta.store_targets_seen.add(
-                ArrayStoreTarget(target_root_label, tuple(target_attr_path), bool(target_is_adjoint))
-            )
+    adj.deterministic.mark_store_target(target)
 
     store_args = adj.format_forward_call_args(fwd_args, use_initializer_list)
     guarded_store_call = f"WP_DET_STORE_IF_ACTIVE(det_ctx, {store_args});"

--- a/warp/native/array.h
+++ b/warp/native/array.h
@@ -1068,6 +1068,43 @@ inline CUDA_CALLABLE T atomic_sub(const A<T>& buf, int i, int j, int k, int l, T
     return atomic_add(&index(buf, i, j, k, l), -value);
 }
 
+// SlotType is the value type of the referenced component returned by access(),
+// such as a scalar vector component or a matrix row.
+template <typename T, typename SlotType, typename Accessor, typename... Ints>
+inline CUDA_CALLABLE SlotType
+array_atomic_add_slot(const array_t<T>& buf, SlotType value, Accessor access, Ints... indices)
+{
+    return atomic_add(&access(index(buf, indices...)), value);
+}
+
+template <typename T, typename SlotType, typename Accessor, typename... Ints>
+inline CUDA_CALLABLE SlotType
+array_atomic_sub_slot(const array_t<T>& buf, SlotType value, Accessor access, Ints... indices)
+{
+    return atomic_add(&access(index(buf, indices...)), -value);
+}
+
+template <typename T, typename SlotType, typename Accessor, typename... Ints>
+inline CUDA_CALLABLE SlotType
+array_atomic_and_slot(const array_t<T>& buf, SlotType value, Accessor access, Ints... indices)
+{
+    return atomic_and(&access(index(buf, indices...)), value);
+}
+
+template <typename T, typename SlotType, typename Accessor, typename... Ints>
+inline CUDA_CALLABLE SlotType
+array_atomic_or_slot(const array_t<T>& buf, SlotType value, Accessor access, Ints... indices)
+{
+    return atomic_or(&access(index(buf, indices...)), value);
+}
+
+template <typename T, typename SlotType, typename Accessor, typename... Ints>
+inline CUDA_CALLABLE SlotType
+array_atomic_xor_slot(const array_t<T>& buf, SlotType value, Accessor access, Ints... indices)
+{
+    return atomic_xor(&access(index(buf, indices...)), value);
+}
+
 template <template <typename> class A, typename T> inline CUDA_CALLABLE T atomic_min(const A<T>& buf, int i, T value)
 {
     return atomic_min(&index(buf, i), value);
@@ -1401,17 +1438,8 @@ adj_array_store(const array_t<T>& buf, int i, T value, const array_t<T>& adj_buf
     FP_VERIFY_ADJ_1(value, adj_value)
 }
 
-// Slot-level variant of adj_array_store. Reads and (optionally) zeros a
-// specific slot within an array element, rather than treating the whole
-// element as the adjoint value. Used to give in-place composite-component
-// writes (``arr[i].y = rhs``, ``arr[i][r, c] = rhs``, ``arr[i].field = rhs``)
-// a correct O(1) backward pass that matches the O(1) single-slot forward
-// instead of the whole-element cost the full ``adj_array_store`` incurs.
-//
-// The ``access`` functor maps an element ``T&`` to the slot reference
-// within it — encode any composite-component access chain at codegen
-// time via a short lambda. Variadic ``Ints`` carries the array indices
-// so this template handles 1-D through N-D arrays uniformly.
+// Slot-level array-store adjoint for composite-component writes.
+// ``access`` maps an array element to the overwritten slot.
 template <typename T, typename Accessor, typename AdjSlot, typename... Ints>
 inline CUDA_CALLABLE void adj_array_store_slot(
     const array_t<T>& buf, const array_t<T>& adj_buf, AdjSlot& adj_value, Accessor access, Ints... indices
@@ -1430,6 +1458,58 @@ inline CUDA_CALLABLE void adj_array_store_slot(
     }
 
     FP_VERIFY_ADJ_SLOT(adj_value)
+}
+
+template <typename T, typename Accessor, typename AdjSlot, typename... Ints>
+inline CUDA_CALLABLE void adj_array_atomic_add_slot(
+    const array_t<T>& buf, const array_t<T>& adj_buf, AdjSlot& adj_value, Accessor access, Ints... indices
+)
+{
+    if (adj_buf.data) {
+        adj_value += access(index(adj_buf, indices...));
+    } else if (buf.grad) {
+        adj_value += access(index_grad(buf, indices...));
+    }
+
+    FP_VERIFY_ADJ_SLOT(adj_value)
+}
+
+template <typename T, typename Accessor, typename AdjSlot, typename... Ints>
+inline CUDA_CALLABLE void adj_array_atomic_sub_slot(
+    const array_t<T>& buf, const array_t<T>& adj_buf, AdjSlot& adj_value, Accessor access, Ints... indices
+)
+{
+    if (adj_buf.data) {
+        adj_value -= access(index(adj_buf, indices...));
+    } else if (buf.grad) {
+        adj_value -= access(index_grad(buf, indices...));
+    }
+
+    FP_VERIFY_ADJ_SLOT(adj_value)
+}
+
+template <typename T, typename Accessor, typename AdjSlot, typename... Ints>
+inline CUDA_CALLABLE void adj_array_atomic_and_slot(
+    const array_t<T>& buf, const array_t<T>& adj_buf, AdjSlot& adj_value, Accessor access, Ints... indices
+)
+{
+    // Bitwise integer atomics are intentionally non-differentiable.
+}
+
+template <typename T, typename Accessor, typename AdjSlot, typename... Ints>
+inline CUDA_CALLABLE void adj_array_atomic_or_slot(
+    const array_t<T>& buf, const array_t<T>& adj_buf, AdjSlot& adj_value, Accessor access, Ints... indices
+)
+{
+    // Bitwise integer atomics are intentionally non-differentiable.
+}
+
+template <typename T, typename Accessor, typename AdjSlot, typename... Ints>
+inline CUDA_CALLABLE void adj_array_atomic_xor_slot(
+    const array_t<T>& buf, const array_t<T>& adj_buf, AdjSlot& adj_value, Accessor access, Ints... indices
+)
+{
+    // Bitwise integer atomics are intentionally non-differentiable.
 }
 
 template <typename T>

--- a/warp/native/array.h
+++ b/warp/native/array.h
@@ -1074,14 +1074,18 @@ template <typename T, typename SlotType, typename Accessor, typename... Ints>
 inline CUDA_CALLABLE SlotType
 array_atomic_add_slot(const array_t<T>& buf, SlotType value, Accessor access, Ints... indices)
 {
-    return atomic_add(&access(index(buf, indices...)), value);
+    SlotType old = atomic_add(&access(index(buf, indices...)), value);
+    FP_VERIFY_FWD(old + value)
+    return old;
 }
 
 template <typename T, typename SlotType, typename Accessor, typename... Ints>
 inline CUDA_CALLABLE SlotType
 array_atomic_sub_slot(const array_t<T>& buf, SlotType value, Accessor access, Ints... indices)
 {
-    return atomic_add(&access(index(buf, indices...)), -value);
+    SlotType old = atomic_add(&access(index(buf, indices...)), -value);
+    FP_VERIFY_FWD(old - value)
+    return old;
 }
 
 template <typename T, typename SlotType, typename Accessor, typename... Ints>

--- a/warp/native/deterministic.h
+++ b/warp/native/deterministic.h
@@ -289,8 +289,12 @@ inline CUDA_CALLABLE void array_store_if_active(det_ctx& ctx, const A<T>& buf, i
 #ifdef __CUDA_ARCH__
 #define WP_DET_SCATTER_OR_FALLBACK(det_ctx, helper, flat_idx, value, cpu_expr) \
     do { \
-        if ((det_ctx).phase != 0 && (helper).count != nullptr) { \
-            wp::deterministic::scatter((det_ctx), (helper), static_cast<int>(flat_idx), (value)); \
+        if ((det_ctx).phase != 0) { \
+            if ((helper).count != nullptr) { \
+                wp::deterministic::scatter((det_ctx), (helper), static_cast<int>(flat_idx), (value)); \
+            } else { \
+                cpu_expr; \
+            } \
         } \
     } while (0)
 
@@ -313,7 +317,8 @@ inline CUDA_CALLABLE void array_store_if_active(det_ctx& ctx, const A<T>& buf, i
             || !wp::deterministic::is_global_store_target(&_wp_det_slot) \
             || wp::deterministic::is_counter_store_target((det_ctx), &_wp_det_slot)) \
         { \
-            _wp_det_slot = (value_expr); \
+            auto _wp_det_value = (value_expr); \
+            wp::store(&_wp_det_slot, _wp_det_value); \
         } \
     } while (0)
 
@@ -349,7 +354,9 @@ inline CUDA_CALLABLE void array_store_if_active(det_ctx& ctx, const A<T>& buf, i
 #define WP_DET_SLOT_STORE_IF_ACTIVE(det_ctx, slot_lvalue, value_expr) \
     do { \
         (void)(det_ctx); \
-        (slot_lvalue) = (value_expr); \
+        auto& _wp_det_slot = (slot_lvalue); \
+        auto _wp_det_value = (value_expr); \
+        wp::store(&_wp_det_slot, _wp_det_value); \
     } while (0)
 
 #define WP_DET_SIDE_EFFECT_IF_ACTIVE(det_ctx, ...) \

--- a/warp/native/quat.h
+++ b/warp/native/quat.h
@@ -81,6 +81,16 @@ template <typename Type> struct quat_t {
             return x;
         }
     }
+
+    // Mutable component reference with Python-style negative indexing.
+    inline CUDA_CALLABLE Type& component_ref(int index)
+    {
+        if (index < 0) {
+            index += 4;
+        }
+        assert(index >= 0 && index < 4);
+        return (*this)[index];
+    }
 };
 
 using quat = quat_t<float>;

--- a/warp/native/spatial.h
+++ b/warp/native/spatial.h
@@ -157,16 +157,32 @@ template <typename Type> struct transform_t {
 
     CUDA_CALLABLE inline Type operator[](int index) const
     {
-        assert(index < 7);
+        assert(index >= 0 && index < 7);
 
-        return p.c[index];
+        if (index < 3) {
+            return p.c[index];
+        }
+        return q[index - 3];
     }
 
     CUDA_CALLABLE inline Type& operator[](int index)
     {
-        assert(index < 7);
+        assert(index >= 0 && index < 7);
 
-        return p.c[index];
+        if (index < 3) {
+            return p.component_ref(index);
+        }
+        return q.component_ref(index - 3);
+    }
+
+    // Mutable component reference with Python-style negative indexing.
+    CUDA_CALLABLE inline Type& component_ref(int index)
+    {
+        if (index < 0) {
+            index += 7;
+        }
+        assert(index >= 0 && index < 7);
+        return (*this)[index];
     }
 };
 
@@ -490,7 +506,7 @@ template <typename Type>
 inline void CUDA_CALLABLE
 adj_extract(const transform_t<Type>& t, int idx, transform_t<Type>& adj_t, int& adj_idx, Type adj_ret)
 {
-    adj_t[idx] += adj_ret;
+    adj_t.component_ref(idx) += adj_ret;
 }
 
 template <unsigned SliceLength, typename Type>
@@ -982,8 +998,7 @@ CUDA_CALLABLE inline void adj_transform_t(
 template <typename Type>
 CUDA_CALLABLE inline void adj_transform_t(Type s, Type& adj_s, const transform_t<Type>& adj_ret)
 {
-    // `transform_t::operator[]` indexes into `p` alone, so the components are
-    // summed explicitly rather than through a seven-element loop.
+    // Sum all transform components into the fill scalar adjoint.
     adj_s += adj_ret.p[0];
     adj_s += adj_ret.p[1];
     adj_s += adj_ret.p[2];

--- a/warp/native/vec.h
+++ b/warp/native/vec.h
@@ -83,6 +83,16 @@ template <unsigned Length, typename Type> struct vec_t {
         assert(index < Length);
         return c[index];
     }
+
+    // Mutable component reference with Python-style negative indexing.
+    inline CUDA_CALLABLE Type& component_ref(int index)
+    {
+        if (index < 0) {
+            index += Length;
+        }
+        assert(index >= 0 && index < (int)Length);
+        return c[index];
+    }
 };
 
 using vec2b = vec_t<2, int8>;

--- a/warp/tests/aux_test_array_slot_operators.py
+++ b/warp/tests/aux_test_array_slot_operators.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import warp as wp
+
+
+@wp.func
+def add(x: wp.float32, y: wp.float32) -> wp.float32:
+    return wp.sub(x, y)
+
+
+@wp.func
+def sub(x: wp.float32, y: wp.float32) -> wp.float32:
+    return wp.mul(x, y)
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def overloaded_slot_augassign(values: wp.array[wp.vec3], rhs: wp.float32):
+    values[0].x += rhs
+    values[0][1] += rhs
+    values[0].z -= rhs
+
+
+@wp.kernel(module="unique")
+def update_double_components_with_float_overloads(values: wp.array[wp.vec3d], rhs: wp.array[wp.float64]):
+    values[0].x += rhs[0]
+    values[0][1] += rhs[0]
+    values[0].z -= rhs[0]
+
+
+@wp.kernel(module="unique")
+def overloaded_slot_add_backward(values: wp.array[wp.vec3], rhs: wp.array[wp.float32]):
+    values[0].x += rhs[0]
+
+
+@wp.kernel(module="unique")
+def overloaded_slot_sub_backward(values: wp.array[wp.vec3], rhs: wp.array[wp.float32]):
+    values[0][1] -= rhs[0]
+
+
+@wp.func
+def update_overloaded_component(values: wp.array[wp.vec3], rhs: wp.array[float]):
+    values[0].x += rhs[0]
+
+
+@wp.kernel(module="test_shared_slot_operators", enable_backward=False)
+def update_shared_component_forward(values: wp.array[wp.vec3], rhs: wp.array[float]):
+    update_overloaded_component(values, rhs)
+
+
+@wp.kernel(module="test_shared_slot_operators")
+def update_shared_component_backward(values: wp.array[wp.vec3], rhs: wp.array[float]):
+    update_overloaded_component(values, rhs)

--- a/warp/tests/deterministic/test_deterministic_backward.py
+++ b/warp/tests/deterministic/test_deterministic_backward.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import ast
 import sys
 import unittest
 
@@ -10,6 +11,7 @@ import numpy as np
 import warp as wp
 import warp.tests.deterministic.test_deterministic_counter as counter_module
 import warp.tests.deterministic.test_deterministic_scatter as scatter_module
+from warp._src import deterministic as wp_deterministic
 from warp.tests.deterministic.common import (
     DeterministicTestBase,
     _reference_scatter_add_float32,
@@ -55,6 +57,33 @@ def vec3_gather_address_kernel(
     """Vector-valued gather covering cloth/particle-style position gradients."""
     tid = wp.tid()
     output[tid] = values[source_indices[tid]]
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.RUN_TO_RUN})
+def slot_store_then_vec3_read_kernel(
+    values: wp.array[wp.vec3],
+    src: wp.array[wp.float32],
+    output: wp.array[wp.vec3],
+):
+    """Overwrite one component before reading the same array element."""
+    values[0].y = src[0]
+    output[0] = values[0]
+
+
+@wp.func
+def _det_read_vec(values: wp.array[wp.vec3]) -> wp.vec3:
+    return values[0]
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.RUN_TO_RUN})
+def slot_store_then_call_read_kernel(
+    values: wp.array[wp.vec3],
+    src: wp.array[wp.float32],
+    output: wp.array[wp.vec3],
+):
+    """Overwrite one component before calling a vector read helper."""
+    values[0].y = src[0]
+    output[0] = _det_read_vec(values)
 
 
 @wp.kernel
@@ -103,6 +132,77 @@ def _adj_det_lookup_value(values: wp.array[wp.float32], index: int, adj_ret: wp.
     wp.adjoint[values][index] += adj_ret
 
 
+@wp.func
+def _det_lookup_vec_x(values: wp.array[wp.vec3], index: int) -> wp.float32:
+    return values[index].x
+
+
+@wp.func_grad(_det_lookup_vec_x)
+def _adj_det_lookup_vec_x(values: wp.array[wp.vec3], index: int, adj_ret: wp.float32):
+    wp.adjoint[values][index].x += adj_ret
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.RUN_TO_RUN})
+def slot_store_then_custom_component_read_kernel(
+    values: wp.array[wp.vec3],
+    src: wp.array[wp.float32],
+    output: wp.array[wp.float32],
+):
+    """Overwrite one component before calling a custom-adjoint read helper."""
+    values[0].x = src[0]
+    output[0] = _det_lookup_vec_x(values, 0)
+
+
+@wp.func
+def _det_lookup_vec_x_then_clear(values: wp.array[wp.vec3], index: int) -> wp.float32:
+    return values[index].x
+
+
+@wp.func_grad(_det_lookup_vec_x_then_clear)
+def _adj_det_lookup_vec_x_then_clear(values: wp.array[wp.vec3], index: int, adj_ret: wp.float32):
+    wp.adjoint[values][index].x += adj_ret
+    wp.adjoint[values][index].x = 0.0
+
+
+@wp.func
+def _det_lookup_vec_x_then_clear_adjoint_alias(values: wp.array[wp.vec3], index: int) -> wp.float32:
+    return values[index].x
+
+
+@wp.func_grad(_det_lookup_vec_x_then_clear_adjoint_alias)
+def _adj_det_lookup_vec_x_then_clear_adjoint_alias(values: wp.array[wp.vec3], index: int, adj_ret: wp.float32):
+    adj_values = wp.adjoint[values]
+    adj_values[index].x += adj_ret
+    adj_values[index].x = 0.0
+
+
+@wp.struct
+class DetVecArrayFieldHolder:
+    values: wp.array[wp.vec3]
+
+
+@wp.func
+def _det_lookup_holder_vec_x(holder: DetVecArrayFieldHolder, index: int) -> wp.float32:
+    return holder.values[index].x
+
+
+@wp.func_grad(_det_lookup_holder_vec_x)
+def _adj_det_lookup_holder_vec_x(holder: DetVecArrayFieldHolder, index: int, adj_ret: wp.float32):
+    wp.adjoint[holder.values][index].x += adj_ret
+
+
+@wp.func
+def _det_lookup_holder_alias_vec_x(holder: DetVecArrayFieldHolder, index: int) -> wp.float32:
+    values = holder.values
+    return values[index].x
+
+
+@wp.func_grad(_det_lookup_holder_alias_vec_x)
+def _adj_det_lookup_holder_alias_vec_x(holder: DetVecArrayFieldHolder, index: int, adj_ret: wp.float32):
+    values = holder.values
+    wp.adjoint[values][index].x += adj_ret
+
+
 @wp.kernel
 def custom_adjoint_lookup_kernel(
     values: wp.array[wp.float32],
@@ -124,6 +224,85 @@ def custom_adjoint_gather_kernel(
     """Use a custom adjoint that scatters per-lane output gradients."""
     tid = wp.tid()
     output[tid] = _det_lookup_value(values, indices[tid])
+
+
+@wp.kernel
+def custom_adjoint_component_gather_kernel(
+    values: wp.array[wp.vec3],
+    indices: wp.array[wp.int32],
+    output: wp.array[wp.float32],
+):
+    """Use a custom adjoint that scatters into one vector component."""
+    tid = wp.tid()
+    output[tid] = _det_lookup_vec_x(values, indices[tid])
+
+
+@wp.kernel
+def custom_adjoint_component_clear_gather_kernel(
+    values: wp.array[wp.vec3],
+    indices: wp.array[wp.int32],
+    output: wp.array[wp.float32],
+):
+    """Use a custom adjoint component scatter followed by an overwrite."""
+    tid = wp.tid()
+    output[tid] = _det_lookup_vec_x_then_clear(values, indices[tid])
+
+
+@wp.kernel
+def custom_adjoint_component_clear_alias_gather_kernel(
+    values: wp.array[wp.vec3],
+    indices: wp.array[wp.int32],
+    output: wp.array[wp.float32],
+):
+    """Use an adjoint alias followed by a component overwrite."""
+    tid = wp.tid()
+    output[tid] = _det_lookup_vec_x_then_clear_adjoint_alias(values, indices[tid])
+
+
+@wp.kernel
+def custom_adjoint_component_struct_field_gather_kernel(
+    holder: DetVecArrayFieldHolder,
+    indices: wp.array[wp.int32],
+    output: wp.array[wp.float32],
+):
+    """Use a struct-field array in a custom adjoint component scatter."""
+    tid = wp.tid()
+    output[tid] = _det_lookup_holder_vec_x(holder, indices[tid])
+
+
+@wp.kernel
+def custom_adjoint_component_struct_field_alias_gather_kernel(
+    holder: DetVecArrayFieldHolder,
+    indices: wp.array[wp.int32],
+    output: wp.array[wp.float32],
+):
+    """Use a struct-field array alias in a custom adjoint component scatter."""
+    tid = wp.tid()
+    output[tid] = _det_lookup_holder_alias_vec_x(holder, indices[tid])
+
+
+@wp.func
+def _det_lookup_view_vec_x_then_clear(values: wp.array2d[wp.vec3], index: int) -> wp.float32:
+    view = values[0]
+    return view[index].x
+
+
+@wp.func_grad(_det_lookup_view_vec_x_then_clear)
+def _adj_det_lookup_view_vec_x_then_clear(values: wp.array2d[wp.vec3], index: int, adj_ret: wp.float32):
+    view = values[0]
+    wp.adjoint[view][index].x += adj_ret
+    wp.adjoint[view][index].x = 0.0
+
+
+@wp.kernel
+def custom_adjoint_component_view_clear_gather_kernel(
+    values: wp.array2d[wp.vec3],
+    indices: wp.array[wp.int32],
+    output: wp.array[wp.float32],
+):
+    """Use a view adjoint scatter followed by a component overwrite."""
+    tid = wp.tid()
+    output[tid] = _det_lookup_view_vec_x_then_clear(values, indices[tid])
 
 
 @wp.func
@@ -356,6 +535,49 @@ def test_deterministic_backward_vec3_address_scatter(test, device):
         np.testing.assert_array_equal(result, expected)
 
 
+def test_deterministic_slot_store_orders_adjoint_read(test, device):
+    """Verify slot stores route later read adjoints before deferred reductions."""
+    for label, kernel in (
+        ("same body", slot_store_then_vec3_read_kernel),
+        ("function call", slot_store_then_call_read_kernel),
+    ):
+        with test.subTest(label):
+            values = wp.array([[2.0, 3.0, 4.0]], dtype=wp.vec3, device=device, requires_grad=True)
+            src = wp.array([7.0], dtype=wp.float32, device=device, requires_grad=True)
+            output = wp.zeros(1, dtype=wp.vec3, device=device, requires_grad=True)
+
+            tape = wp.Tape()
+            with tape:
+                wp.launch(kernel, dim=1, inputs=[values, src], outputs=[output], device=device)
+
+            tape.backward(grads={output: wp.ones_like(output)})
+
+            np.testing.assert_allclose(output.numpy(), np.array([[2.0, 7.0, 4.0]], dtype=np.float32), rtol=0, atol=0)
+            np.testing.assert_allclose(src.grad.numpy(), np.array([1.0], dtype=np.float32), rtol=0, atol=0)
+            np.testing.assert_allclose(
+                values.grad.numpy(), np.array([[1.0, 0.0, 1.0]], dtype=np.float32), rtol=0, atol=0
+            )
+
+
+def test_deterministic_slot_store_orders_custom_adjoint_call(test, device):
+    """Verify slot stores route later custom-adjoint calls before deferred reductions."""
+    values = wp.array([[2.0, 3.0, 4.0]], dtype=wp.vec3, device=device, requires_grad=True)
+    src = wp.array([7.0], dtype=wp.float32, device=device, requires_grad=True)
+    output = wp.zeros(1, dtype=wp.float32, device=device, requires_grad=True)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(
+            slot_store_then_custom_component_read_kernel, dim=1, inputs=[values, src], outputs=[output], device=device
+        )
+
+    tape.backward(grads={output: wp.ones_like(output)})
+
+    np.testing.assert_allclose(output.numpy(), np.array([7.0], dtype=np.float32), rtol=0, atol=0)
+    np.testing.assert_allclose(src.grad.numpy(), np.array([1.0], dtype=np.float32), rtol=0, atol=0)
+    np.testing.assert_allclose(values.grad.numpy(), np.array([[0.0, 0.0, 0.0]], dtype=np.float32), rtol=0, atol=0)
+
+
 def test_deterministic_backward_missing_adjoint_target(test, device):
     """Verify backward deterministic reductions ignore array reads with no grad buffer."""
     n = 2048
@@ -513,6 +735,138 @@ def test_deterministic_custom_adjoint_gather_atomic(test, device):
         np.testing.assert_array_equal(result, expected)
 
 
+def test_deterministic_custom_adjoint_component_atomic(test, device):
+    """Verify custom adjoints atomically update ``wp.adjoint[array]`` components."""
+    n = 2048
+    value_count = 31
+    rng = np.random.default_rng(307)
+    values_np = rng.random((value_count, 3), dtype=np.float32)
+    indices_np = rng.integers(0, value_count, size=n, dtype=np.int32)
+    grad_np = rng.random(n, dtype=np.float32)
+
+    expected = np.zeros((value_count, 3), dtype=np.float32)
+    expected[:, 0] = _reference_scatter_add_float32(grad_np, indices_np, value_count)
+
+    values = wp.array(values_np, dtype=wp.vec3, device=device, requires_grad=True)
+    indices = wp.array(indices_np, dtype=wp.int32, device=device)
+    output_grad = wp.array(grad_np, dtype=wp.float32, device=device)
+
+    old_det = _get_test_module_options()["deterministic"]
+    try:
+        _set_test_module_options({"deterministic": wp.DeterministicMode.GPU_TO_GPU})
+        results = []
+        for _ in range(3):
+            values.grad.zero_()
+            output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
+            tape = wp.Tape()
+            with tape:
+                wp.launch(
+                    custom_adjoint_component_gather_kernel,
+                    dim=n,
+                    inputs=[values, indices],
+                    outputs=[output],
+                    device=device,
+                )
+            tape.backward(grads={output: output_grad})
+            results.append(tape.gradients[values].numpy().copy())
+    finally:
+        _set_test_module_options({"deterministic": old_det})
+
+    for result in results:
+        np.testing.assert_array_equal(result, expected)
+
+
+def test_deterministic_custom_adjoint_component_store_order(test, device):
+    """Verify adjoint component overwrites stay ordered after ``+=``."""
+    n = 128
+    value_count = 17
+    indices_np = (np.arange(n, dtype=np.int32) * 5) % value_count
+    indices = wp.array(indices_np, dtype=wp.int32, device=device)
+    output_grad = wp.ones(n, dtype=wp.float32, device=device)
+
+    old_det = _get_test_module_options()["deterministic"]
+    try:
+        _set_test_module_options({"deterministic": wp.DeterministicMode.GPU_TO_GPU})
+        for label, kernel in (
+            ("direct", custom_adjoint_component_clear_gather_kernel),
+            ("adjoint alias", custom_adjoint_component_clear_alias_gather_kernel),
+        ):
+            with test.subTest(label):
+                values = wp.zeros(value_count, dtype=wp.vec3, device=device, requires_grad=True)
+                output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
+
+                tape = wp.Tape()
+                with tape:
+                    wp.launch(kernel, dim=n, inputs=[values, indices], outputs=[output], device=device)
+                tape.backward(grads={output: output_grad})
+
+                np.testing.assert_array_equal(
+                    tape.gradients[values].numpy(), np.zeros((value_count, 3), dtype=np.float32)
+                )
+
+        with test.subTest("view"):
+            values = wp.zeros((1, value_count), dtype=wp.vec3, device=device, requires_grad=True)
+            output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
+
+            tape = wp.Tape()
+            with tape:
+                wp.launch(
+                    custom_adjoint_component_view_clear_gather_kernel,
+                    dim=n,
+                    inputs=[values, indices],
+                    outputs=[output],
+                    device=device,
+                )
+            tape.backward(grads={output: output_grad})
+
+            np.testing.assert_array_equal(
+                tape.gradients[values].numpy(), np.zeros((1, value_count, 3), dtype=np.float32)
+            )
+    finally:
+        _set_test_module_options({"deterministic": old_det})
+
+
+def test_deterministic_custom_adjoint_component_struct_field_atomic(test, device):
+    """Verify struct-field adjoint arrays reduce component gradients deterministically."""
+    n = 2048
+    value_count = 31
+    rng = np.random.default_rng(308)
+    values_np = rng.random((value_count, 3), dtype=np.float32)
+    indices_np = rng.integers(0, value_count, size=n, dtype=np.int32)
+    grad_np = rng.random(n, dtype=np.float32)
+
+    expected = np.zeros((value_count, 3), dtype=np.float32)
+    expected[:, 0] = _reference_scatter_add_float32(grad_np, indices_np, value_count)
+
+    values = wp.array(values_np, dtype=wp.vec3, device=device, requires_grad=True)
+    holder = DetVecArrayFieldHolder()
+    holder.values = values
+    indices = wp.array(indices_np, dtype=wp.int32, device=device)
+    output_grad = wp.array(grad_np, dtype=wp.float32, device=device)
+
+    old_det = _get_test_module_options()["deterministic"]
+    try:
+        _set_test_module_options({"deterministic": wp.DeterministicMode.GPU_TO_GPU})
+        for kernel in (
+            custom_adjoint_component_struct_field_gather_kernel,
+            custom_adjoint_component_struct_field_alias_gather_kernel,
+        ):
+            results = []
+            for _ in range(3):
+                values.grad.zero_()
+                output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
+                tape = wp.Tape()
+                with tape:
+                    wp.launch(kernel, dim=n, inputs=[holder, indices], outputs=[output], device=device)
+                tape.backward(grads={output: output_grad})
+                results.append(tape.gradients[values].numpy().copy())
+
+            for result in results:
+                np.testing.assert_array_equal(result, expected)
+    finally:
+        _set_test_module_options({"deterministic": old_det})
+
+
 def test_deterministic_custom_adjoint_store_function(test, device):
     """Verify custom adjoints on functions with deterministic store context compile."""
     n = 32
@@ -630,6 +984,25 @@ class TestDeterministicBackward(DeterministicTestBase):
 
     deterministic_modules = (_THIS_MODULE, scatter_module, counter_module)
 
+    def test_adjoint_store_scan_preserves_chained_aliases(self):
+        """Verify chained adjoint aliases remain visible to the store pre-scan."""
+        tree = ast.parse(
+            """
+def adjoint_body(values, index, adj_ret):
+    adj_values = alias_values = wp.adjoint[values]
+    alias_values[index].x += adj_ret
+    adj_values[index].x = 0.0
+"""
+        ).body[0]
+        aliases = {}
+
+        targets = wp_deterministic._deterministic_scan_adjoint_store_targets(tree.body, aliases)
+
+        expected_alias = ("values", (), True)
+        self.assertEqual(aliases["adj_values"], expected_alias)
+        self.assertEqual(aliases["alias_values"], expected_alias)
+        self.assertIn(wp_deterministic.ArrayStoreTarget("values", (), True), targets)
+
 
 def _add(name, devices=cuda_devices):
     add_function_test(TestDeterministicBackward, name, globals()[name], devices=devices)
@@ -640,10 +1013,15 @@ for _name in (
     "test_deterministic_backward_address_scatter",
     "test_deterministic_backward_strided_adjoint_address_scatter",
     "test_deterministic_backward_vec3_address_scatter",
+    "test_deterministic_slot_store_orders_adjoint_read",
     "test_deterministic_backward_missing_adjoint_target",
     "test_deterministic_custom_replay_counter",
     "test_deterministic_custom_adjoint_array_atomic",
     "test_deterministic_custom_adjoint_gather_atomic",
+    "test_deterministic_custom_adjoint_component_atomic",
+    "test_deterministic_slot_store_orders_custom_adjoint_call",
+    "test_deterministic_custom_adjoint_component_store_order",
+    "test_deterministic_custom_adjoint_component_struct_field_atomic",
     "test_deterministic_custom_adjoint_store_function",
     "test_deterministic_scratch_overwrite_replay_gradient",
 ):

--- a/warp/tests/deterministic/test_deterministic_backward.py
+++ b/warp/tests/deterministic/test_deterministic_backward.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-import ast
 import sys
 import unittest
 
@@ -11,7 +10,6 @@ import numpy as np
 import warp as wp
 import warp.tests.deterministic.test_deterministic_counter as counter_module
 import warp.tests.deterministic.test_deterministic_scatter as scatter_module
-from warp._src import deterministic as wp_deterministic
 from warp.tests.deterministic.common import (
     DeterministicTestBase,
     _reference_scatter_add_float32,
@@ -86,6 +84,55 @@ def slot_store_then_call_read_kernel(
     output[0] = _det_read_vec(values)
 
 
+@wp.func
+def _det_gather_x(values: wp.array[wp.vec3]) -> wp.float32:
+    return values[0].x
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.GPU_TO_GPU})
+def slot_store_then_contended_call_kernel(values: wp.array[wp.vec3], output: wp.array[wp.float32]):
+    tid = wp.tid()
+    values[tid].y = 2.0
+    output[tid] = _det_gather_x(values)
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.GPU_TO_GPU})
+def slot_store_then_contended_alias_kernel(values: wp.array[wp.vec3], output: wp.array[wp.float32]):
+    tid = wp.tid()
+    alias = values
+    alias[tid].y = 2.0
+    output[tid] = _det_gather_x(values)
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.GPU_TO_GPU})
+def contended_call_without_store_kernel(values: wp.array[wp.vec3], output: wp.array[wp.float32]):
+    output[wp.tid()] = _det_gather_x(values)
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.GPU_TO_GPU})
+def overwrite_sliced_component_then_read_original(
+    values: wp.array[wp.vec3], source: wp.array[float], output: wp.array[float]
+):
+    i = wp.tid()
+    sliced = values[1::2]
+    alias = sliced
+    alias[i].x = source[i]
+    output[i] = values[2 * i + 1].x
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.GPU_TO_GPU})
+def argument_alias_slot_store_kernel(
+    a: wp.array[wp.vec3],
+    b: wp.array[wp.vec3],
+    src: wp.array[wp.float32],
+    offset: int,
+    output: wp.array[wp.float32],
+):
+    tid = wp.tid()
+    a[tid + offset].x = src[tid]
+    output[tid] = b[tid].x
+
+
 @wp.kernel
 def gather_with_nongrad_input_kernel(
     values: wp.array[wp.float32],
@@ -154,26 +201,14 @@ def slot_store_then_custom_component_read_kernel(
 
 
 @wp.func
-def _det_lookup_vec_x_then_clear(values: wp.array[wp.vec3], index: int) -> wp.float32:
-    return values[index].x
-
-
-@wp.func_grad(_det_lookup_vec_x_then_clear)
-def _adj_det_lookup_vec_x_then_clear(values: wp.array[wp.vec3], index: int, adj_ret: wp.float32):
-    wp.adjoint[values][index].x += adj_ret
-    wp.adjoint[values][index].x = 0.0
-
-
-@wp.func
 def _det_lookup_vec_x_then_clear_adjoint_alias(values: wp.array[wp.vec3], index: int) -> wp.float32:
     return values[index].x
 
 
 @wp.func_grad(_det_lookup_vec_x_then_clear_adjoint_alias)
 def _adj_det_lookup_vec_x_then_clear_adjoint_alias(values: wp.array[wp.vec3], index: int, adj_ret: wp.float32):
-    adj_values = wp.adjoint[values]
-    adj_values[index].x += adj_ret
-    adj_values[index].x = 0.0
+    wp.adjoint[values][index].x += adj_ret
+    wp.adjoint[values][index].x = 0.0
 
 
 @wp.struct
@@ -238,17 +273,6 @@ def custom_adjoint_component_gather_kernel(
 
 
 @wp.kernel
-def custom_adjoint_component_clear_gather_kernel(
-    values: wp.array[wp.vec3],
-    indices: wp.array[wp.int32],
-    output: wp.array[wp.float32],
-):
-    """Use a custom adjoint component scatter followed by an overwrite."""
-    tid = wp.tid()
-    output[tid] = _det_lookup_vec_x_then_clear(values, indices[tid])
-
-
-@wp.kernel
 def custom_adjoint_component_clear_alias_gather_kernel(
     values: wp.array[wp.vec3],
     indices: wp.array[wp.int32],
@@ -279,30 +303,6 @@ def custom_adjoint_component_struct_field_alias_gather_kernel(
     """Use a struct-field array alias in a custom adjoint component scatter."""
     tid = wp.tid()
     output[tid] = _det_lookup_holder_alias_vec_x(holder, indices[tid])
-
-
-@wp.func
-def _det_lookup_view_vec_x_then_clear(values: wp.array2d[wp.vec3], index: int) -> wp.float32:
-    view = values[0]
-    return view[index].x
-
-
-@wp.func_grad(_det_lookup_view_vec_x_then_clear)
-def _adj_det_lookup_view_vec_x_then_clear(values: wp.array2d[wp.vec3], index: int, adj_ret: wp.float32):
-    view = values[0]
-    wp.adjoint[view][index].x += adj_ret
-    wp.adjoint[view][index].x = 0.0
-
-
-@wp.kernel
-def custom_adjoint_component_view_clear_gather_kernel(
-    values: wp.array2d[wp.vec3],
-    indices: wp.array[wp.int32],
-    output: wp.array[wp.float32],
-):
-    """Use a view adjoint scatter followed by a component overwrite."""
-    tid = wp.tid()
-    output[tid] = _det_lookup_view_vec_x_then_clear(values, indices[tid])
 
 
 @wp.func
@@ -535,8 +535,8 @@ def test_deterministic_backward_vec3_address_scatter(test, device):
         np.testing.assert_array_equal(result, expected)
 
 
-def test_deterministic_slot_store_orders_adjoint_read(test, device):
-    """Verify slot stores route later read adjoints before deferred reductions."""
+def test_deterministic_single_thread_slot_store_backward(test, device):
+    """Preserve gradients for single-thread mutation and reads."""
     for label, kernel in (
         ("same body", slot_store_then_vec3_read_kernel),
         ("function call", slot_store_then_call_read_kernel),
@@ -559,8 +559,8 @@ def test_deterministic_slot_store_orders_adjoint_read(test, device):
             )
 
 
-def test_deterministic_slot_store_orders_custom_adjoint_call(test, device):
-    """Verify slot stores route later custom-adjoint calls before deferred reductions."""
+def test_deterministic_single_thread_custom_adjoint_slot_store_backward(test, device):
+    """Preserve gradients for single-thread mutation followed by a custom adjoint."""
     values = wp.array([[2.0, 3.0, 4.0]], dtype=wp.vec3, device=device, requires_grad=True)
     src = wp.array([7.0], dtype=wp.float32, device=device, requires_grad=True)
     output = wp.zeros(1, dtype=wp.float32, device=device, requires_grad=True)
@@ -576,6 +576,132 @@ def test_deterministic_slot_store_orders_custom_adjoint_call(test, device):
     np.testing.assert_allclose(output.numpy(), np.array([7.0], dtype=np.float32), rtol=0, atol=0)
     np.testing.assert_allclose(src.grad.numpy(), np.array([1.0], dtype=np.float32), rtol=0, atol=0)
     np.testing.assert_allclose(values.grad.numpy(), np.array([[0.0, 0.0, 0.0]], dtype=np.float32), rtol=0, atol=0)
+
+
+def test_deterministic_parallel_slot_store_backward_rejected(test, device):
+    """Reject unsafe parallel mutation and gradient accumulation."""
+    n = 64
+    for label, kernel, shape in (
+        ("call", slot_store_then_contended_call_kernel, n),
+        ("alias", slot_store_then_contended_alias_kernel, n),
+    ):
+        with test.subTest(label):
+            values = wp.ones(shape, dtype=wp.vec3, device=device, requires_grad=True)
+            output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
+            tape = wp.Tape()
+            with tape:
+                wp.launch(kernel, dim=n, inputs=[values], outputs=[output], device=device)
+            np.testing.assert_array_equal(output.numpy(), np.ones(n, dtype=np.float32))
+
+            with test.assertRaisesRegex(RuntimeError, "Deterministic.*parallel backward"):
+                tape.backward(grads={output: wp.ones_like(output)})
+            np.testing.assert_array_equal(values.grad.numpy(), np.zeros((*values.shape, 3), dtype=np.float32))
+
+
+def test_recorded_deterministic_backward_respects_updated_dim(test, device):
+    """Apply the mutation restriction after a recorded launch changes dimensions."""
+    n = 64
+    values = wp.ones(n, dtype=wp.vec3, device=device, requires_grad=True)
+    output = wp.ones(n, dtype=wp.float32, device=device, requires_grad=True)
+    output.grad.fill_(1.0)
+    command = wp.launch(
+        slot_store_then_contended_call_kernel,
+        dim=1,
+        inputs=[values],
+        outputs=[output],
+        adj_inputs=[values.grad],
+        adj_outputs=[output.grad],
+        adjoint=True,
+        device=device,
+        record_cmd=True,
+    )
+    command.launch()
+    expected = np.zeros((n, 3), dtype=np.float32)
+    expected[0, 0] = 1.0
+    np.testing.assert_array_equal(values.grad.numpy(), expected)
+
+    command.set_dim(n)
+    with test.assertRaisesRegex(RuntimeError, "Deterministic.*parallel backward.*mutation"):
+        command.launch()
+    np.testing.assert_array_equal(values.grad.numpy(), expected)
+
+    command.set_dim(1)
+    output.grad.fill_(1.0)
+    command.launch()
+    expected[0, 0] = 2.0
+    np.testing.assert_array_equal(values.grad.numpy(), expected)
+
+
+def test_deterministic_read_only_helper_backward(test, device):
+    """Read-only helper gradients retain deterministic parallel reductions."""
+    n = 65536
+    values = wp.ones(1, dtype=wp.vec3, device=device, requires_grad=True)
+    output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
+    seeds_np = np.random.default_rng(2026).random(n, dtype=np.float32)
+    seeds = wp.array(seeds_np, dtype=wp.float32, device=device)
+    expected_x = _reference_scatter_add_float32(seeds_np, np.zeros(n, dtype=np.int32), 1)[0]
+    expected = np.array([[expected_x, 0.0, 0.0]], dtype=np.float32)
+
+    for _ in range(3):
+        values.grad.zero_()
+        tape = wp.Tape()
+        with tape:
+            wp.launch(contended_call_without_store_kernel, dim=n, inputs=[values], outputs=[output], device=device)
+        tape.backward(grads={output: seeds})
+        np.testing.assert_array_equal(values.grad.numpy(), expected)
+
+
+def test_deterministic_sliced_store_backward_is_serial_only(test, device):
+    """Keep slice overwrites ordered with reads through the original array."""
+    for n in (1, 2):
+        with test.subTest(n=n):
+            values = wp.zeros(2 * n, dtype=wp.vec3, device=device, requires_grad=True)
+            source = wp.full(n, 7.0, dtype=float, device=device, requires_grad=True)
+            output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
+            with wp.Tape() as tape:
+                wp.launch(overwrite_sliced_component_then_read_original, n, [values, source, output], device=device)
+            np.testing.assert_array_equal(output.numpy(), np.full(n, 7.0))
+            if device.is_cuda and n > 1:
+                with test.assertRaisesRegex(RuntimeError, "Deterministic.*parallel backward.*mutation"):
+                    tape.backward(grads={output: wp.ones_like(output)})
+            else:
+                tape.backward(grads={output: wp.ones_like(output)})
+                np.testing.assert_array_equal(source.grad.numpy(), np.ones(n))
+                np.testing.assert_array_equal(values.grad.numpy(), np.zeros((2 * n, 3)))
+
+
+def test_deterministic_overlapping_arguments_backward_rejected(test, device):
+    """Reject unsafe CUDA gradients when separate arguments overlap in storage."""
+    n = 64
+    for alias_kind in ("same array", "overlapping views", "distinct arrays"):
+        with test.subTest(alias_kind=alias_kind):
+            offset = int(alias_kind == "overlapping views")
+            a = wp.ones(n + offset, dtype=wp.vec3, device=device, requires_grad=True)
+            if alias_kind == "same array":
+                b = a
+            elif alias_kind == "overlapping views":
+                b = a[1:]
+            else:
+                b = wp.ones(n, dtype=wp.vec3, device=device, requires_grad=True)
+            src = wp.full(n, 2.0, device=device, requires_grad=True)
+            output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
+            tape = wp.Tape()
+            with tape:
+                wp.launch(
+                    argument_alias_slot_store_kernel,
+                    dim=n,
+                    inputs=[a, b, src, offset],
+                    outputs=[output],
+                    device=device,
+                )
+            if device.is_cuda and alias_kind != "distinct arrays":
+                with test.assertRaisesRegex(RuntimeError, "Deterministic.*parallel backward.*mutation"):
+                    tape.backward(grads={output: wp.ones_like(output)})
+                np.testing.assert_array_equal(src.grad.numpy(), np.zeros(n, dtype=np.float32))
+            else:
+                tape.backward(grads={output: wp.ones_like(output)})
+                expected = np.full(n, float(alias_kind != "distinct arrays"), dtype=np.float32)
+                np.testing.assert_array_equal(src.grad.numpy(), expected)
 
 
 def test_deterministic_backward_missing_adjoint_target(test, device):
@@ -735,8 +861,8 @@ def test_deterministic_custom_adjoint_gather_atomic(test, device):
         np.testing.assert_array_equal(result, expected)
 
 
-def test_deterministic_custom_adjoint_component_atomic(test, device):
-    """Verify custom adjoints atomically update ``wp.adjoint[array]`` components."""
+def test_deterministic_custom_adjoint_component_gradient(test, device):
+    """Accumulate deterministic component gradients from custom adjoints."""
     n = 2048
     value_count = 31
     rng = np.random.default_rng(307)
@@ -776,57 +902,40 @@ def test_deterministic_custom_adjoint_component_atomic(test, device):
         np.testing.assert_array_equal(result, expected)
 
 
-def test_deterministic_custom_adjoint_component_store_order(test, device):
-    """Verify adjoint component overwrites stay ordered after ``+=``."""
-    n = 128
+def test_deterministic_custom_adjoint_component_overwrite_is_serial_only(test, device):
+    """Preserve ordered component overwrites only for serial backward launches."""
     value_count = 17
-    indices_np = (np.arange(n, dtype=np.int32) * 5) % value_count
-    indices = wp.array(indices_np, dtype=wp.int32, device=device)
-    output_grad = wp.ones(n, dtype=wp.float32, device=device)
 
     old_det = _get_test_module_options()["deterministic"]
     try:
         _set_test_module_options({"deterministic": wp.DeterministicMode.GPU_TO_GPU})
-        for label, kernel in (
-            ("direct", custom_adjoint_component_clear_gather_kernel),
-            ("adjoint alias", custom_adjoint_component_clear_alias_gather_kernel),
-        ):
-            with test.subTest(label):
-                values = wp.zeros(value_count, dtype=wp.vec3, device=device, requires_grad=True)
-                output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
-
-                tape = wp.Tape()
-                with tape:
-                    wp.launch(kernel, dim=n, inputs=[values, indices], outputs=[output], device=device)
-                tape.backward(grads={output: output_grad})
-
-                np.testing.assert_array_equal(
-                    tape.gradients[values].numpy(), np.zeros((value_count, 3), dtype=np.float32)
-                )
-
-        with test.subTest("view"):
-            values = wp.zeros((1, value_count), dtype=wp.vec3, device=device, requires_grad=True)
+        for n in (1, 128):
+            indices_np = (np.arange(n, dtype=np.int32) * 5) % value_count
+            indices = wp.array(indices_np, dtype=wp.int32, device=device)
+            output_grad = wp.ones(n, dtype=wp.float32, device=device)
+            values = wp.zeros(value_count, dtype=wp.vec3, device=device, requires_grad=True)
             output = wp.zeros(n, dtype=wp.float32, device=device, requires_grad=True)
-
             tape = wp.Tape()
             with tape:
                 wp.launch(
-                    custom_adjoint_component_view_clear_gather_kernel,
+                    custom_adjoint_component_clear_alias_gather_kernel,
                     dim=n,
                     inputs=[values, indices],
                     outputs=[output],
                     device=device,
                 )
-            tape.backward(grads={output: output_grad})
+            if device.is_cuda and n > 1:
+                with test.assertRaisesRegex(RuntimeError, "Deterministic.*parallel backward.*mutation"):
+                    tape.backward(grads={output: output_grad})
+            else:
+                tape.backward(grads={output: output_grad})
 
-            np.testing.assert_array_equal(
-                tape.gradients[values].numpy(), np.zeros((1, value_count, 3), dtype=np.float32)
-            )
+            np.testing.assert_array_equal(values.grad.numpy(), np.zeros((value_count, 3), dtype=np.float32))
     finally:
         _set_test_module_options({"deterministic": old_det})
 
 
-def test_deterministic_custom_adjoint_component_struct_field_atomic(test, device):
+def test_deterministic_custom_adjoint_struct_field_component_gradient(test, device):
     """Verify struct-field adjoint arrays reduce component gradients deterministically."""
     n = 2048
     value_count = 31
@@ -984,25 +1093,6 @@ class TestDeterministicBackward(DeterministicTestBase):
 
     deterministic_modules = (_THIS_MODULE, scatter_module, counter_module)
 
-    def test_adjoint_store_scan_preserves_chained_aliases(self):
-        """Verify chained adjoint aliases remain visible to the store pre-scan."""
-        tree = ast.parse(
-            """
-def adjoint_body(values, index, adj_ret):
-    adj_values = alias_values = wp.adjoint[values]
-    alias_values[index].x += adj_ret
-    adj_values[index].x = 0.0
-"""
-        ).body[0]
-        aliases = {}
-
-        targets = wp_deterministic._deterministic_scan_adjoint_store_targets(tree.body, aliases)
-
-        expected_alias = ("values", (), True)
-        self.assertEqual(aliases["adj_values"], expected_alias)
-        self.assertEqual(aliases["alias_values"], expected_alias)
-        self.assertIn(wp_deterministic.ArrayStoreTarget("values", (), True), targets)
-
 
 def _add(name, devices=cuda_devices):
     add_function_test(TestDeterministicBackward, name, globals()[name], devices=devices)
@@ -1013,15 +1103,17 @@ for _name in (
     "test_deterministic_backward_address_scatter",
     "test_deterministic_backward_strided_adjoint_address_scatter",
     "test_deterministic_backward_vec3_address_scatter",
-    "test_deterministic_slot_store_orders_adjoint_read",
+    "test_deterministic_single_thread_slot_store_backward",
+    "test_deterministic_parallel_slot_store_backward_rejected",
+    "test_recorded_deterministic_backward_respects_updated_dim",
+    "test_deterministic_read_only_helper_backward",
     "test_deterministic_backward_missing_adjoint_target",
     "test_deterministic_custom_replay_counter",
     "test_deterministic_custom_adjoint_array_atomic",
     "test_deterministic_custom_adjoint_gather_atomic",
-    "test_deterministic_custom_adjoint_component_atomic",
-    "test_deterministic_slot_store_orders_custom_adjoint_call",
-    "test_deterministic_custom_adjoint_component_store_order",
-    "test_deterministic_custom_adjoint_component_struct_field_atomic",
+    "test_deterministic_custom_adjoint_component_gradient",
+    "test_deterministic_single_thread_custom_adjoint_slot_store_backward",
+    "test_deterministic_custom_adjoint_struct_field_component_gradient",
     "test_deterministic_custom_adjoint_store_function",
     "test_deterministic_scratch_overwrite_replay_gradient",
 ):
@@ -1031,6 +1123,9 @@ _add("test_deterministic_backward_counter_store_rejected", devices=all_devices)
 _add("test_deterministic_backward_counter_manual_launch_rejected", devices=cuda_devices)
 _add("test_deterministic_custom_adjoint_consumed_counter_rejected", devices=all_devices)
 _add("test_custom_adjoint_not_guaranteed_mode", devices=all_devices)
+_add("test_deterministic_custom_adjoint_component_overwrite_is_serial_only", devices=all_devices)
+_add("test_deterministic_sliced_store_backward_is_serial_only", devices=all_devices)
+_add("test_deterministic_overlapping_arguments_backward_rejected", devices=all_devices)
 
 
 if __name__ == "__main__":

--- a/warp/tests/deterministic/test_deterministic_counter.py
+++ b/warp/tests/deterministic/test_deterministic_counter.py
@@ -314,7 +314,7 @@ def counter_with_int_slot_augassign_kernel(
     values: wp.array[wp.vec3i],
     output: wp.array[wp.int32],
 ):
-    """Integer slot atomics in counter kernels must be skipped during phase 0."""
+    """Update an integer component alongside a deterministic counter."""
     slot = wp.atomic_add(counter, 0, 1)
     values[0].x += 1
     output[slot] = slot
@@ -331,7 +331,7 @@ def counter_with_helper_int_slot_augassign_kernel(
     values: wp.array[wp.vec3i],
     output: wp.array[wp.int32],
 ):
-    """Verify helper slot atomics are skipped during phase 0."""
+    """Update an integer component from a counter-kernel helper."""
     slot = wp.atomic_add(counter, 0, 1)
     _det_int_slot_augassign(values)
     output[slot] = slot
@@ -581,8 +581,8 @@ def test_counter_phase0_suppresses_component_stores(test, device):
     test.assertEqual(int(output.numpy()[0]), 0)
 
 
-def test_counter_phase0_suppresses_integer_slot_augassign(test, device):
-    """Verify integer slot atomics do not double-execute in counter mode."""
+def test_deterministic_counter_slot_augassign_runs_once(test, device):
+    """Run integer component updates once in deterministic counter kernels."""
     for kernel in (counter_with_int_slot_augassign_kernel, counter_with_helper_int_slot_augassign_kernel):
         with test.subTest(kernel=kernel.key):
             counter = wp.zeros(1, dtype=wp.int32, device=device)
@@ -596,7 +596,7 @@ def test_counter_phase0_suppresses_integer_slot_augassign(test, device):
             test.assertEqual(int(output.numpy()[0]), 0)
 
 
-def test_float_slot_augassign_deterministic_rejected(test, device):
+def test_deterministic_float_slot_augassign_rejected(test, device):
     """Verify deterministic mode rejects unsupported floating-point slot atomics."""
     values = wp.zeros(1, dtype=wp.vec3, device=device)
     x = wp.ones(1, dtype=wp.float32, device=device)
@@ -1080,8 +1080,8 @@ for _name in (
     "test_counter_function_parameter_unconsumed_atomic",
     "test_counter_consumed_bitwise_atomic_rejected",
     "test_counter_phase0_suppresses_component_stores",
-    "test_counter_phase0_suppresses_integer_slot_augassign",
-    "test_float_slot_augassign_deterministic_rejected",
+    "test_deterministic_counter_slot_augassign_runs_once",
+    "test_deterministic_float_slot_augassign_rejected",
     "test_counter_nonzero_initial_value",
     "test_counter_multi_launch_accumulates",
     "test_counter_variable_total_writeback",

--- a/warp/tests/deterministic/test_deterministic_counter.py
+++ b/warp/tests/deterministic/test_deterministic_counter.py
@@ -308,6 +308,41 @@ def counter_with_component_store_kernel(
     output[slot] = tid
 
 
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.RUN_TO_RUN})
+def counter_with_int_slot_augassign_kernel(
+    counter: wp.array[wp.int32],
+    values: wp.array[wp.vec3i],
+    output: wp.array[wp.int32],
+):
+    """Integer slot atomics in counter kernels must be skipped during phase 0."""
+    slot = wp.atomic_add(counter, 0, 1)
+    values[0].x += 1
+    output[slot] = slot
+
+
+@wp.func
+def _det_int_slot_augassign(values: wp.array[wp.vec3i]):
+    values[0].x += 1
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.RUN_TO_RUN})
+def counter_with_helper_int_slot_augassign_kernel(
+    counter: wp.array[wp.int32],
+    values: wp.array[wp.vec3i],
+    output: wp.array[wp.int32],
+):
+    """Verify helper slot atomics are skipped during phase 0."""
+    slot = wp.atomic_add(counter, 0, 1)
+    _det_int_slot_augassign(values)
+    output[slot] = slot
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.RUN_TO_RUN})
+def deterministic_float_slot_augassign_kernel(values: wp.array[wp.vec3], x: wp.array[wp.float32]):
+    """Floating-point slot atomics need deterministic scatter support."""
+    values[0].x += x[0]
+
+
 @wp.kernel
 def mixed_pattern_kernel(
     data: wp.array[wp.float32],
@@ -544,6 +579,30 @@ def test_counter_phase0_suppresses_component_stores(test, device):
     np.testing.assert_array_equal(values.numpy(), np.array([[1.0, 0.0, 0.0]], dtype=np.float32))
     test.assertEqual(int(counter.numpy()[0]), 1)
     test.assertEqual(int(output.numpy()[0]), 0)
+
+
+def test_counter_phase0_suppresses_integer_slot_augassign(test, device):
+    """Verify integer slot atomics do not double-execute in counter mode."""
+    for kernel in (counter_with_int_slot_augassign_kernel, counter_with_helper_int_slot_augassign_kernel):
+        with test.subTest(kernel=kernel.key):
+            counter = wp.zeros(1, dtype=wp.int32, device=device)
+            values = wp.zeros(1, dtype=wp.vec3i, device=device)
+            output = wp.full(1, value=-1, dtype=wp.int32, device=device)
+
+            wp.launch(kernel, dim=1, inputs=[counter, values], outputs=[output], device=device)
+
+            np.testing.assert_array_equal(values.numpy(), np.array([[1, 0, 0]], dtype=np.int32))
+            test.assertEqual(int(counter.numpy()[0]), 1)
+            test.assertEqual(int(output.numpy()[0]), 0)
+
+
+def test_float_slot_augassign_deterministic_rejected(test, device):
+    """Verify deterministic mode rejects unsupported floating-point slot atomics."""
+    values = wp.zeros(1, dtype=wp.vec3, device=device)
+    x = wp.ones(1, dtype=wp.float32, device=device)
+
+    with test.assertRaisesRegex(Exception, "floating-point composite slot augmented assignment atomics"):
+        wp.launch(deterministic_float_slot_augassign_kernel, dim=1, inputs=[values, x], device=device)
 
 
 def test_counter_correctness(test, device):
@@ -1021,6 +1080,8 @@ for _name in (
     "test_counter_function_parameter_unconsumed_atomic",
     "test_counter_consumed_bitwise_atomic_rejected",
     "test_counter_phase0_suppresses_component_stores",
+    "test_counter_phase0_suppresses_integer_slot_augassign",
+    "test_float_slot_augassign_deterministic_rejected",
     "test_counter_nonzero_initial_value",
     "test_counter_multi_launch_accumulates",
     "test_counter_variable_total_writeback",

--- a/warp/tests/test_bool.py
+++ b/warp/tests/test_bool.py
@@ -135,6 +135,7 @@ def test_bool_constant_mat(test, device):
 
 
 vec3bool_type = wp.types.vector(length=3, dtype=bool)
+vec2bool_type = wp.types.vector(length=2, dtype=bool)
 
 
 @wp.kernel
@@ -188,6 +189,28 @@ def test_bool_mat_typing(test, device):
     wp.launch(test_bool_mat_anonymous_typing, (1,), inputs=[], device=device)
 
 
+@wp.kernel
+def bool_mat_assign_kernel(array_out: wp.array[mat22bool_type], local_out: wp.array[mat22bool_type]):
+    row = vec2bool_type(True, False)
+    array_out[0][1] = row
+
+    local = mat22bool_type()
+    local[1] = row
+    local[0, 1] = True
+    local_out[0] = local
+
+
+def test_bool_mat_assign(test, device):
+    """Verify bool matrix rows and elements can be assigned."""
+    array_out = wp.zeros(1, dtype=mat22bool_type, device=device)
+    local_out = wp.zeros(1, dtype=mat22bool_type, device=device)
+
+    wp.launch(bool_mat_assign_kernel, 1, outputs=[array_out, local_out], device=device)
+
+    assert_np_equal(array_out.numpy(), np.array([[[False, False], [True, False]]], dtype=np.bool_))
+    assert_np_equal(local_out.numpy(), np.array([[[False, True], [True, False]]], dtype=np.bool_))
+
+
 @wp.func
 def bool_vec_assign():
     v = vec3bool_type(True, False, True)
@@ -231,6 +254,7 @@ add_function_test(TestBool, "test_bool_constant_vec", test_bool_constant_vec, de
 add_function_test(TestBool, "test_bool_constant_mat", test_bool_constant_mat, devices=devices)
 add_function_test(TestBool, "test_bool_vec_typing", test_bool_vec_typing, devices=devices)
 add_function_test(TestBool, "test_bool_mat_typing", test_bool_mat_typing, devices=devices)
+add_function_test(TestBool, "test_bool_mat_assign", test_bool_mat_assign, devices=devices)
 add_function_test(TestBool, "test_bool_vec_assign", test_bool_vec_assign, devices=devices)
 
 

--- a/warp/tests/test_bool.py
+++ b/warp/tests/test_bool.py
@@ -200,7 +200,7 @@ def bool_mat_assign_kernel(array_out: wp.array[mat22bool_type], local_out: wp.ar
     local_out[0] = local
 
 
-def test_bool_mat_assign(test, device):
+def test_bool_matrix_row_and_element_assignment(test, device):
     """Verify bool matrix rows and elements can be assigned."""
     array_out = wp.zeros(1, dtype=mat22bool_type, device=device)
     local_out = wp.zeros(1, dtype=mat22bool_type, device=device)
@@ -254,7 +254,12 @@ add_function_test(TestBool, "test_bool_constant_vec", test_bool_constant_vec, de
 add_function_test(TestBool, "test_bool_constant_mat", test_bool_constant_mat, devices=devices)
 add_function_test(TestBool, "test_bool_vec_typing", test_bool_vec_typing, devices=devices)
 add_function_test(TestBool, "test_bool_mat_typing", test_bool_mat_typing, devices=devices)
-add_function_test(TestBool, "test_bool_mat_assign", test_bool_mat_assign, devices=devices)
+add_function_test(
+    TestBool,
+    "test_bool_matrix_row_and_element_assignment",
+    test_bool_matrix_row_and_element_assignment,
+    devices=devices,
+)
 add_function_test(TestBool, "test_bool_vec_assign", test_bool_vec_assign, devices=devices)
 
 

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -1615,6 +1615,98 @@ def test_augassign_no_double_eval_both(test, device):
 
 
 @wp.func
+def store_index_mutate_src(scratch: wp.array[float]) -> int:
+    # Side effect: overwrite scratch[0] (which the rhs reads) and return index 0.
+    scratch[0] = 7.0
+    return 0
+
+
+@wp.kernel
+def assign_rhs_before_target_index_kernel(
+    dst: wp.array[float],
+    scratch: wp.array[float],
+):
+    # Plain array store: Python evaluates the rhs (scratch[0]) before the
+    # assignment target's index expression (which mutates scratch[0]), so
+    # dst[0] must receive the original scratch[0].
+    dst[store_index_mutate_src(scratch)] = scratch[0]
+
+
+def test_assign_rhs_before_target_index(test, device):
+    """Verify plain assignment evaluates RHS before target indices."""
+    dst = wp.zeros(1, dtype=float, device=device)
+    scratch = wp.array([3.0], dtype=float, device=device)
+
+    wp.launch(assign_rhs_before_target_index_kernel, dim=1, inputs=[dst, scratch], device=device)
+
+    test.assertAlmostEqual(dst.numpy()[0], 3.0, msg="rhs was read after the target index expression mutated it")
+    test.assertAlmostEqual(scratch.numpy()[0], 7.0)
+
+
+@wp.kernel
+def array_copy_grad_kernel(dst: wp.array[float], src: wp.array[float]):
+    i = wp.tid()
+    dst[i] = src[i]
+
+
+def test_assign_array_copy_preserves_gradient(test, device):
+    """Verify array-to-array assignment preserves source gradients."""
+    # A bare array-to-array store `dst[i] = src[i]` materializes the rhs
+    # reference before storing. That materialization must be differentiable
+    # (copy), not a non-differentiable load -- otherwise the read-side gradient
+    # to src is silently dropped while the forward result stays correct.
+    n = 4
+    src = wp.array([1.0, 2.0, 3.0, 4.0], dtype=float, requires_grad=True, device=device)
+    dst = wp.zeros(n, dtype=float, requires_grad=True, device=device)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(array_copy_grad_kernel, dim=n, inputs=[dst, src], device=device)
+
+    dst.grad = wp.array([1.0, 1.0, 1.0, 1.0], dtype=float, device=device)
+    tape.backward()
+
+    assert_np_equal(dst.numpy(), np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
+    assert_np_equal(src.grad.numpy(), np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float32))
+
+
+@wp.func
+def augassign_index_bump(state: wp.array[int]) -> int:
+    # Returns the current index and bumps state[0]; the rhs reads state[0] after.
+    i = state[0]
+    state[0] = 1
+    return i
+
+
+@wp.func
+def augassign_rhs_read_state(state: wp.array[int]) -> float:
+    return float(state[0]) * 100.0
+
+
+@wp.kernel
+def augassign_slot_target_before_rhs_kernel(
+    dst: wp.array[wp.mat33],
+    state: wp.array[int],
+):
+    # The row-index expression has a side effect the RHS reads, so the
+    # target/index must be evaluated before the RHS.
+    dst[augassign_index_bump(state)][1] += wp.vec3(augassign_rhs_read_state(state), 0.0, 0.0)
+
+
+def test_augassign_slot_target_before_rhs(test, device):
+    """Verify slot augmented assignment evaluates target before RHS."""
+    dst = wp.zeros(2, dtype=wp.mat33, device=device)
+    state = wp.zeros(1, dtype=int, device=device)
+
+    wp.launch(augassign_slot_target_before_rhs_kernel, dim=1, inputs=[dst, state], device=device)
+
+    # Index first (-> row 0 of dst[0], state -> 1), then rhs reads state == 1 -> 100.
+    expected = np.zeros((2, 3, 3), dtype=np.float32)
+    expected[0, 1, 0] = 100.0
+    assert_np_equal(dst.numpy(), expected)
+
+
+@wp.func
 def func_to_local_double(a: float):
     return a * 2.0
 
@@ -2790,6 +2882,24 @@ add_function_test(
     TestCodeGen,
     "test_augassign_no_double_eval_both",
     test_augassign_no_double_eval_both,
+    devices=devices,
+)
+add_function_test(
+    TestCodeGen,
+    "test_assign_rhs_before_target_index",
+    test_assign_rhs_before_target_index,
+    devices=devices,
+)
+add_function_test(
+    TestCodeGen,
+    "test_assign_array_copy_preserves_gradient",
+    test_assign_array_copy_preserves_gradient,
+    devices=devices,
+)
+add_function_test(
+    TestCodeGen,
+    "test_augassign_slot_target_before_rhs",
+    test_augassign_slot_target_before_rhs,
     devices=devices,
 )
 add_function_test(TestCodeGen, "test_assign_function_to_local", test_assign_function_to_local, devices=devices)

--- a/warp/tests/test_codegen.py
+++ b/warp/tests/test_codegen.py
@@ -20,6 +20,7 @@ from unittest import mock
 
 import warp as wp
 from warp._src import codegen
+from warp.tests import aux_test_array_slot_operators as slot_operators
 from warp.tests import aux_test_extract_source_patterns as patterns
 from warp.tests.aux_test_extract_source_patterns import contains_truncating_string
 from warp.tests.unittest_utils import *
@@ -1706,6 +1707,44 @@ def test_augassign_slot_target_before_rhs(test, device):
     assert_np_equal(dst.numpy(), expected)
 
 
+def test_array_slot_augassign_uses_user_operator(test, device):
+    """Preserve user operator dispatch for attribute and indexed array slots."""
+    values = wp.array([wp.vec3(3.0)], dtype=wp.vec3, device=device)
+
+    wp.launch(slot_operators.overloaded_slot_augassign, dim=1, inputs=[values, 2.0], device=device)
+
+    np.testing.assert_array_equal(values.numpy(), np.array([[1.0, 1.0, 6.0]], dtype=np.float32))
+
+
+def test_overloaded_slot_update_backward_rejected(test, device):
+    """Reject overloaded slot updates that cannot preserve gradients through an overwrite."""
+    for update in (
+        slot_operators.overloaded_slot_add_backward,
+        slot_operators.overloaded_slot_sub_backward,
+        slot_operators.update_shared_component_backward,
+    ):
+        with test.subTest(update=update.key):
+            values = wp.array([wp.vec3(3.0)], dtype=wp.vec3, requires_grad=True, device=device)
+            rhs = wp.array([2.0], dtype=wp.float32, requires_grad=True, device=device)
+            with test.assertRaisesRegex(
+                codegen.WarpCodegenError, "Differentiable composite slot augmented assignments"
+            ):
+                wp.launch(update, dim=1, inputs=[values, rhs], device=device)
+
+
+def test_slot_updates_ignore_nonmatching_operator_overloads(test, device):
+    """Use builtin updates and adjoints when user operators have different argument types."""
+    values = wp.full(1, wp.vec3d(3.0), dtype=wp.vec3d, device=device, requires_grad=True)
+    rhs = wp.array([2.0], dtype=wp.float64, device=device, requires_grad=True)
+    with wp.Tape() as tape:
+        wp.launch(slot_operators.update_double_components_with_float_overloads, 1, [values, rhs], device=device)
+
+    np.testing.assert_array_equal(values.numpy(), [[5.0, 5.0, 1.0]])
+    tape.backward(grads={values: wp.full_like(values, wp.vec3d(1.0))})
+    np.testing.assert_array_equal(values.grad.numpy(), [[1.0, 1.0, 1.0]])
+    np.testing.assert_array_equal(rhs.grad.numpy(), [1.0])
+
+
 @wp.func
 def func_to_local_double(a: float):
     return a * 2.0
@@ -2900,6 +2939,24 @@ add_function_test(
     TestCodeGen,
     "test_augassign_slot_target_before_rhs",
     test_augassign_slot_target_before_rhs,
+    devices=devices,
+)
+add_function_test(
+    TestCodeGen,
+    "test_array_slot_augassign_uses_user_operator",
+    test_array_slot_augassign_uses_user_operator,
+    devices=devices,
+)
+add_function_test(
+    TestCodeGen,
+    "test_overloaded_slot_update_backward_rejected",
+    test_overloaded_slot_update_backward_rejected,
+    devices=devices,
+)
+add_function_test(
+    TestCodeGen,
+    "test_slot_updates_ignore_nonmatching_operator_overloads",
+    test_slot_updates_ignore_nonmatching_operator_overloads,
     devices=devices,
 )
 add_function_test(TestCodeGen, "test_assign_function_to_local", test_assign_function_to_local, devices=devices)

--- a/warp/tests/test_composite_component_adjoint.py
+++ b/warp/tests/test_composite_component_adjoint.py
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Correctness tests for adjoints of in-place composite-component writes.
+"""Correctness tests for representative composite-component slot writes.
 
-Covers the shapes the v2 lowering currently handles — array-rooted writes
-where the access chain from ``arr[i]`` lands on a composite slot, single
-assignment (``=``). Augmented assignments, nested struct chains, and
-local-struct composite-field writes are tracked as follow-ups.
+Covers the critical paths for array-rooted writes where the access chain from
+``arr[i]`` lands on a composite slot, including plain assignment, selected
+augmented assignments, and struct-field array aliases.
 
 See ``asv/benchmarks/codegen/composite_component_*.py`` for the
 performance contract that these tests complement.
@@ -18,6 +17,10 @@ import numpy as np
 
 import warp as wp
 from warp.tests.unittest_utils import *
+
+mat22i = wp.types.matrix(shape=(2, 2), dtype=wp.int32)
+mat22s = wp.types.matrix(shape=(2, 2), dtype=wp.int16)
+mat23 = wp.types.matrix(shape=(2, 3), dtype=float)
 
 
 @wp.struct
@@ -33,13 +36,13 @@ class StateStruct:
 
 
 @wp.kernel
-def _seed_scalar_grad(g: wp.array[Scalar], a_val: wp.float32, b_val: wp.float32):
+def seed_scalar_grad_kernel(g: wp.array[Scalar], a_val: wp.float32, b_val: wp.float32):
     i = wp.tid()
     g[i] = Scalar(a_val, b_val)
 
 
 @wp.kernel
-def _seed_state_grad(g: wp.array[StateStruct], pos: wp.vec3, vel: wp.vec3):
+def seed_state_grad_kernel(g: wp.array[StateStruct], pos: wp.vec3, vel: wp.vec3):
     i = wp.tid()
     s = StateStruct()
     s.position = pos
@@ -47,17 +50,22 @@ def _seed_state_grad(g: wp.array[StateStruct], pos: wp.vec3, vel: wp.vec3):
     g[i] = s
 
 
+@wp.kernel
+def read_state_position_kernel(src: wp.array[StateStruct], dst: wp.array[wp.vec3]):
+    dst[0] = src[0].position
+
+
 # --------- kernels under test ---------
 
 
 @wp.kernel
-def _k_array_vec_component(dst: wp.array[wp.vec3], src: wp.array[wp.float32]):
+def gh583_kernel(dst: wp.array[wp.vec3], src: wp.array[wp.float32]):
     i = wp.tid()
     dst[i].y = src[i]
 
 
 @wp.kernel
-def _k_sequential_component_writes(y: wp.array[wp.vec3], x: wp.array[wp.float32]):
+def gh248_kernel(y: wp.array[wp.vec3], x: wp.array[wp.float32]):
     tid = wp.tid()
     y[tid].x = x[tid] * 2.0
     y[tid].y = x[tid] * 3.0
@@ -65,152 +73,272 @@ def _k_sequential_component_writes(y: wp.array[wp.vec3], x: wp.array[wp.float32]
 
 
 @wp.kernel
-def _k_array_struct_field(y: wp.array[Scalar], x: wp.array[wp.float32]):
+def gh1174_kernel(y: wp.array[Scalar], x: wp.array[wp.float32]):
     i = wp.tid()
     y[i].a = x[i]
 
 
 @wp.kernel
-def _k_vec2_component(y: wp.array[wp.vec2], x: wp.array[wp.float32]):
-    i = wp.tid()
-    y[i].y = x[i]
-
-
-@wp.kernel
-def _k_vec4_component(y: wp.array[wp.vec4], x: wp.array[wp.float32]):
-    i = wp.tid()
-    y[i].z = x[i]
-
-
-@wp.kernel
-def _k_quat_component(y: wp.array[wp.quatf], x: wp.array[wp.float32]):
-    i = wp.tid()
-    y[i].x = x[i]
-
-
-@wp.kernel
-def _k_mat22_element(y: wp.array[wp.mat22], x: wp.array[wp.float32]):
-    i = wp.tid()
-    y[i][0, 1] = x[i]
-
-
-@wp.kernel
-def _k_mat33_element(y: wp.array[wp.mat33], x: wp.array[wp.float32]):
+def mat33_element_kernel(y: wp.array[wp.mat33], x: wp.array[wp.float32]):
     i = wp.tid()
     y[i][1, 2] = x[i]
 
 
 @wp.kernel
-def _k_transform_p(y: wp.array[wp.transformf], p: wp.array[wp.vec3]):
-    i = wp.tid()
-    y[i].p = p[i]
-
-
-@wp.kernel
-def _k_transform_q(y: wp.array[wp.transformf], q: wp.array[wp.quatf]):
-    i = wp.tid()
-    y[i].q = q[i]
-
-
-@wp.kernel
-def _k_struct_vec_field(y: wp.array[StateStruct], p: wp.array[wp.vec3]):
-    i = wp.tid()
-    y[i].position = p[i]
-
-
-@wp.kernel
-def _k_vec3_subscript(y: wp.array[wp.vec3], x: wp.array[wp.float32]):
+def mat33_row_kernel(y: wp.array[wp.mat33], x: wp.array[wp.vec3]):
     i = wp.tid()
     y[i][1] = x[i]
 
 
 @wp.kernel
-def _k_quat_subscript(y: wp.array[wp.quatf], x: wp.array[wp.float32]):
+def array_rooted_vec3_subscript_component_iadd_kernel(src: wp.array[wp.float32], dst: wp.array[wp.vec3]):
+    dst[0][0] += src[0]
+
+
+@wp.kernel
+def array_rooted_vec3_attribute_component_iadd_kernel(src: wp.array[wp.float32], dst: wp.array[wp.vec3]):
+    dst[0].x += src[0]
+
+
+@wp.kernel(module="unique")
+def array_rooted_vec3_component_imul_backward_enabled_kernel(src: wp.array[wp.float32], dst: wp.array[wp.vec3]):
+    dst[0].x *= src[0]
+
+
+@wp.kernel
+def array_rooted_mat23_row_store_kernel(src: wp.array[wp.vec3], dst: wp.array[mat23]):
+    dst[0][0] = src[0]
+
+
+@wp.kernel
+def mat33_row_iadd_kernel(y: wp.array[wp.mat33], x: wp.array[wp.vec3]):
     i = wp.tid()
-    y[i][0] = x[i]
+    y[i][1] += x[i]
+
+
+@wp.kernel
+def mat33_row_iadd_side_effect_index_kernel(counter: wp.array[wp.int32], y: wp.array[wp.mat33], x: wp.array[wp.vec3]):
+    y[wp.atomic_add(counter, 0, 1)][1] += x[0]
+
+
+@wp.func
+def choose_slot_and_mutate_src(src: wp.array[wp.float32]) -> int:
+    # Side-effecting slot-index expression: mutates the array the rhs reads.
+    src[0] = 7.0
+    return 0
+
+
+@wp.kernel
+def slot_write_rhs_eval_order_kernel(dst: wp.array[wp.vec3], src: wp.array[wp.float32]):
+    # Plain assignment: the rhs (``src[0]``) must be read before the slot
+    # index expression (which mutates ``src[0]``) runs.
+    dst[choose_slot_and_mutate_src(src)].x = src[0]
+
+
+@wp.kernel
+def slot_write_reference_index_kernel(dst: wp.array[wp.vec3], idx: wp.array[wp.int32]):
+    # The array index ``idx[0]`` is a reference (an array read). The composite
+    # slot fast path must load it to a value before emitting it into
+    # ``wp::index(...)``; otherwise a pointer reaches an integer parameter and
+    # the kernel fails to compile.
+    dst[idx[0]].x = 9.0
+
+
+@wp.kernel(module="unique")
+def slot_write_float_array_index_kernel(dst: wp.array[wp.vec3]):
+    dst[0.0].x = 1.0
+
+
+@wp.kernel(module="unique")
+def slot_augassign_float_array_index_kernel(dst: wp.array[wp.vec3], idx: wp.array[wp.float32]):
+    dst[idx[0]].x += 1.0
+
+
+@wp.kernel
+def mat22_row_iadd_atomic_kernel(values: wp.array[wp.vec2], out: wp.array[wp.mat22]):
+    tid = wp.tid()
+    out[0][1] += values[tid]
+
+
+@wp.kernel
+def vec3_component_iadd_atomic_kernel(values: wp.array[wp.float32], out: wp.array[wp.vec3]):
+    tid = wp.tid()
+    out[0][1] += values[tid]
+
+
+@wp.kernel
+def vec2_component_iadd_replay_kernel(
+    vec_y: wp.array[wp.vec2],
+    scalar_y: wp.array[wp.float32],
+    vec_x: wp.array[wp.float32],
+    scalar_x: wp.array[wp.float32],
+    vec_out: wp.array[wp.float32],
+    scalar_out: wp.array[wp.float32],
+):
+    vec_y[0].x += vec_x[0]
+    scalar_y[0] += scalar_x[0]
+
+    vec_out[0] = vec_y[0].x * vec_y[0].x
+    scalar_out[0] = scalar_y[0] * scalar_y[0]
+
+
+@wp.kernel
+def vec2_component_isub_replay_kernel(
+    vec_y: wp.array[wp.vec2],
+    scalar_y: wp.array[wp.float32],
+    vec_x: wp.array[wp.float32],
+    scalar_x: wp.array[wp.float32],
+    vec_out: wp.array[wp.float32],
+    scalar_out: wp.array[wp.float32],
+):
+    vec_y[0].x -= vec_x[0]
+    scalar_y[0] -= scalar_x[0]
+
+    vec_out[0] = vec_y[0].x * vec_y[0].x
+    scalar_out[0] = scalar_y[0] * scalar_y[0]
+
+
+@wp.kernel
+def mat22i_row_iand_atomic_kernel(values: wp.array[wp.vec2i], out: wp.array[mat22i]):
+    tid = wp.tid()
+    out[0][1] &= values[tid]
+
+
+@wp.kernel
+def vec2s_component_iadd_non_atomic_slot_kernel(values: wp.array[wp.int16], out: wp.array[wp.vec2s]):
+    i = wp.tid()
+    out[i].x += values[i]
+
+
+@wp.kernel
+def mat22s_row_iadd_non_atomic_slot_kernel(values: wp.array[wp.vec2s], out: wp.array[mat22s]):
+    i = wp.tid()
+    out[i][1] += values[i]
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def vec3_component_idiv_reference_array_index_kernel(out: wp.array[wp.vec3], idx: wp.array[wp.int32]):
+    out[idx[0]][0] /= 2.0
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def vec3_component_idiv_reference_component_index_kernel(out: wp.array[wp.vec3], comp: wp.array[wp.int32]):
+    out[0][comp[0]] /= 2.0
+
+
+def test_array_composite_slot_augassign_non_atomic_fallback_forward(test, device):
+    """Verify non-atomic slot augmented-assignment fallback updates values."""
+    scalar_values = wp.array(np.array([7], dtype=np.int16), dtype=wp.int16, device=device)
+    vec_out = wp.zeros(1, dtype=wp.vec2s, device=device)
+    wp.launch(vec2s_component_iadd_non_atomic_slot_kernel, 1, inputs=[scalar_values, vec_out], device=device)
+    assert_np_equal(vec_out.numpy(), np.array([[7, 0]], dtype=np.int16))
+
+    row_values = wp.array(np.array([[1, 2]], dtype=np.int16), dtype=wp.vec2s, device=device)
+    mat_out = wp.zeros(1, dtype=mat22s, device=device)
+    wp.launch(mat22s_row_iadd_non_atomic_slot_kernel, 1, inputs=[row_values, mat_out], device=device)
+    expected_mat = np.zeros((1, 2, 2), dtype=np.int16)
+    expected_mat[0, 1, :] = [1, 2]
+    assert_np_equal(mat_out.numpy(), expected_mat)
+
+
+def test_array_composite_slot_augassign_non_atomic_reference_indices(test, device):
+    """Verify fallback slot augmented assignment loads reference indices."""
+    # Unsupported atomic ops such as `/=` fall back to evaluated slot writes.
+    # Reference-typed indices from `idx[0]` / `comp[0]` must be loaded before
+    # they are emitted into raw C++ slot accessors.
+    values = np.array([[8.0, 6.0, 4.0], [10.0, 12.0, 14.0]], dtype=np.float32)
+
+    idx = wp.array([1], dtype=wp.int32, device=device)
+    out = wp.array(values, dtype=wp.vec3, device=device)
+    wp.launch(vec3_component_idiv_reference_array_index_kernel, 1, inputs=[out, idx], device=device)
+
+    expected = values.copy()
+    expected[1, 0] = 5.0
+    assert_np_equal(out.numpy(), expected)
+
+    comp = wp.array([2], dtype=wp.int32, device=device)
+    out = wp.array(values, dtype=wp.vec3, device=device)
+    wp.launch(vec3_component_idiv_reference_component_index_kernel, 1, inputs=[out, comp], device=device)
+
+    expected = values.copy()
+    expected[0, 2] = 2.0
+    assert_np_equal(out.numpy(), expected)
+
+
+@wp.kernel
+def transform_p_kernel(y: wp.array[wp.transformf], p: wp.array[wp.vec3]):
+    i = wp.tid()
+    y[i].p = p[i]
+
+
+@wp.kernel
+def struct_vec_field_kernel(y: wp.array[StateStruct], p: wp.array[wp.vec3]):
+    i = wp.tid()
+    y[i].position = p[i]
 
 
 @wp.struct
-class Inner:
-    a: wp.float32
-    b: wp.float32
+class VecArrayFieldHolder:
+    values: wp.array[wp.vec3]
 
 
 @wp.struct
-class Outer:
-    inner: Inner
-    tag: wp.float32
+class MatArrayFieldHolder:
+    values: wp.array[wp.mat33]
 
 
 @wp.kernel
-def _k_nested_struct_scalar(out: wp.array[Outer], src: wp.array[wp.float32]):
+def struct_field_slot_write_rhs_eval_order_kernel(holder: VecArrayFieldHolder, src: wp.array[wp.float32]):
+    holder.values[choose_slot_and_mutate_src(src)].x = src[0]
+
+
+@wp.kernel
+def _k_struct_field_vec_component_write(holder: VecArrayFieldHolder, x: wp.array[wp.float32]):
+    holder.values[0].x = x[0]
+
+
+@wp.kernel
+def _k_struct_field_array_alias_component_write(holder: VecArrayFieldHolder, x: wp.array[wp.float32]):
+    values = holder.values
+    values[0].x = x[0]
+
+
+@wp.kernel
+def _k_array_view_component_write(values: wp.array2d[wp.vec3], x: wp.array[wp.float32]):
+    view = values[0]
+    view[0].x = x[0]
+
+
+@wp.kernel
+def _k_struct_field_mat_row_write(holder: MatArrayFieldHolder, x: wp.array[wp.vec3]):
+    holder.values[0][1] = x[0]
+
+
+@wp.kernel
+def _k_struct_field_vec_component_iadd_replay(
+    holder: VecArrayFieldHolder,
+    x: wp.array[wp.float32],
+    out: wp.array[wp.float32],
+):
+    holder.values[0].x += x[0]
+    out[0] = holder.values[0].x * holder.values[0].x
+
+
+@wp.kernel
+def _k_struct_field_array_alias_component_iadd_replay(
+    holder: VecArrayFieldHolder,
+    x: wp.array[wp.float32],
+    out: wp.array[wp.float32],
+):
+    values = holder.values
+    values[0].x += x[0]
+    out[0] = values[0].x * values[0].x
+
+
+@wp.kernel(module="unique", enable_backward=False)
+def _k_struct_field_vec_component_iadd_atomic(holder: VecArrayFieldHolder, x: wp.array[wp.float32]):
     i = wp.tid()
-    out[i].inner.a = src[i]
-
-
-@wp.struct
-class MatHolder:
-    m: wp.mat33
-    tag: wp.float32
-
-
-@wp.kernel
-def _k_struct_mat_elem(out: wp.array[MatHolder], src: wp.array[wp.float32]):
-    i = wp.tid()
-    out[i].m[1, 2] = src[i]
-
-
-@wp.kernel
-def _k_struct_vec_component(out: wp.array[StateStruct], src: wp.array[wp.float32]):
-    i = wp.tid()
-    out[i].position.y = src[i]
-
-
-@wp.kernel
-def _seed_outer_grad(g: wp.array[Outer], a_val: wp.float32):
-    i = wp.tid()
-    t = Outer()
-    t.inner = Inner(a_val, 0.0)
-    t.tag = 0.0
-    g[i] = t
-
-
-@wp.kernel
-def _seed_matholder_grad(g: wp.array[MatHolder]):
-    i = wp.tid()
-    t = MatHolder()
-    t.m = wp.mat33(0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)
-    t.tag = 0.0
-    g[i] = t
-
-
-@wp.kernel
-def _k_array2d(y: wp.array2d[wp.vec3], x: wp.array2d[wp.float32]):
-    i, j = wp.tid()
-    y[i, j].y = x[i, j]
-
-
-@wp.kernel
-def _k_array3d(y: wp.array3d[wp.vec3], x: wp.array3d[wp.float32]):
-    i, j, k = wp.tid()
-    y[i, j, k].z = x[i, j, k]
-
-
-@wp.struct
-class ArrayFieldHolder:
-    v: wp.array[wp.float32]
-
-
-@wp.kernel
-def _k_struct_array_field(holder: ArrayFieldHolder, x: wp.array[wp.float32]):
-    i = wp.tid()
-    holder.v[i] = x[i] * 2.0
-
-
-@wp.kernel
-def _k_indexedarray_component(y: wp.indexedarray[wp.vec3], x: wp.array[wp.float32]):
-    i = wp.tid()
-    y[i].y = x[i]
+    holder.values[0].x += x[i]
 
 
 @wp.struct
@@ -235,313 +363,195 @@ def _k_adjoint_component_write(xs: wp.array[AdjVecHolder], out: wp.array[wp.floa
     out[i] = _adj_sum_vec(xs[i])
 
 
+@wp.func
+def _lookup_vec_x(values: wp.array[wp.vec3], index: int) -> wp.float32:
+    return values[index].x
+
+
+@wp.func_grad(_lookup_vec_x)
+def _adj_lookup_vec_x(values: wp.array[wp.vec3], index: int, adj_ret: wp.float32):
+    wp.adjoint[values][index].x += adj_ret
+
+
+@wp.kernel(module="unique", module_options={"deterministic": wp.DeterministicMode.NOT_GUARANTEED})
+def _k_adjoint_component_atomic(values: wp.array[wp.vec3], indices: wp.array[wp.int32], out: wp.array[wp.float32]):
+    i = wp.tid()
+    out[i] = _lookup_vec_x(values, indices[i])
+
+
 # --------- tests ---------
 
 
 class TestCompositeComponentAdjoint(unittest.TestCase):
-    def test_array_vec_component(self):
-        """Backpropagate through a single write to one vec3 component of an array element.
+    pass
 
-        The kernel writes ``src[i]`` into ``dst[i].y``, so only that component's gradient flows
-        back to ``src[i]``. With a unit seed on every ``dst`` component, ``src.grad`` is all ones.
-        """
-        n = 4
-        src = wp.array(np.ones(n, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        dst = wp.zeros(n, dtype=wp.vec3, requires_grad=True)
 
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_array_vec_component, n, inputs=[dst, src])
+def test_gh583_array_vec_component(test, device):
+    """Verify array vector component writes propagate scalar gradients."""
+    n = 4
+    src = wp.array(np.ones(n, dtype=np.float32), dtype=wp.float32, requires_grad=True, device=device)
+    dst = wp.zeros(n, dtype=wp.vec3, requires_grad=True, device=device)
 
-        dst.grad = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3)
-        tape.backward()
+    tape = wp.Tape()
+    with tape:
+        wp.launch(gh583_kernel, n, inputs=[dst, src], device=device)
 
-        assert_np_equal(src.grad.numpy(), np.ones(n, dtype=np.float32))
+    dst.grad = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3, device=device)
+    tape.backward()
 
-    def test_sequential_component_writes(self):
-        """Accumulate gradients across sequential writes to different components of one element.
+    assert_np_equal(src.grad.numpy(), np.ones(n, dtype=np.float32))
 
-        The kernel writes ``x[tid]`` scaled by 2, 3, and 4 into ``y[tid].x``/``.y``/``.z``. With a
-        unit seed on every ``y`` component, the adjoint sums the three contributions, so ``x.grad``
-        is 9 everywhere.
-        """
-        n = 3
-        x = wp.array(np.ones(n, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.vec3, requires_grad=True)
 
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_sequential_component_writes, n, inputs=[y, x])
+def test_gh248_sequential_component_writes(test, device):
+    """Verify sequential vector component writes propagate gradients."""
+    n = 3
+    x = wp.array(np.ones(n, dtype=np.float32), dtype=wp.float32, requires_grad=True, device=device)
+    y = wp.zeros(n, dtype=wp.vec3, requires_grad=True, device=device)
 
-        y.grad = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3)
-        tape.backward()
+    tape = wp.Tape()
+    with tape:
+        wp.launch(gh248_kernel, n, inputs=[y, x], device=device)
 
-        assert_np_equal(x.grad.numpy(), np.full(n, 9.0, dtype=np.float32))
+    y.grad = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3, device=device)
+    tape.backward()
 
-    def test_array_struct_field(self):
-        """Backpropagate through a write to a struct field of an array element.
+    assert_np_equal(x.grad.numpy(), np.full(n, 9.0, dtype=np.float32))
 
-        The kernel writes ``x[i]`` into the ``a`` field of ``y[i]`` (a ``Scalar`` struct). Seeding
-        the adjoint so field ``a`` carries a unit gradient and ``b`` zero, ``x.grad`` is all ones.
-        """
-        n = 3
-        x = wp.array(np.ones(n, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros(n, dtype=Scalar, requires_grad=True)
 
-        wp.launch(_seed_scalar_grad, n, inputs=[y.grad, 1.0, 0.0])
+def test_gh1174_array_struct_field(test, device):
+    """Verify array struct field writes propagate scalar gradients."""
+    n = 3
+    x = wp.array(np.ones(n, dtype=np.float32), dtype=wp.float32, requires_grad=True, device=device)
+    y = wp.zeros(n, dtype=Scalar, requires_grad=True, device=device)
 
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_array_struct_field, n, inputs=[y, x])
-        tape.backward()
+    wp.launch(seed_scalar_grad_kernel, n, inputs=[y.grad, 1.0, 0.0], device=device)
 
-        assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
+    tape = wp.Tape()
+    with tape:
+        wp.launch(gh1174_kernel, n, inputs=[y, x], device=device)
+    tape.backward()
 
-    def test_vec2_component_write(self):
-        n = 2
-        x = wp.array(np.full(n, 2.0, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.vec2, requires_grad=True)
+    assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
 
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_vec2_component, n, inputs=[y, x])
-        y.grad = wp.array(np.ones((n, 2), dtype=np.float32), dtype=wp.vec2)
-        tape.backward()
 
-        assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
+def test_mat33_element_write(test, device):
+    """Verify mat33 element writes propagate scalar gradients."""
+    n = 2
+    x = wp.array(np.full(n, 7.0, dtype=np.float32), dtype=wp.float32, requires_grad=True, device=device)
+    y = wp.zeros(n, dtype=wp.mat33, requires_grad=True, device=device)
 
-    def test_vec4_component_write(self):
-        n = 2
-        x = wp.array(np.full(n, 1.5, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.vec4, requires_grad=True)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(mat33_element_kernel, n, inputs=[y, x], device=device)
+    y.grad = wp.array(np.ones((n, 3, 3), dtype=np.float32), dtype=wp.mat33, device=device)
+    tape.backward()
 
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_vec4_component, n, inputs=[y, x])
-        y.grad = wp.array(np.ones((n, 4), dtype=np.float32), dtype=wp.vec4)
-        tape.backward()
+    assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
 
-        assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
 
-    def test_quaternion_component_write(self):
-        n = 2
-        x = wp.array(np.full(n, 0.5, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.quatf, requires_grad=True)
+def test_transform_translation_write(test, device):
+    """Verify array transform translation writes propagate vector gradients."""
+    n = 2
+    p = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3, requires_grad=True, device=device)
+    y = wp.zeros(n, dtype=wp.transformf, requires_grad=True, device=device)
 
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_quat_component, n, inputs=[y, x])
-        y.grad = wp.array(np.ones((n, 4), dtype=np.float32), dtype=wp.quatf)
-        tape.backward()
+    tape = wp.Tape()
+    with tape:
+        wp.launch(transform_p_kernel, n, inputs=[y, p], device=device)
+    y.grad = wp.array(np.ones((n, 7), dtype=np.float32), dtype=wp.transformf, device=device)
+    tape.backward()
 
-        assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
+    assert_np_equal(p.grad.numpy(), np.ones((n, 3), dtype=np.float32))
 
-    def test_mat22_element_write(self):
-        n = 2
-        x = wp.array(np.full(n, 3.0, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.mat22, requires_grad=True)
 
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_mat22_element, n, inputs=[y, x])
-        y.grad = wp.array(np.ones((n, 2, 2), dtype=np.float32), dtype=wp.mat22)
-        tape.backward()
+def test_struct_vec_field_write(test, device):
+    """Verify struct vec field writes propagate vector gradients."""
+    n = 2
+    p = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3, requires_grad=True, device=device)
+    y = wp.zeros(n, dtype=StateStruct, requires_grad=True, device=device)
 
-        assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
+    wp.launch(seed_state_grad_kernel, n, inputs=[y.grad, wp.vec3(1.0, 1.0, 1.0), wp.vec3(0.0, 0.0, 0.0)], device=device)
 
-    def test_mat33_element_write(self):
-        n = 2
-        x = wp.array(np.full(n, 7.0, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.mat33, requires_grad=True)
+    tape = wp.Tape()
+    with tape:
+        wp.launch(struct_vec_field_kernel, n, inputs=[y, p], device=device)
+    tape.backward()
+
+    assert_np_equal(p.grad.numpy(), np.ones((n, 3), dtype=np.float32))
+
+
+def test_struct_field_array_composite_slot_write(test, device):
+    """Verify struct-field array slot writes propagate gradients."""
+    with test.subTest("direct struct field"):
+        scalar_src = wp.array([2.0], dtype=wp.float32, requires_grad=True, device=device)
+        vec_values = wp.zeros(1, dtype=wp.vec3, requires_grad=True, device=device)
+        vec_holder = VecArrayFieldHolder()
+        vec_holder.values = vec_values
 
         tape = wp.Tape()
         with tape:
-            wp.launch(_k_mat33_element, n, inputs=[y, x])
-        y.grad = wp.array(np.ones((n, 3, 3), dtype=np.float32), dtype=wp.mat33)
+            wp.launch(_k_struct_field_vec_component_write, 1, inputs=[vec_holder, scalar_src], device=device)
+
+        vec_values.grad = wp.array([[3.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
         tape.backward()
 
-        assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
+        assert_np_equal(vec_values.numpy(), np.array([[2.0, 0.0, 0.0]], dtype=np.float32))
+        assert_np_equal(scalar_src.grad.numpy(), np.array([3.0], dtype=np.float32))
 
-    def test_transform_translation_write(self):
-        n = 2
-        p = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.transformf, requires_grad=True)
+    with test.subTest("array alias"):
+        alias_src = wp.array([4.0], dtype=wp.float32, requires_grad=True, device=device)
+        alias_values = wp.zeros(1, dtype=wp.vec3, requires_grad=True, device=device)
+        alias_holder = VecArrayFieldHolder()
+        alias_holder.values = alias_values
 
         tape = wp.Tape()
         with tape:
-            wp.launch(_k_transform_p, n, inputs=[y, p])
-        y.grad = wp.array(np.ones((n, 7), dtype=np.float32), dtype=wp.transformf)
+            wp.launch(_k_struct_field_array_alias_component_write, 1, inputs=[alias_holder, alias_src], device=device)
+
+        alias_values.grad = wp.array([[5.0, 0.0, 0.0]], dtype=wp.vec3, device=device)
         tape.backward()
 
-        assert_np_equal(p.grad.numpy(), np.ones((n, 3), dtype=np.float32))
+        assert_np_equal(alias_values.numpy(), np.array([[4.0, 0.0, 0.0]], dtype=np.float32))
+        assert_np_equal(alias_src.grad.numpy(), np.array([5.0], dtype=np.float32))
 
-    def test_transform_rotation_write(self):
-        n = 2
-        q = wp.array(np.tile([0.0, 0.0, 0.0, 1.0], (n, 1)).astype(np.float32), dtype=wp.quatf, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.transformf, requires_grad=True)
+    with test.subTest("view"):
+        view_src = wp.array([6.0], dtype=wp.float32, requires_grad=True, device=device)
+        view_values = wp.zeros((1, 1), dtype=wp.vec3, requires_grad=True, device=device)
 
         tape = wp.Tape()
         with tape:
-            wp.launch(_k_transform_q, n, inputs=[y, q])
-        y.grad = wp.array(np.ones((n, 7), dtype=np.float32), dtype=wp.transformf)
+            wp.launch(_k_array_view_component_write, 1, inputs=[view_values, view_src], device=device)
+
+        view_values.grad = wp.array([[[7.0, 0.0, 0.0]]], dtype=wp.vec3, device=device)
         tape.backward()
 
-        assert_np_equal(q.grad.numpy(), np.ones((n, 4), dtype=np.float32))
+        assert_np_equal(view_values.numpy(), np.array([[[6.0, 0.0, 0.0]]], dtype=np.float32))
+        assert_np_equal(view_src.grad.numpy(), np.array([7.0], dtype=np.float32))
 
-    def test_struct_vec_field_write(self):
-        n = 2
-        p = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3, requires_grad=True)
-        y = wp.zeros(n, dtype=StateStruct, requires_grad=True)
-
-        wp.launch(_seed_state_grad, n, inputs=[y.grad, wp.vec3(1.0, 1.0, 1.0), wp.vec3(0.0, 0.0, 0.0)])
+    with test.subTest("matrix row"):
+        row_src = wp.array([[1.0, 2.0, 3.0]], dtype=wp.vec3, requires_grad=True, device=device)
+        mat_values = wp.zeros(1, dtype=wp.mat33, requires_grad=True, device=device)
+        mat_holder = MatArrayFieldHolder()
+        mat_holder.values = mat_values
 
         tape = wp.Tape()
         with tape:
-            wp.launch(_k_struct_vec_field, n, inputs=[y, p])
+            wp.launch(_k_struct_field_mat_row_write, 1, inputs=[mat_holder, row_src], device=device)
+
+        grad_seed = np.zeros((1, 3, 3), dtype=np.float32)
+        grad_seed[0, 1, :] = [4.0, 5.0, 6.0]
+        mat_values.grad = wp.array(grad_seed, dtype=wp.mat33, device=device)
         tape.backward()
 
-        assert_np_equal(p.grad.numpy(), np.ones((n, 3), dtype=np.float32))
+        expected = np.zeros((1, 3, 3), dtype=np.float32)
+        expected[0, 1, :] = [1.0, 2.0, 3.0]
+        assert_np_equal(mat_values.numpy(), expected)
+        assert_np_equal(row_src.grad.numpy(), np.array([[4.0, 5.0, 6.0]], dtype=np.float32))
 
-    def test_array2d_composite_component(self):
-        rows, cols = 2, 3
-        x = wp.array(np.ones((rows, cols), dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros((rows, cols), dtype=wp.vec3, requires_grad=True)
 
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_array2d, (rows, cols), inputs=[y, x])
-        y.grad = wp.array(np.ones((rows, cols, 3), dtype=np.float32), dtype=wp.vec3)
-        tape.backward()
-
-        assert_np_equal(x.grad.numpy(), np.ones((rows, cols), dtype=np.float32))
-
-    def test_vec3_subscript_write(self):
-        """Test a ``vec3`` scalar subscript write through ``arr[i][1]``.
-
-        Exercise the ``[k]`` access path rather than the ``.y`` attribute.
-        """
-        n = 3
-        x = wp.array(np.full(n, 4.0, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.vec3, requires_grad=True)
-
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_vec3_subscript, n, inputs=[y, x])
-        y.grad = wp.array(np.ones((n, 3), dtype=np.float32), dtype=wp.vec3)
-        tape.backward()
-
-        assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
-
-    def test_quaternion_subscript_write(self):
-        """Test ``arr[i][0] = rhs`` — quat scalar subscript via ``operator[]``."""
-        n = 2
-        x = wp.array(np.full(n, 0.25, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros(n, dtype=wp.quatf, requires_grad=True)
-
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_quat_subscript, n, inputs=[y, x])
-        y.grad = wp.array(np.ones((n, 4), dtype=np.float32), dtype=wp.quatf)
-        tape.backward()
-
-        assert_np_equal(x.grad.numpy(), np.ones(n, dtype=np.float32))
-
-    def test_nested_struct_scalar_field(self):
-        """Test a scalar-field write through a two-level struct chain.
-
-        Assign through ``arr[i].inner.a``.
-        """
-        n = 3
-        src = wp.array(np.ones(n, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        out = wp.zeros(n, dtype=Outer, requires_grad=True)
-        wp.launch(_seed_outer_grad, n, inputs=[out.grad, 1.0])
-
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_nested_struct_scalar, n, inputs=[out, src])
-        tape.backward()
-
-        assert_np_equal(src.grad.numpy(), np.ones(n, dtype=np.float32))
-
-    def test_struct_mat_element_write(self):
-        """Test a matrix-element write through a struct field.
-
-        Assign through ``arr[i].m[r, c]``, crossing a composite-valued field
-        before terminating in a scalar slot.
-        """
-        n = 2
-        src = wp.array(np.full(n, 7.0, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        out = wp.zeros(n, dtype=MatHolder, requires_grad=True)
-        wp.launch(_seed_matholder_grad, n, inputs=[out.grad])
-
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_struct_mat_elem, n, inputs=[out, src])
-        tape.backward()
-
-        assert_np_equal(src.grad.numpy(), np.ones(n, dtype=np.float32))
-
-    def test_struct_vec_component_write(self):
-        """Test a vector-component write through a struct field.
-
-        Assign through ``arr[i].position.y``.
-        """
-        n = 3
-        src = wp.array(np.full(n, 2.0, dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        out = wp.zeros(n, dtype=StateStruct, requires_grad=True)
-        # Seed upstream adj_out[i].position.y = 1.
-        wp.launch(_seed_state_grad, n, inputs=[out.grad, wp.vec3(0.0, 1.0, 0.0), wp.vec3(0.0, 0.0, 0.0)])
-
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_struct_vec_component, n, inputs=[out, src])
-        tape.backward()
-
-        assert_np_equal(src.grad.numpy(), np.ones(n, dtype=np.float32))
-
-    def test_array3d_composite_component(self):
-        a, b, c = 2, 2, 2
-        x = wp.array(np.ones((a, b, c), dtype=np.float32), dtype=wp.float32, requires_grad=True)
-        y = wp.zeros((a, b, c), dtype=wp.vec3, requires_grad=True)
-
-        tape = wp.Tape()
-        with tape:
-            wp.launch(_k_array3d, (a, b, c), inputs=[y, x])
-        y.grad = wp.array(np.ones((a, b, c, 3), dtype=np.float32), dtype=wp.vec3)
-        tape.backward()
-
-        assert_np_equal(x.grad.numpy(), np.ones((a, b, c), dtype=np.float32))
-
-    def test_struct_array_field_write(self):
-        """Verify struct-held arrays still compile and write through the regular array assignment path."""
-        n = 4
-        x = wp.array(np.full(n, 3.0, dtype=np.float32), dtype=wp.float32)
-        v = wp.zeros(n, dtype=wp.float32)
-        holder = ArrayFieldHolder()
-        holder.v = v
-
-        wp.launch(_k_struct_array_field, n, inputs=[holder, x])
-        wp.synchronize_device()
-
-        assert_np_equal(v.numpy(), np.full(n, 6.0, dtype=np.float32))
-
-    def test_indexedarray_composite_component_write(self):
-        """Verify indexed arrays keep the generic lowering and preserve forward write behavior."""
-        n = 4
-        base = wp.zeros(n, dtype=wp.vec3, requires_grad=True)
-        indices = wp.array(np.arange(n, dtype=np.int32), dtype=wp.int32)
-        y = wp.indexedarray(base, [indices])
-        x = wp.array(np.full(n, 5.0, dtype=np.float32), dtype=wp.float32)
-
-        wp.launch(_k_indexedarray_component, n, inputs=[y, x])
-        wp.synchronize_device()
-
-        expected = np.zeros((n, 3), dtype=np.float32)
-        expected[:, 1] = 5.0
-        assert_np_equal(base.numpy(), expected)
-
-    def test_slot_type_mismatch_reference_rhs_reports_error(self):
-        """Reject a vector reference assigned into a scalar component with a type mismatch and no slot-store call."""
+def test_slot_type_mismatch_reference_rhs_reports_error(test, device):
+    """Verify slot write type mismatches fail before emitting slot adjoints."""
+    with wp.ScopedDevice(device):
 
         @wp.kernel(module="unique")
         def _k_mismatch(y: wp.array[wp.vec3], src: wp.array[wp.vec3]):
@@ -556,18 +566,20 @@ class TestCompositeComponentAdjoint(unittest.TestCase):
         # what a user hits, and driving a build through the adjoint leaves a failed
         # build in the kernel's module without the module ever being asked to load.
         # Match the message so an unrelated runtime failure cannot satisfy this assertion.
-        with self.assertRaisesRegex(RuntimeError, "must be of the same type as the reference"):
+        with test.assertRaisesRegex(RuntimeError, "must be of the same type as the reference"):
             wp.launch(_k_mismatch, n, inputs=[y, src])
 
         # No public API exposes the emitted code, so read it off the adjoint: the
         # mismatch has to be rejected before any slot store is written.
-        self.assertTrue(_k_mismatch.adj.blocks, "Expected build() to initialize codegen blocks before failing.")
+        test.assertTrue(_k_mismatch.adj.blocks, "Expected build() to initialize codegen blocks before failing.")
         forward = "\n".join(_k_mismatch.adj.blocks[0].body_forward)
         reverse = "\n".join(_k_mismatch.adj.blocks[0].body_reverse)
-        self.assertNotIn("adj_array_store_slot", forward + reverse)
+        test.assertNotIn("adj_array_store_slot", forward + reverse)
 
-    def test_wp_adjoint_composite_component_write(self):
-        """Verify plain component writes to ``wp.adjoint`` inside a custom grad behave like normal adjoint stores."""
+
+def test_wp_adjoint_composite_component_write(test, device):
+    """Verify custom adjoint component writes use normal adjoint stores."""
+    with wp.ScopedDevice(device):
         n = 2
         x = AdjVecHolder()
         x.vec = wp.vec3(1.0, 2.0, 3.0)
@@ -583,6 +595,395 @@ class TestCompositeComponentAdjoint(unittest.TestCase):
         expected = np.tile(np.array([0.0, 5.0, 0.0], dtype=np.float32), (n, 1))
         assert_np_equal(grad_vec, expected)
 
+
+def test_wp_adjoint_array_component_atomic_cuda(test, device):
+    """Verify custom adjoint component ``+=`` uses CUDA atomics."""
+    n = 4096
+    value_count = 31
+    rng = np.random.default_rng(307)
+    values_np = rng.random((value_count, 3), dtype=np.float32)
+    indices_np = rng.integers(0, value_count, size=n, dtype=np.int32)
+
+    values = wp.array(values_np, dtype=wp.vec3, device=device, requires_grad=True)
+    indices = wp.array(indices_np, dtype=wp.int32, device=device)
+    out = wp.zeros(n, dtype=wp.float32, device=device)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(_k_adjoint_component_atomic, dim=n, inputs=[values, indices], outputs=[out], device=device)
+    tape.backward(grads={out: wp.ones(n, dtype=wp.float32, device=device)})
+
+    expected = np.zeros((value_count, 3), dtype=np.float32)
+    expected[:, 0] = np.bincount(indices_np, minlength=value_count).astype(np.float32)
+    assert_np_equal(values.grad.numpy(), expected)
+
+
+def test_array_mat33_row_write_backward(test, device):
+    """Verify mat33 row writes propagate row gradients."""
+    n = 2
+    src = wp.array(np.tile([1.0, 2.0, 3.0], (n, 1)), dtype=wp.vec3, requires_grad=True, device=device)
+    dst = wp.zeros(n, dtype=wp.mat33, requires_grad=True, device=device)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(mat33_row_kernel, n, inputs=[dst, src], device=device)
+
+    grad_seed = np.zeros((n, 3, 3), dtype=np.float32)
+    grad_seed[:, 1, :] = [10.0, 20.0, 30.0]
+    dst.grad = wp.array(grad_seed, dtype=wp.mat33, device=device)
+    tape.backward()
+
+    expected = np.tile([10.0, 20.0, 30.0], (n, 1))
+    assert_np_equal(src.grad.numpy(), expected)
+
+
+def test_array_rooted_composite_slot_gradients(test, device):
+    """Verify array-rooted slot writes propagate gradients."""
+    component_kernels = (
+        array_rooted_vec3_subscript_component_iadd_kernel,
+        array_rooted_vec3_attribute_component_iadd_kernel,
+    )
+
+    for kernel in component_kernels:
+        src = wp.array([2.0], dtype=wp.float32, requires_grad=True, device=device)
+        dst = wp.array([[5.0, 0.0, 0.0]], dtype=wp.vec3, requires_grad=True, device=device)
+
+        tape = wp.Tape()
+        with tape:
+            wp.launch(kernel, dim=1, inputs=[src, dst], device=device)
+
+        dst.grad = wp.array(np.ones((1, 3), dtype=np.float32), dtype=wp.vec3, device=device)
+        tape.backward()
+
+        assert_np_equal(dst.numpy(), np.array([[7.0, 0.0, 0.0]], dtype=np.float32))
+        assert_np_equal(src.grad.numpy(), np.array([1.0], dtype=np.float32))
+
+    src = wp.array([[1.0, 2.0, 3.0]], dtype=wp.vec3, requires_grad=True, device=device)
+    dst = wp.zeros(1, dtype=mat23, requires_grad=True, device=device)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(array_rooted_mat23_row_store_kernel, dim=1, inputs=[src, dst], device=device)
+
+    dst.grad = wp.array(np.ones((1, 2, 3), dtype=np.float32), dtype=mat23, device=device)
+    tape.backward()
+
+    expected = np.zeros((1, 2, 3), dtype=np.float32)
+    expected[0, 0, :] = [1.0, 2.0, 3.0]
+    assert_np_equal(dst.numpy(), expected)
+    assert_np_equal(src.grad.numpy(), np.ones((1, 3), dtype=np.float32))
+
+
+def test_array_composite_slot_non_atomic_augassign_backward_rejected(test, device):
+    """Verify unsupported differentiable slot ``*=`` fails with backward enabled."""
+    src = wp.array([2.0], dtype=wp.float32, requires_grad=True, device=device)
+    dst = wp.array([[5.0, 0.0, 0.0]], dtype=wp.vec3, requires_grad=True, device=device)
+
+    with test.assertRaisesRegex(Exception, "Differentiable composite slot augmented assignments"):
+        wp.launch(array_rooted_vec3_component_imul_backward_enabled_kernel, dim=1, inputs=[src, dst], device=device)
+
+
+def test_array_mat33_row_iadd_side_effect_index_forward(test, device):
+    """Verify row ``+=`` evaluates side-effecting indices once."""
+    counter = wp.zeros(1, dtype=wp.int32, device=device)
+    src = wp.array([[1.0, 2.0, 3.0]], dtype=wp.vec3, device=device)
+    dst = wp.zeros(2, dtype=wp.mat33, device=device)
+
+    wp.launch(mat33_row_iadd_side_effect_index_kernel, 1, inputs=[counter, dst, src], device=device)
+
+    expected = np.zeros((2, 3, 3), dtype=np.float32)
+    expected[0, 1, :] = [1.0, 2.0, 3.0]
+    assert_np_equal(counter.numpy(), np.array([1], dtype=np.int32))
+    assert_np_equal(dst.numpy(), expected)
+
+
+def test_slot_write_rhs_eval_order(test, device):
+    """Verify plain slot writes evaluate RHS before target indices."""
+    # The index expression mutates ``src[0]``, but plain assignment must store
+    # the original RHS value.
+    src = wp.array([3.0], dtype=wp.float32, device=device)
+    dst = wp.zeros(1, dtype=wp.vec3, device=device)
+
+    wp.launch(slot_write_rhs_eval_order_kernel, dim=1, inputs=[dst, src], device=device)
+
+    assert_np_equal(dst.numpy()[0, 0], np.float32(3.0))
+    assert_np_equal(src.numpy()[0], np.float32(7.0))
+
+    struct_src = wp.array([5.0], dtype=wp.float32, device=device)
+    struct_dst = wp.zeros(1, dtype=wp.vec3, device=device)
+    holder = VecArrayFieldHolder()
+    holder.values = struct_dst
+
+    wp.launch(struct_field_slot_write_rhs_eval_order_kernel, dim=1, inputs=[holder, struct_src], device=device)
+
+    assert_np_equal(struct_dst.numpy()[0, 0], np.float32(5.0))
+    assert_np_equal(struct_src.numpy()[0], np.float32(7.0))
+
+
+def test_slot_write_reference_index(test, device):
+    """Verify slot writes load reference-typed root array indices."""
+    # Reference-typed array indices must be loaded before raw slot access.
+    dst = wp.zeros(2, dtype=wp.vec3, device=device)
+    idx = wp.zeros(1, dtype=wp.int32, device=device)  # idx[0] == 0
+
+    wp.launch(slot_write_reference_index_kernel, dim=1, inputs=[dst, idx], device=device)
+
+    expected = np.zeros((2, 3), dtype=np.float32)
+    expected[0, 0] = 9.0
+    assert_np_equal(dst.numpy(), expected)
+
+
+def test_slot_write_rejects_non_integer_array_index(test, device):
+    """Verify slot writes reject non-integer root array indices during codegen."""
+    with test.assertRaisesRegex(TypeError, "Array slot write indices must be integers"):
+        slot_write_float_array_index_kernel.module.load(device=device)
+
+    with test.assertRaisesRegex(TypeError, "Array slot write indices must be integers"):
+        slot_augassign_float_array_index_kernel.module.load(device=device)
+
+
+def test_array_composite_slot_augassign_atomic_cuda(test, device):
+    """Verify atomic slot augmented assignments update contended slots."""
+    n = 4096
+
+    row_values = wp.array(np.ones((n, 2), dtype=np.float32), dtype=wp.vec2, device=device)
+    scalar_values = wp.array(np.ones(n, dtype=np.float32), dtype=wp.float32, device=device)
+
+    mat_out = wp.zeros(1, dtype=wp.mat22, device=device)
+    wp.launch(mat22_row_iadd_atomic_kernel, n, inputs=[row_values, mat_out], device=device)
+    expected_mat = np.zeros((1, 2, 2), dtype=np.float32)
+    expected_mat[0, 1, :] = float(n)
+    assert_np_equal(mat_out.numpy(), expected_mat)
+
+    vec_out = wp.zeros(1, dtype=wp.vec3, device=device)
+    wp.launch(vec3_component_iadd_atomic_kernel, n, inputs=[scalar_values, vec_out], device=device)
+    expected_vec = np.zeros((1, 3), dtype=np.float32)
+    expected_vec[0, 1] = float(n)
+    assert_np_equal(vec_out.numpy(), expected_vec)
+
+    struct_vec_out = wp.zeros(1, dtype=wp.vec3, device=device)
+    struct_holder = VecArrayFieldHolder()
+    struct_holder.values = struct_vec_out
+    wp.launch(_k_struct_field_vec_component_iadd_atomic, n, inputs=[struct_holder, scalar_values], device=device)
+    expected_vec = np.zeros((1, 3), dtype=np.float32)
+    expected_vec[0, 0] = float(n)
+    assert_np_equal(struct_vec_out.numpy(), expected_vec)
+
+    row_bits = wp.array(np.tile([0x0F, 0xF0], (n, 1)).astype(np.int32), dtype=wp.vec2i, device=device)
+
+    mat_bits = np.zeros((1, 2, 2), dtype=np.int32)
+    mat_bits[0, 1, :] = [-1, -1]
+    mat_iand_out = wp.array(mat_bits, dtype=mat22i, device=device)
+    wp.launch(mat22i_row_iand_atomic_kernel, n, inputs=[row_bits, mat_iand_out], device=device)
+    expected_iand = mat_bits.copy()
+    expected_iand[0, 1, :] = [0x0F, 0xF0]
+    assert_np_equal(mat_iand_out.numpy(), expected_iand)
+
+
+def test_array_composite_slot_atomic_replay_backward(test, device):
+    """Verify atomic slot augmented assignments replay backward correctly."""
+    for label, kernel, initial_y in (
+        ("add", vec2_component_iadd_replay_kernel, 2.0),
+        ("sub", vec2_component_isub_replay_kernel, 8.0),
+    ):
+        with test.subTest(label):
+            vec_y = wp.array(
+                np.array([[initial_y, 0.0]], dtype=np.float32), dtype=wp.vec2, requires_grad=True, device=device
+            )
+            scalar_y = wp.array(
+                np.array([initial_y], dtype=np.float32), dtype=wp.float32, requires_grad=True, device=device
+            )
+            vec_x = wp.array(np.array([3.0], dtype=np.float32), dtype=wp.float32, requires_grad=True, device=device)
+            scalar_x = wp.array(np.array([3.0], dtype=np.float32), dtype=wp.float32, requires_grad=True, device=device)
+            vec_out = wp.zeros(1, dtype=wp.float32, requires_grad=True, device=device)
+            scalar_out = wp.zeros(1, dtype=wp.float32, requires_grad=True, device=device)
+
+            tape = wp.Tape()
+            with tape:
+                wp.launch(
+                    kernel,
+                    1,
+                    inputs=[vec_y, scalar_y, vec_x, scalar_x, vec_out, scalar_out],
+                    device=device,
+                )
+
+            assert_np_equal(vec_y.numpy()[:, 0], scalar_y.numpy())
+            assert_np_equal(vec_out.numpy(), scalar_out.numpy())
+
+            vec_out.grad = wp.ones(1, dtype=wp.float32, device=device)
+            scalar_out.grad = wp.ones(1, dtype=wp.float32, device=device)
+            tape.backward()
+
+            assert_np_equal(vec_y.numpy()[:, 0], scalar_y.numpy())
+            assert_np_equal(vec_x.grad.numpy(), scalar_x.grad.numpy())
+            assert_np_equal(vec_y.grad.numpy()[:, 0], scalar_y.grad.numpy())
+
+    for kernel in (
+        _k_struct_field_vec_component_iadd_replay,
+        _k_struct_field_array_alias_component_iadd_replay,
+    ):
+        x = wp.array(np.array([3.0], dtype=np.float32), dtype=wp.float32, requires_grad=True, device=device)
+        values = wp.array(
+            np.array([[2.0, 0.0, 0.0]], dtype=np.float32), dtype=wp.vec3, requires_grad=True, device=device
+        )
+        holder = VecArrayFieldHolder()
+        holder.values = values
+        out = wp.zeros(1, dtype=wp.float32, requires_grad=True, device=device)
+
+        tape = wp.Tape()
+        with tape:
+            wp.launch(kernel, 1, inputs=[holder, x], outputs=[out], device=device)
+
+        assert_np_equal(values.numpy(), np.array([[5.0, 0.0, 0.0]], dtype=np.float32))
+        assert_np_equal(out.numpy(), np.array([25.0], dtype=np.float32))
+
+        tape.backward(grads={out: wp.ones(1, dtype=wp.float32, device=device)})
+
+        assert_np_equal(x.grad.numpy(), np.array([10.0], dtype=np.float32))
+        assert_np_equal(values.grad.numpy(), np.array([[10.0, 0.0, 0.0]], dtype=np.float32))
+
+
+def test_array_mat33_row_iadd_backward(test, device):
+    """Verify mat33 row ``+=`` propagates row gradients."""
+    n = 2
+    src = wp.array(np.tile([1.0, 2.0, 3.0], (n, 1)), dtype=wp.vec3, requires_grad=True, device=device)
+    init = np.zeros((n, 3, 3), dtype=np.float32)
+    init[:, 1, :] = [5.0, 5.0, 5.0]
+    dst = wp.array(init, dtype=wp.mat33, requires_grad=True, device=device)
+
+    tape = wp.Tape()
+    with tape:
+        wp.launch(mat33_row_iadd_kernel, n, inputs=[dst, src], device=device)
+
+    # seed adj on dst: row 1 of each mat33 receives [10, 20, 30]
+    grad_seed = np.zeros((n, 3, 3), dtype=np.float32)
+    grad_seed[:, 1, :] = [10.0, 20.0, 30.0]
+    dst.grad = wp.array(grad_seed, dtype=wp.mat33, device=device)
+    tape.backward()
+
+    # augassign d/dsrc(y[i][1] += x[i]) = identity, so adj_src = seeded row
+    expected = np.tile([10.0, 20.0, 30.0], (n, 1))
+    assert_np_equal(src.grad.numpy(), expected)
+
+
+devices = get_test_devices()
+cuda_devices = get_cuda_test_devices()
+
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_composite_slot_augassign_non_atomic_fallback_forward",
+    test_array_composite_slot_augassign_non_atomic_fallback_forward,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_composite_slot_augassign_non_atomic_reference_indices",
+    test_array_composite_slot_augassign_non_atomic_reference_indices,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint, "test_gh583_array_vec_component", test_gh583_array_vec_component, devices=devices
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_gh248_sequential_component_writes",
+    test_gh248_sequential_component_writes,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint, "test_gh1174_array_struct_field", test_gh1174_array_struct_field, devices=devices
+)
+add_function_test(TestCompositeComponentAdjoint, "test_mat33_element_write", test_mat33_element_write, devices=devices)
+add_function_test(
+    TestCompositeComponentAdjoint, "test_transform_translation_write", test_transform_translation_write, devices=devices
+)
+add_function_test(
+    TestCompositeComponentAdjoint, "test_struct_vec_field_write", test_struct_vec_field_write, devices=devices
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_struct_field_array_composite_slot_write",
+    test_struct_field_array_composite_slot_write,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_slot_type_mismatch_reference_rhs_reports_error",
+    test_slot_type_mismatch_reference_rhs_reports_error,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_wp_adjoint_composite_component_write",
+    test_wp_adjoint_composite_component_write,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_wp_adjoint_array_component_atomic_cuda",
+    test_wp_adjoint_array_component_atomic_cuda,
+    devices=cuda_devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_mat33_row_write_backward",
+    test_array_mat33_row_write_backward,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_rooted_composite_slot_gradients",
+    test_array_rooted_composite_slot_gradients,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_composite_slot_non_atomic_augassign_backward_rejected",
+    test_array_composite_slot_non_atomic_augassign_backward_rejected,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_mat33_row_iadd_side_effect_index_forward",
+    test_array_mat33_row_iadd_side_effect_index_forward,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_slot_write_rhs_eval_order",
+    test_slot_write_rhs_eval_order,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_slot_write_reference_index",
+    test_slot_write_reference_index,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_slot_write_rejects_non_integer_array_index",
+    test_slot_write_rejects_non_integer_array_index,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_composite_slot_augassign_atomic_cuda",
+    test_array_composite_slot_augassign_atomic_cuda,
+    devices=cuda_devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_composite_slot_atomic_replay_backward",
+    test_array_composite_slot_atomic_replay_backward,
+    devices=devices,
+)
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_mat33_row_iadd_backward",
+    test_array_mat33_row_iadd_backward,
+    devices=devices,
+)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/warp/tests/test_composite_component_adjoint.py
+++ b/warp/tests/test_composite_component_adjoint.py
@@ -116,9 +116,54 @@ def mat33_row_iadd_kernel(y: wp.array[wp.mat33], x: wp.array[wp.vec3]):
     y[i][1] += x[i]
 
 
-@wp.kernel
-def mat33_row_iadd_side_effect_index_kernel(counter: wp.array[wp.int32], y: wp.array[wp.mat33], x: wp.array[wp.vec3]):
-    y[wp.atomic_add(counter, 0, 1)][1] += x[0]
+@wp.kernel(module="unique")
+def update_inline_sliced_arrays(
+    components: wp.array[wp.vec3],
+    source: wp.array[float],
+    start: int,
+    stop: int,
+    step: int,
+):
+    i = wp.tid()
+    components[start:stop:step][i].x = source[i]
+    components[start:stop:step][i][1] += source[i]
+
+
+def test_inline_slice_updates_preserve_values_and_gradients(test, device):
+    """Write through inline slices and route gradients to the selected elements."""
+    for start, stop, step, selected in ((0, 4, 2, [0, 2]), (3, -5, -2, [3, 1])):
+        with test.subTest(step=step):
+            components = wp.full(4, wp.vec3(7.0), dtype=wp.vec3, requires_grad=True, device=device)
+            source = wp.array([3.0, 5.0], dtype=float, requires_grad=True, device=device)
+            with wp.Tape() as tape:
+                wp.launch(
+                    update_inline_sliced_arrays,
+                    dim=2,
+                    inputs=[components, source, start, stop, step],
+                    device=device,
+                )
+
+            expected_store = np.full(4, 7.0)
+            expected_store[selected] = [3.0, 5.0]
+            expected_add = np.full(4, 7.0)
+            expected_add[selected] = [10.0, 12.0]
+            expected_components = np.full((4, 3), 7.0)
+            expected_components[:, 0] = expected_store
+            expected_components[:, 1] = expected_add
+            np.testing.assert_array_equal(components.numpy(), expected_components)
+
+            tape.backward(
+                grads={
+                    components: wp.full(4, wp.vec3(1.0), dtype=wp.vec3, device=device),
+                }
+            )
+            expected_store_grad = np.ones(4)
+            expected_store_grad[selected] = 0.0
+            expected_component_grad = np.ones((4, 3))
+            expected_component_grad[:, 0] = expected_store_grad
+            np.testing.assert_array_equal(components.grad.numpy(), expected_component_grad)
+            np.testing.assert_array_equal(source.grad.numpy(), [2.0, 2.0])
+            np.testing.assert_array_equal(components.numpy(), expected_components)
 
 
 @wp.func
@@ -226,8 +271,8 @@ def vec3_component_idiv_reference_component_index_kernel(out: wp.array[wp.vec3],
     out[0][comp[0]] /= 2.0
 
 
-def test_array_composite_slot_augassign_non_atomic_fallback_forward(test, device):
-    """Verify non-atomic slot augmented-assignment fallback updates values."""
+def test_array_composite_slot_int16_augassign(test, device):
+    """Update ``int16`` vector components and matrix rows in place."""
     scalar_values = wp.array(np.array([7], dtype=np.int16), dtype=wp.int16, device=device)
     vec_out = wp.zeros(1, dtype=wp.vec2s, device=device)
     wp.launch(vec2s_component_iadd_non_atomic_slot_kernel, 1, inputs=[scalar_values, vec_out], device=device)
@@ -241,11 +286,8 @@ def test_array_composite_slot_augassign_non_atomic_fallback_forward(test, device
     assert_np_equal(mat_out.numpy(), expected_mat)
 
 
-def test_array_composite_slot_augassign_non_atomic_reference_indices(test, device):
-    """Verify fallback slot augmented assignment loads reference indices."""
-    # Unsupported atomic ops such as `/=` fall back to evaluated slot writes.
-    # Reference-typed indices from `idx[0]` / `comp[0]` must be loaded before
-    # they are emitted into raw C++ slot accessors.
+def test_array_composite_slot_augassign_with_array_indices(test, device):
+    """Update composite slots selected by array-valued indices."""
     values = np.array([[8.0, 6.0, 4.0], [10.0, 12.0, 14.0]], dtype=np.float32)
 
     idx = wp.array([1], dtype=wp.int32, device=device)
@@ -288,6 +330,26 @@ class MatArrayFieldHolder:
 
 
 @wp.kernel
+def embedded_array_slot_write_kernel(holders: wp.array[VecArrayFieldHolder], src: wp.array[float]):
+    holders[0].values[0].x = src[0]
+
+
+def test_embedded_array_without_outer_gradient(test, device):
+    """Differentiate an embedded component store without an outer gradient array."""
+    holder = VecArrayFieldHolder()
+    holder.values = wp.array([[2.0, 3.0, 4.0]], dtype=wp.vec3, device=device, requires_grad=True)
+    holders = wp.array([holder], dtype=VecArrayFieldHolder, device=device)
+    src = wp.array([5.0], dtype=float, device=device, requires_grad=True)
+    with wp.Tape() as tape:
+        wp.launch(embedded_array_slot_write_kernel, 1, [holders, src], device=device)
+    holder.values.grad.fill_(wp.vec3(1.0))
+    tape.backward()
+    np.testing.assert_array_equal(holder.values.numpy(), [[5.0, 3.0, 4.0]])
+    np.testing.assert_array_equal(src.grad.numpy(), [1.0])
+    np.testing.assert_array_equal(holder.values.grad.numpy(), [[0.0, 1.0, 1.0]])
+
+
+@wp.kernel
 def struct_field_slot_write_rhs_eval_order_kernel(holder: VecArrayFieldHolder, src: wp.array[wp.float32]):
     holder.values[choose_slot_and_mutate_src(src)].x = src[0]
 
@@ -307,6 +369,31 @@ def _k_struct_field_array_alias_component_write(holder: VecArrayFieldHolder, x: 
 def _k_array_view_component_write(values: wp.array2d[wp.vec3], x: wp.array[wp.float32]):
     view = values[0]
     view[0].x = x[0]
+
+
+@wp.kernel(module="unique")
+def nested_view_component_write(values: wp.array3d[wp.vec3], indices: wp.array[int], src: wp.array[float]):
+    plane = values[0]
+    row = plane[indices[0]]
+    row[0].x = src[0]
+
+
+def test_nested_view_component_gradient(test, device):
+    """Route component gradients through chained views with an array-valued index."""
+    values = wp.zeros((1, 2, 1), dtype=wp.vec3, device=device, requires_grad=True)
+    indices = wp.array([1], dtype=int, device=device)
+    src = wp.array([3.0], dtype=float, device=device, requires_grad=True)
+    with wp.Tape() as tape:
+        wp.launch(nested_view_component_write, 1, [values, indices, src], device=device)
+    values.grad = wp.full_like(values, wp.vec3(2.0, 3.0, 4.0))
+    tape.backward()
+    expected = np.zeros((1, 2, 1, 3), dtype=np.float32)
+    expected[0, 1, 0, 0] = 3.0
+    np.testing.assert_array_equal(values.numpy(), expected)
+    np.testing.assert_array_equal(src.grad.numpy(), [2.0])
+    expected_grad = np.tile([2.0, 3.0, 4.0], (1, 2, 1, 1))
+    expected_grad[0, 1, 0, 0] = 0.0
+    np.testing.assert_array_equal(values.grad.numpy(), expected_grad)
 
 
 @wp.kernel
@@ -549,8 +636,8 @@ def test_struct_field_array_composite_slot_write(test, device):
         assert_np_equal(row_src.grad.numpy(), np.array([[4.0, 5.0, 6.0]], dtype=np.float32))
 
 
-def test_slot_type_mismatch_reference_rhs_reports_error(test, device):
-    """Verify slot write type mismatches fail before emitting slot adjoints."""
+def test_composite_slot_type_mismatch_reports_error(test, device):
+    """Report incompatible values assigned to composite slots."""
     with wp.ScopedDevice(device):
 
         @wp.kernel(module="unique")
@@ -562,19 +649,8 @@ def test_slot_type_mismatch_reference_rhs_reports_error(test, device):
         y = wp.zeros(n, dtype=wp.vec3)
         src = wp.zeros(n, dtype=wp.vec3)
 
-        # Launch rather than calling adj.build() directly: rejecting the mismatch is
-        # what a user hits, and driving a build through the adjoint leaves a failed
-        # build in the kernel's module without the module ever being asked to load.
-        # Match the message so an unrelated runtime failure cannot satisfy this assertion.
-        with test.assertRaisesRegex(RuntimeError, "must be of the same type as the reference"):
+        with test.assertRaisesRegex(TypeError, "Composite slot assignment expects value of type"):
             wp.launch(_k_mismatch, n, inputs=[y, src])
-
-        # No public API exposes the emitted code, so read it off the adjoint: the
-        # mismatch has to be rejected before any slot store is written.
-        test.assertTrue(_k_mismatch.adj.blocks, "Expected build() to initialize codegen blocks before failing.")
-        forward = "\n".join(_k_mismatch.adj.blocks[0].body_forward)
-        reverse = "\n".join(_k_mismatch.adj.blocks[0].body_reverse)
-        test.assertNotIn("adj_array_store_slot", forward + reverse)
 
 
 def test_wp_adjoint_composite_component_write(test, device):
@@ -596,8 +672,8 @@ def test_wp_adjoint_composite_component_write(test, device):
         assert_np_equal(grad_vec, expected)
 
 
-def test_wp_adjoint_array_component_atomic_cuda(test, device):
-    """Verify custom adjoint component ``+=`` uses CUDA atomics."""
+def test_wp_adjoint_array_component_accumulates_cuda(test, device):
+    """Accumulate contended array-component gradients on CUDA."""
     n = 4096
     value_count = 31
     rng = np.random.default_rng(307)
@@ -674,27 +750,13 @@ def test_array_rooted_composite_slot_gradients(test, device):
     assert_np_equal(src.grad.numpy(), np.ones((1, 3), dtype=np.float32))
 
 
-def test_array_composite_slot_non_atomic_augassign_backward_rejected(test, device):
+def test_array_composite_slot_multiply_assign_backward_rejected(test, device):
     """Verify unsupported differentiable slot ``*=`` fails with backward enabled."""
     src = wp.array([2.0], dtype=wp.float32, requires_grad=True, device=device)
     dst = wp.array([[5.0, 0.0, 0.0]], dtype=wp.vec3, requires_grad=True, device=device)
 
     with test.assertRaisesRegex(Exception, "Differentiable composite slot augmented assignments"):
         wp.launch(array_rooted_vec3_component_imul_backward_enabled_kernel, dim=1, inputs=[src, dst], device=device)
-
-
-def test_array_mat33_row_iadd_side_effect_index_forward(test, device):
-    """Verify row ``+=`` evaluates side-effecting indices once."""
-    counter = wp.zeros(1, dtype=wp.int32, device=device)
-    src = wp.array([[1.0, 2.0, 3.0]], dtype=wp.vec3, device=device)
-    dst = wp.zeros(2, dtype=wp.mat33, device=device)
-
-    wp.launch(mat33_row_iadd_side_effect_index_kernel, 1, inputs=[counter, dst, src], device=device)
-
-    expected = np.zeros((2, 3, 3), dtype=np.float32)
-    expected[0, 1, :] = [1.0, 2.0, 3.0]
-    assert_np_equal(counter.numpy(), np.array([1], dtype=np.int32))
-    assert_np_equal(dst.numpy(), expected)
 
 
 def test_slot_write_rhs_eval_order(test, device):
@@ -720,7 +782,7 @@ def test_slot_write_rhs_eval_order(test, device):
     assert_np_equal(struct_src.numpy()[0], np.float32(7.0))
 
 
-def test_slot_write_reference_index(test, device):
+def test_slot_write_with_array_index(test, device):
     """Verify slot writes load reference-typed root array indices."""
     # Reference-typed array indices must be loaded before raw slot access.
     dst = wp.zeros(2, dtype=wp.vec3, device=device)
@@ -742,8 +804,8 @@ def test_slot_write_rejects_non_integer_array_index(test, device):
         slot_augassign_float_array_index_kernel.module.load(device=device)
 
 
-def test_array_composite_slot_augassign_atomic_cuda(test, device):
-    """Verify atomic slot augmented assignments update contended slots."""
+def test_contended_array_composite_slot_augassign_cuda(test, device):
+    """Update contended vector components and matrix rows on CUDA."""
     n = 4096
 
     row_values = wp.array(np.ones((n, 2), dtype=np.float32), dtype=wp.vec2, device=device)
@@ -780,8 +842,8 @@ def test_array_composite_slot_augassign_atomic_cuda(test, device):
     assert_np_equal(mat_iand_out.numpy(), expected_iand)
 
 
-def test_array_composite_slot_atomic_replay_backward(test, device):
-    """Verify atomic slot augmented assignments replay backward correctly."""
+def test_array_composite_slot_augassign_backward(test, device):
+    """Match scalar gradients for composite-slot ``+=`` and ``-=``."""
     for label, kernel, initial_y in (
         ("add", vec2_component_iadd_replay_kernel, 2.0),
         ("sub", vec2_component_isub_replay_kernel, 8.0),
@@ -843,7 +905,7 @@ def test_array_composite_slot_atomic_replay_backward(test, device):
         assert_np_equal(values.grad.numpy(), np.array([[10.0, 0.0, 0.0]], dtype=np.float32))
 
 
-def test_array_mat33_row_iadd_backward(test, device):
+def test_array_mat33_row_add_assign_backward(test, device):
     """Verify mat33 row ``+=`` propagates row gradients."""
     n = 2
     src = wp.array(np.tile([1.0, 2.0, 3.0], (n, 1)), dtype=wp.vec3, requires_grad=True, device=device)
@@ -871,14 +933,37 @@ cuda_devices = get_cuda_test_devices()
 
 add_function_test(
     TestCompositeComponentAdjoint,
-    "test_array_composite_slot_augassign_non_atomic_fallback_forward",
-    test_array_composite_slot_augassign_non_atomic_fallback_forward,
+    "test_nested_view_component_gradient",
+    test_nested_view_component_gradient,
+    devices=devices,
+)
+
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_inline_slice_updates_preserve_values_and_gradients",
+    test_inline_slice_updates_preserve_values_and_gradients,
+    devices=devices,
+)
+
+
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_embedded_array_without_outer_gradient",
+    test_embedded_array_without_outer_gradient,
+    devices=devices,
+)
+
+
+add_function_test(
+    TestCompositeComponentAdjoint,
+    "test_array_composite_slot_int16_augassign",
+    test_array_composite_slot_int16_augassign,
     devices=devices,
 )
 add_function_test(
     TestCompositeComponentAdjoint,
-    "test_array_composite_slot_augassign_non_atomic_reference_indices",
-    test_array_composite_slot_augassign_non_atomic_reference_indices,
+    "test_array_composite_slot_augassign_with_array_indices",
+    test_array_composite_slot_augassign_with_array_indices,
     devices=devices,
 )
 add_function_test(
@@ -908,8 +993,8 @@ add_function_test(
 )
 add_function_test(
     TestCompositeComponentAdjoint,
-    "test_slot_type_mismatch_reference_rhs_reports_error",
-    test_slot_type_mismatch_reference_rhs_reports_error,
+    "test_composite_slot_type_mismatch_reports_error",
+    test_composite_slot_type_mismatch_reports_error,
     devices=devices,
 )
 add_function_test(
@@ -920,8 +1005,8 @@ add_function_test(
 )
 add_function_test(
     TestCompositeComponentAdjoint,
-    "test_wp_adjoint_array_component_atomic_cuda",
-    test_wp_adjoint_array_component_atomic_cuda,
+    "test_wp_adjoint_array_component_accumulates_cuda",
+    test_wp_adjoint_array_component_accumulates_cuda,
     devices=cuda_devices,
 )
 add_function_test(
@@ -938,14 +1023,8 @@ add_function_test(
 )
 add_function_test(
     TestCompositeComponentAdjoint,
-    "test_array_composite_slot_non_atomic_augassign_backward_rejected",
-    test_array_composite_slot_non_atomic_augassign_backward_rejected,
-    devices=devices,
-)
-add_function_test(
-    TestCompositeComponentAdjoint,
-    "test_array_mat33_row_iadd_side_effect_index_forward",
-    test_array_mat33_row_iadd_side_effect_index_forward,
+    "test_array_composite_slot_multiply_assign_backward_rejected",
+    test_array_composite_slot_multiply_assign_backward_rejected,
     devices=devices,
 )
 add_function_test(
@@ -956,8 +1035,8 @@ add_function_test(
 )
 add_function_test(
     TestCompositeComponentAdjoint,
-    "test_slot_write_reference_index",
-    test_slot_write_reference_index,
+    "test_slot_write_with_array_index",
+    test_slot_write_with_array_index,
     devices=devices,
 )
 add_function_test(
@@ -968,20 +1047,20 @@ add_function_test(
 )
 add_function_test(
     TestCompositeComponentAdjoint,
-    "test_array_composite_slot_augassign_atomic_cuda",
-    test_array_composite_slot_augassign_atomic_cuda,
+    "test_contended_array_composite_slot_augassign_cuda",
+    test_contended_array_composite_slot_augassign_cuda,
     devices=cuda_devices,
 )
 add_function_test(
     TestCompositeComponentAdjoint,
-    "test_array_composite_slot_atomic_replay_backward",
-    test_array_composite_slot_atomic_replay_backward,
+    "test_array_composite_slot_augassign_backward",
+    test_array_composite_slot_augassign_backward,
     devices=devices,
 )
 add_function_test(
     TestCompositeComponentAdjoint,
-    "test_array_mat33_row_iadd_backward",
-    test_array_mat33_row_iadd_backward,
+    "test_array_mat33_row_add_assign_backward",
+    test_array_mat33_row_add_assign_backward,
     devices=devices,
 )
 

--- a/warp/tests/test_fabricarray.py
+++ b/warp/tests/test_fabricarray.py
@@ -1119,6 +1119,26 @@ def fa_generic_sums_kernel_indexed(a: wp.indexedfabricarrayarray(dtype=Any), sum
         sums[i] = sums[i] + row[j]
 
 
+@wp.kernel(module="unique")
+def fabric_view_component_store(values: Any):
+    row = values[0]
+    row[0].x = 7.0
+
+
+def test_fabricarrayarray_component_store(test, device):
+    """Compile component stores through Fabric and indexed Fabric array views."""
+    for indexed in (False, True):
+        with test.subTest(indexed=indexed):
+            rows = [wp.zeros(1, dtype=wp.vec3, device=device) for _ in range(2)]
+            iface = _create_fabric_array_array_interface(rows, "values", bucket_sizes=[2])
+            values = wp.fabricarrayarray(data=iface, attrib="values")
+            if indexed:
+                values = values[wp.array([1], dtype=int, device=device)]
+            wp.launch(fabric_view_component_store, 1, [values], device=device)
+            np.testing.assert_array_equal(rows[int(indexed)].numpy(), [[7.0, 0.0, 0.0]])
+            np.testing.assert_array_equal(rows[1 - int(indexed)].numpy(), [[0.0, 0.0, 0.0]])
+
+
 def test_fabricarrayarray(test, device):
     for T in _fabric_types:
         if hasattr(T, "_wp_scalar_type_"):
@@ -1390,6 +1410,9 @@ add_function_test(TestFabricArray, "test_fabricarray_indexing_types", test_fabri
 
 # fabric arrays of arrays
 add_function_test(TestFabricArray, "test_fabricarrayarray", test_fabricarrayarray, devices=devices)
+add_function_test(
+    TestFabricArray, "test_fabricarrayarray_component_store", test_fabricarrayarray_component_store, devices=devices
+)
 
 
 if __name__ == "__main__":

--- a/warp/tests/test_ref.py
+++ b/warp/tests/test_ref.py
@@ -518,6 +518,49 @@ def test_array_tuple_unpack_preserves_adjoint(test, device):
     np.testing.assert_allclose(b.grad.numpy(), a.numpy())
 
 
+array2d_float_ref = wp.ref[wp.array2d[float]]
+
+
+@wp.func
+def ref_array_view_value(values: array2d_float_ref, row_index: int) -> float:
+    alias = values
+    row = alias[row_index]
+    return row[1]
+
+
+@wp.func_grad(ref_array_view_value)
+def adj_ref_array_view_value(values: array2d_float_ref, row_index: int, adj_ret: float):
+    alias = values
+    row = alias[row_index]
+    wp.adjoint[values][row_index, 1] += adj_ret + row[0] * 0.0
+
+
+@wp.kernel
+def kernel_ref_array_view_value(values: wp.array2d[float], out: wp.array[float]):
+    i = wp.tid()
+    out[i] = ref_array_view_value(values, i)
+
+
+def test_ref_array_view_adjoint(test, device):
+    """Preserve aliases and views of ref array parameters in custom adjoints."""
+    values = wp.array(
+        np.array([[2.0, 3.0], [4.0, 5.0]], dtype=np.float32),
+        dtype=float,
+        ndim=2,
+        device=device,
+        requires_grad=True,
+    )
+    out = wp.zeros(2, dtype=float, device=device, requires_grad=True)
+
+    with wp.Tape() as tape:
+        wp.launch(kernel_ref_array_view_value, dim=2, inputs=[values], outputs=[out], device=device)
+
+    tape.backward(grads={out: wp.ones_like(out)})
+
+    np.testing.assert_array_equal(out.numpy(), [3.0, 5.0])
+    np.testing.assert_array_equal(values.grad.numpy(), [[0.0, 1.0], [0.0, 1.0]])
+
+
 @wp.func_native(
     "x = x + 5;",
 )
@@ -1162,6 +1205,7 @@ add_function_test(
     name="test_array_tuple_unpack_preserves_adjoint",
     devices=devices,
 )
+add_function_test(TestRef, func=test_ref_array_view_adjoint, name="test_ref_array_view_adjoint", devices=devices)
 add_function_test(TestRef, func=test_native_ref_param_alias, name="test_native_ref_param_alias", devices=["cpu"])
 add_function_test(
     TestRef, func=test_native_ref_param_adjoint_local, name="test_native_ref_param_adjoint_local", devices=devices

--- a/warp/tests/test_verify_fp.py
+++ b/warp/tests/test_verify_fp.py
@@ -46,6 +46,42 @@ def test_finite(test, device):
 
 
 @wp.kernel(enable_backward=False)
+def slot_atomic_add_overflow_kernel(foos: wp.array[TestStruct]):
+    foos[0].field += wp.float32(3.0e38)
+
+
+@wp.kernel(enable_backward=False)
+def slot_atomic_sub_overflow_kernel(foos: wp.array[TestStruct]):
+    foos[0].field -= wp.float32(3.0e38)
+
+
+def test_verify_fp_reports_composite_slot_overflow(test, device):
+    """Report non-finite values produced by composite slot atomics."""
+    if wp.config.mode == "debug":
+        test.skipTest("verify_fp asserts before infinity warning checks in debug mode")
+
+    if sys.platform == "win32":
+        test.skipTest("Skipping test on Windows due to unreliable stdout capture")
+
+    for op, kernel, initial in (
+        ("add", slot_atomic_add_overflow_kernel, 3.0e38),
+        ("sub", slot_atomic_sub_overflow_kernel, -3.0e38),
+    ):
+        with test.subTest(op=op):
+            foo = TestStruct()
+            foo.field = initial
+            foos = wp.array([foo], dtype=TestStruct, device=device)
+
+            capture = StdOutCapture()
+            capture.begin()
+            wp.launch(kernel=kernel, dim=1, inputs=[foos], device=device)
+            wp.synchronize_device(device)
+            output = capture.end()
+
+            test.assertRegex(output, r"inf")
+
+
+@wp.kernel(enable_backward=False)
 def nan_kernel(foos: wp.array[TestStruct]):
     i = wp.tid()
     foos[i].field /= wp.float32(0.0)  # Division by zero produces Not-a-Number (NaN)
@@ -85,6 +121,13 @@ class TestVerifyFP(unittest.TestCase):
 
 
 add_function_test(TestVerifyFP, "test_finite", test_finite, devices=devices)
+add_function_test(
+    TestVerifyFP,
+    "test_verify_fp_reports_composite_slot_overflow",
+    test_verify_fp_reports_composite_slot_overflow,
+    devices=devices,
+    check_output=False,
+)
 add_function_test(TestVerifyFP, "test_nan", test_nan, devices=devices, check_output=False)
 
 

--- a/warp/tests/test_verify_fp.py
+++ b/warp/tests/test_verify_fp.py
@@ -21,7 +21,7 @@ class TestStruct:
     field: wp.float32
 
 
-@wp.kernel
+@wp.kernel(enable_backward=False)
 def finite_kernel(foos: wp.array[TestStruct]):
     i = wp.tid()
     foos[i].field += wp.float32(1.0)
@@ -45,7 +45,7 @@ def test_finite(test, device):
             raise AssertionError(f"Unexpected result, got: {f} expected: {expected}")
 
 
-@wp.kernel
+@wp.kernel(enable_backward=False)
 def nan_kernel(foos: wp.array[TestStruct]):
     i = wp.tid()
     foos[i].field /= wp.float32(0.0)  # Division by zero produces Not-a-Number (NaN)


### PR DESCRIPTION
## Description

This PR adds differentiable assignments to composite components stored in Warp arrays. Expressions such as `vectors[i].x += value`, `matrices[i][row] = vector`, and writes through array-valued struct fields now compile and propagate gradients correctly.

The code generator resolves these assignments through a single evaluated destination. This preserves Python's target-before-RHS evaluation order across attribute and index expressions. Gradient descriptors are tracked independently from copied forward descriptors, so rebinding an array field does not redirect later reads or gradients through the original descriptor.

Closes #1451.

## How the two commits relate

The first commit contains Zach's original implementation. The second keeps the native component and adjoint support, but changes codegen so it evaluates each assignment once and uses the same path for regular assignments and supported augmented assignments. It also addresses issues found during review: copied or reassigned array fields now point to the right data, user-defined operators and `verify_fp` keep their existing behavior, and deterministic CUDA code reports cases it cannot order safely instead of quietly falling back to nondeterministic atomics.

## Changes

- Support component assignments and supported augmented assignments for vectors, matrices, quaternions, transformations, and structs stored in arrays.
- Handle matrix rows, nested attribute and index access, negative component indices, and inline array views.
- Add adjoints for supported component `+=` and `-=` operations while preserving user-defined operator dispatch. Warp reports a build error when an overloaded component update cannot be differentiated safely.
- Use deterministic reductions for supported component gradients. Parallel CUDA backward launches are rejected when mutation, aliases, in-kernel views, or descriptor rebinding prevent Warp from preserving the required order.
- Preserve `verify_fp` checks for atomic component updates and support Boolean matrix row and element assignments.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment because this change affects users.

## Validation summary

The reproducer from #1451 was checked on CPU and CUDA. The new tests cover component and matrix-row stores, augmented assignments, copied and rebound array descriptors, inline views, user-defined operators, `verify_fp`, and deterministic backward execution.

A broader run completed 2,393 tests across CPU and the available CUDA devices. It included the composite-adjoint, codegen, deterministic, reference, function, and tile suites. A final focused run of 18 CPU and `cuda:0` regression tests also passed, along with pre-commit checks.

## Bug fix

```python
import warp as wp


@wp.kernel
def update_composite_components(
    source: wp.array[float],
    rows: wp.array[wp.vec3],
    vectors: wp.array[wp.vec3],
    matrices: wp.array[wp.mat33],
):
    i = wp.tid()
    vectors[i].x += source[i]
    matrices[i][0] = rows[i]
```

Both writes now compile and propagate gradients to `source` and `rows`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added differentiable assignments and supported augmented assignments for composite array components, including indexed and matrix-element updates.
  * Added boolean matrix row and element indexing, assignment, and copy-assignment support.
  * Added mutable component access with Python-style negative indexing for vectors, quaternions, and transforms.

* **Documentation**
  * Documented supported differentiable updates, deterministic execution restrictions, and available workarounds.

* **Bug Fixes**
  * Improved gradient propagation, atomic updates, evaluation order, alias handling, and deterministic behavior for composite array operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
