### PR TITLE
Fix quat_rpy, quat_inverse, quat_slerp docs (GH-1856)

### DIFF
--- a/changelog/1856.documentation.md
+++ b/changelog/1856.documentation.md
@@ -1,0 +1,1 @@
+Correct the `quat_rpy`, `quat_inverse`, and `quat_slerp` documentation to state the roll-X, pitch-Y, yaw-Z convention, the unit-length requirement for a true inverse, and spherical interpolation.

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -2450,10 +2450,10 @@ def quat_slerp(a: Quaternion[Float], b: Quaternion[Float], t: Float) -> Quaterni
     Args:
         a: Start quaternion (unit length).
         b: End quaternion (unit length).
-        t: Blend factor, where ``0`` returns ``a`` and ``1`` returns ``b``.
+        t: Blend factor, where ``0`` returns ``a`` and ``1`` returns a quaternion equivalent to ``b`` (exact components except for antipodal inputs where ``b == -a``).
 
     Returns:
-        Interpolated unit quaternion."""
+        Interpolated unit quaternion on the slerp path."""
     ...
 
 def quat_to_matrix(quat: Quaternion[Float]) -> Matrix[Float, Literal[3], Literal[3]]:

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -2445,7 +2445,7 @@ def quat_rotate_inv(quat: Quaternion[Float], vec: Vector[Float, Literal[3]]) -> 
 def quat_slerp(a: Quaternion[Float], b: Quaternion[Float], t: Float) -> Quaternion[Float]:
     """Spherically interpolate between two quaternions.
 
-    Follow the shortest arc from ``a`` to ``b``. Both inputs should be unit length.
+    Follow the shortest arc from ``a`` to ``b``. Both inputs should be unit length. ``q`` and ``-q`` denote the same rotation, so the result can differ by sign without changing orientation.
 
     Args:
         a: Start quaternion (unit length).

--- a/warp/__init__.pyi
+++ b/warp/__init__.pyi
@@ -2409,11 +2409,29 @@ def quat_from_matrix(mat: Matrix[Float, Literal[4], Literal[4]]) -> Quaternion[F
     ...
 
 def quat_rpy(roll: Float, pitch: Float, yaw: Float) -> Quaternion[Float]:
-    """Construct a quaternion representing a combined roll (z), pitch (x), yaw rotations (y) in radians."""
+    """Construct a quaternion from roll-pitch-yaw Euler angles.
+
+    Roll is rotation about X, pitch about Y, and yaw about Z, all in radians. Rotations compose as ``yaw * pitch * roll``.
+
+    Args:
+        roll: Roll angle in radians about X.
+        pitch: Pitch angle in radians about Y.
+        yaw: Yaw angle in radians about Z.
+
+    Returns:
+        Unit quaternion for the composed rotation."""
     ...
 
 def quat_inverse(quat: Quaternion[Float]) -> Quaternion[Float]:
-    """Compute quaternion conjugate."""
+    """Compute the conjugate of a quaternion.
+
+    The conjugate equals the inverse only for unit-length quaternions. Normalize ``quat`` with :func:`warp.normalize` first if needed.
+
+    Args:
+        quat: Input quaternion. Must have unit length for a true inverse.
+
+    Returns:
+        Conjugate ``(-x, -y, -z, w)``."""
     ...
 
 def quat_rotate(quat: Quaternion[Float], vec: Vector[Float, Literal[3]]) -> Vector[Float, Literal[3]]:
@@ -2425,7 +2443,17 @@ def quat_rotate_inv(quat: Quaternion[Float], vec: Vector[Float, Literal[3]]) -> 
     ...
 
 def quat_slerp(a: Quaternion[Float], b: Quaternion[Float], t: Float) -> Quaternion[Float]:
-    """Linearly interpolate between two quaternions."""
+    """Spherically interpolate between two quaternions.
+
+    Follow the shortest arc from ``a`` to ``b``. Both inputs should be unit length.
+
+    Args:
+        a: Start quaternion (unit length).
+        b: End quaternion (unit length).
+        t: Blend factor, where ``0`` returns ``a`` and ``1`` returns ``b``.
+
+    Returns:
+        Interpolated unit quaternion."""
     ...
 
 def quat_to_matrix(quat: Quaternion[Float]) -> Matrix[Float, Literal[3], Literal[3]]:

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -1880,10 +1880,10 @@ add_builtin(
     Args:
         a: Start quaternion (unit length).
         b: End quaternion (unit length).
-        t: Blend factor, where ``0`` returns ``a`` and ``1`` returns ``b``.
+        t: Blend factor, where ``0`` returns ``a`` and ``1`` returns a quaternion equivalent to ``b`` (exact components except for antipodal inputs where ``b == -a``).
 
     Returns:
-        Interpolated unit quaternion.
+        Interpolated unit quaternion on the slerp path.
     """,
     require_original_output_arg=True,
 )

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -1875,7 +1875,7 @@ add_builtin(
     group="Quaternion Math",
     doc="""Spherically interpolate between two quaternions.
 
-    Follow the shortest arc from ``a`` to ``b``. Both inputs should be unit length.
+    Follow the shortest arc from ``a`` to ``b``. Both inputs should be unit length. ``q`` and ``-q`` denote the same rotation, so the result can differ by sign without changing orientation.
 
     Args:
         a: Start quaternion (unit length).

--- a/warp/_src/builtins.py
+++ b/warp/_src/builtins.py
@@ -1825,14 +1825,34 @@ add_builtin(
     input_types={"roll": Float, "pitch": Float, "yaw": Float},
     value_func=lambda arg_types, arg_values: quaternion(dtype=float_infer_type(arg_types)),
     group="Quaternion Math",
-    doc="Construct a quaternion representing a combined roll (z), pitch (x), yaw rotations (y) in radians.",
+    doc="""Construct a quaternion from roll-pitch-yaw Euler angles.
+
+    Roll is rotation about X, pitch about Y, and yaw about Z, all in radians. Rotations compose as ``yaw * pitch * roll``.
+
+    Args:
+        roll: Roll angle in radians about X.
+        pitch: Pitch angle in radians about Y.
+        yaw: Yaw angle in radians about Z.
+
+    Returns:
+        Unit quaternion for the composed rotation.
+    """,
 )
 add_builtin(
     "quat_inverse",
     input_types={"quat": quaternion(dtype=Float)},
     value_func=lambda arg_types, arg_values: quaternion(dtype=float_infer_type(arg_types)),
     group="Quaternion Math",
-    doc="Compute quaternion conjugate.",
+    doc="""Compute the conjugate of a quaternion.
+
+    The conjugate equals the inverse only for unit-length quaternions. Normalize ``quat`` with :func:`warp.normalize` first if needed.
+
+    Args:
+        quat: Input quaternion. Must have unit length for a true inverse.
+
+    Returns:
+        Conjugate ``(-x, -y, -z, w)``.
+    """,
 )
 add_builtin(
     "quat_rotate",
@@ -1853,7 +1873,18 @@ add_builtin(
     input_types={"a": quaternion(dtype=Float), "b": quaternion(dtype=Float), "t": Float},
     value_func=lambda arg_types, arg_values: quaternion(dtype=float_infer_type(arg_types)),
     group="Quaternion Math",
-    doc="Linearly interpolate between two quaternions.",
+    doc="""Spherically interpolate between two quaternions.
+
+    Follow the shortest arc from ``a`` to ``b``. Both inputs should be unit length.
+
+    Args:
+        a: Start quaternion (unit length).
+        b: End quaternion (unit length).
+        t: Blend factor, where ``0`` returns ``a`` and ``1`` returns ``b``.
+
+    Returns:
+        Interpolated unit quaternion.
+    """,
     require_original_output_arg=True,
 )
 add_builtin(


### PR DESCRIPTION
## Description
Fixes #1856. `quat_rpy` listed roll-Z/pitch-X/yaw-Y, `quat_slerp` said linear, `quat_inverse` omitted unit-length caveat. Docs-only, no runtime change.

## Changes
- `warp/_src/builtins.py:1828`: roll-X, pitch-Y, yaw-Z + `yaw * pitch * roll` order
- `warp/_src/builtins.py:1835`: conjugate equals inverse only if unit length
- `warp/_src/builtins.py:1856`: spherical (not linear) interpolation, unit inputs
- `changelog/1856.documentation.md`: added

## Checklist
- [x] I am familiar with the Contributing Guidelines.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] I added a changelog fragment if this change affects users.

## Validation summary
- `uvx pre-commit run --files warp/_src/builtins.py` — clean
- `uv run warp/tests/test_quat.py` — CPU-only on macOS, pass (no GPU, slerp/rpy/inverse logic unchanged)
- `uv run --extra docs build_docs.py` — quat pages render, no Sphinx warnings

## Bug fix
N/A — docs fix, no repro needed. Verified against `warp/native/quat.h:184,202,334`.

## New feature / enhancement
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified quaternion roll, pitch, and yaw axis conventions, angle units, and composition order.
  - Documented that quaternion inversion is a true inverse only for unit quaternions.
  - Expanded spherical interpolation guidance, including shortest-arc behavior, unit-length inputs, blend factors, arguments, and return values.
  - Updated API documentation consistently across public reference materials and the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->