### PR TITLE
Add MuJoCo Warp GitHub CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -999,6 +999,76 @@ jobs:
           show: "fail"
         if: always()
 
+  # Test against the latest MuJoCo Warp without making upstream failures block CI.
+  # Run after the free-threaded test to avoid competing for RTX PRO 6000 capacity.
+  test-mujoco-warp-gpu-linux:
+    runs-on: linux-amd64-gpu-rtxpro6000-latest-1
+    needs: [build-warp, test-warp-gpu-linux-python-free-threaded]
+    continue-on-error: true
+    permissions:
+      contents: read
+    container:
+      image: ubuntu:24.04
+      options: -u root --security-opt seccomp=unconfined --shm-size 16g
+      env:
+        NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+    timeout-minutes: 60
+    env:
+      UV_PYTHON: "3.12"
+      WARP_CACHE_PATH: /tmp/warp-cache-${{ github.run_id }}-${{ github.run_attempt }}-mujoco-warp
+    steps:
+      - name: Display GPU information
+        run: nvidia-smi
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        with:
+          enable-apt: true
+
+      - name: Install system dependencies
+        run: |
+          apt-get update
+          apt-get install -y git git-lfs
+          git lfs install
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
+        with:
+          version: "0.12.7"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Download Warp build artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifact-ubuntu-x86_64-cuda13
+          path: warp/bin/
+
+      - name: Install Python dependencies
+        run: |
+          uv venv
+          uv pip install -e . mujoco "git+https://github.com/google-deepmind/mujoco_warp@main" pytest pytest-xdist "jax[cuda13]"
+
+      - name: Report Warp diagnostics
+        run: uv run --no-sync python -c "import warp as wp; wp.print_diagnostics(); assert wp.get_cuda_devices(), 'No CUDA device visible to Warp'"
+
+      - name: Run MuJoCo Warp tests
+        run: uv run --no-sync pytest -n 4 --pyargs mujoco_warp --junit-xml=rspec.xml
+
+      - name: Test Summary
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        with:
+          paths: "rspec.xml"
+          show: "fail"
+        if: always()
+
   test-warp-gpu-linux-mgpu-python310:
     runs-on: linux-amd64-gpu-rtxpro6000-latest-2
     needs: [build-warp, gpu-changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,7 +613,7 @@ jobs:
         run: uv run --extra dev -m warp.tests --junit-report-xml rspec.xml -s autodetect
       
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"
@@ -651,7 +651,7 @@ jobs:
         run: uv run --extra dev -m warp.tests --junit-report-xml rspec.xml --suite debug --warp-debug --failfast
       
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"
@@ -812,7 +812,7 @@ jobs:
         run: uv run --extra dev --extra ${{ matrix.torch-extra }} --with "${{ matrix.jax-extra }}" ${{ matrix.rmm-args }} -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
 
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"
@@ -896,7 +896,7 @@ jobs:
         run: uv run --extra dev --with "jax[cuda13]" -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
 
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"
@@ -993,7 +993,7 @@ jobs:
         run: uv run --python 3.14t --no-sync -m warp.tests --junit-report-xml rspec.xml -s autodetect --failfast
 
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"
@@ -1004,6 +1004,13 @@ jobs:
   test-mujoco-warp-gpu-linux:
     runs-on: linux-amd64-gpu-rtxpro6000-latest-1
     needs: [build-warp, test-warp-gpu-linux-python-free-threaded]
+    if: |
+      always() &&
+      needs.build-warp.result == 'success' &&
+      (
+        needs.test-warp-gpu-linux-python-free-threaded.result == 'success' ||
+        needs.test-warp-gpu-linux-python-free-threaded.result == 'failure'
+      )
     continue-on-error: true
     permissions:
       contents: read
@@ -1060,14 +1067,28 @@ jobs:
         run: uv run --no-sync python -c "import warp as wp; wp.print_diagnostics(); assert wp.get_cuda_devices(), 'No CUDA device visible to Warp'"
 
       - name: Run MuJoCo Warp tests
-        run: uv run --no-sync pytest -n 4 --pyargs mujoco_warp --junit-xml=rspec.xml
+        id: mujoco_tests
+        run: uv run --no-sync pytest -n 4 -ra --pyargs mujoco_warp --junit-xml=rspec.xml
+
+      - name: Re-run failed MuJoCo Warp tests serially
+        if: ${{ failure() && steps.mujoco_tests.outcome == 'failure' }}
+        run: uv run --no-sync pytest --lf --last-failed-no-failures none -vv -ra --tb=long --pyargs mujoco_warp
 
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"
         if: always()
+
+      - name: Upload MuJoCo Warp test report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: mujoco-warp-test-results-${{ github.run_attempt }}
+          path: rspec.xml
+          if-no-files-found: warn
+          retention-days: 7
 
   test-warp-gpu-linux-mgpu-python310:
     runs-on: linux-amd64-gpu-rtxpro6000-latest-2
@@ -1138,7 +1159,7 @@ jobs:
         run: uv run --extra dev -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
 
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"
@@ -1213,7 +1234,7 @@ jobs:
         run: uv run --extra dev --extra torch-cu13 --with usd-core==25.5.1 -m warp.tests --junit-report-xml rspec.xml --coverage --coverage-xml coverage.xml -s autodetect
 
       - name: Test Summary
-        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86  # v2.4
+        uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5  # v2.6
         with:
           paths: "rspec.xml"
           show: "fail"


### PR DESCRIPTION
## Description

Add a non-blocking GitHub Actions job that tests the checked-out Warp build against the latest MuJoCo Warp `main` branch on an RTX PRO 6000 runner. This brings the existing optional GitLab compatibility coverage to GitHub while limiting concurrent demand on RTX PRO 6000 capacity.

## Changes

- Run the MuJoCo Warp test suite with four pytest-xdist workers to retain parallelism coverage.
- Start the job after the existing free-threaded RTX PRO 6000 test and the standard Warp build complete.
- Mark the compatibility job as non-blocking so upstream failures remain visible without failing Warp CI.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/warp/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary

Before the workflow change, a targeted YAML structure assertion failed because the MuJoCo Warp job did not exist. Afterward, the same assertion verified the runner, dependencies, non-blocking setting, CUDA 13 JAX dependency, and four-worker pytest command.

The targeted pre-commit hooks passed for `.github/workflows/ci.yml`, including generated-file consistency and typo checks. `git diff --check` also passed.

The RTX PRO 6000 job has not run locally; this draft PR is intended to exercise it on GitHub Actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added non-blocking Linux GPU coverage for MuJoCo Warp.
  - Runs the test suite in parallel with automatic retries for failed tests.
  - Verifies GPU availability before testing and publishes test results for improved visibility.
  - Uses a dedicated high-performance GPU runner to validate GPU-based workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->